### PR TITLE
Remove one-time binding in simple example

### DIFF
--- a/examples/simple.html
+++ b/examples/simple.html
@@ -14,7 +14,7 @@
     </style>
   </head>
   <body ng-controller="MainController">
-    <div id="map" go-map go-map-map="::map"></div>
+    <div id="map" go-map go-map-map="map"></div>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.0-beta.10/angular.min.js"></script>
     <script src="/@?main=simple.js"></script>
   </body>


### PR DESCRIPTION
It produces a "RangeError: Maximum call stack size exceeded" error.
