### PR TITLE
Add an ngeoSearch directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,10 @@ dist/ngeo.css: node_modules/openlayers/css/ol.css .build/node_modules.timestamp
 	mkdir -p $(dir $@)
 	cp $< $@
 
+.build/examples-hosted/typeahead.bundle.min.js: node_modules/typeahead.js/dist/typeahead.bundle.min.js
+	mkdir -p $(dir $@)
+	cp $< $@
+
 .build/examples-hosted/partials: examples/partials
 	mkdir -p $@
 	cp examples/partials/* $@
@@ -201,6 +205,7 @@ node_modules/angular/angular.min.js node_modules/angular-animate/angular-animate
 	    -e 's|\.\./node_modules/angular/angular.js|angular.min.js|' \
 	    -e 's|\.\./node_modules/angular-animate/angular-animate.js|angular-animate.min.js|' \
 	    -e 's|\.\./node_modules/d3/d3.js|d3.min.js|' \
+	    -e 's|\.\./node_modules/typeahead.js/dist/typeahead.bundle.js|typeahead.bundle.min.js|' \
 	    -e 's/\/@?main=$*.js/$*.js/' \
 	    -e '/$*.js/i\    <script src="ngeo.js"></script>' $< > $@
 
@@ -222,6 +227,7 @@ node_modules/angular/angular.min.js node_modules/angular-animate/angular-animate
 	    .build/examples-hosted/bootstrap.min.css \
 	    .build/examples-hosted/jquery.min.js \
 	    .build/examples-hosted/d3.min.js \
+	    .build/examples-hosted/typeahead.bundle.min.js \
 	    .build/examples-hosted/data \
 	    .build/examples-hosted/partials \
 	    .build/node_modules.timestamp

--- a/buildtools/example.json
+++ b/buildtools/example.json
@@ -23,7 +23,8 @@
       ".build/externs/angular-1.3-http-promise.js",
       ".build/externs/jquery-1.9.js",
       "externs/ngeox.js",
-      "externs/d3.js"
+      "externs/d3.js",
+      "externs/typeahead.js"
     ],
     "define": [
       "goog.dom.ASSUME_STANDARDS_MODE=true",

--- a/buildtools/examples-all.json
+++ b/buildtools/examples-all.json
@@ -22,7 +22,8 @@
       ".build/externs/angular-1.3-http-promise.js",
       ".build/externs/jquery-1.9.js",
       "externs/ngeox.js",
-      "externs/d3.js"
+      "externs/d3.js",
+      "externs/typeahead.js"
     ],
     "define": [
       "goog.dom.ASSUME_STANDARDS_MODE=true",

--- a/buildtools/ngeo.json
+++ b/buildtools/ngeo.json
@@ -25,7 +25,8 @@
       ".build/externs/angular-1.3-http-promise.js",
       ".build/externs/jquery-1.9.js",
       "externs/ngeox.js",
-      "externs/d3.js"
+      "externs/d3.js",
+      "externs/typeahead.js"
     ],
     "define": [
       "goog.DEBUG=false"

--- a/examples/search.html
+++ b/examples/search.html
@@ -1,0 +1,94 @@
+<!DOCTYPE>
+<html ng-app='app'>
+  <head>
+    <title>Search example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+    <style>
+      #map {
+        width: 600px;
+        height: 400px;
+      }
+      /* CSS stolen from https://github.com/bassjobsen/typeahead.js-bootstrap-css/ */
+      span.twitter-typeahead .tt-dropdown-menu {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        z-index: 1000;
+        display: none;
+        float: left;
+        min-width: 160px;
+        padding: 5px 0;
+        margin: 2px 0 0;
+        list-style: none;
+        font-size: 14px;
+        text-align: left;
+        background-color: #ffffff;
+        border: 1px solid #cccccc;
+        border: 1px solid rgba(0, 0, 0, 0.15);
+        border-radius: 4px;
+        -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+        box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+        background-clip: padding-box;
+      }
+      span.twitter-typeahead .tt-suggestion > p {
+        display: block;
+        padding: 3px 20px;
+        margin-bottom: 0px;
+        clear: both;
+        font-weight: normal;
+        line-height: 1.42857143;
+        color: #333333;
+        white-space: nowrap;
+      }
+      span.twitter-typeahead .tt-suggestion > p:hover,
+      span.twitter-typeahead .tt-suggestion > p:focus {
+        color: #ffffff;
+        text-decoration: none;
+        outline: 0;
+        background-color: #428bca;
+      }
+      span.twitter-typeahead .tt-suggestion.tt-cursor {
+        color: #ffffff;
+        background-color: #428bca;
+      }
+      span.twitter-typeahead .tt-suggestion button {
+        background: none;
+        border: 0;
+        float: right;
+      }
+      span.twitter-typeahead {
+        width: 100%;
+      }
+      .input-group span.twitter-typeahead {
+        display: block !important;
+      }
+      .input-group span.twitter-typeahead .tt-dropdown-menu {
+        top: 32px !important;
+      }
+      .input-group.input-group-lg span.twitter-typeahead .tt-dropdown-menu {
+        top: 44px !important;
+      }
+      .input-group.input-group-sm span.twitter-typeahead .tt-dropdown-menu {
+        top: 28px !important;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <div class="container-fluid">
+      <div id="map" ngeo-map="ctrl.map"></div>
+      <p>Search for « 45 did » for example…<p>
+      <app-search app-search-map="ctrl.map"></app-search>
+      <p id="desc">This example shows how to use the <code>ngeo-search</code> directive, which
+      is based on Twitter's <code>typeahead</code> component.</p>
+    </div>
+    <script src="../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/typeahead.js/dist/typeahead.bundle.js"></script>
+    <script src="/@?main=search.js"></script>
+  </body>
+</html>

--- a/examples/search.js
+++ b/examples/search.js
@@ -1,0 +1,194 @@
+goog.provide('search');
+
+goog.require('ngeo.CreateGeoJSONBloodhound');
+goog.require('ngeo.mapDirective');
+goog.require('ngeo.searchDirective');
+goog.require('ol.FeatureOverlay');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.proj');
+goog.require('ol.source.OSM');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['ngeo']);
+
+
+/**
+ * @return {angular.Directive} Directive Definition Object.
+ */
+app.searchDirective = function() {
+  return {
+    restrict: 'E',
+    scope: {
+      'map': '=appSearchMap'
+    },
+    controller: 'AppSearchController',
+    bindToController: true,
+    controllerAs: 'ctrl',
+    template:
+        '<input type="text" placeholder="search…" ' +
+        'ngeo-search="ctrl.options" ' +
+        'ngeo-search-datasets="ctrl.datasets" ' +
+        'ngeo-search-listeners="ctrl.listeners">',
+    link:
+        /**
+         * @param {angular.Scope} scope Scope.
+         * @param {angular.JQLite} element Element.
+         * @param {angular.Attributes} attrs Atttributes.
+         */
+        function(scope, element, attrs) {
+          // Empty the search field on focus and blur.
+          element.find('input').on('focus blur', function() {
+            $(this).val('');
+          });
+        }
+  };
+};
+
+
+app.module.directive('appSearch', app.searchDirective);
+
+
+
+/**
+ * @constructor
+ * @param {angular.Scope} $rootScope Angular root scope.
+ * @param {angular.$compile} $compile Angular compile service.
+ * @param {ngeo.CreateGeoJSONBloodhound} ngeoCreateGeoJSONBloodhound The ngeo
+ *     create GeoJSON Bloodhound service.
+ * @ngInject
+ */
+app.SearchController = function($rootScope, $compile,
+    ngeoCreateGeoJSONBloodhound) {
+
+  /**
+   * @type {ol.FeatureOverlay}
+   * @private
+   */
+  this.featureOverlay_ = this.createFeatureOverlay_();
+
+  /** @type {Bloodhound} */
+  var bloodhoundEngine = this.createAndInitBloodhound_(
+      ngeoCreateGeoJSONBloodhound);
+
+  /** @type {TypeaheadOptions} */
+  this['options'] = {
+    highlight: true
+  };
+
+  /** @type {Array.<TypeaheadDataset>} */
+  this['datasets'] = [{
+    source: bloodhoundEngine.ttAdapter(),
+    displayKey: function(suggestion) {
+      var feature = /** @type {ol.Feature} */ (suggestion);
+      return feature.get('label');
+    },
+    templates: {
+      header: function() {
+        return '<div class="header">Addresses</div>';
+      },
+      suggestion: function(suggestion) {
+        var feature = /** @type {ol.Feature} */ (suggestion);
+
+        // A scope for the ng-click on the suggestion's « i » button.
+        var scope = $rootScope.$new(true);
+        scope['feature'] = feature;
+        scope['click'] = function(event) {
+          window.alert(feature.get('label'));
+          event.stopPropagation();
+        };
+
+        var html = '<p>' + feature.get('label') +
+            '<button ng-click="click($event)">i</button></p>';
+        return $compile(html)(scope);
+      }
+    }
+  }];
+
+  this['listeners'] = /** @type {ngeox.SearchDirectiveListeners} */ ({
+    selected: angular.bind(this, app.SearchController.selected_)
+  });
+
+};
+
+
+/**
+ * @return {ol.FeatureOverlay} The feature overlay.
+ * @private
+ */
+app.SearchController.prototype.createFeatureOverlay_ = function() {
+  var featureOverlay = new ol.FeatureOverlay();
+  featureOverlay.setMap(this['map']);
+  return featureOverlay;
+};
+
+
+/**
+ * @param {ngeo.CreateGeoJSONBloodhound} ngeoCreateGeoJSONBloodhound The ngeo
+ *     create GeoJSON Bloodhound service.
+ * @return {Bloodhound} The bloodhound engine.
+ * @private
+ */
+app.SearchController.prototype.createAndInitBloodhound_ =
+    function(ngeoCreateGeoJSONBloodhound) {
+  var url = 'http://devv3.geoportail.lu/main/wsgi/fulltextsearch?query=%QUERY';
+  var bloodhound = ngeoCreateGeoJSONBloodhound(url, ol.proj.get('EPSG:3857'));
+  bloodhound.initialize();
+  return bloodhound;
+};
+
+
+/**
+ * @param {jQuery.event} event Event.
+ * @param {Object} suggestion Suggestion.
+ * @param {TypeaheadDataset} dataset Dataset.
+ * @this {app.SearchController}
+ * @private
+ */
+app.SearchController.selected_ = function(event, suggestion, dataset) {
+  var map = /** @type {ol.Map} */ (this['map']);
+  var feature = /** @type {ol.Feature} */ (suggestion);
+  var features = this.featureOverlay_.getFeatures();
+  var featureGeometry = /** @type {ol.geom.SimpleGeometry} */
+      (feature.getGeometry());
+  var mapSize = /** @type {ol.Size} */ (map.getSize());
+  features.clear();
+  features.push(feature);
+  map.getView().fitGeometry(featureGeometry, mapSize,
+      /** @type {olx.view.FitGeometryOptions} */ ({maxZoom: 16}));
+};
+
+
+app.module.controller('AppSearchController', app.SearchController);
+
+
+
+/**
+ * @constructor
+ */
+app.MainController = function() {
+  /**
+   * @type {ol.Map}
+   */
+  this['map'] = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      })
+    ],
+    view: new ol.View({
+      center: [0, 0],
+      zoom: 4
+    })
+  });
+
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -193,3 +193,47 @@ ngeox.MeasureEvent = function() {};
  */
 ngeox.MeasureEvent.prototype.feature;
 
+
+/**
+ * @typedef {{
+ *   opened: (function()|undefined),
+ *   closed: (function()|undefined),
+ *   cursorchanged: (function(jQuery.event, Object,
+ *       TypeaheadDataset)|undefined),
+ *   selected: (function(jQuery.event, Object,
+ *       TypeaheadDataset)|undefined),
+ *   autocompleted: (function(jQuery.event, Object,
+ *       TypeaheadDataset)|undefined)
+ * }}
+ */
+ngeox.SearchDirectiveListeners;
+
+
+/**
+ * @type {function()|undefined}
+ */
+ngeox.SearchDirectiveListeners.prototype.opened;
+
+
+/**
+ * @type {function()|undefined}
+ */
+ngeox.SearchDirectiveListeners.prototype.closed;
+
+
+/**
+ * @type {function(jQuery.event, Object, TypeaheadDataset)|undefined}
+ */
+ngeox.SearchDirectiveListeners.prototype.cursorchanged;
+
+
+/**
+ * @type {function(jQuery.event, Object, TypeaheadDataset)|undefined}
+ */
+ngeox.SearchDirectiveListeners.prototype.selected;
+
+
+/**
+ * @type {function(jQuery.event, Object, TypeaheadDataset)|undefined}
+ */
+ngeox.SearchDirectiveListeners.prototype.autocompleted;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "openlayers": "openlayers/ol3#master",
     "phantomjs": "~1.9.7-5",
     "temp": "~0.7.0",
+    "typeahead.js": "~0.10.5",
     "walk": "~2.3.3"
   }
 }

--- a/src/directives/search.js
+++ b/src/directives/search.js
@@ -1,0 +1,145 @@
+/**
+ * @fileoverview Provides the "ngeoSearch" directive, which uses Twitter's
+ * typeahead component to change an input text into a search field.
+ *
+ * Example:
+ *
+ * <input type="text"
+ *   ngeo-search="ctrl.typeaheadOptions"
+ *   ngeo-search-datasets="ctrl.typeaheadDatasets"
+ *   ngeo-search-listeners="crtl.typeaheadListeners">
+ */
+goog.provide('ngeo.searchDirective');
+
+goog.require('goog.asserts');
+goog.require('ngeo');
+
+
+/**
+ * @return {angular.Directive} Directive Definition Object.
+ * @ngInject
+ */
+ngeo.searchDirective = function() {
+  return {
+    restrict: 'A',
+    link:
+        /**
+         * @param {angular.Scope} scope Scope.
+         * @param {angular.JQLite} element Element.
+         * @param {angular.Attributes} attrs Attributes.
+         */
+        function(scope, element, attrs) {
+
+          var typeaheadOptionsExpr = attrs['ngeoSearch'];
+          var typeaheadOptions = /** @type {TypeaheadOptions} */
+              (scope.$eval(typeaheadOptionsExpr));
+
+          var typeaheadDatasetsExpr = attrs['ngeoSearchDatasets'];
+          var typeaheadDatasets = /** @type {Array.<TypeaheadDataset>} */
+              (scope.$eval(typeaheadDatasetsExpr));
+
+          var args = typeaheadDatasets.slice();
+          args.unshift(typeaheadOptions);
+
+          element.typeahead.apply(element, args);
+
+          var typeaheadListenersExpr = attrs['ngeoSearchListeners'];
+          var typeaheadListeners_ =
+              /** @type {ngeox.SearchDirectiveListeners} */
+              (scope.$eval(typeaheadListenersExpr));
+
+          /**
+           * @type {ngeox.SearchDirectiveListeners}
+           */
+          var typeaheadListeners = ngeo.searchDirective.adaptListeners_(
+              typeaheadListeners_);
+
+          element.on('typeahead:opened', function() {
+            scope.$apply(function() {
+              typeaheadListeners.opened();
+            });
+          });
+
+          element.on('typeahead:closed', function() {
+            scope.$apply(function() {
+              typeaheadListeners.closed();
+            });
+          });
+
+          element.on('typeahead:cursorchanged',
+              /**
+               * @param {jQuery.event} event Event.
+               * @param {Object} suggestion Suggestion.
+               * @param {TypeaheadDataset} dataset Dataset.
+               */
+              function(event, suggestion, dataset) {
+                scope.$apply(function() {
+                  typeaheadListeners.cursorchanged(event, suggestion, dataset);
+                });
+              });
+
+          element.on('typeahead:selected',
+              /**
+               * @param {jQuery.event} event Event.
+               * @param {Object} suggestion Suggestion.
+               * @param {TypeaheadDataset} dataset Dataset.
+               */
+              function(event, suggestion, dataset) {
+                scope.$apply(function() {
+                  typeaheadListeners.selected(event, suggestion, dataset);
+                });
+              });
+
+          element.on('typeahead:autocompleted',
+              /**
+               * @param {jQuery.event} event Event.
+               * @param {Object} suggestion Suggestion.
+               * @param {TypeaheadDataset} dataset Dataset.
+               */
+              function(event, suggestion, dataset) {
+                scope.$apply(function() {
+                  typeaheadListeners.autocompleted(event, suggestion, dataset);
+                });
+              });
+        }
+  };
+};
+
+
+/**
+ * Create a real ngeox.SearchDirectiveListeners object out of the object
+ * returned by $eval.
+ * @param {ngeox.SearchDirectiveListeners} object Object.
+ * @return {ngeox.SearchDirectiveListeners} The listeners object.
+ * @private
+ */
+ngeo.searchDirective.adaptListeners_ = function(object) {
+  /** @type {ngeox.SearchDirectiveListeners} */
+  var typeaheadListeners;
+  if (!goog.isDef(object)) {
+    typeaheadListeners = {
+      opened: goog.nullFunction,
+      closed: goog.nullFunction,
+      cursorchanged: goog.nullFunction,
+      selected: goog.nullFunction,
+      autocompleted: goog.nullFunction
+    };
+  } else {
+    typeaheadListeners = {
+      opened: goog.isDef(object.opened) ?
+          object.opened : goog.nullFunction,
+      closed: goog.isDef(object.closed) ?
+          object.closed : goog.nullFunction,
+      cursorchanged: goog.isDef(object.cursorchanged) ?
+          object.cursorchanged : goog.nullFunction,
+      selected: goog.isDef(object.selected) ?
+          object.selected : goog.nullFunction,
+      autocompleted: goog.isDef(object.autocompleted) ?
+          object.autocompleted : goog.nullFunction
+    };
+  }
+  return typeaheadListeners;
+};
+
+
+ngeoModule.directive('ngeoSearch', ngeo.searchDirective);

--- a/src/services/creategeojsonbloodhound.js
+++ b/src/services/creategeojsonbloodhound.js
@@ -1,0 +1,80 @@
+/**
+ * @fileoverview Provides a function that creates a Bloodhound engine
+ * expecting GeoJSON responses from the search web service, and creating
+ * `ol.Feature` objects as suggestions.
+ *
+ * Example #1:
+ *
+ * var bloodhound = ngeoCreateGeoJSONBloodhound(
+ *   'http://example.com/fulltextsearch?query=%QUERY',
+ *   ol.proj.get('EPSG:3857'));
+ * bloodhound.initialize();
+ *
+ * Example #2:
+ *
+ * var bloodhound = ngeoCreateGeoJSONBloodhound({
+ *   remote: {
+ *     limit: 10,
+ *     url: mySearchEngineUrl,
+ *     replace: function(url, query) {
+ *       return url +
+ *           '?qtext=' + encodeURIComponent(query) +
+ *           '&lang=' + gettextCatalog.currentLanguage;
+ *     }
+ *   }
+ * }, ol.proj.get('EPSG:3857'), ol.proj.get('EPSG:21781'));
+ * bloodhound.initialize
+ */
+
+goog.provide('ngeo.CreateGeoJSONBloodhound');
+
+goog.require('ngeo');
+goog.require('ol.format.GeoJSON');
+
+
+/**
+ * @typedef {function(string, ol.proj.Projection=,
+ *     ol.proj.Projection=):Bloodhound}
+ */
+ngeo.CreateGeoJSONBloodhound;
+
+
+/**
+ * @param {BloodhoundOptions|string} options Bloodhound options or a URL to the
+ *     search service. If a URL is provided then default Bloodhound options are
+ *     used.
+ * @param {ol.proj.Projection=} opt_featureProjection Feature projection.
+ * @param {ol.proj.Projection=} opt_dataProjection Data projection.
+ * @return {Bloodhound} The Bloodhound object.
+ */
+ngeo.createGeoJSONBloodhound = function(options, opt_featureProjection,
+    opt_dataProjection) {
+  var geojsonFormat = new ol.format.GeoJSON();
+  var bloodhoundOptions = /** @type {BloodhoundOptions} */ ({
+    remote: {
+      url: goog.isString(options) ? options : '',
+      ajax: {
+        dataType: 'jsonp'
+      },
+      filter: function(parsedResponse) {
+        var featureCollection = /** @type {GeoJSONFeatureCollection} */
+            (parsedResponse);
+        return geojsonFormat.readFeatures(featureCollection, {
+          featureProjection: opt_featureProjection,
+          dataProjection: opt_dataProjection
+        });
+      }
+    },
+    // datumTokenizer is required by the Bloodhound constructor but it
+    // is not used when only a remote is passsed to Bloodhound.
+    datumTokenizer: goog.nullFunction,
+    queryTokenizer: Bloodhound.tokenizers.whitespace
+  });
+  if (!goog.isString(options)) {
+    goog.object.extend(bloodhoundOptions, options);
+  }
+  return new Bloodhound(bloodhoundOptions);
+};
+
+
+ngeoModule.value('ngeoCreateGeoJSONBloodhound', ngeo.createGeoJSONBloodhound);


### PR DESCRIPTION
This PR adds an `ngeoSearch` directive, an `ngeoCreateGeoJSONBloodhound` service, and a `search` example.

The `ngeoSearch` directive is very generic/low-level. It just provides a directive for decorating an element with `typeahead`.

The `ngeoCreateGeoJSONBloodhound` service is a function returning a Bloodhound engine that expects GeoJSON responses from the remote service, and create `ol.Feature` objects as the suggestions.

The `search` example shows how to use the `ngeoSearch` directive and the `ngeoCreateGeoJSONBloodhound` service.

Please review.