### PR TITLE
Introduce an ngeox.profile.ProfileOptions

### DIFF
--- a/examples/profile.html
+++ b/examples/profile.html
@@ -19,7 +19,7 @@
   </head>
   <body ng-controller="MainController as ctrl">
     <div class="profile" ngeo-profile="::ctrl.profileData"
-         ngeo-profile-options="::ctrl.profileOptions">
+         ngeo-profile-options="ctrl.profileOptions">
     </div>
 
     <ul ng-show="ctrl.point != null">

--- a/examples/profile.html
+++ b/examples/profile.html
@@ -19,8 +19,8 @@
   </head>
   <body ng-controller="MainController as ctrl">
     <div class="profile" ngeo-profile="::ctrl.profileData"
-         ngeo-profile-onhover="ctrl.onProfileHover(point)"
-         ngeo-profile-onout="ctrl.onProfileOut()"></div>
+         ngeo-profile-options="::ctrl.profileOptions">
+    </div>
 
     <ul ng-show="ctrl.point != null">
       <li>Longitude: {{ctrl.point.x}}</li>

--- a/examples/profile.js
+++ b/examples/profile.js
@@ -25,22 +25,21 @@ app.MainController = function($http, $scope) {
     this['profileData'] = resp.data['profile'];
   }));
 
-  this['point'] = null;
-};
+  var profileOptions = {
+    extractor: {
+      z: function(item) { return item['values']['mnt']; },
+      dist: function(item) { return item['dist']; }
+    },
+    hoverCallback: angular.bind(this, function(point) {
+      // An item in the list of points given to the profile.
+      this['point'] = point;
+    }),
+    outCallback: angular.bind(this, function() {
+      this['point'] = null;
+    })
+  };
 
-
-/**
- * @param {Object} point The point object. It correspond to an item in the list
- * of points given to the profile.
- */
-app.MainController.prototype.onProfileHover = function(point) {
-  this['point'] = point;
-};
-
-
-/**
- */
-app.MainController.prototype.onProfileOut = function() {
+  this['profileOptions'] = profileOptions;
   this['point'] = null;
 };
 

--- a/examples/profile.js
+++ b/examples/profile.js
@@ -25,21 +25,53 @@ app.MainController = function($http, $scope) {
     this['profileData'] = resp.data['profile'];
   }));
 
-  var profileOptions = {
-    extractor: {
-      z: function(item) { return item['values']['mnt']; },
-      dist: function(item) { return item['dist']; }
-    },
-    hoverCallback: angular.bind(this, function(point) {
-      // An item in the list of points given to the profile.
-      this['point'] = point;
-    }),
-    outCallback: angular.bind(this, function() {
-      this['point'] = null;
-    })
+  /**
+   * @param {Object} item
+   * @return {number}
+   */
+  var z = function(item) {
+    return item['values']['mnt'];
   };
 
-  this['profileOptions'] = profileOptions;
+  /**
+    * @param {Object} item
+    * @return {number}
+    */
+  var dist = function(item) {
+    return item['dist'];
+  };
+
+  /**
+   * @type {ngeox.profile.ProfileExtractor}
+   */
+  var extractor = {z: z, dist: dist};
+
+
+  // Using closures for hoverCallback and outCallback since
+  // wrapping in angular.bind leads to a closure error.
+  // See PR https://github.com/google/closure-compiler/pull/867
+  var that = this;
+
+  /**
+   * @param {Object} point
+   */
+  var hoverCallback = function(point) {
+    // An item in the list of points given to the profile.
+    that['point'] = point;
+  };
+
+  var outCallback = function() {
+    that['point'] = null;
+  };
+
+
+  this['profileOptions'] = {
+    extractor: extractor,
+    hoverCallback: hoverCallback,
+    outCallback: outCallback
+  };
+
+
   this['point'] = null;
 };
 

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -49,3 +49,68 @@ ngeox.interaction.MeasureOptions.prototype.style;
  * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined}
  */
 ngeox.interaction.MeasureOptions.prototype.sketchStyle;
+
+
+/**
+ * Namespace.
+ * @type {Object}
+ */
+ngeox.profile;
+
+
+/**
+ * Options for the profile.
+ *  @typedef {{
+ *    extractor: ngeox.profile.ProfileExtractor,
+ *    light: (boolean|undefined),
+ *    hoverCallback: (function(Object)|undefined),
+ *    outCallback: (function()|undefined)
+ *  }}
+ */
+ngeox.profile.ProfileOptions;
+
+
+/**
+ * @type {ngeox.profile.ProfileExtractor}
+ */
+ngeox.profile.ProfileOptions.prototype.extractor;
+
+
+/**
+ * @type {boolean|undefined}
+ */
+ngeox.profile.ProfileOptions.prototype.light;
+
+
+/**
+ * @type {function(Object)|undefined}
+ */
+ngeox.profile.ProfileOptions.prototype.hoverCallback;
+
+
+/**
+ * @type {function()|undefined}
+ */
+ngeox.profile.ProfileOptions.prototype.outCallback;
+
+
+/**
+ * Profile data extractor.
+ * @typedef {{
+ *   z: function(Object): number,
+ *   dist: function(Object): number
+ * }}
+ */
+ngeox.profile.ProfileExtractor;
+
+
+/**
+ * @type {function(Object, string=): number}
+ */
+ngeox.profile.ProfileExtractor.prototype.z;
+
+
+/**
+ * @type {function(Object): number}
+ */
+ngeox.profile.ProfileExtractor.prototype.dist;

--- a/src/directives/profile.js
+++ b/src/directives/profile.js
@@ -34,25 +34,16 @@ ngeo.profileDirective = function() {
           goog.asserts.assert(goog.isDef(optionsAttr));
 
           var selection = d3.select(element[0]);
-          var profile, options, data;
 
-          scope.$watch(attrs['ngeoProfileOptions'], function(newVal, oldVal) {
-            options = newVal;
-            if (options) {
-              profile = ngeo.profile(options);
-              refreshData();
-            }
-          });
-
-          function refreshData() {
-            if (profile && data) {
-              selection.datum(data).call(profile);
-            }
-          }
+          var options = /** @type {ngeox.profile.ProfileOptions} */
+              (scope.$eval(optionsAttr));
+          var profile = ngeo.profile(options);
 
           scope.$watch(attrs['ngeoProfile'], function(newVal, oldVal) {
-            data = newVal;
-            refreshData();
+            var data = newVal;
+            if (goog.isDef(data)) {
+              selection.datum(data).call(profile);
+            }
           });
         }
   };

--- a/src/directives/profile.js
+++ b/src/directives/profile.js
@@ -5,16 +5,13 @@
  * Example:
  *
  * <div ngeo-profile="ctrl.profileData"
- *      ngeo-profile-onhover="ctrl.onHover(point)"
- *      ngeo-profile-onout="ctrl.onProfileOut()"></div>
+ *      ngeo-profile-ooptions="ctrl.profileOptions"></div>
  *
- * Note: "point" in the onhover callback corresponds to an item of the data
- * provided to the profile (profileData in the above example). It's
- * integrator's job to extract the information he/she wants for the given
- * point (coordinates, elevation, distance, ...).
+ * Note: "ctrl.profileOptions" is of type ngeox.profile.ProfileOptions.
  */
 goog.provide('ngeo.profileDirective');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ngeo.profile');
 
@@ -33,25 +30,29 @@ ngeo.profileDirective = function() {
          */
         function(scope, element, attrs) {
 
-          var selection = d3.select(element[0]);
-          var profile = ngeo.profile();
+          var optionsAttr = attrs['ngeoProfileOptions'];
+          goog.asserts.assert(goog.isDef(optionsAttr));
 
-          scope.$watch(attrs['ngeoProfile'], function(newVal, oldVal) {
-            if (goog.isDef(newVal)) {
-              selection.datum(newVal).call(profile);
+          var selection = d3.select(element[0]);
+          var profile, options, data;
+
+          scope.$watch(attrs['ngeoProfileOptions'], function(newVal, oldVal) {
+            options = newVal;
+            if (options) {
+              profile = ngeo.profile(options);
+              refreshData();
             }
           });
 
-          profile.onHover(function(point) {
-            scope.$apply(function() {
-              scope.$eval(attrs['ngeoProfileOnhover'], {'point': point});
-            });
-          });
+          function refreshData() {
+            if (profile && data) {
+              selection.datum(data).call(profile);
+            }
+          }
 
-          profile.onOut(function() {
-            scope.$apply(function() {
-              scope.$eval(attrs['ngeoProfileOnout']);
-            });
+          scope.$watch(attrs['ngeoProfile'], function(newVal, oldVal) {
+            data = newVal;
+            refreshData();
           });
         }
   };


### PR DESCRIPTION
An `ngeox.profile.ProfileOptions` typedef has been introduced and must be passed to the `ngeo.profile` factory. Additionally, the profile now depends on an `ngeo.ProfileExtractor`  to support any tabular data.

The directive has been updated to require the options attribute.
Basic support for updating the profile was added.