### PR TITLE
Make it possible to use goog.require's for ol

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,37 @@ updated as new ol3 objects are used in ngeo.
         });
   ```
 
+## Building Closure Compiler
+
+When building the standalone version of ngeo, `ngeo.js`, the compiler complains
+on `goog.require`'s that don't have corresponding `goog.provide`'s. This
+happens on `goog.require`'s for `ol` namespaces, because, when building
+`ngeo.js`, we don't pass `ol` source files to the compiler.
+
+To prevent this compilation error we set the `brokenClosureRequiresLevel`
+compiler
+[option](https://github.com/google/closure-compiler/blob/da97b6b/src/com/google/javascript/jscomp/CompilerOptions.java#L938)
+to `off`. This option is not available on the command line, so setting it to
+`off` requires building our own version of the compiler.
+
+Building the compiler:
+
+```shell
+$ git clone git@github.com:google/closure-compiler.git
+$ # edit the CompilerOptions.java file and set `brokenClosureRequiresLevel` to
+$ # `CheckLevel.OFF` in the `CompilerOptions` constructor.
+$ ant jar
+$ mkdir compiler-20140611 # use the correct date here!
+$ cp build/compiler.jar compiler-20140611/
+$ zip -r compiler-20140611.zip compiler-20140611
+  adding: compiler-20140611/ (stored 0%)
+  adding: compiler-20140611/compiler.jar (deflated 9%)
+```
+
+Now make the zip file available on
+http://dev.camptocamp.com/files/closure-compiler/compiler-20140611.zip and
+change `closure-util.json` as appropriate.
+
 ## Issues
 
 * We use our own closure-compiler.js externs file because ol3's includes the

--- a/buildtools/build.js
+++ b/buildtools/build.js
@@ -68,12 +68,15 @@ function readConfig(configPath, callback) {
  * Get the list of sources sorted in dependency order.
  * @param {Array.<string>} src List of paths or patterns to source files.  By
  *     default, all .js files in the src directory are included.
+ * @param {string} ignoreRequires Ignore requires pattern.  Will be used in
+ *     a RegExp object.
  * @param {function(Error, Array.<string>)} callback Called with a list of paths
  *     or any error.
  */
-function getDependencies(src, callback) {
+function getDependencies(src, ignoreRequires, callback) {
   log.info('ol', 'Parsing dependencies');
-  closure.getDependencies({lib: src}, function(err, paths) {
+  var options = {lib: src, ignoreRequires: ignoreRequires};
+  closure.getDependencies(options, function(err, paths) {
     if (err) {
       callback(err);
       return;
@@ -137,7 +140,7 @@ function build(config, paths, callback) {
 function main(config, callback) {
   async.waterfall([
     assertValidConfig.bind(null, config),
-    getDependencies.bind(null, config.src),
+    getDependencies.bind(null, config.src, config.ignoreRequires),
     build.bind(null, config)
   ], callback);
 }

--- a/buildtools/ngeo.json
+++ b/buildtools/ngeo.json
@@ -1,5 +1,6 @@
 {
   "src": ["src/**/*.js"],
+  "ignoreRequires": "^ol\\.*",
   "compile": {
     "externs": [
       "externs/closure-compiler.js",

--- a/closure-util.json
+++ b/closure-util.json
@@ -1,0 +1,3 @@
+{
+  "compiler_url": "http://dev.camptocamp.com/files/closure-compiler/compiler-20140611.zip"
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "htmlparser2": "~3.7.1"
   },
   "devDependencies": {
-    "closure-util": "~0.14.0",
+    "closure-util": "~0.16.0",
     "jshint": "~2.5.1",
     "walk": "~2.3.3",
     "fs-extra": "~0.8.1",


### PR DESCRIPTION
This PR makes use of closure-util's `ignoreRequires` option and a custom build of the compiler to be able to add `goog.require`'s for ol namespaces in ngeo files.

Depends on https://github.com/openlayers/closure-util/pull/22.
