### PR TITLE
Do not use goog in examples

### DIFF
--- a/examples/interactionbtngroup.js
+++ b/examples/interactionbtngroup.js
@@ -96,7 +96,7 @@ goog.require('ol.source.MapQuest');
              * @param {angular.Scope} btnScope Scope of the goBtn directive.
              */
             this.activate = function(btnScope) {
-              goog.array.forEach(buttons, function(b) {
+              buttons.forEach(function(b) {
                 if (b.scope != btnScope) {
                   b.setter(b.scope, false);
                 }


### PR DESCRIPTION
We cannot use goog in examples because that won't work when the example is not compiled.

(Already discussed with @fgravin, so merging…)
