### PR TITLE
Make the measure tooltips translatable

### DIFF
--- a/examples/measure.html
+++ b/examples/measure.html
@@ -53,8 +53,10 @@
   </head>
   <body ng-controller="MainController as ctrl">
     <div id="map" ngeo-map="::ctrl.map"></div>
-
-    <div app-measuretools app-measuretools-map="::ctrl.map"></div>
+    <div app-measuretools app-measuretools-map="::ctrl.map" app-measuretools-lang="ctrl.lang"></div>
+    <p>Use the following selector to change the language used for the measure tooltips.</p>
+    <label>Select language:</label>
+    <select ng-options="lang for lang in ['en', 'fr']" ng-model="ctrl.lang"></select>
     <script src="../node_modules/angular/angular.js"></script>
     <script src="/@?main=measure.js"></script>
   </body>

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -35,7 +35,8 @@ app.measuretoolsDirective = function() {
   return {
     restrict: 'A',
     scope: {
-      'map': '=appMeasuretoolsMap'
+      'map': '=appMeasuretoolsMap',
+      'lang': '=appMeasuretoolsLang'
     },
     controller: 'AppMeasuretoolsController',
     controllerAs: 'ctrl',
@@ -49,12 +50,63 @@ app.module.directive('appMeasuretools', app.measuretoolsDirective);
 
 
 /**
+ * @param {angular.Scope} $scope Angular scope.
+ * @param {angular.$compile} $compile Angular compile service.
+ * @param {angular.$sce} $sce Angular sce service.
  * @param {ngeo.DecorateInteraction} ngeoDecorateInteraction Decorate
  *     interaction service.
  * @constructor
  * @ngInject
  */
-app.MeasuretoolsController = function(ngeoDecorateInteraction) {
+app.MeasuretoolsController = function($scope, $compile, $sce,
+    ngeoDecorateInteraction) {
+
+  // Translations for the measure tools' tooltips.
+  var measureStartMsgs = {
+    'en': $sce.trustAsHtml('Click to start drawing.'),
+    'fr': $sce.trustAsHtml('Cliquer pour commencer à dessiner.')
+  };
+  var measureLengthContinueMsgs = {
+    'en': $sce.trustAsHtml('Click to continue drawing.<br>' +
+        'Double-click or click last point to finish.'),
+    'fr': $sce.trustAsHtml('Cliquer pour continuer le dessin.<br>' +
+        'Double-cliquer ou cliquer sur dernier point pour finir.')
+  };
+  var measureAreaContinueMsgs = {
+    'en': $sce.trustAsHtml('Click to continue drawing.<br>' +
+        'Double-click or click starting point to finish.'),
+    'fr': $sce.trustAsHtml('Cliquer pour continuer le dessin.<br>' +
+        'Double-cliquer ou cliquer sur point de départ pour finir.')
+  };
+  var measureAzimutContinueMsgs = {
+    'en': $sce.trustAsHtml('Click to finish.'),
+    'fr': $sce.trustAsHtml('Cliquer pour finir.')
+  };
+
+  // Create elements for the measure tools' tooltips.
+  var measureStartMsg = angular.element(
+      '<span ng-bind-html="ctrl.measureStartMsg"></span>');
+  measureStartMsg = $compile(measureStartMsg)($scope);
+  var measureLengthContinueMsg = angular.element(
+      '<span ng-bind-html="ctrl.measureLengthContinueMsg"></span>');
+  measureLengthContinueMsg = $compile(measureLengthContinueMsg)($scope);
+  var measureAreaContinueMsg = angular.element(
+      '<span ng-bind-html="ctrl.measureAreaContinueMsg"></span>');
+  measureAreaContinueMsg = $compile(measureAreaContinueMsg)($scope);
+  var measureAzimutContinueMsg = angular.element(
+      '<span ng-bind-html="ctrl.measureAzimutContinueMsg"></span>');
+  measureAzimutContinueMsg = $compile(measureAzimutContinueMsg)($scope);
+
+  // Watch the "lang" property and update the toolip messages
+  // based on the selected language.
+  $scope.$watch(angular.bind(this, function() {
+    return this['lang'];
+  }), angular.bind(this, function(newVal) {
+    this['measureStartMsg'] = measureStartMsgs[newVal];
+    this['measureLengthContinueMsg'] = measureLengthContinueMsgs[newVal];
+    this['measureAreaContinueMsg'] = measureAreaContinueMsgs[newVal];
+    this['measureAzimutContinueMsg'] = measureAzimutContinueMsgs[newVal];
+  }));
 
   var style = new ol.style.Style({
     fill: new ol.style.Fill({
@@ -80,7 +132,9 @@ app.MeasuretoolsController = function(ngeoDecorateInteraction) {
 
   /** @type {ngeo.interaction.MeasureLength} */
   var measureLength = new ngeo.interaction.MeasureLength({
-    sketchStyle: style
+    sketchStyle: style,
+    startMsg: measureStartMsg[0],
+    continueMsg: measureLengthContinueMsg[0]
   });
   measureLength.setActive(false);
   ngeoDecorateInteraction(measureLength);
@@ -89,7 +143,9 @@ app.MeasuretoolsController = function(ngeoDecorateInteraction) {
 
   /** @type {ngeo.interaction.MeasureArea} */
   var measureArea = new ngeo.interaction.MeasureArea({
-    sketchStyle: style
+    sketchStyle: style,
+    startMsg: measureStartMsg[0],
+    continueMsg: measureAreaContinueMsg[0]
   });
   measureArea.setActive(false);
   ngeoDecorateInteraction(measureArea);
@@ -98,7 +154,9 @@ app.MeasuretoolsController = function(ngeoDecorateInteraction) {
 
   /** @type {ngeo.interaction.MeasureAzimut} */
   var measureAzimut = new ngeo.interaction.MeasureAzimut({
-    sketchStyle: style
+    sketchStyle: style,
+    startMsg: measureStartMsg[0],
+    continueMsg: measureAzimutContinueMsg[0]
   });
   measureAzimut.setActive(false);
   ngeoDecorateInteraction(measureAzimut);
@@ -114,6 +172,9 @@ app.module.controller('AppMeasuretoolsController', app.MeasuretoolsController);
  * @constructor
  */
 app.MainController = function() {
+
+  /** @type {string} */
+  this['lang'] = 'en';
 
   /** @type {ol.Map} */
   var map = new ol.Map({

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -12,8 +12,8 @@ ngeox.interaction;
 /**
  * Interactions for measure tools.
  * @typedef {{
- *    startMsg: (string|undefined),
- *    continueMsg: (string|undefined),
+ *    startMsg: (Element|undefined),
+ *    continueMsg: (Element|undefined),
  *    style: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined),
  *    sketchStyle: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined)
  * }}
@@ -22,17 +22,17 @@ ngeox.interaction.MeasureOptions;
 
 
 /**
- * The message to show in the help tooltip when the user just activated the
- * interaction.
- * @type {string|undefined}
+ * Element including the message to display in the help tooltip when the user
+ * just activated the interaction.
+ * @type {Element|undefined}
  */
 ngeox.interaction.MeasureOptions.prototype.startMsg;
 
 
 /**
- * The message to show in the help tooltip when the user already added the
- * first point.
- * @type {string|undefined}
+ * Element including the message to display in the help tooltip when the user
+ * already added the first point.
+ * @type {Element|undefined}
  */
 ngeox.interaction.MeasureOptions.prototype.continueMsg;
 

--- a/src/ol-ext/interaction/measure.js
+++ b/src/ol-ext/interaction/measure.js
@@ -18,7 +18,7 @@ goog.require('ol.style.Style');
 /**
  * Interactions for measure tools base class.
  * @typedef {{
- *    startMsg: (string|undefined),
+ *    startMsg: (Element|undefined),
  *    style:(ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined)
  * }}
  */
@@ -82,10 +82,10 @@ ngeo.interaction.Measure = function(opt_options) {
 
   /**
    * The message to show when user is about to start drawing.
-   * @type {string}
+   * @type {Element}
    */
   this.startMsg = goog.isDef(options.startMsg) ? options.startMsg :
-      'Click to start drawing';
+      goog.dom.createDom(goog.dom.TagName.SPAN, {}, 'Click to start drawing.');
 
   var style = goog.isDef(options.style) ? options.style :
       [
@@ -161,7 +161,8 @@ ngeo.interaction.Measure.handleEvent_ = function(evt) {
     }, this));
   }
 
-  this.helpTooltipElement_.innerHTML = helpMsg;
+  goog.dom.removeChildren(this.helpTooltipElement_);
+  goog.dom.appendChild(this.helpTooltipElement_, helpMsg);
   this.helpTooltipOverlay_.setPosition(evt.coordinate);
 
   return true;
@@ -309,8 +310,8 @@ ngeo.interaction.Measure.prototype.updateState_ = function() {
 /**
  * Function implemented in inherited classes to compute measurement, determine
  * where to place the tooltip and determine which help message to display.
- * @param {function(string, ?ol.Coordinate, string)} callback The function
- * to be called.
+ * @param {function(string, ?ol.Coordinate, Element)} callback The function
+ *     to be called.
  * @protected
  */
 ngeo.interaction.Measure.prototype.handleMeasure = goog.abstractMethod;

--- a/src/ol-ext/interaction/measure.js
+++ b/src/ol-ext/interaction/measure.js
@@ -54,7 +54,7 @@ ngeo.interaction.Measure = function(opt_options) {
    * @type {ol.Overlay}
    * @private
    */
-  this.helpTooltip_ = null;
+  this.helpTooltipOverlay_ = null;
 
 
   /**
@@ -70,7 +70,7 @@ ngeo.interaction.Measure = function(opt_options) {
    * @type {ol.Overlay}
    * @private
    */
-  this.measureTooltip_ = null;
+  this.measureTooltipOverlay_ = null;
 
 
   /**
@@ -155,14 +155,14 @@ ngeo.interaction.Measure.handleEvent_ = function(evt) {
     this.handleMeasure(goog.bind(function(measure, coord, helpMsg_) {
       if (!goog.isNull(coord)) {
         this.measureTooltipElement_.innerHTML = measure;
-        this.measureTooltip_.setPosition(coord);
+        this.measureTooltipOverlay_.setPosition(coord);
       }
       helpMsg = helpMsg_;
     }, this));
   }
 
   this.helpTooltipElement_.innerHTML = helpMsg;
-  this.helpTooltip_.setPosition(evt.coordinate);
+  this.helpTooltipOverlay_.setPosition(evt.coordinate);
 
   return true;
 };
@@ -217,7 +217,7 @@ ngeo.interaction.Measure.prototype.onDrawStart_ = function(evt) {
  */
 ngeo.interaction.Measure.prototype.onDrawEnd_ = function(evt) {
   goog.dom.classlist.add(this.measureTooltipElement_, 'tooltip-static');
-  this.measureTooltip_.setOffset([0, -7]);
+  this.measureTooltipOverlay_.setOffset([0, -7]);
   this.sketchFeature = null;
 };
 
@@ -230,12 +230,12 @@ ngeo.interaction.Measure.prototype.createHelpTooltip_ = function() {
   this.removeHelpTooltip_();
   this.helpTooltipElement_ = goog.dom.createDom(goog.dom.TagName.DIV);
   goog.dom.classlist.add(this.helpTooltipElement_, 'tooltip');
-  this.helpTooltip_ = new ol.Overlay({
+  this.helpTooltipOverlay_ = new ol.Overlay({
     element: this.helpTooltipElement_,
     offset: [15, 0],
     positioning: 'center-left'
   });
-  this.getMap().addOverlay(this.helpTooltip_);
+  this.getMap().addOverlay(this.helpTooltipOverlay_);
 };
 
 
@@ -244,12 +244,12 @@ ngeo.interaction.Measure.prototype.createHelpTooltip_ = function() {
  * @private
  */
 ngeo.interaction.Measure.prototype.removeHelpTooltip_ = function() {
-  this.getMap().removeOverlay(this.helpTooltip_);
+  this.getMap().removeOverlay(this.helpTooltipOverlay_);
   if (!goog.isNull(this.helpTooltipElement_)) {
     this.helpTooltipElement_.parentNode.removeChild(this.helpTooltipElement_);
   }
   this.helpTooltipElement_ = null;
-  this.helpTooltip_ = null;
+  this.helpTooltipOverlay_ = null;
 };
 
 
@@ -262,12 +262,12 @@ ngeo.interaction.Measure.prototype.createMeasureTooltip_ = function() {
   this.measureTooltipElement_ = goog.dom.createDom(goog.dom.TagName.DIV);
   goog.dom.classlist.addAll(this.measureTooltipElement_,
       ['tooltip', 'tooltip-measure']);
-  this.measureTooltip_ = new ol.Overlay({
+  this.measureTooltipOverlay_ = new ol.Overlay({
     element: this.measureTooltipElement_,
     offset: [0, -15],
     positioning: 'bottom-center'
   });
-  this.getMap().addOverlay(this.measureTooltip_);
+  this.getMap().addOverlay(this.measureTooltipOverlay_);
 };
 
 
@@ -280,7 +280,7 @@ ngeo.interaction.Measure.prototype.removeMeasureTooltip_ = function() {
     this.measureTooltipElement_.parentNode.removeChild(
         this.measureTooltipElement_);
     this.measureTooltipElement_ = null;
-    this.measureTooltip_ = null;
+    this.measureTooltipOverlay_ = null;
   }
 };
 
@@ -299,7 +299,7 @@ ngeo.interaction.Measure.prototype.updateState_ = function() {
     this.createHelpTooltip_();
   } else {
     this.overlay_.getFeatures().clear();
-    this.getMap().removeOverlay(this.measureTooltip_);
+    this.getMap().removeOverlay(this.measureTooltipOverlay_);
     this.removeMeasureTooltip_();
     this.removeHelpTooltip_();
   }

--- a/src/ol-ext/interaction/measurearea.js
+++ b/src/ol-ext/interaction/measurearea.js
@@ -24,12 +24,14 @@ ngeo.interaction.MeasureArea = function(opt_options) {
 
   /**
    * Message to show after the first point is clicked.
-   * @type {string}
+   * @type {Element}
    * @private
    */
   this.continueMsg_ = goog.isDef(options.continueMsg) ? options.continueMsg :
-      'Click to continue drawing the polygon<br>' +
-      'Double-click or click starting point to finish';
+      goog.dom.createDom(goog.dom.TagName.SPAN, {},
+          'Click to continue drawing the polygon.',
+          goog.dom.createDom(goog.dom.TagName.BR),
+          'Double-click or click starting point to finish.');
 
 };
 goog.inherits(ngeo.interaction.MeasureArea, ngeo.interaction.Measure);

--- a/src/ol-ext/interaction/measureazimut.js
+++ b/src/ol-ext/interaction/measureazimut.js
@@ -41,11 +41,11 @@ ngeo.interaction.MeasureAzimut = function(opt_options) {
 
   /**
    * Message to show after the first point is clicked.
-   * @type {string}
+   * @type {Element}
    * @private
    */
   this.continueMsg_ = goog.isDef(options.continueMsg) ? options.continueMsg :
-      'Click to finish';
+      goog.dom.createDom(goog.dom.TagName.SPAN, {}, 'Click to finish.');
 
 };
 goog.inherits(ngeo.interaction.MeasureAzimut, ngeo.interaction.Measure);

--- a/src/ol-ext/interaction/measurelength.js
+++ b/src/ol-ext/interaction/measurelength.js
@@ -24,12 +24,14 @@ ngeo.interaction.MeasureLength = function(opt_options) {
 
   /**
    * Message to show after the first point is clicked.
-   * @type {string}
+   * @type {Element}
    * @private
    */
   this.continueMsg_ = goog.isDef(options.continueMsg) ? options.continueMsg :
-      'Click to continue drawing the line<br>' +
-      'Double-click or click last point to finish';
+      goog.dom.createDom(goog.dom.TagName.SPAN, {},
+          'Click to continue drawing the line.',
+          goog.dom.createDom(goog.dom.TagName.BR),
+          'Double-click or click last point to finish.');
 
 };
 goog.inherits(ngeo.interaction.MeasureLength, ngeo.interaction.Measure);


### PR DESCRIPTION
This PR makes it possible to use Angular (angular-gettext) to translate measure tooltips. The `measure` example shows how it works.

Please review.