### PR TITLE
Replace the layer tree layer factory by a layer expression

### DIFF
--- a/examples/partials/layertreenode.html
+++ b/examples/partials/layertreenode.html
@@ -5,5 +5,7 @@
         ng-click="ctrl.onButtonClick(layertreenodeCtrl.node, layertreenodeCtrl.layer)">i</button>
 <ul ng-if="::layertreenodeCtrl.node.children">
   <li ng-repeat="node in ::layertreenodeCtrl.node.children"
-      ngeo-layertreenode="::node" ngeo-layertreenode-map="::layertreenodeCtrl.map"></li>
+      ngeo-layertreenode="::node" ngeo-layertreenode-map="::layertreenodeCtrl.map"
+      ngeo-layertreenode-layerexpr="layertreenodeCtrl.layerExpr">
+  </li>
 </ul>

--- a/src/directives/layertree.js
+++ b/src/directives/layertree.js
@@ -1,12 +1,26 @@
 /**
- * @fileoverview Provides a layer tree widget directive. This directive uses
- * the "ngeoLayertreenode" directive.
+ * @fileoverview Provides the "ngeoLayertree" directive, a layer tree widget
+ * directive. This directive uses the "ngeoLayertreenode" directive.
  *
  * Example usage:
  *
  * <div ngeo-layertree="ctrl.tree" ngeo-layertree-map="ctrl.map"
  *      ngeo-layertree-layer="ctrl.getLayer(node)">
  * </div>
+ *
+ * The "ngeo-layertree", "ngeo-layertree-map" and "ngeo-layertree-layer"
+ * attributes are mandatory.
+ *
+ * - The "ngeo-layertree" attribute specifies the scope property whose value
+ *   is a reference to the layer tree structure/object.
+ *
+ * - The "ngeo-layertree-map" attribute specifies the scope property whose
+ *   value is a reference to the map.
+ *
+ * -  The "ngeo-layertree-layer" attribute specifies the expression to evaluate
+ *    to get the layer object for a specific node of the tree. The directive
+ *    will evaluate this expression for each node of the tree. `node` can be
+ *    used in the expression to refer to the current tree node.
  *
  * Things to know about this directive:
  *
@@ -16,8 +30,9 @@
  * - By default the directive uses "layertree.html" as its templateUrl. This
  *   can be changed by redefining the "ngeoLayertreeTemplateUrl" value.
  *
- * - The directive has its own scope, but it is not isolate scope. The name of
- *   this directive's scope, as used in the template, is "layertreeCtrl".
+ * - The directive has its own scope, but it is not isolate scope. That scope
+ *   includes a reference to the directive's controller: the "layertreeCtrl"
+ *   scope property.
  *
  * - The directive creates a watcher on the "tree" expression ("ctrl.tree" in
  *   the usage example given above). Use a one-time binding expression if you

--- a/src/directives/layertree.js
+++ b/src/directives/layertree.js
@@ -4,17 +4,14 @@
  *
  * Example usage:
  *
- * <div ngeo-layertree="ctrl.tree" ngeo-layertree-map="ctrl.map">
+ * <div ngeo-layertree="ctrl.tree" ngeo-layertree-map="ctrl.map"
+ *      ngeo-layertree-layer="ctrl.getLayer(node)">
  * </div>
  *
  * Things to know about this directive:
  *
  * - The directive assumes that the root of the tree includes a "children"
  *   property containing tree nodes.
- *
- * - The directive relies on the "ngeoLayertreenode" directive which assumes
- *   that a service named "ngeoLayertreeLayerFactory" is defined by the
- *   application. See the "ngeoLayertreenode" docs for more information.
  *
  * - By default the directive uses "layertree.html" as its templateUrl. This
  *   can be changed by redefining the "ngeoLayertreeTemplateUrl" value.
@@ -26,7 +23,8 @@
  *   the usage example given above). Use a one-time binding expression if you
  *   know that the layer tree definition won't change:
  *
- *   <div ngeo-layertree="::ctrl.tree" ngeo-layertree-map="ctrl.map">
+ *   <div ngeo-layertree="::ctrl.tree" ngeo-layertree-map="ctrl.map"
+ *        ngeo-layertree-layer="ctrl.getLayer(node)">
  *   </div>
  */
 
@@ -75,21 +73,26 @@ ngeoModule.directive('ngeoLayertree', ngeo.layertreeDirective);
  * @ngInject
  */
 ngeo.NgeoLayertreeController = function($scope, $element, $attrs) {
+
   var treeExpr = $attrs['ngeoLayertree'];
   var tree = /** @type {Object} */ ($scope.$eval(treeExpr));
+  this['tree'] = tree;
 
   var mapExpr = $attrs['ngeoLayertreeMap'];
   var map = /** @type {ol.Map} */ ($scope.$eval(mapExpr));
-
-  $scope['layertreeCtrl'] = this;
-  this['tree'] = tree;
   this['map'] = map;
-  $scope['uid'] = this['uid'] = goog.getUid(this);
-  $scope['depth'] = 0;
+
+  var layerExpr = $attrs['ngeoLayertreeLayer'];
+  this['layerExpr'] = layerExpr;
 
   $scope.$watch(treeExpr, goog.bind(function(newVal, oldVal) {
     this['tree'] = newVal;
   }, this));
+
+  $scope['uid'] = this['uid'] = goog.getUid(this);
+  $scope['depth'] = 0;
+
+  $scope['layertreeCtrl'] = this;
 };
 
 

--- a/src/directives/layertreenode.js
+++ b/src/directives/layertreenode.js
@@ -5,12 +5,6 @@
  * The directive assumes that tree nodes that are not leaves have a "children"
  * property referencing an array of child nodes.
  *
- * It also assumes that a service named "ngeoLayertreeLayerFactory" is
- * defined. This service must be defined by the application. This service
- * is a function that takes a node object and returns an OpenLayers layer.
- * The function should return `null` when the node should not have
- * a corresponding layer, because it's not a leaf for example.
- *
  * By default the directive uses "layertreenode.html" as its templateUrl.
  * This can be changed by redefining the "ngeoLayertreenodeTemplateUrl"
  * value.
@@ -93,29 +87,34 @@ ngeoModule.directive('ngeoLayertreenode', ngeo.layertreenodeDirective);
  * @param {angular.Scope} $scope Scope.
  * @param {angular.JQLite} $element Element.
  * @param {angular.Attributes} $attrs Attributes.
- * @param {function(Object):ol.layer.Layer} ngeoLayertreeLayerFactory Layer
- *     factory. This is a function provided by the application. The function
- *     receives a tree node and returns an `ol.layer.Layer` or `null` if no
- *     layer is to be created for that node.
  * @constructor
  * @ngInject
  * @export
  */
-ngeo.LayertreenodeController = function(
-    $scope, $element, $attrs, ngeoLayertreeLayerFactory) {
+ngeo.LayertreenodeController = function($scope, $element, $attrs) {
 
-  var nodeProp = $attrs['ngeoLayertreenode'];
-  var node = /** @type {Object} */ ($scope.$eval(nodeProp));
+  var nodeExpr = $attrs['ngeoLayertreenode'];
+  var node = /** @type {Object} */ ($scope.$eval(nodeExpr));
+  goog.asserts.assert(goog.isDef(node));
+  this['node'] = node;
 
-  var mapProp = $attrs['ngeoLayertreenodeMap'];
-  var map = /** @type {ol.Map} */ ($scope.$eval(mapProp));
+  var mapExpr = $attrs['ngeoLayertreenodeMap'];
+  var map = /** @type {ol.Map} */ ($scope.$eval(mapExpr));
+  goog.asserts.assert(goog.isDef(map));
+  this['map'] = map;
 
-  /**
-   * This node's layer. `null` if there's no layer for that node.
-   * @type {ol.layer.Layer}
-   * @private
-   */
-  this.layer_ = ngeoLayertreeLayerFactory(node);
+  var layerexprExpr = $attrs['ngeoLayertreenodeLayerexpr'];
+  var layerExpr = /** @type {string} */ ($scope.$eval(layerexprExpr));
+  goog.asserts.assert(goog.isDef(layerExpr));
+  this['layerExpr'] = layerExpr;
+
+  // The node is passed in the "locals" object (2nd arg to $eval). This
+  // is to allow expressions like "ctrl.getLayer(node)".
+  console.log('directive', node.children, layerexprExpr);
+  var layer = /** @type {ol.layer.Layer} */
+      ($scope.$eval(layerExpr, {'node': node}));
+  goog.asserts.assert(goog.isDef(layer));
+  this['layer'] = layer;
 
   /**
    * @type {ol.Map}
@@ -123,20 +122,25 @@ ngeo.LayertreenodeController = function(
    */
   this.map_ = map;
 
-  $scope['layertreenodeCtrl'] = this;
-  this['layer'] = this.layer_;
-  this['map'] = map;
-  this['node'] = node;
-  this['parentUid'] = $scope.$parent['uid'];
+  /**
+   * This node's layer. `null` if there's no layer for that node (for
+   * example if the node is not a leaf).
+   * @type {ol.layer.Layer}
+   * @private
+   */
+  this.layer_ = layer;
 
+  this['parentUid'] = $scope.$parent['uid'];
   this['uid'] = goog.getUid(this);
   this['depth'] = $scope.$parent['depth'] + 1;
 
-  // we set 'uid' and 'depth' in the scope as well to access the parent values
+  // We set 'uid' and 'depth' in the scope as well to access the parent values
   // in the inherited scopes. This is intended to be used in the javascript not
   // in the templates.
   $scope['uid'] = this['uid'];
   $scope['depth'] = this['depth'];
+
+  $scope['layertreenodeCtrl'] = this;
 };
 
 

--- a/src/directives/layertreenode.js
+++ b/src/directives/layertreenode.js
@@ -1,16 +1,38 @@
 /**
- * @fileoverview Provides a layer tree node directive. This directive is
- * used by the "ngeoLayertree" directive.
+ * @fileoverview Provides the "ngeoLayertreenode" directive, a layer tree node
+ * directive. This directive is used by the "ngeoLayertree" directive.
  *
  * The directive assumes that tree nodes that are not leaves have a "children"
  * property referencing an array of child nodes.
  *
- * By default the directive uses "layertreenode.html" as its templateUrl.
- * This can be changed by redefining the "ngeoLayertreenodeTemplateUrl"
- * value.
+ * Example usage:
  *
- * The directive has its own scope, but it is not isolate scope. The name of
- * this directive's scope, as used in the template, is "layertreenodeCtrl".
+ * <div ngeo-layertreenode="ctrl.node" ngeo-layertreenode-map="ctrl.map"
+ *      ngeo-layertreenode-layerexpr="ctrl.layerExpr">
+ * </div>
+ *
+ * The "ngeo-layertreenode", "ngeo-layertreenode-map" and
+ * "ngeo-layertreenode-layerexpr" attributes are mandatory.
+ *
+ * - The "ngeo-layertreenode" specifies the scope property whose value is
+ *   a reference to the tree node object.
+ *
+ * - The "ngeo-layertreenode-map" specifies the scope property whose value is
+ *   a reference to the map.
+ *
+ * - The "ngeo-layertreenode-layerexpr" specifies the scope property whose
+ *   value is the layer expression (a string) to evaluate to get the layer
+ *   object for this tree node.
+ *
+ * By default the directive uses "layertreenode.html" as its templateUrl. This
+ * can be changed by redefining the "ngeoLayertreenodeTemplateUrl" value.
+ *
+ * The directive has its own scope, but it is not isolate scope. That scope
+ * includes a reference to the directive's controller: the "layertreenodeCtrl"
+ * property.
+ *
+ * This directive doesn't itself create watchers, but its partial uses Angular
+ * directives like ngRepeat and ngModel which do create watchers.
  */
 
 goog.provide('ngeo.layertreenodeDirective');

--- a/src/directives/partials/layertree.html
+++ b/src/directives/partials/layertree.html
@@ -1,4 +1,5 @@
 <ul>
   <li ng-repeat="node in ::layertreeCtrl.tree.children"
-      ngeo-layertreenode="::node" ngeo-layertreenode-map="::layertreeCtrl.map"></li>
+      ngeo-layertreenode="::node" ngeo-layertreenode-map="::layertreeCtrl.map"
+      ngeo-layertreenode-layerexpr="layertreeCtrl.layerExpr"></li>
 </ul>

--- a/src/directives/partials/layertreenode.html
+++ b/src/directives/partials/layertreenode.html
@@ -3,5 +3,7 @@
     ng-model="layertreenodeCtrl.getSetActive" ng-model-options="{getterSetter: true}"/>
 <ul ng-if="::layertreenodeCtrl.node.children">
   <li ng-repeat="node in ::layertreenodeCtrl.node.children"
-      ngeo-layertreenode="::node" ngeo-layertreenode-map="::layertreenodeCtrl.map"></li>
+      ngeo-layertreenode="::node" ngeo-layertreenode-map="::layertreenodeCtrl.map"
+      ngeo-layertreenode-layerexpr="layertreenodeCtrl.layerExpr">
+  </li>
 </ul>


### PR DESCRIPTION
Currently, when using the `ngeoLayertree` and/or `ngeoLayertreenode` directives the `ngeoLayertreeLayerFactory` service should be defined by the application (this service is a function responsible for returning a layer for a tree node). This works well when only one layer tree is used in the page, but it is inflexible when multiple layer trees are used, because the layer factory function is the same for all the layer trees.

This PR fixes the problem by adding a new attribute to the `ngeoLayertree` and `ngeoLayertreenode` directives. This new attribute allows specifying a a layer expression, which, in most cases, will be a function called on the application controller. This does add some complexity to the user of the directive, but it is also more flexible.

I also took the opportunity to improve the documentation of the `ngeoLayertree` and `ngeoLayertreenode` directives.