### PR TITLE
Generate info/exports for both openlayers and ngeo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ clean:
 	rm -f .build/gjslint.timestamp
 	rm -f .build/jshint.timestamp
 	rm -f .build/ol-deps.js
-	rm -f .build/info.json
+	rm -f .build/info-*.json
 	rm -f dist/ngeo.js
 	rm -f dist/ngeo.css
 


### PR DESCRIPTION
This PR makes the build tools/tasks more generic, and makes it possible to generate info/exports for both openlayers and ngeo. This is necessary for exporting symbols using the `@api` annotation for ngeo.

Note: most of the changes could also be done in the ol3 scripts.
