### PR TITLE
Add ol.css to examples

### DIFF
--- a/examples/interactionbtngroup.html
+++ b/examples/interactionbtngroup.html
@@ -6,6 +6,7 @@
     <meta name="viewport"
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
     <style>
         #map {
           width: 800px;

--- a/examples/interactiontoggle.html
+++ b/examples/interactiontoggle.html
@@ -6,6 +6,7 @@
     <meta name="viewport"
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
     <style>
         #map {
           width: 800px;

--- a/examples/layermanager.html
+++ b/examples/layermanager.html
@@ -6,6 +6,7 @@
     <meta name="viewport"
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
     <style>
         #map {
           width: 100%;

--- a/examples/layeropacity.html
+++ b/examples/layeropacity.html
@@ -6,6 +6,7 @@
     <meta name="viewport"
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
     <style>
         #map {
           width: 600px;

--- a/examples/layervisibility.html
+++ b/examples/layervisibility.html
@@ -6,6 +6,7 @@
     <meta name="viewport"
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
     <style>
         #map {
           width: 800px;

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -6,6 +6,7 @@
     <meta name="viewport"
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
     <style>
       #map {
         width: 600px;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "htmlparser2": "~3.7.1"
   },
   "devDependencies": {
+    "clean-css": "^2.2.7",
     "fs-extra": "~0.8.1",
     "graceful-fs": "~3.0.2",
     "jsdoc": "~3.3.0-alpha7",


### PR DESCRIPTION
Currently the examples do not include ol.css. See http://camptocamp.github.io/ngeo/master/simple.html for example. As you can see the zoom and attribution controls are not displayed on the map. This PR fixes that. See http://erilem.net/ngeo/css/simple.html.

Note: at this point `ngeo.css` just include the ol css. In the future ngeo will probably have its own css, so `ngeo.css` will include both the ol css and the ngeo css. We will also need to decide whether we use a CSS pre-processor like Less.

Please review.
