### PR TITLE
ol.Overlay autoPan now false by default

### DIFF
--- a/src/ol-ext/interactions/measure.js
+++ b/src/ol-ext/interactions/measure.js
@@ -197,7 +197,6 @@ ngeo.interaction.Measure.prototype.createHelpTooltip_ = function() {
   this.helpTooltipElement_ = goog.dom.createDom(goog.dom.TagName.DIV);
   goog.dom.classlist.add(this.helpTooltipElement_, 'tooltip');
   this.helpTooltip_ = new ol.Overlay({
-    autoPan: false,
     element: this.helpTooltipElement_,
     offset: [15, 0],
     positioning: 'center-left'
@@ -230,7 +229,6 @@ ngeo.interaction.Measure.prototype.createMeasureTooltip_ = function() {
   goog.dom.classlist.addAll(this.measureTooltipElement_,
       ['tooltip', 'tooltip-measure']);
   this.measureTooltip_ = new ol.Overlay({
-    autoPan: false,
     element: this.measureTooltipElement_,
     offset: [0, -15],
     positioning: 'bottom-center'


### PR DESCRIPTION
The default value for ol.Overlay autoPan is now  false. So there's no need to set autoPan to false for the measure tooltips.