### PR TITLE
Add externs for ngeo : ngeox.js

### DIFF
--- a/buildtools/example.json
+++ b/buildtools/example.json
@@ -13,7 +13,8 @@
       "node_modules/openlayers/externs/tilejson.js",
       "node_modules/openlayers/externs/topojson.js",
       "node_modules/openlayers/externs/vbarray.js",
-      ".build/externs/angular-1.3.js"
+      ".build/externs/angular-1.3.js",
+      "externs/ngeox.js"
     ],
     "define": [
       "goog.dom.ASSUME_STANDARDS_MODE=true",

--- a/buildtools/examples-all.json
+++ b/buildtools/examples-all.json
@@ -20,7 +20,8 @@
     ],
     "js": [
       ".build/examples/all.js",
-      "node_modules/openlayers/externs/olx.js"
+      "node_modules/openlayers/externs/olx.js",
+      "externs/ngeox.js"
     ],
     "jscomp_error": [
       "accessControls",

--- a/buildtools/ngeo.json
+++ b/buildtools/ngeo.json
@@ -13,7 +13,8 @@
       "node_modules/openlayers/externs/tilejson.js",
       "node_modules/openlayers/externs/topojson.js",
       "node_modules/openlayers/externs/vbarray.js",
-      ".build/externs/angular-1.3.js"
+      ".build/externs/angular-1.3.js",
+      "externs/ngeox.js"
     ],
     "define": [
       "goog.DEBUG=false"

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -1,0 +1,18 @@
+/**
+ * @type {Object}
+ */
+var gox;
+
+/**
+ * Object literal with config options for goBtn directive.
+ * @typedef {{cls: (string|undefined)}}
+ */
+gox.BtnOptions;
+
+/**
+ * Class to apply to the element when the ngModel is true. If null,
+ * no class is applied.
+ * @type {string|undefined}
+ */
+gox.BtnOptions.cls;
+


### PR DESCRIPTION
The prupose is to type some objects that a third application could pass to ngeo directives or services.
Type definition of an option object passed to `goBtn` through an attribute is provided.
