### PR TITLE
Improvements to layertree directive

### DIFF
--- a/examples/layertree.js
+++ b/examples/layertree.js
@@ -51,7 +51,7 @@ app.layertreeDirective = function() {
     // layer tree won't change
     template: '<div ngeo-layertree="::ctrl.tree" ' +
         'ngeo-layertree-map="ctrl.map" ' +
-        'ngeo-layertree-layer="ctrl.getLayer(node)">' +
+        'ngeo-layertree-nodelayer="ctrl.getLayer(node)">' +
         '</div>'
   };
 };

--- a/src/directives/layertree.js
+++ b/src/directives/layertree.js
@@ -97,8 +97,8 @@ ngeo.NgeoLayertreeController = function($scope, $element, $attrs) {
   var map = /** @type {ol.Map} */ ($scope.$eval(mapExpr));
   this['map'] = map;
 
-  var layerExpr = $attrs['ngeoLayertreeLayer'];
-  this['layerExpr'] = layerExpr;
+  var nodelayerExpr = $attrs['ngeoLayertreeNodelayer'];
+  this['layerExpr'] = nodelayerExpr;
 
   $scope.$watch(treeExpr, goog.bind(function(newVal, oldVal) {
     this['tree'] = newVal;

--- a/src/directives/layertreenode.js
+++ b/src/directives/layertreenode.js
@@ -132,7 +132,6 @@ ngeo.LayertreenodeController = function($scope, $element, $attrs) {
 
   // The node is passed in the "locals" object (2nd arg to $eval). This
   // is to allow expressions like "ctrl.getLayer(node)".
-  console.log('directive', node.children, layerexprExpr);
   var layer = /** @type {ol.layer.Layer} */
       ($scope.$eval(layerExpr, {'node': node}));
   goog.asserts.assert(goog.isDef(layer));

--- a/src/directives/partials/layertree.html
+++ b/src/directives/partials/layertree.html
@@ -1,5 +1,5 @@
 <ul>
   <li ng-repeat="node in ::layertreeCtrl.tree.children"
-      ngeo-layertreenode="::node" ngeo-layertreenode-map="::layertreeCtrl.map"
+      ngeo-layertreenode="node" ngeo-layertreenode-map="layertreeCtrl.map"
       ngeo-layertreenode-layerexpr="layertreeCtrl.layerExpr"></li>
 </ul>

--- a/src/directives/partials/layertreenode.html
+++ b/src/directives/partials/layertreenode.html
@@ -3,7 +3,7 @@
     ng-model="layertreenodeCtrl.getSetActive" ng-model-options="{getterSetter: true}"/>
 <ul ng-if="::layertreenodeCtrl.node.children">
   <li ng-repeat="node in ::layertreenodeCtrl.node.children"
-      ngeo-layertreenode="::node" ngeo-layertreenode-map="::layertreenodeCtrl.map"
+      ngeo-layertreenode="node" ngeo-layertreenode-map="layertreenodeCtrl.map"
       ngeo-layertreenode-layerexpr="layertreenodeCtrl.layerExpr">
   </li>
 </ul>


### PR DESCRIPTION
As discussed with @pgiraud this PR brings further improvements to the layertree directive. In particular the `ngeo-layertree-layer` attr is renamed to `ngeo-layertree-nodelayer`.