### PR TITLE
Fix goMap directive when parsing map attribute

### DIFF
--- a/src/directives/map.js
+++ b/src/directives/map.js
@@ -21,8 +21,7 @@ goModule.directive('goMap', ['goDefaultMap',
             var attr = 'goMap';
             var prop = attrs[attr] || goDefaultMap;
 
-            /** @type {ol.Map} */
-            var map = scope[prop];
+            var map = /** @type {ol.Map} */ (scope.$eval(prop));
             goog.asserts.assertInstanceof(map, ol.Map);
 
             map.setTarget(element[0]);


### PR DESCRIPTION
This PR fixes the parsing of the goMap attribute to retrieve the map into the directive's scope.

The use of `scope.$eval(prop)` makes the parser able to read a property from the  scope that could be like `scope.config.map` while `scope[prop]`  only accept property like `scope.map`.
