### PR TITLE
Change param type for ngeo.Popup#setContent

### DIFF
--- a/src/services/popup.js
+++ b/src/services/popup.js
@@ -80,7 +80,9 @@ ngeo.Popup.prototype.setTitle = function(title) {
 
 /**
  * Set the popup's content.
- * @param {string} content The content.
+ * Note: the type of the `content` param is `*` instead of `string`, this
+ * is because the content may be trusted using `$sce.trustAsHtml`.
+ * @param {*} content The content.
  */
 ngeo.Popup.prototype.setContent = function(content) {
   this.scope_['content'] = content;

--- a/src/services/popup.js
+++ b/src/services/popup.js
@@ -53,7 +53,7 @@ ngeo.Popup = function($compile, $rootScope) {
 
 
 /**
- * Display the popup
+ * Display the popup.
  */
 ngeo.Popup.prototype.show = function() {
   this.scope_['open'] = true;
@@ -61,7 +61,7 @@ ngeo.Popup.prototype.show = function() {
 
 
 /**
- * Destroy the popup
+ * Destroy the popup.
  */
 ngeo.Popup.prototype.destroy = function() {
   this.scope_.$destroy();
@@ -70,8 +70,8 @@ ngeo.Popup.prototype.destroy = function() {
 
 
 /**
- * Set the popup's title
- * @param {string} title The title
+ * Set the popup's title.
+ * @param {string} title The title.
  */
 ngeo.Popup.prototype.setTitle = function(title) {
   this.scope_['title'] = title;
@@ -79,8 +79,8 @@ ngeo.Popup.prototype.setTitle = function(title) {
 
 
 /**
- * Set the popup's content
- * @param {string} content The content
+ * Set the popup's content.
+ * @param {string} content The content.
  */
 ngeo.Popup.prototype.setContent = function(content) {
   this.scope_['content'] = content;


### PR DESCRIPTION
This is to handle the cases where the popup content is trusted with `$sce.trustAsHtml`.