### PR TITLE
Optionnaly display POIs in profile

### DIFF
--- a/examples/profile.html
+++ b/examples/profile.html
@@ -19,7 +19,7 @@
   </head>
   <body ng-controller="MainController as ctrl">
     <div class="profile" ngeo-profile="::ctrl.profileData"
-         ngeo-profile-options="ctrl.profileOptions">
+         ngeo-profile-options="::ctrl.profileOptions">
     </div>
 
     <ul ng-show="ctrl.point != null">

--- a/examples/profile.html
+++ b/examples/profile.html
@@ -19,7 +19,8 @@
   </head>
   <body ng-controller="MainController as ctrl">
     <div class="profile" ngeo-profile="::ctrl.profileData"
-         ngeo-profile-options="::ctrl.profileOptions">
+         ngeo-profile-options="::ctrl.profileOptions"
+         ngeo-profile-pois="::ctrl.profilePoisData">
     </div>
 
     <ul ng-show="ctrl.point != null">

--- a/examples/profile.js
+++ b/examples/profile.js
@@ -42,7 +42,7 @@ app.MainController = function($http, $scope) {
   };
 
   /**
-   * @type {ngeox.profile.ProfileExtractor}
+   * @type {ngeox.profile.ElevationExtractor}
    */
   var extractor = {z: z, dist: dist};
 
@@ -66,7 +66,7 @@ app.MainController = function($http, $scope) {
 
 
   this['profileOptions'] = {
-    extractor: extractor,
+    elevationExtractor: extractor,
     hoverCallback: hoverCallback,
     outCallback: outCallback
   };

--- a/externs/d3.js
+++ b/externs/d3.js
@@ -366,6 +366,7 @@ d3.select.prototype = function () {};
 d3.selectAll.prototype = function () {};
 d3.selection.prototype = {
     "enter": function () {},
+    "exit": function () {},
     "select": function () {},
     "selectAll": function () {},
     "attr": function () {},

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -72,37 +72,45 @@ ngeox.profile.ProfileOptions;
 
 
 /**
+ * Extractor for parsing elevation data.
  * @type {ngeox.profile.ElevationExtractor}
  */
 ngeox.profile.ProfileOptions.prototype.elevationExtractor;
 
 
 /**
+ * Extractor for parsing POI data.
  * @type {ngeox.profile.PoiExtractor}
  */
 ngeox.profile.ProfileOptions.prototype.poiExtractor;
 
 
 /**
+ * Show a simplified profile when true.
  * @type {boolean|undefined}
  */
 ngeox.profile.ProfileOptions.prototype.light;
 
 
 /**
+ * A callback called from the profile when the mouse moves over a point.
+ * The point, an item of the elevation data array, is passed as the first
+ * argument of the function.
  * @type {function(Object)|undefined}
  */
 ngeox.profile.ProfileOptions.prototype.hoverCallback;
 
 
 /**
+ * A callback called from the profile when the mouse leaves the profile.
  * @type {function()|undefined}
  */
 ngeox.profile.ProfileOptions.prototype.outCallback;
 
 
 /**
- * Elevation data extractor.
+ * The elevation data extractor is used to extract data from a point.
+ * The point is an item of the elevation data array.
  * @typedef {{
  *   z: function(Object): number,
  *   dist: function(Object): number
@@ -126,7 +134,8 @@ ngeox.profile.ElevationExtractor.prototype.dist;
 
 
 /**
- * POI data extractor.
+ * The POI data extractor is used to extract data from a POI.
+ * The POI is an item of the POI data array.
  * @typedef {{
  *   id: function(Object): string,
  *   dist: function(Object): number,
@@ -139,35 +148,35 @@ ngeox.profile.PoiExtractor;
 
 
 /**
- * Extract the id of a point.
+ * Extract the id of a POI.
  * @type {function(Object): string}
  */
 ngeox.profile.PoiExtractor.prototype.id;
 
 
 /**
- * Extract the distance from origin of a point.
+ * Extract the distance from origin of a POI.
  * @type {function(Object): number}
  */
 ngeox.profile.PoiExtractor.prototype.dist;
 
 
 /**
- * Extract the elevation of a point.
+ * Extract the elevation of a POI.
  * @type {function(Object, number=): number}
  */
 ngeox.profile.PoiExtractor.prototype.z;
 
 
 /**
- * Extract the sequence number of a point.
+ * Extract the sequence number of a POI.
  * @type {function(Object): number}
  */
 ngeox.profile.PoiExtractor.prototype.sort;
 
 
 /**
- * Extract the title of a point.
+ * Extract the title of a POI.
  * @type {function(Object): string}
  */
 ngeox.profile.PoiExtractor.prototype.title;

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -61,7 +61,8 @@ ngeox.profile;
 /**
  * Options for the profile.
  *  @typedef {{
- *    extractor: ngeox.profile.ProfileExtractor,
+ *    elevationExtractor: ngeox.profile.ElevationExtractor,
+ *    poiExtractor: ngeox.profile.PoiExtractor,
  *    light: (boolean|undefined),
  *    hoverCallback: (function(Object)|undefined),
  *    outCallback: (function()|undefined)
@@ -71,9 +72,15 @@ ngeox.profile.ProfileOptions;
 
 
 /**
- * @type {ngeox.profile.ProfileExtractor}
+ * @type {ngeox.profile.ElevationExtractor}
  */
-ngeox.profile.ProfileOptions.prototype.extractor;
+ngeox.profile.ProfileOptions.prototype.elevationExtractor;
+
+
+/**
+ * @type {ngeox.profile.PoiExtractor}
+ */
+ngeox.profile.ProfileOptions.prototype.poiExtractor;
 
 
 /**
@@ -95,25 +102,75 @@ ngeox.profile.ProfileOptions.prototype.outCallback;
 
 
 /**
- * Profile data extractor.
+ * Elevation data extractor.
  * @typedef {{
  *   z: function(Object): number,
  *   dist: function(Object): number
  * }}
  */
-ngeox.profile.ProfileExtractor;
+ngeox.profile.ElevationExtractor;
 
 
 /**
- * @type {function(Object, string=): number}
- */
-ngeox.profile.ProfileExtractor.prototype.z;
-
-
-/**
+ * Extract the elevation of a point.
  * @type {function(Object): number}
  */
-ngeox.profile.ProfileExtractor.prototype.dist;
+ngeox.profile.ElevationExtractor.prototype.z;
+
+
+/**
+ * Extract the distance from origin of a point.
+ * @type {function(Object): number}
+ */
+ngeox.profile.ElevationExtractor.prototype.dist;
+
+
+/**
+ * POI data extractor.
+ * @typedef {{
+ *   id: function(Object): string,
+ *   dist: function(Object): number,
+ *   z: function(Object, number=): number,
+ *   sort: function(Object): number,
+ *   title: function(Object): string
+ * }}
+ */
+ngeox.profile.PoiExtractor;
+
+
+/**
+ * Extract the id of a point.
+ * @type {function(Object): string}
+ */
+ngeox.profile.PoiExtractor.prototype.id;
+
+
+/**
+ * Extract the distance from origin of a point.
+ * @type {function(Object): number}
+ */
+ngeox.profile.PoiExtractor.prototype.dist;
+
+
+/**
+ * Extract the elevation of a point.
+ * @type {function(Object, number=): number}
+ */
+ngeox.profile.PoiExtractor.prototype.z;
+
+
+/**
+ * Extract the sequence number of a point.
+ * @type {function(Object): number}
+ */
+ngeox.profile.PoiExtractor.prototype.sort;
+
+
+/**
+ * Extract the title of a point.
+ * @type {function(Object): string}
+ */
+ngeox.profile.PoiExtractor.prototype.title;
 
 
 /**
@@ -126,3 +183,4 @@ ngeox.MeasureEvent = function() {};
  * @type {ol.Feature}
  */
 ngeox.MeasureEvent.prototype.feature;
+

--- a/src/d3-ext/profile.js
+++ b/src/d3-ext/profile.js
@@ -6,7 +6,7 @@
  *
  * var selection = d3.select('#element_id');
  * var profile = ngeo.profile({
- *  extractor: {
+ *  elevationExtractor: {
  *    z: function (item) {return item['values']['z'];)},
  *    dist: function (item) {return item['dist'];)}
  *  },
@@ -20,7 +20,9 @@
  *
  * The selection data must be an array.
  * The layout for the items of this array is unconstrained: the elevation
- * and distance values are extracted using the extractor config option.
+ * and distance values are extracted using the elevationExtractor config
+ * option. Optionally, POIs can be displayed and depend on a poiExtractor
+ * config option.
  *
  * The data below will work for the above example:
  * [

--- a/src/d3-ext/profile.js
+++ b/src/d3-ext/profile.js
@@ -43,12 +43,18 @@ goog.provide('ngeo.profile');
  *
  */
 ngeo.profile = function(options) {
+  /**
+   * @type {boolean}
+   * Whether the simplified profile should be shown.
+   */
+  var light = goog.isDef(options.light) ? options.light : false;
 
 
   /**
    * The values for margins around the chart defined in pixels.
    */
-  var margin = {top: 10, right: 10, bottom: 30, left: 40};
+  var margin = light ? {top: 0, right: 0, bottom: 0, left: 0} :
+      {top: 10, right: 10, bottom: 30, left: 40};
 
   /**
    * Method to get the coordinate in pixels from a distance.
@@ -80,12 +86,6 @@ ngeo.profile = function(options) {
    */
   var outCallback = goog.isDef(options.outCallback) ?
       options.outCallback : goog.nullFunction;
-
-  /**
-   * @type {boolean}
-   * Whether the simplified profile should be shown.
-   */
-  var light = goog.isDef(options.light) ? options.light : false;
 
   /**
    * The color to be used for filling the area.

--- a/src/directives/profile.js
+++ b/src/directives/profile.js
@@ -34,7 +34,7 @@ ngeo.profileDirective = function() {
           goog.asserts.assert(goog.isDef(optionsAttr));
 
           var selection = d3.select(element[0]);
-          var profile, options, data;
+          var profile, options, elevationData, poiData;
 
           scope.$watchCollection(optionsAttr, function(newVal) {
             options = newVal;
@@ -45,13 +45,19 @@ ngeo.profileDirective = function() {
           });
 
           scope.$watch(attrs['ngeoProfile'], function(newVal, oldVal) {
-            data = newVal;
+            elevationData = newVal;
+            refreshData();
+          });
+
+          scope.$watch(attrs['ngeoProfilePois'], function(newVal, oldVal) {
+            poiData = newVal;
             refreshData();
           });
 
           function refreshData() {
-            if (goog.isDef(profile) && goog.isDef(data)) {
-              selection.datum(data).call(profile);
+            if (goog.isDef(profile) && goog.isDef(elevationData)) {
+              selection.datum(elevationData).call(profile);
+              profile.showPois(poiData);
             }
           }
         }

--- a/src/directives/profile.js
+++ b/src/directives/profile.js
@@ -5,7 +5,7 @@
  * Example:
  *
  * <div ngeo-profile="ctrl.profileData"
- *      ngeo-profile-ooptions="ctrl.profileOptions"></div>
+ *      ngeo-profile-options="ctrl.profileOptions"></div>
  *
  * Note: "ctrl.profileOptions" is of type ngeox.profile.ProfileOptions.
  */
@@ -34,17 +34,26 @@ ngeo.profileDirective = function() {
           goog.asserts.assert(goog.isDef(optionsAttr));
 
           var selection = d3.select(element[0]);
+          var profile, options, data;
 
-          var options = /** @type {ngeox.profile.ProfileOptions} */
-              (scope.$eval(optionsAttr));
-          var profile = ngeo.profile(options);
-
-          scope.$watch(attrs['ngeoProfile'], function(newVal, oldVal) {
-            var data = newVal;
-            if (goog.isDef(data)) {
-              selection.datum(data).call(profile);
+          scope.$watchCollection(optionsAttr, function(newVal) {
+            options = newVal;
+            if (goog.isDef(options)) {
+              profile = ngeo.profile(options);
+              refreshData();
             }
           });
+
+          scope.$watch(attrs['ngeoProfile'], function(newVal, oldVal) {
+            data = newVal;
+            refreshData();
+          });
+
+          function refreshData() {
+            if (goog.isDef(profile) && goog.isDef(data)) {
+              selection.datum(data).call(profile);
+            }
+          }
         }
   };
 };

--- a/src/directives/profile.js
+++ b/src/directives/profile.js
@@ -5,9 +5,14 @@
  * Example:
  *
  * <div ngeo-profile="ctrl.profileData"
- *      ngeo-profile-options="ctrl.profileOptions"></div>
+ *      ngeo-profile-options="ctrl.profileOptions"
+ *      ngeo-profile-pois="ctrl.profilePois"
+ * ></div>
  *
- * Note: "ctrl.profileOptions" is of type ngeox.profile.ProfileOptions.
+ * Where "ctrl.profileOptions" is of type {@link ngeox.profile.ProfileOptions);
+ * "ctrl.profileData" and "ctrl.profilePois" are arrays which will be
+ * processed by {@link ngeox.profile.ElevationExtractor) and
+ * {@link ngeox.profile.PoiExtractor).
  */
 goog.provide('ngeo.profileDirective');
 


### PR DESCRIPTION
This PR allows displaying POIs along the elevation curve.

There is now two extractors: one for elevation, and one for the POIs.
The `showPois` method on the profile can be used to update the POIs, allowing modification of the POIs without redrawing the curves: this operation may be common when editing POIs.