### PR TITLE
Revert "Make map directive watch map expr"

### DIFF
--- a/examples/animation.js
+++ b/examples/animation.js
@@ -33,7 +33,7 @@ app.mapDirective = function() {
     controller: function() {},
     controllerAs: 'ctrl',
     bindToController: true,
-    template: '<div ngeo-map="::ctrl.map"></div>'
+    template: '<div ngeo-map="ctrl.map"></div>'
   };
 };
 

--- a/examples/control.html
+++ b/examples/control.html
@@ -17,7 +17,7 @@
     </style>
   </head>
   <body ng-controller="MainController as ctrl">
-    <div id="map" ngeo-map="::ctrl.map"></div>
+    <div id="map" ngeo-map="ctrl.map"></div>
     Mouse position: <div id="mouse-position" ngeo-control="ctrl.createControl" ngeo-control-map="ctrl.map"></div>
     <script src="../node_modules/angular/angular.js"></script>
     <script src="/@?main=control.js"></script>

--- a/examples/geolocation.html
+++ b/examples/geolocation.html
@@ -15,7 +15,7 @@
     </style>
   </head>
   <body ng-controller="MainController as ctrl">
-    <div id="map" ngeo-map="::ctrl.map"></div>
+    <div id="map" ngeo-map="ctrl.map"></div>
     <p>
       <label for="checkbox">Enable Geolocation interaction:</label>
       <input id="checkbox" type="checkbox" ng-model="ctrl.geolocation.tracking"  />

--- a/examples/interactionbtngroup.html
+++ b/examples/interactionbtngroup.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css" type="text/css">
   </head>
   <body ng-controller="MainController as ctrl">
-    <div id="map" ngeo-map="::ctrl.map"></div>
+    <div id="map" ngeo-map="ctrl.map"></div>
 
     <div ngeo-btn-group>
       <button ngeo-btn class="btn btn-success" ng-model="ctrl.drawPoint.active">Point</button>

--- a/examples/interactiontoggle.html
+++ b/examples/interactiontoggle.html
@@ -15,7 +15,7 @@
     </style>
   </head>
   <body ng-controller="MainController as ctrl">
-    <div id="map" ngeo-map="::ctrl.map"></div>
+    <div id="map" ngeo-map="ctrl.map"></div>
     <p>
       <label for="checkbox">Draw point interaction:</label>
       <input id="checkbox" type="checkbox" ng-model="ctrl.interaction.active" />

--- a/examples/layermanager.html
+++ b/examples/layermanager.html
@@ -26,7 +26,7 @@
   </head>
   <body ng-controller="MainController as ctrl">
 
-    <div id="map" ngeo-map="::ctrl.map"></div>
+    <div id="map" ngeo-map="ctrl.map"></div>
 
     <div class="main-container row" ng-cloak>
         <div class="col-md-offset-1 col-md-2">

--- a/examples/layeropacity.html
+++ b/examples/layeropacity.html
@@ -15,7 +15,7 @@
     </style>
   </head>
   <body ng-controller="MainController as ctrl">
-    <div id="map" ngeo-map="::ctrl.map"></div>
+    <div id="map" ngeo-map="ctrl.map"></div>
     <p>
       <label for="range">Layer opacity:</label>
       <input id="range" type="range" min="0" max="1" step="0.05" ng-model="ctrl.layer.opacity" />

--- a/examples/layertree.html
+++ b/examples/layertree.html
@@ -23,7 +23,7 @@
     </style>
   </head>
   <body ng-controller="MainController as mainCtrl">
-    <div id="map" ngeo-map="::mainCtrl.map"></div>
+    <div id="map" ngeo-map="mainCtrl.map"></div>
     <app-layertree app-layertree-map="::mainCtrl.map"></app-layertree>
     <p>This example shows how to use ngeo's layer tree directive (<code>ngeo-layertree</code>). It also shows how to define an application-specific HTML partial for the tree nodes.</p>
     <script src="../node_modules/angular/angular.js"></script>

--- a/examples/layervisibility.html
+++ b/examples/layervisibility.html
@@ -15,7 +15,7 @@
     </style>
   </head>
   <body ng-controller="MainController as ctrl">
-    <div id="map" ngeo-map="::ctrl.map"></div>
+    <div id="map" ngeo-map="ctrl.map"></div>
     <p>
       <label>
         Layer visibility

--- a/examples/permalink.html
+++ b/examples/permalink.html
@@ -15,7 +15,7 @@
     </style>
   </head>
   <body ng-controller="MainController as ctrl">
-    <app-map app-map="::ctrl.map"></app-map>
+    <app-map app-map="ctrl.map"></app-map>
     <p>This example shows how to create an application-specific map directive based on the <code>ngeoMap</code> directive that uses the <code>ngeoLocation</code> and <code>ngeoDebounce</code> services to update the browser address bar URL when the map view changes.</p>
     <script src="../node_modules/angular/angular.js"></script>
     <script src="/@?main=permalink.js"></script>

--- a/examples/permalink.js
+++ b/examples/permalink.js
@@ -36,7 +36,7 @@ app.mapDirective = function() {
     controller: 'AppMapController',
     controllerAs: 'ctrl',
     bindToController: true,
-    template: '<div ngeo-map="::ctrl.map"></div>'
+    template: '<div ngeo-map=ctrl.map></div>'
   };
 };
 

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -15,7 +15,7 @@
     </style>
   </head>
   <body ng-controller="MainController as ctrl">
-    <div id="map" ngeo-map="::ctrl.map"></div>
+    <div id="map" ngeo-map="ctrl.map"></div>
     <script src="../node_modules/angular/angular.js"></script>
     <script src="/@?main=simple.js"></script>
   </body>

--- a/src/directives/map.js
+++ b/src/directives/map.js
@@ -5,12 +5,6 @@
  * Example:
  *
  * <div ngeo-map="ctrl.map"></div>
- *
- * This directive creates a watcher on the "map" expression ("ctrl.map" in
- * the above example). Use a one-time binding expression if you know the map
- * won't changed:
- *
- * <div ngeo-map="::ctrl.map"></div>
  */
 goog.provide('ngeo.mapDirective');
 
@@ -33,24 +27,12 @@ ngeo.mapDirective = function() {
          */
         function(scope, element, attrs) {
           var attr = 'ngeoMap';
-          var expr = attrs[attr];
+          var prop = attrs[attr];
 
-          /**
-           * The current map attached to this directive/element.
-           * @type {ol.Map}
-           */
-          var map = null;
+          var map = /** @type {ol.Map} */ (scope.$eval(prop));
+          goog.asserts.assertInstanceof(map, ol.Map);
 
-          scope.$watch(expr, function(newVal, oldVal) {
-            if (!goog.isNull(map)) {
-              map.setTarget(null);
-            }
-            map = goog.isDef(newVal) ? /** @type {ol.Map} */ (newVal) : null;
-            if (!goog.isNull(map)) {
-              goog.asserts.assertInstanceof(map, ol.Map);
-              map.setTarget(element[0]);
-            }
-          });
+          map.setTarget(element[0]);
         }
   };
 };


### PR DESCRIPTION
This pull request reverts commit 2dd3937b290f177339bbef292743fcfdacb5b8a7, which was added as part as https://github.com/camptocamp/ngeo/pull/129.

2dd3937b290f177339bbef292743fcfdacb5b8a7 may make sense, but I think it requires more thinking. And if we decide to make the map directive watch map changes we need to do the same in the other directives that use a map, namely `ngeoControl`, `ngeoLayertree`, `ngeoLayertreenode`, and `ngeoResizemap`.

The question is: do we want to support changing the map during the lifetime of the application?