### PR TITLE
Add ol.ext/*.js to "lib" in serve.js

### DIFF
--- a/buildtools/serve.js
+++ b/buildtools/serve.js
@@ -31,7 +31,8 @@ var manager = new closure.Manager({
   closure: true, // use the bundled Closure Library
   lib: [
     'src/**/*.js',
-    'node_modules/openlayers/src/**/*.js'
+    'node_modules/openlayers/src/**/*.js',
+    'node_modules/openlayers/build/ol.ext/*.js'
   ],
   main: 'examples/*.js'
 });


### PR DESCRIPTION
Currently the `interactionbtngroup.html` does not work in development mode (`make serve`) because of that.

Please review.
