### PR TITLE
Rename ngeoArraySync to ngeoSyncArrays

### DIFF
--- a/examples/layerorder.js
+++ b/examples/layerorder.js
@@ -1,7 +1,7 @@
 goog.provide('layerorder');
 
-goog.require('ngeo.ArraySync');
 goog.require('ngeo.DecorateLayer');
+goog.require('ngeo.SyncArrays');
 goog.require('ngeo.mapDirective');
 goog.require('ngeo.sortableDirective');
 goog.require('ol.Map');
@@ -23,12 +23,12 @@ app.module = angular.module('app', ['ngeo']);
 /**
  * @param {angular.Scope} $scope Scope.
  * @param {ngeo.DecorateLayer} ngeoDecorateLayer Decorate layer service.
- * @param {ngeo.ArraySync} ngeoArraySync Array sync service.
+ * @param {ngeo.SyncArrays} ngeoSyncArrays Array sync service.
  * @constructor
  * @export
  * @ngInject
  */
-app.MainController = function($scope, ngeoDecorateLayer, ngeoArraySync) {
+app.MainController = function($scope, ngeoDecorateLayer, ngeoSyncArrays) {
 
   /** @type {ol.layer.Tile} */
   var mapquest = new ol.layer.Tile({
@@ -115,7 +115,7 @@ app.MainController = function($scope, ngeoDecorateLayer, ngeoArraySync) {
   var mapLayers = map.getLayers().getArray();
   this['selectedLayers'] = [];
   var selectedLayers = this['selectedLayers'];
-  ngeoArraySync(mapLayers, selectedLayers, true, $scope, layerFilter);
+  ngeoSyncArrays(mapLayers, selectedLayers, true, $scope, layerFilter);
 
   // watch any change on layers array to refresh the map
   $scope.$watchCollection(function() {

--- a/src/services/syncarrays.js
+++ b/src/services/syncarrays.js
@@ -11,8 +11,8 @@
  *
  * Example:
  *
- * var dereg = ngeoArraySync(map.getLayers().getArray(), selectedLayers, scope,
- *     function(layer) {
+ * var dereg = ngeoSyncArrays(map.getLayers().getArray(), selectedLayers,
+ *     true, scope, function(layer) {
  *       // exclude the layer at index 0 in the map
  *       return map.getLayers().indexOf(layer) !== 0;
  *     });
@@ -21,7 +21,7 @@
  *
  */
 
-goog.provide('ngeo.ArraySync');
+goog.provide('ngeo.SyncArrays');
 
 goog.require('goog.asserts');
 goog.require('ngeo');
@@ -31,7 +31,7 @@ goog.require('ngeo');
  * @typedef {function(Array, Array, boolean, angular.Scope,
  *     function(?):boolean)}
  */
-ngeo.ArraySync;
+ngeo.SyncArrays;
 
 
 /**
@@ -45,7 +45,7 @@ ngeo.ArraySync;
  * @return {function()} Function to call to stop synchronization
  * @template T
  */
-ngeo.arraySync = function(arr1, arr2, reverse, scope, filter) {
+ngeo.syncArrays = function(arr1, arr2, reverse, scope, filter) {
 
 
   // Update arr2 when elements are added to, or removed from, arr1.
@@ -101,4 +101,4 @@ ngeo.arraySync = function(arr1, arr2, reverse, scope, filter) {
 };
 
 
-ngeoModule.value('ngeoArraySync', ngeo.arraySync);
+ngeoModule.value('ngeoSyncArrays', ngeo.syncArrays);

--- a/test/spec/services/syncarrays.spec.js
+++ b/test/spec/services/syncarrays.spec.js
@@ -1,6 +1,6 @@
-goog.require('ngeo.ArraySync');
+goog.require('ngeo.SyncArrays');
 
-describe('ngeo.ArraySync', function() {
+describe('ngeo.SyncArrays', function() {
   var $rootScope;
 
   beforeEach(function() {
@@ -15,13 +15,13 @@ describe('ngeo.ArraySync', function() {
 
     beforeEach(function() {
       inject(function($injector) {
-        var ngeoArraySync = $injector.get('ngeoArraySync');
+        var ngeoSyncArrays = $injector.get('ngeoSyncArrays');
         arr1 = [0, 10, 1, 20, 2, 30, 3];
         arr2 = [];
         var filter = function(n) {
           return n < 10;
         };
-        dereg = ngeoArraySync(arr1, arr2, false, $rootScope, filter);
+        dereg = ngeoSyncArrays(arr1, arr2, false, $rootScope, filter);
         $rootScope.$digest();
         expect(arr2).toEqual([0, 1, 2, 3]);
       });
@@ -66,13 +66,13 @@ describe('ngeo.ArraySync', function() {
 
     beforeEach(function() {
       inject(function($injector) {
-        var ngeoArraySync = $injector.get('ngeoArraySync');
+        var ngeoSyncArrays = $injector.get('ngeoSyncArrays');
         arr1 = [0, 10, 1, 20, 2, 30, 3];
         arr2 = [];
         var filter = function(n) {
           return n < 10;
         };
-        dereg = ngeoArraySync(arr1, arr2, true, $rootScope, filter);
+        dereg = ngeoSyncArrays(arr1, arr2, true, $rootScope, filter);
         $rootScope.$digest();
         expect(arr2).toEqual([3, 2, 1, 0]);
       });


### PR DESCRIPTION
As discussed with @pgiraud this PR renames the `ngeoArraySync` service to `ngeoSyncArrays`. This service is a function so we name it after a verb, just like `ngeoDecorateLayer` and friends.