### PR TITLE
Create a single Angular module for ngeo

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -7,9 +7,7 @@ goog.require('ol.layer.Tile');
 goog.require('ol.source.OSM');
 
 (function() {
-  var module = angular.module('app', [
-    'go_map_directive'
-  ]);
+  var module = angular.module('app', ['go']);
 
   module.controller('MainController', ['$scope',
     /**

--- a/src/mapdirective.js
+++ b/src/mapdirective.js
@@ -1,31 +1,28 @@
 goog.provide('go_map_directive');
 
+goog.require('go');
 goog.require('goog.object');
 
-(function() {
-  var module = angular.module('go_map_directive', []);
-
-  module.directive('goMap',
-      /**
-       * @return {angular.Directive} The directive specs.
-       */
-      function() {
-        return {
-          restrict: 'A',
-          scope: {
-            'm': '=goMapMap'
-          },
-          link:
-              /**
-               * @param {angular.Scope} scope Scope.
-               * @param {angular.JQLite} element Element.
-               * @param {angular.Attributes} attrs Attributes.
-               */
-              function(scope, element, attrs) {
-                /** @type {ol.Map} */
-                var map = goog.object.get(scope, 'm');
-                map.setTarget(element[0]);
-              }
-        };
-      });
-})();
+goModule.directive('goMap',
+    /**
+     * @return {angular.Directive} The directive specs.
+     */
+    function() {
+      return {
+        restrict: 'A',
+        scope: {
+          'm': '=goMapMap'
+        },
+        link:
+            /**
+             * @param {angular.Scope} scope Scope.
+             * @param {angular.JQLite} element Element.
+             * @param {angular.Attributes} attrs Attributes.
+             */
+            function(scope, element, attrs) {
+              /** @type {ol.Map} */
+              var map = goog.object.get(scope, 'm');
+              map.setTarget(element[0]);
+            }
+      };
+    });

--- a/src/ngeo.js
+++ b/src/ngeo.js
@@ -1,0 +1,5 @@
+goog.provide('go');
+
+
+/** @type {!angular.Module} */
+var goModule = angular.module('go', []);


### PR DESCRIPTION
This PR creates a single Angular module for ngeo, in the same way as ngAnimate, ngTouch, …

Note: `goModule` is global in debug mode but it's local to the anonymous function [created](https://github.com/camptocamp/ngeo/blob/master/buildtools/ngeo.json#L51) by the compiler.
