### PR TITLE
Make sure the history API is fully supported before using it

### DIFF
--- a/src/services/location.js
+++ b/src/services/location.js
@@ -101,7 +101,7 @@ ngeo.LocationFactory = function($rootScope, $window) {
     if (lastUri !== newUri) {
       $rootScope.$evalAsync(function() {
         lastUri = newUri;
-        if (goog.isDef(history)) {
+        if (goog.isDef(history) && goog.isDef(history.replaceState)) {
           history.replaceState(null, '', newUri);
         }
         $rootScope.$broadcast('ngeoLocationChange');


### PR DESCRIPTION
As for now, IE9 complains about that "Object doesn't support property or method 'replaceState'" when the map is changed (permalink update). This may be observed in http://erilem.net/ngeo/location/permalink.html

IE9 indeed doesn't support the "history" API that is used to update the address bar.
The ngeoLocation service does have a test on the availability of history but it seems this is not enough.

This PR improves the test, making sure that "replaceState" is actually available.