### PR TITLE
Changes to the popup service

### DIFF
--- a/examples/layertree.js
+++ b/examples/layertree.js
@@ -144,7 +144,7 @@ app.LayertreeController.prototype.onButtonClick = function(node, layer) {
   this.promises_[layerType].then(function(html) {
     infoPopup.setTitle(node['name']);
     infoPopup.setContent(html);
-    infoPopup.show();
+    infoPopup.setOpen(true);
   });
 };
 

--- a/exports/services/popup.js
+++ b/exports/services/popup.js
@@ -2,8 +2,8 @@ goog.require('ngeo.Popup');
 
 goog.exportProperty(
     ngeo.Popup.prototype,
-    'show',
-    ngeo.Popup.prototype.show);
+    'setOpen',
+    ngeo.Popup.prototype.setOpen);
 
 goog.exportProperty(
     ngeo.Popup.prototype,

--- a/exports/services/popup.js
+++ b/exports/services/popup.js
@@ -2,6 +2,11 @@ goog.require('ngeo.Popup');
 
 goog.exportProperty(
     ngeo.Popup.prototype,
+    'getOpen',
+    ngeo.Popup.prototype.getOpen);
+
+goog.exportProperty(
+    ngeo.Popup.prototype,
     'setOpen',
     ngeo.Popup.prototype.setOpen);
 

--- a/src/services/popup.js
+++ b/src/services/popup.js
@@ -7,7 +7,7 @@
  * var popup = ngeoCreatePopup();
  * popup.setTitle("A title");
  * popup.setContent("Some content");
- * popup.show();
+ * popup.setOpen(true);
  *
  */
 
@@ -54,10 +54,11 @@ ngeo.Popup = function($compile, $rootScope) {
 
 
 /**
- * Display the popup.
+ * Show/hide the popup.
+ * @param {boolean} open `true` to show the popup, `false` to hide it.
  */
-ngeo.Popup.prototype.show = function() {
-  this.scope_['open'] = true;
+ngeo.Popup.prototype.setOpen = function(open) {
+  this.scope_['open'] = open;
 };
 
 

--- a/src/services/popup.js
+++ b/src/services/popup.js
@@ -46,9 +46,10 @@ ngeo.Popup = function($compile, $rootScope) {
    */
   this.element_ = angular.element('<div ngeo-popup></div>');
 
-  // Add the element and its content to the document
-  angular.element(document.body).append(this.element_);
+
+  // Compile the element, link it to the scope and add it to the document.
   $compile(this.element_)(this.scope_);
+  angular.element(document.body).append(this.element_);
 };
 
 

--- a/src/services/popup.js
+++ b/src/services/popup.js
@@ -33,7 +33,7 @@ ngeo.CreatePopup;
 ngeo.Popup = function($compile, $rootScope) {
 
   /**
-   * The scope the element is compiled with.
+   * The scope the compiled element is link to.
    * @type {angular.Scope}
    * @private
    */

--- a/src/services/popup.js
+++ b/src/services/popup.js
@@ -54,6 +54,15 @@ ngeo.Popup = function($compile, $rootScope) {
 
 
 /**
+ * Get the current popup state.
+ * @return {boolean} `true` if the popup is currently, otherwise `false`.
+ */
+ngeo.Popup.prototype.getOpen = function() {
+  return this.scope_['open'];
+};
+
+
+/**
  * Show/hide the popup.
  * @param {boolean} open `true` to show the popup, `false` to hide it.
  */

--- a/src/services/popup.js
+++ b/src/services/popup.js
@@ -37,7 +37,7 @@ ngeo.Popup = function($compile, $rootScope) {
    * @type {angular.Scope}
    * @private
    */
-  this.scope_ = $rootScope.$new();
+  this.scope_ = $rootScope.$new(true);
 
   /**
    * The element.


### PR DESCRIPTION
This PR makes a number of changes to the ngeo popup service:

* Use an isolate scope
* Replace the `show` method by `setOpen` (making it possible to hide the popup using `setOpen(false)`)
* Add a `getOpen` method to know whether the popup is currently open

Please review.