### PR TITLE
Compute length and area using a wsg84 sphere (geodesic)

### DIFF
--- a/examples/measure.js
+++ b/examples/measure.js
@@ -11,6 +11,7 @@ goog.require('ol.Map');
 goog.require('ol.Observable');
 goog.require('ol.Overlay');
 goog.require('ol.View');
+goog.require('ol.control.ScaleLine');
 goog.require('ol.layer.Tile');
 goog.require('ol.source.OSM');
 
@@ -127,6 +128,8 @@ app.MainController = function() {
     })
   });
   this['map'] = map;
+
+  map.addControl(new ol.control.ScaleLine());
 
 };
 

--- a/src/ol-ext/interaction/measurearea.js
+++ b/src/ol-ext/interaction/measurearea.js
@@ -3,6 +3,7 @@ goog.provide('ngeo.interaction.MeasureArea');
 goog.require('ngeo.interaction.Measure');
 goog.require('ol.geom.Polygon');
 goog.require('ol.interaction.Draw');
+goog.require('ol.sphere.WGS84');
 
 
 
@@ -74,7 +75,12 @@ ngeo.interaction.MeasureArea.prototype.handleMeasure = function(callback) {
  * @private
  */
 ngeo.interaction.MeasureArea.prototype.formatMeasure_ = function(polygon) {
-  var area = polygon.getArea();
+  var map = this.getMap();
+  var sourceProj = map.getView().getProjection();
+  var geom = /** @type {ol.geom.Polygon} */ (polygon.clone().transform(
+      sourceProj, 'EPSG:4326'));
+  var coordinates = geom.getLinearRing(0).getCoordinates();
+  var area = Math.abs(ol.sphere.WGS84.geodesicArea(coordinates));
   var output;
   if (area > 10000) {
     output = (Math.round(area / 1000000 * 100) / 100) +

--- a/src/ol-ext/interaction/measurelength.js
+++ b/src/ol-ext/interaction/measurelength.js
@@ -3,6 +3,7 @@ goog.provide('ngeo.interaction.MeasureLength');
 goog.require('ngeo.interaction.Measure');
 goog.require('ol.geom.LineString');
 goog.require('ol.interaction.Draw');
+goog.require('ol.sphere.WGS84');
 
 
 
@@ -69,7 +70,15 @@ ngeo.interaction.MeasureLength.prototype.handleMeasure = function(callback) {
  * @private
  */
 ngeo.interaction.MeasureLength.prototype.formatMeasure_ = function(line) {
-  var length = line.getLength();
+  var length = 0;
+  var map = this.getMap();
+  var sourceProj = map.getView().getProjection();
+  var coordinates = line.getCoordinates();
+  for (var i = 0, ii = coordinates.length - 1; i < ii; ++i) {
+    var c1 = ol.proj.transform(coordinates[i], sourceProj, 'EPSG:4326');
+    var c2 = ol.proj.transform(coordinates[i + 1], sourceProj, 'EPSG:4326');
+    length += ol.sphere.WGS84.haversineDistance(c1, c2);
+  }
   var output;
   if (length > 1000) {
     output = parseFloat((length / 1000).toPrecision(3)) +


### PR DESCRIPTION
This pull request's goal is to get more realistic values for length and area measurements by converting coordinates to wsg84 and using geodesic measurements.
I don't think it needs to be optional since it will work in all cases no matter what the map projection is.
Please review.