### PR TITLE
Base the sortable directive on Closure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ test: .build/ol-deps.js .build/ngeo-deps.js .build/node_modules.timestamp
 	./node_modules/karma/bin/karma start karma-conf.js --single-run
 
 .PHONY: serve
-serve: .build/node_modules.timestamp .build/bower_components.timestamp
+serve: .build/node_modules.timestamp
 	node buildtools/serve.js
 
 .PHONY: gh-pages
@@ -147,10 +147,6 @@ dist/ngeo.css: node_modules/openlayers/css/ol.css .build/node_modules.timestamp
 	mkdir -p $(dir $@)
 	cp $< $@
 
-.build/examples-hosted/jquery-ui-sortable.min.js: bower_components/jquery-ui-sortable/jquery-ui-sortable.min.js
-	mkdir -p $(dir $@)
-	cp $< $@
-
 .build/examples-hosted/partials: examples/partials
 	mkdir -p $@
 	cp examples/partials/* $@
@@ -161,15 +157,12 @@ dist/ngeo.css: node_modules/openlayers/css/ol.css .build/node_modules.timestamp
 
 node_modules/angular/angular.min.js node_modules/angular-animate/angular-animate.min.js: .build/node_modules.timestamp
 
-bower_components/jquery-ui-sortable/jquery-ui-sortable.min.js: .build/bower_components.timestamp
-
 .PRECIOUS: .build/examples-hosted/%.html
 .build/examples-hosted/%.html: examples/%.html
 	mkdir -p $(dir $@)
 	sed -e 's|\.\./node_modules/openlayers/css/ol.css|ngeo.css|' \
 	        -e 's|\.\./node_modules/bootstrap/dist/css/bootstrap.css|bootstrap.min.css|' \
 	        -e 's|\.\./node_modules/jquery/dist/jquery.js|jquery.min.js|' \
-	        -e 's|\.\./bower_components/jquery-ui-sortable/jquery-ui-sortable.js|jquery-ui-sortable.min.js|' \
 	        -e 's|\.\./node_modules/bootstrap/dist/js/bootstrap.js|bootstrap.min.js|' \
 		-e 's|\.\./node_modules/angular/angular.js|angular.min.js|' \
 		-e 's|\.\./node_modules/angular-animate/angular-animate.js|angular-animate.min.js|' \
@@ -182,19 +175,17 @@ bower_components/jquery-ui-sortable/jquery-ui-sortable.min.js: .build/bower_comp
 	sed -e '/^goog\.provide/d' -e '/^goog\.require/d' $< > $@
 
 .build/%.check.timestamp: .build/examples-hosted/%.html \
-                          .build/examples-hosted/%.js \
-	                  .build/examples-hosted/ngeo.js \
-	                  .build/examples-hosted/ngeo.css \
-			  .build/examples-hosted/angular.min.js \
-			  .build/examples-hosted/angular-animate.min.js \
-			  .build/examples-hosted/bootstrap.min.js \
-			  .build/examples-hosted/bootstrap.min.css \
-			  .build/examples-hosted/jquery.min.js \
-			  .build/examples-hosted/jquery-ui-sortable.min.js \
-			  .build/examples-hosted/data \
-			  .build/examples-hosted/partials \
-			  .build/node_modules.timestamp \
-			  .build/bower_components.timestamp
+						.build/examples-hosted/%.js \
+						.build/examples-hosted/ngeo.js \
+						.build/examples-hosted/ngeo.css \
+						.build/examples-hosted/angular.min.js \
+						.build/examples-hosted/angular-animate.min.js \
+						.build/examples-hosted/bootstrap.min.js \
+						.build/examples-hosted/bootstrap.min.css \
+						.build/examples-hosted/jquery.min.js \
+						.build/examples-hosted/data \
+						.build/examples-hosted/partials \
+						.build/node_modules.timestamp
 	mkdir -p $(dir $@)
 	./node_modules/phantomjs/bin/phantomjs buildtools/check-example.js $<
 	touch $@
@@ -204,11 +195,6 @@ bower_components/jquery-ui-sortable/jquery-ui-sortable.min.js: .build/bower_comp
 
 .build/node_modules.timestamp: package.json
 	npm install
-	mkdir -p $(dir $@)
-	touch $@
-
-.build/bower_components.timestamp: bower.json .build/node_modules.timestamp
-	./node_modules/bower/bin/bower install
 	mkdir -p $(dir $@)
 	touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -75,26 +75,26 @@ gh-pages: .build/ngeo-$(GITHUB_USERNAME)-gh-pages check-examples
 	touch $@
 
 dist/ngeo.js: buildtools/ngeo.json \
-	          .build/externs/angular-1.3.js \
-		  .build/externs/angular-1.3-q.js \
-	          .build/externs/angular-1.3-http-promise.js \
-	          .build/externs/jquery-1.9.js \
-		  $(SRC_JS_FILES) \
-		  .build/templatecache.js \
-		  $(EXPORTS_JS_FILES) \
-		  .build/node_modules.timestamp
+	    .build/externs/angular-1.3.js \
+	    .build/externs/angular-1.3-q.js \
+	    .build/externs/angular-1.3-http-promise.js \
+	    .build/externs/jquery-1.9.js \
+	    $(SRC_JS_FILES) \
+	    .build/templatecache.js \
+	    $(EXPORTS_JS_FILES) \
+	    .build/node_modules.timestamp
 	mkdir -p $(dir $@)
 	node buildtools/build.js $< $@
 
 dist/ngeo-debug.js: buildtools/ngeo-debug.json \
-	          .build/externs/angular-1.3.js \
-		  .build/externs/angular-1.3-q.js \
-	          .build/externs/angular-1.3-http-promise.js \
-	          .build/externs/jquery-1.9.js \
-		  $(SRC_JS_FILES) \
-		  .build/templatecache.js \
-		  $(EXPORTS_JS_FILES) \
-		  .build/node_modules.timestamp
+	    .build/externs/angular-1.3.js \
+	    .build/externs/angular-1.3-q.js \
+	    .build/externs/angular-1.3-http-promise.js \
+	    .build/externs/jquery-1.9.js \
+	    $(SRC_JS_FILES) \
+	    .build/templatecache.js \
+	    $(EXPORTS_JS_FILES) \
+	    .build/node_modules.timestamp
 	mkdir -p $(dir $@)
 	node buildtools/build.js $< $@
 
@@ -104,14 +104,27 @@ dist/ngeo.css: node_modules/openlayers/css/ol.css .build/node_modules.timestamp
 	mkdir -p $(dir $@)
 	./node_modules/.bin/cleancss $< > $@
 
-.build/examples/%.min.js: .build/examples/%.json $(SRC_JS_FILES) $(EXPORTS_JS_FILES) .build/externs/angular-1.3.js .build/externs/angular-1.3-q.js \
-	                      .build/externs/angular-1.3-http-promise.js .build/externs/jquery-1.9.js examples/%.js .build/node_modules.timestamp
-	           \
+.build/examples/%.min.js: .build/examples/%.json \
+	    $(SRC_JS_FILES) \
+	    $(EXPORTS_JS_FILES) \
+	    .build/externs/angular-1.3.js \
+	    .build/externs/angular-1.3-q.js \
+	    .build/externs/angular-1.3-http-promise.js \
+	    .build/externs/jquery-1.9.js \
+	    examples/%.js \
+	    .build/node_modules.timestamp
 	mkdir -p $(dir $@)
 	node buildtools/build.js $< $@
 
-.build/examples/all.min.js: buildtools/examples-all.json $(SRC_JS_FILES) $(EXPORTS_JS_FILES) .build/externs/angular-1.3.js .build/externs/angular-1.3-q.js \
-	                        .build/externs/angular-1.3-http-promise.js .build/externs/jquery-1.9.js .build/examples/all.js .build/node_modules.timestamp
+.build/examples/all.min.js: buildtools/examples-all.json \
+	    $(SRC_JS_FILES) \
+	    $(EXPORTS_JS_FILES) \
+	    .build/externs/angular-1.3.js \
+	    .build/externs/angular-1.3-q.js \
+	    .build/externs/angular-1.3-http-promise.js \
+	    .build/externs/jquery-1.9.js \
+	    .build/examples/all.js \
+	    .build/node_modules.timestamp
 	mkdir -p $(dir $@)
 	node buildtools/build.js $< $@
 
@@ -161,13 +174,13 @@ node_modules/angular/angular.min.js node_modules/angular-animate/angular-animate
 .build/examples-hosted/%.html: examples/%.html
 	mkdir -p $(dir $@)
 	sed -e 's|\.\./node_modules/openlayers/css/ol.css|ngeo.css|' \
-	        -e 's|\.\./node_modules/bootstrap/dist/css/bootstrap.css|bootstrap.min.css|' \
-	        -e 's|\.\./node_modules/jquery/dist/jquery.js|jquery.min.js|' \
-	        -e 's|\.\./node_modules/bootstrap/dist/js/bootstrap.js|bootstrap.min.js|' \
-		-e 's|\.\./node_modules/angular/angular.js|angular.min.js|' \
-		-e 's|\.\./node_modules/angular-animate/angular-animate.js|angular-animate.min.js|' \
-		-e 's/\/@?main=$*.js/$*.js/' \
-		-e '/$*.js/i\    <script src="ngeo.js"></script>' $< > $@
+	    -e 's|\.\./node_modules/bootstrap/dist/css/bootstrap.css|bootstrap.min.css|' \
+	    -e 's|\.\./node_modules/jquery/dist/jquery.js|jquery.min.js|' \
+	    -e 's|\.\./node_modules/bootstrap/dist/js/bootstrap.js|bootstrap.min.js|' \
+	    -e 's|\.\./node_modules/angular/angular.js|angular.min.js|' \
+	    -e 's|\.\./node_modules/angular-animate/angular-animate.js|angular-animate.min.js|' \
+	    -e 's/\/@?main=$*.js/$*.js/' \
+	    -e '/$*.js/i\    <script src="ngeo.js"></script>' $< > $@
 
 .PRECIOUS: .build/examples-hosted/%.js
 .build/examples-hosted/%.js: examples/%.js
@@ -175,17 +188,17 @@ node_modules/angular/angular.min.js node_modules/angular-animate/angular-animate
 	sed -e '/^goog\.provide/d' -e '/^goog\.require/d' $< > $@
 
 .build/%.check.timestamp: .build/examples-hosted/%.html \
-						.build/examples-hosted/%.js \
-						.build/examples-hosted/ngeo.js \
-						.build/examples-hosted/ngeo.css \
-						.build/examples-hosted/angular.min.js \
-						.build/examples-hosted/angular-animate.min.js \
-						.build/examples-hosted/bootstrap.min.js \
-						.build/examples-hosted/bootstrap.min.css \
-						.build/examples-hosted/jquery.min.js \
-						.build/examples-hosted/data \
-						.build/examples-hosted/partials \
-						.build/node_modules.timestamp
+	    .build/examples-hosted/%.js \
+	    .build/examples-hosted/ngeo.js \
+	    .build/examples-hosted/ngeo.css \
+	    .build/examples-hosted/angular.min.js \
+	    .build/examples-hosted/angular-animate.min.js \
+	    .build/examples-hosted/bootstrap.min.js \
+	    .build/examples-hosted/bootstrap.min.css \
+	    .build/examples-hosted/jquery.min.js \
+	    .build/examples-hosted/data \
+	    .build/examples-hosted/partials \
+	    .build/node_modules.timestamp
 	mkdir -p $(dir $@)
 	./node_modules/phantomjs/bin/phantomjs buildtools/check-example.js $<
 	touch $@
@@ -250,13 +263,13 @@ node_modules/angular/angular.min.js node_modules/angular-animate/angular-animate
 
 .build/ol-deps.js: .build/python-venv
 	.build/python-venv/bin/python buildtools/closure/depswriter.py \
-	  --root_with_prefix="node_modules/openlayers/src ../../../../../../../../openlayers/src" \
-	  --root_with_prefix="node_modules/openlayers/build/ol.ext ../../../../../../../../openlayers/build/ol.ext" \
-	  --output_file=$@
+	    --root_with_prefix="node_modules/openlayers/src ../../../../../../../../openlayers/src" \
+	    --root_with_prefix="node_modules/openlayers/build/ol.ext ../../../../../../../../openlayers/build/ol.ext" \
+	    --output_file=$@
 
 .build/ngeo-deps.js: .build/python-venv
 	.build/python-venv/bin/python buildtools/closure/depswriter.py \
-	  --root_with_prefix="src ../../../../../../../../../src" --output_file=$@
+	    --root_with_prefix="src ../../../../../../../../../src" --output_file=$@
 
 # The keys in the template cache begin with "../src/directives/partials". This
 # is done so ngeo.js works for the examples on github.io. If another key

--- a/examples/layerorder.html
+++ b/examples/layerorder.html
@@ -23,10 +23,10 @@
           border: 1px solid;
           padding: 5px;
         }
-        li:hover .handle {
+        li:hover .sortable-handle {
           opacity: 1;
         }
-        .handle {
+        .sortable-handle {
           opacity: 0.3;
           margin-right: 10px;
           cursor: -moz-grab;
@@ -43,17 +43,15 @@
       <br>
       Hint: drag-drop elements using the handle.
     </p>
-    <ul ngeo-sortable="ctrl.selectedLayers">
+    <ul ngeo-sortable="ctrl.selectedLayers" ngeo-sortable-options="{handleClassName: 'sortable-handle'}">
       <li ng-repeat="layer in ctrl.selectedLayers">
-        <span class="handle fa fa-reorder"></span>{{layer.get('name')}}
+        <span class="sortable-handle fa fa-reorder"></span>{{layer.get('name')}}
       </li>
     </ul>
     <label>
       Add/remove the "Roads" layer:
       <input type="checkbox" ng-model="ctrl.toggleRoadsLayer" ng-model-options="{getterSetter: true}"/>
     <label>
-    <script src="../node_modules/jquery/dist/jquery.js"></script>
-    <script src="../bower_components/jquery-ui-sortable/jquery-ui-sortable.js"></script>
     <script src="../node_modules/angular/angular.js"></script>
     <script src="/@?main=layerorder.js"></script>
   </body>

--- a/examples/layerorder.js
+++ b/examples/layerorder.js
@@ -1,6 +1,7 @@
 goog.provide('layerorder');
 
 goog.require('ngeo.DecorateLayer');
+goog.require('ngeo.SortableOptions');
 goog.require('ngeo.SyncArrays');
 goog.require('ngeo.mapDirective');
 goog.require('ngeo.sortableDirective');
@@ -66,7 +67,6 @@ app.MainController = function($scope, ngeoDecorateLayer, ngeoSyncArrays) {
   });
   cities.set('name', 'Cities');
 
-
   /** @type {ol.Map} */
   this['map'] = new ol.Map({
     layers: [
@@ -86,6 +86,7 @@ app.MainController = function($scope, ngeoDecorateLayer, ngeoSyncArrays) {
   /**
    * @type {ol.Map}
    * @private
+   * @const
    */
   this.map_ = map;
 
@@ -103,6 +104,23 @@ app.MainController = function($scope, ngeoDecorateLayer, ngeoSyncArrays) {
   this.roads_.set('name', 'Roads');
 
   /**
+   * @type {Array.<ol.layer.Base>}
+   * @const
+   */
+  this['selectedLayers'] = [];
+
+  var selectedLayers = this['selectedLayers'];
+  ngeoSyncArrays(map.getLayers().getArray(), selectedLayers, true, $scope,
+      layerFilter);
+
+  // watch any change on layers array to refresh the map
+  $scope.$watchCollection(function() {
+    return selectedLayers;
+  }, function() {
+    map.render();
+  });
+
+  /**
    * @param {ol.layer.Base} layer Layer.
    * @return {boolean} `false` if the layer shouldn't be part of the selected
    *     layers.
@@ -111,18 +129,6 @@ app.MainController = function($scope, ngeoDecorateLayer, ngeoSyncArrays) {
     return layer !== mapquest;
   }
 
-  /** @type {Array.<ol.layer.Layer>} */
-  var mapLayers = map.getLayers().getArray();
-  this['selectedLayers'] = [];
-  var selectedLayers = this['selectedLayers'];
-  ngeoSyncArrays(mapLayers, selectedLayers, true, $scope, layerFilter);
-
-  // watch any change on layers array to refresh the map
-  $scope.$watchCollection(function() {
-    return selectedLayers;
-  }, function() {
-    map.render();
-  });
 };
 
 


### PR DESCRIPTION
This PR changes the `ngeo-sortable` directive to rely on Closure's `goog.fx.DragListGroup` rather than jQuery UI's sortable plugin.

This removes the dependency on jQuery UI and it will make the `ngeo-sortable` directive work on touch devices when https://github.com/google/closure-library/pull/405 is fixed.

Please review.