### PR TITLE
Add a scale selector example

### DIFF
--- a/examples/backgroundlayerdropdown.html
+++ b/examples/backgroundlayerdropdown.html
@@ -23,7 +23,6 @@
     <div>
       This example shows how to write an application-specific directive (<code>app-backgroundlayer</code>) to create a background layer selector. The directive is based on Bootstrap's <code>dropdown</code> jQuery plugin, and on the <code>ngeoBackgroundLayerMgr</code> service.
     </div>
-
     <script src="../node_modules/jquery/dist/jquery.js"></script>
     <script src="../node_modules/angular/angular.js"></script>
     <script src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>

--- a/examples/backgroundlayerdropdown.js
+++ b/examples/backgroundlayerdropdown.js
@@ -22,8 +22,8 @@ app.module = angular.module('app', ['ngeo']);
 /**
  * The application-specific background layer directive.
  *
- * The directive is based on Angular UI Bootstrap's dropdown and dropdownToggle
- * directives. It also uses Angular's ngRepeat and ngClick directives.
+ * The directive is based on Bootstrap's dropdown jQuery plugin and on
+ * the ngeoBackgroundLayerMgr service.
  *
  * @return {angular.Directive} Directive Defintion Object.
  */

--- a/examples/scaleselector.html
+++ b/examples/scaleselector.html
@@ -1,0 +1,38 @@
+<!DOCTYPE>
+<html ng-app='app'>
+  <head>
+    <title>Scale selector example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+    <style>
+      #map {
+        height: 400px;
+      }
+      app-scaleselector {
+        display: inline-block;
+      }
+      app-scaleselector .dropdown button {
+        min-width: 132px;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as mainCtrl">
+    <div id="map" ngeo-map="mainCtrl.map"></div>
+    <label>
+      Select scale:
+      <app-scaleselector app-scaleselector-map="::mainCtrl.map"></app-scaleselector>
+    </label>
+    <div>
+      This example shows how to write an application-specific directive (<code>app-scaleselecor</code>) based on <code>ngeo-scaleselector</code>to create a scale selector.
+    </div>
+    <script src="../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="/@?main=scaleselector.js"></script>
+    <script src="../utils/watchwatchers.js"></script>
+  </body>
+</html>

--- a/examples/scaleselector.js
+++ b/examples/scaleselector.js
@@ -1,0 +1,113 @@
+goog.provide('scaleselector');
+
+goog.require('ngeo.ScaleselectorOptions');
+goog.require('ngeo.mapDirective');
+goog.require('ngeo.scaleselectorDirective');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['ngeo']);
+
+
+// Use the default "scale selector" template.
+app.module.value('ngeoScaleselectorTemplateUrl',
+    '../src/directives/partials/scaleselector.html');
+
+
+/**
+ * The application-specific scale selector directive, based on the
+ * ngeo-scaleselector directive.
+ *
+ * @return {angular.Directive} Directive Definition Object.
+ */
+app.scaleselectorDirective = function() {
+  return {
+    restrict: 'E',
+    scope: {
+      'map': '=appScaleselectorMap'
+    },
+    template: '<div ngeo-scaleselector="ctrl.scales" ' +
+        'ngeo-scaleselector-map="ctrl.map" ' +
+        'ngeo-scaleselector-options="ctrl.options"></div>',
+    controllerAs: 'ctrl',
+    bindToController: true,
+    controller: 'AppScaleselectorController'
+  };
+};
+
+
+app.module.directive('appScaleselector', app.scaleselectorDirective);
+
+
+
+/**
+ * @constructor
+ * @param {angular.$sce} $sce Angular sce service.
+ * @ngInject
+ */
+app.ScaleselectorController = function($sce) {
+
+  /**
+   * The zoom level/scale map object for the ngeoScaleselector directive.
+   * The values need to be trusted as HTML.
+   * @type {Object.<string, string>}
+   * @const
+   */
+  this['scales'] = {
+    '0': $sce.trustAsHtml('1&nbsp;:&nbsp;200\'000\'000'),
+    '1': $sce.trustAsHtml('1&nbsp;:&nbsp;100\'000\'000'),
+    '2': $sce.trustAsHtml('1&nbsp;:&nbsp;50\'000\'000'),
+    '3': $sce.trustAsHtml('1&nbsp;:&nbsp;25\'000\'000'),
+    '4': $sce.trustAsHtml('1&nbsp;:&nbsp;12\'000\'000')
+  };
+
+  /**
+   * Use the "dropup" variation of the Bootstrap dropdown.
+   * @type {ngeo.ScaleselectorOptions}
+   */
+  this['options'] = {
+    'dropup': true
+  };
+};
+
+app.module.controller('AppScaleselectorController',
+    app.ScaleselectorController);
+
+
+
+/**
+ * @constructor
+ * @param {angular.Scope} $scope Controller scope.
+ * @ngInject
+ */
+app.MainController = function($scope) {
+
+  /**
+   * @type {ol.Map}
+   */
+  var map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      })
+    ],
+    view: new ol.View({
+      center: [-10635142.37, 4813698.29],
+      zoom: 1,
+      maxZoom: 4
+    })
+  });
+  this['map'] = map;
+
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/src/directives/partials/scaleselector.html
+++ b/src/directives/partials/scaleselector.html
@@ -1,0 +1,10 @@
+<div ng-class="::{'dropdown': true, 'dropup': scaleselectorCtrl.options.dropup}">
+  <button type="button" class="btn btn-primary" data-toggle="dropdown">
+    <span ng-bind-html="scaleselectorCtrl.currentScale"></span>&nbsp;<span class="caret"></span>
+  </button>
+  <ul class="dropdown-menu" role="menu">
+    <li ng-repeat="(zoom, scale) in ::scaleselectorCtrl.scales">
+      <a href ng-click="scaleselectorCtrl.changeZoom(zoom)" ng-bind-html="::scale"></a>
+    </li>
+  </ul>
+</div>

--- a/src/directives/scaleselector.js
+++ b/src/directives/scaleselector.js
@@ -1,0 +1,239 @@
+/**
+ * @fileoverview Provides the "ngeoScaleselector" directive, a widget for
+ * selecting map scales.
+ *
+ * Example usage:
+ *
+ * <div ngeo-scaleselector="ctrl.scales" ngeo-scaleselector-map="ctrl.map">
+ * </div>
+ *
+ * The expression passed to the ngeo-scaleselector attribute should return an
+ * object of this form:
+ *
+ * {
+ *   '0': $sce.trustAsHtml('1&nbsp;:&nbsp;200\'000\'000'),
+ *   '1': $sce.trustAsHtml('1&nbsp;:&nbsp;100\'000\'000'),
+ *   '2': $sce.trustAsHtml('1&nbsp;:&nbsp;50\'000\'000'),
+ *   '3': $sce.trustAsHtml('1&nbsp;:&nbsp;25\'000\'000'),
+ *   '4': $sce.trustAsHtml('1&nbsp;:&nbsp;12\'000\'000')
+ * }
+ *
+ * This object's keys are strings representing zoom levels, the values are
+ * strings representing scales. The directive's partial uses ng-bind-html so
+ * the scale strings should be trusted.
+ *
+ * That directive's partial uses Bootstrap's `dropdown` and `dropdown-menu`
+ * classes, and `data-toggle="dropdown"`, so it is meant to be used with
+ * Bootstrap's "dropdown" jQuery plugin.
+ *
+ * By default the directive uses "scaleselector.html" as its templateUrl. This
+ * an be changed by redefining the "ngeoScaleselectorTemplateUrl" value.
+ *
+ * The directive has its own scope, but it is not isolate scope. That scope
+ * includes a reference to the directive's controller: the "scaleselectorCtrl"
+ * scope property.
+ *
+ * The directive doesn't create any watcher. In particular the object including
+ * the scales information is now watched.
+ */
+goog.provide('ngeo.ScaleselectorOptions');
+goog.provide('ngeo.scaleselectorDirective');
+
+goog.require('goog.events');
+goog.require('goog.events.Key');
+goog.require('ngeo');
+goog.require('ol.Map');
+goog.require('ol.Object');
+
+
+/**
+ * @const
+ * @type {string}
+ */
+ngeo.scaleselectorTemplateUrl = 'scaleselector.html';
+
+
+ngeoModule.value('ngeoScaleselectorTemplateUrl',
+    ngeo.scaleselectorTemplateUrl);
+
+
+/**
+ * @typedef {{dropup: (boolean|undefined)}}
+ */
+ngeo.ScaleselectorOptions;
+
+
+/**
+ * @param {string|function(!angular.JQLite=, !angular.Attributes=)}
+ *     ngeoScaleselectorTemplateUrl Template URL for the directive.
+ * @return {angular.Directive} Directive Definition Object.
+ * @ngInject
+ */
+ngeo.scaleselectorDirective = function(ngeoScaleselectorTemplateUrl) {
+  return {
+    restrict: 'A',
+    scope: true,
+    controller: 'NgeoScaleselectorController',
+    templateUrl: ngeoScaleselectorTemplateUrl
+  };
+};
+
+
+ngeoModule.directive('ngeoScaleselector', ngeo.scaleselectorDirective);
+
+
+
+/**
+ * @constructor
+ * @param {angular.Scope} $scope Directive scope.
+ * @param {angular.JQLite} $element Element.
+ * @param {angular.Attributes} $attrs Attributes.
+ * @param {angular.$timeout} $timeout Angular timeout service.
+ * @export
+ * @ngInject
+ */
+ngeo.ScaleselectorController = function($scope, $element, $attrs, $timeout) {
+
+  var scalesExpr = $attrs['ngeoScaleselector'];
+
+  /**
+   * The zoom level/scale map object.
+   * @type {Object.<string, string>}
+   */
+  this['scales'] = /** @type {Object.<string, string>} */
+      ($scope.$eval(scalesExpr));
+  goog.asserts.assert(goog.isDef(this['scales']));
+
+  var mapExpr = $attrs['ngeoScaleselectorMap'];
+
+  /**
+   * @type {ol.Map}
+   * @private
+   */
+  this.map_ = /** @type {ol.Map} */ ($scope.$eval(mapExpr));
+  goog.asserts.assertInstanceof(this.map_, ol.Map);
+
+  var optionsExpr = $attrs['ngeoScaleselectorOptions'];
+  var options = $scope.$eval(optionsExpr);
+
+  /**
+   * @type {!ngeo.ScaleselectorOptions}
+   */
+  this['options'] = ngeo.ScaleselectorController.getOptions_(options);
+
+  /**
+   * @type {angular.Scope}
+   * @private
+   */
+  this.$scope_ = $scope;
+
+  /**
+   * @type {angular.$timeout}
+   * @private
+   */
+  this.$timeout_ = $timeout;
+
+  /**
+   * @type {goog.events.Key}
+   * @private
+   */
+  this.resolutionChangeKey_ = null;
+
+  /**
+   * @type {string|undefined}
+   */
+  this['currentScale'] = undefined;
+
+  var view = this.map_.getView();
+  if (!goog.isNull(view)) {
+    var currentZoom = this.map_.getView().getZoom();
+    if (goog.isDef(currentZoom)) {
+      this['currentScale'] = this['scales'][currentZoom.toString()];
+    }
+  }
+
+  goog.events.listen(this.map_, ol.Object.getChangeEventType('view'),
+      this.handleViewChange_, false, this);
+
+  this.registerResolutionChangeListener_();
+
+  $scope['scaleselectorCtrl'] = this;
+
+};
+
+
+/**
+ * @param {?} options Options after expression evaluation.
+ * @return {!ngeo.ScaleselectorOptions} Options object.
+ * @private
+ */
+ngeo.ScaleselectorController.getOptions_ = function(options) {
+  var ret;
+  if (!goog.isDef(options)) {
+    ret = {'dropup': false};
+  } else {
+    if (!goog.isDef(options['dropup'])) {
+      options['dropup'] = false;
+    }
+    ret = /** @type {ngeo.ScaleselectorOptions} */ (options);
+  }
+  return ret;
+};
+
+
+/**
+ * @param {string} zoom Zoom level.
+ * @export
+ */
+ngeo.ScaleselectorController.prototype.changeZoom = function(zoom) {
+  // setZoom triggers a change:resolution event, and our change:resolution
+  // handler uses $apply to change the currentScale state, so we use $timeout
+  // and make sure that setZoom is called outside Angular context.
+  var view = this.map_.getView();
+  this.$timeout_(function() {
+    view.setZoom(+zoom);
+  }, 0, false);
+};
+
+
+/**
+ * @param {ol.ObjectEvent} e OpenLayers ObjectEvent.
+ * @private
+ */
+ngeo.ScaleselectorController.prototype.handleResolutionChange_ = function(e) {
+  var view = this.map_.getView();
+  var currentScale = this['scales'][view.getZoom().toString()];
+  this.$scope_.$apply(
+      /** @type {function(?)} */ (
+      angular.bind(this, function() {
+        this['currentScale'] = currentScale;
+      })));
+};
+
+
+/**
+ * @param {ol.ObjectEvent} e OpenLayers ObjectEvent.
+ * @private
+ */
+ngeo.ScaleselectorController.prototype.handleViewChange_ = function(e) {
+  this.registerResolutionChangeListener_();
+};
+
+
+/**
+ * @private
+ */
+ngeo.ScaleselectorController.prototype.registerResolutionChangeListener_ =
+    function() {
+  if (!goog.isNull(this.resolutionChangeKey_)) {
+    goog.events.unlistenByKey(this.resolutionChangeKey_);
+  }
+  var view = this.map_.getView();
+  this.resolutionChangeKey_ = goog.events.listen(view,
+      ol.Object.getChangeEventType('resolution'), this.handleResolutionChange_,
+      false, this);
+};
+
+
+ngeoModule.controller('NgeoScaleselectorController',
+    ngeo.ScaleselectorController);


### PR DESCRIPTION
This PR adds a scale selector example. This example creates a "scale selector" directive based on Bootstrap's `dropdown` jQuery plugin. The view resolution changes when a scale is selected in the scale selector. And the selected scale changes in the scale selector when the view resolution changes.

See http://erilem.net/ngeo/scaleselector/scaledropdown.html.