### PR TITLE
Remove unnecessary watchers

### DIFF
--- a/examples/partials/backgroundlayerdropdown.html
+++ b/examples/partials/backgroundlayerdropdown.html
@@ -4,7 +4,7 @@
   </button>
   <ul class="dropdown-menu" role="menu">
     <li ng-repeat="layer in ::ctrl.bgLayers">
-      <a href ng-click="ctrl.setLayer(layer)">{{layer.name}}</a>
+      <a href ng-click="ctrl.setLayer(layer)">{{::layer.name}}</a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
This PR removes 3 watchers in the `backgroundlayerdropdown` example: 1 watcher par item in the dropdown.