### PR TITLE
Add a map-extension example

### DIFF
--- a/examples/map-extension.html
+++ b/examples/map-extension.html
@@ -1,0 +1,22 @@
+<!DOCTYPE>
+<html ng-app='app'>
+  <head>
+    <title>Map directive extension example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
+    <style>
+      app-map > div {
+        width: 600px;
+        height: 400px;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <app-map app-map="ctrl.map"></app-map>
+    <script src="../node_modules/angular/angular.js"></script>
+    <script src="/@?main=map-extension.js"></script>
+  </body>
+</html>

--- a/examples/map-extension.js
+++ b/examples/map-extension.js
@@ -1,0 +1,65 @@
+goog.provide('mapextension');
+
+goog.require('ngeo_map_directive');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+
+(function() {
+  var module = angular.module('app', ['ngeo']);
+
+  /**
+   * An application-specific map directive. This directive gets a reference
+   * to the map instance through the "app-map" attribute.
+   */
+  module.directive('appMap', [
+    /**
+     * @return {angular.Directive} The directive specs.
+     */
+    function() {
+      return {
+        restrict: 'E',
+        scope: {
+          'map': '=appMap'
+        },
+        controller: function() {
+          var map = this['map'];
+          // do something with map…
+          map.getView().on('propertychange',
+              /**
+               * @param {ol.ObjectEvent} e Object event.
+               */
+              function(e) {
+                // we simply output the view property here, but we
+                // could update the browser URL for example…
+                window.console.log('"' + e.key + '" event received');
+              });
+        },
+        controllerAs: 'ctrl',
+        bindToController: true,
+        template: '<div ngeo-map=ctrl.map></div>'
+      };
+    }]);
+
+
+  module.controller('MainController', ['$scope',
+    /**
+     * @param {angular.Scope} $scope Scope.
+     */
+    function($scope) {
+      /** @type {ol.Map} */
+      this['map'] = new ol.Map({
+        layers: [
+          new ol.layer.Tile({
+            source: new ol.source.OSM()
+          })
+        ],
+        view: new ol.View({
+          center: [0, 0],
+          zoom: 4
+        })
+      });
+    }]);
+
+})();


### PR DESCRIPTION
This PR supersedes #70. It shows how to create an application-level map directive that wraps an `ngeo-map` directive. It also shows how to use the `controllerAs` and `bindToController` directive definition options, which are now recommended when writing component/widget type directives.
