### PR TITLE
Layertree levels

### DIFF
--- a/src/directives/layertree.js
+++ b/src/directives/layertree.js
@@ -84,7 +84,8 @@ ngeo.NgeoLayertreeController = function($scope, $element, $attrs) {
   $scope['layertreeCtrl'] = this;
   this['tree'] = tree;
   this['map'] = map;
-  this['uid'] = goog.getUid(this);
+  $scope['uid'] = this['uid'] = goog.getUid(this);
+  $scope['depth'] = 0;
 
   $scope.$watch(treeExpr, goog.bind(function(newVal, oldVal) {
     this['tree'] = newVal;

--- a/src/directives/layertreenode.js
+++ b/src/directives/layertreenode.js
@@ -127,7 +127,16 @@ ngeo.LayertreenodeController = function(
   this['layer'] = this.layer_;
   this['map'] = map;
   this['node'] = node;
+  this['parentUid'] = $scope.$parent['uid'];
+
   this['uid'] = goog.getUid(this);
+  this['depth'] = $scope.$parent['depth'] + 1;
+
+  // we set 'uid' and 'depth' in the scope as well to access the parent values
+  // in the inherited scopes. This is intended to be used in the javascript not
+  // in the templates.
+  $scope['uid'] = this['uid'];
+  $scope['depth'] = this['depth'];
 };
 
 


### PR DESCRIPTION
This pull request addresses two goals. It gives the user the opportunity to get for each node:
 - the level depth,
 - the uid of the parent element. This corresponds to tree uid for the nodes of the first level.

One purpose of this is for example to get only one node expanded at a time for a given level when using bootstrap and collapse/accordion.

Please review.