### PR TITLE
Use goog.bind instead of angular.bind

### DIFF
--- a/src/directives/scaleselector.js
+++ b/src/directives/scaleselector.js
@@ -205,9 +205,9 @@ ngeo.ScaleselectorController.prototype.handleResolutionChange_ = function(e) {
   var currentScale = this['scales'][view.getZoom().toString()];
   this.$scope_.$apply(
       /** @type {function(?)} */ (
-      angular.bind(this, function() {
+      goog.bind(function() {
         this['currentScale'] = currentScale;
-      })));
+      }, this)));
 };
 
 


### PR DESCRIPTION
This PR follows the guidelines to use `goog.bind` instead of `angular.bind` in the ngeo code.