### PR TITLE
Update to closure-util 0.19.0

### DIFF
--- a/closure-util.json
+++ b/closure-util.json
@@ -1,0 +1,3 @@
+{
+  "library_url": "https://github.com/google/closure-library/archive/ab89cf45c216615d73a2f5dea720afb9d3415d1f.zip"
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "htmlparser2": "~3.7.1"
   },
   "devDependencies": {
-    "closure-util": "~0.17.0",
+    "closure-util": "0.19.0",
     "fs-extra": "~0.8.1",
     "graceful-fs": "~3.0.2",
     "jsdoc": "~3.3.0-alpha7",


### PR DESCRIPTION
This PR updates ngeo with the latest version of closure-util. closure-util now uses the latest version of the Closure Library, with which ol3 is not yet compatible. For that reason we need to peg to version of Closure Library here.
