### PR TITLE
Better typing for the map-extension example

### DIFF
--- a/examples/map-extension.js
+++ b/examples/map-extension.js
@@ -23,23 +23,36 @@ goog.require('ol.source.OSM');
         scope: {
           'map': '=appMap'
         },
-        controller: function() {
-          var map = this['map'];
-          // do something with map…
-          map.getView().on('propertychange',
-              /**
-               * @param {ol.ObjectEvent} e Object event.
-               */
-              function(e) {
-                // we simply output the view property here, but we
-                // could update the browser URL for example…
-                window.console.log('"' + e.key + '" event received');
-              });
-        },
+        controller: 'appMapController',
         controllerAs: 'ctrl',
         bindToController: true,
         template: '<div ngeo-map=ctrl.map></div>'
       };
+    }]);
+
+
+  /**
+   * Controller for the `appMap` directive.
+   */
+  module.controller('appMapController', ['$scope',
+    /**
+     * @param {angular.Scope} $scope Scope.
+     */
+    function($scope) {
+      /**
+       * @type {ol.Map}
+       */
+      var map = this['map'];
+      // do something with map…
+      map.getView().on('propertychange',
+          /**
+           * @param {ol.ObjectEvent} e Object event.
+           */
+          function(e) {
+            // we simply output the view property here, but we
+            // could update the browser URL for example…
+            window.console.log('"' + e.key + '" event received');
+          });
     }]);
 
 


### PR DESCRIPTION
This PR improves the typing in the `map-extension` example. It also shows that the directive controller can be defined using `module.controller`.
