### PR TITLE
Use one-time binding in layermanager example

### DIFF
--- a/examples/layermanager.html
+++ b/examples/layermanager.html
@@ -31,14 +31,14 @@
     <div class="main-container row" ng-cloak>
         <div class="col-md-offset-1 col-md-2">
           <h3>Layer catalog</h3>
-          <label ng-repeat="layer in ctrl.layers" class="catalog-item">
+          <label ng-repeat="layer in ::ctrl.layers" class="catalog-item">
               <input type="checkbox" ng-model="layer.inmap" />
               {{layer.get('label')}}
           </label>
         </div>
         <div class="col-md-3">
             <h3>Layer manager</h3>
-          <div layer-manager="ctrl.map" layer-manager-layers="ctrl.layers"></div>
+          <div layer-manager="::ctrl.map"></div>
         </div>
     </div>
 

--- a/examples/layermanager.js
+++ b/examples/layermanager.js
@@ -121,12 +121,14 @@ app.layerManagerDirective = function() {
   return {
     restrict: 'A',
     scope: {
-      map: '=layerManager',
-      layers: '=layerManagerLayers'
+      map: '=layerManager'
     },
+    controller: function() {},
+    controllerAs: 'ctrl',
+    bindToController: true,
     template: '<ul class="list-group">' +
         '<li class="list-group-item" ng-repeat="layer in ' +
-            'map.getLayers().getArray()' +
+            'ctrl.map.getLayers().getArray()' +
             ' | reverse track by layer.get(\'id\')">' +
         '<button type="button" ng-click="layer.inmap = false" ' +
             'class="btn btn-primary btn-xs badge">×</button>' +


### PR DESCRIPTION
This PR simplifies the layermanager example and uses one-time binding where possible for that example.