### PR TITLE
Make combine-examples skip goog.provide statements

### DIFF
--- a/buildtools/combine-examples.py
+++ b/buildtools/combine-examples.py
@@ -12,7 +12,9 @@ def main(argv):
         if len(lines) > 0 and lines[0].startswith('// NOCOMPILE'):
             continue
         requires.update(line for line in lines if line.startswith('goog.require'))
-        examples[filename] = [line for line in lines if not line.startswith('goog.require')]
+        examples[filename] = [line for line in lines if \
+            not (line.startswith('goog.require') or \
+                 line.startswith('goog.provide'))]
     for require in sorted(requires):
         sys.stdout.write(require)
     for filename in sorted(examples.keys()):


### PR DESCRIPTION
Fixes #121 by making the `combine-examples.py` script skip `goog.provide` statements entirely.
