### PR TITLE
Add groupinteraction example

### DIFF
--- a/examples/interactionbtngroup.html
+++ b/examples/interactionbtngroup.html
@@ -1,0 +1,29 @@
+<!DOCTYPE>
+<html ng-app='app'>
+  <head>
+    <title>Interaction buuton group example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <style>
+        #map {
+          width: 800px;
+          height: 400px;
+        }
+    </style>
+    <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css" type="text/css">
+  </head>
+  <body ng-controller="MainController">
+    <div id="map" go-map></div>
+
+    <div go-btn-group>
+      <button go-btn class="btn btn-success" ng-model="drawPoint.active">Point</button>
+      <button go-btn class="btn btn-success" ng-model="drawLine.active">Linestring</button>
+      <button go-btn class="btn btn-success" ng-model="drawPolygon.active">Polygon</button>
+    </div>
+
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.0-beta.10/angular.min.js"></script>
+    <script src="/@?main=interactionbtngroup.js"></script>
+  </body>
+</html>

--- a/examples/interactionbtngroup.js
+++ b/examples/interactionbtngroup.js
@@ -1,0 +1,159 @@
+goog.provide('interactionbtngroup');
+
+goog.require('go_decorateinteraction_service');
+goog.require('go_map_directive');
+goog.require('ol.FeatureOverlay');
+goog.require('ol.Map');
+goog.require('ol.View2D');
+goog.require('ol.interaction.Draw');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.MapQuest');
+
+(function() {
+  var module = angular.module('app', ['go']);
+
+  module.controller('MainController', ['$scope', 'goDecorateInteraction',
+    /**
+     * @param {angular.Scope} $scope Scope.
+     * @param {go.DecorateInteraction} goDecorateInteraction Decorate
+     *     interaction service.
+     */
+    function($scope, goDecorateInteraction) {
+
+      var source = new ol.source.Vector();
+
+      var vector = new ol.layer.Vector({
+        source: source,
+        style: new ol.style.Style({
+          fill: new ol.style.Fill({
+            color: 'rgba(255, 255, 255, 0.2)'
+          }),
+          stroke: new ol.style.Stroke({
+            color: '#ffcc33',
+            width: 2
+          }),
+          image: new ol.style.Circle({
+            radius: 7,
+            fill: new ol.style.Fill({
+              color: '#ffcc33'
+            })
+          })
+        })
+      });
+
+      /** @type {ol.Map} */
+      $scope.map = new ol.Map({
+        layers: [
+          new ol.layer.Tile({
+            source: new ol.source.MapQuest({layer: 'sat'})
+          }),
+          vector
+        ],
+        view: new ol.View2D({
+          center: [-10997148, 4569099],
+          zoom: 4
+        })
+      });
+
+      /** @type {ol.interaction.Draw} */
+      $scope.drawPolygon = new ol.interaction.Draw(
+          /** @type {olx.interaction.DrawOptions} */ ({
+            type: 'Polygon',
+            source: source
+          }));
+      goDecorateInteraction($scope.drawPolygon, $scope.map);
+
+
+      /** @type {ol.interaction.Draw} */
+      $scope.drawPoint = new ol.interaction.Draw(
+          /** @type {olx.interaction.DrawOptions} */ ({
+            type: 'Point',
+            source: source
+          }));
+      goDecorateInteraction($scope.drawPoint, $scope.map);
+
+      /** @type {ol.interaction.Draw} */
+      $scope.drawLine = new ol.interaction.Draw(
+          /** @type {olx.interaction.DrawOptions} */ ({
+            type: 'LineString',
+            source: source
+          }));
+      goDecorateInteraction($scope.drawLine, $scope.map);
+    }]);
+
+  module.directive('goBtnGroup', function() {
+    return {
+      restrict: 'A',
+      controller:
+          function() {
+            /**
+             * @type {Array.<{scope:angular.Scope,
+             *                setter:function((!angular.Scope), *)}>}
+             */
+            var buttons = [];
+
+            /**
+             * @param {angular.Scope} btnScope Scope of the goBtn directive.
+             */
+            this.activate = function(btnScope) {
+              goog.array.forEach(buttons, function(b) {
+                if (b.scope != btnScope) {
+                  b.setter(b.scope, false);
+                }
+              });
+            };
+
+            /**
+             * @param {angular.Scope} btnScope Scope of the goBtn directive.
+             * @param {function((!angular.Scope), *)} ngModelSet Setter.
+             */
+            this.addButton = function(btnScope, ngModelSet) {
+              buttons.push({
+                scope: btnScope,
+                setter: ngModelSet
+              });
+            };
+          }
+    };
+  })
+    .directive('goBtn', ['$parse',
+        function($parse) {
+          return {
+            require: ['^goBtnGroup', 'ngModel'],
+            restrict: 'A',
+            scope: true,
+            link:
+                /**
+                 * @param {angular.Scope} scope Scope.
+                 * @param {angular.JQLite} element Element.
+                 * @param {angular.Attributes} attrs Attributes.
+                 * @param {!Array.<!Object>} ctrls Controllers.
+                 */
+                function(scope, element, attrs, ctrls) {
+                  var buttonsCtrl = ctrls[0];
+                  var ngModelCtrl = ctrls[1];
+
+                  var ngModelGet = $parse(attrs['ngModel']);
+                  var ngModelSet = ngModelGet.assign;
+
+                  buttonsCtrl.addButton(scope, ngModelSet);
+
+                  //ui->model
+                  element.bind('click', function() {
+                    scope.$apply(function() {
+                      ngModelCtrl.$setViewValue(!ngModelCtrl.$viewValue);
+                      ngModelCtrl.$render();
+                    });
+                  });
+
+                  //model -> UI
+                  ngModelCtrl.$render = function() {
+                    if (ngModelCtrl.$viewValue) {
+                      buttonsCtrl.activate(scope);
+                    }
+                    element.toggleClass('active', ngModelCtrl.$viewValue);
+                  };
+                }
+          };
+        }]);
+})();

--- a/externs/examples.js
+++ b/externs/examples.js
@@ -6,3 +6,10 @@ angular.Scope.layer;
 
 /** @type {ol.interaction.Interaction} */
 angular.Scope.interaction;
+
+/** @type {ol.interaction.Draw} */
+angular.Scope.drawPoint;
+/** @type {ol.interaction.Draw} */
+angular.Scope.drawLine;
+/** @type {ol.interaction.Draw} */
+angular.Scope.drawPolygon;


### PR DESCRIPTION
This PR provides an example on how we could use angular directives to manage a button group that toggles exclusive _ol3_ interactions.

Each toggle button is managed by a _goBtn_ directive and is binded to an interaction.active property.
The _goBtnGroup_ controller manage an array of _goBtn_ scopes, and assumes that only one interaction is active at the same time.
