### PR TITLE
Fix goog.provides in measure.js

### DIFF
--- a/src/ol-ext/interaction/measure.js
+++ b/src/ol-ext/interaction/measure.js
@@ -1,5 +1,5 @@
 goog.provide('ngeo.MeasureEvent');
-goog.provide('ngeo.interaction');
+goog.provide('ngeo.MeasureEventType');
 goog.provide('ngeo.interaction.Measure');
 
 goog.require('goog.dom');


### PR DESCRIPTION
This PR removes the `goog.provides('ngeo.interaction')` statement from `interaction/measure.js`. It also adds `goog.provides('ngeo.MeasureEventType')` to that file.