### PR TITLE
Profile y lower bound

### DIFF
--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -68,6 +68,7 @@ ngeox.profile;
  *    poiExtractor: (ngeox.profile.PoiExtractor|undefined),
  *    light: (boolean|undefined),
  *    lightXAxis: (boolean|undefined),
+ *    yLowerBound: (number|undefined),
  *    ratioXYRule: (function(number): number|undefined),
  *    hoverCallback: (function(Object)|undefined),
  *    outCallback: (function()|undefined)
@@ -123,6 +124,13 @@ ngeox.profile.ProfileOptions.prototype.light;
  * @type {boolean|undefined}
  */
 ngeox.profile.ProfileOptions.prototype.lightXAxis;
+
+
+/**
+ * Lower bound for the y domain.
+ * @type {number|undefined}
+ */
+ngeox.profile.ProfileOptions.prototype.yLowerBound;
 
 
 /**

--- a/src/d3-ext/profile.js
+++ b/src/d3-ext/profile.js
@@ -124,6 +124,11 @@ ngeo.profile = function(options) {
    */
   var lightXAxis = goog.isDef(options.lightXAxis) ? options.lightXAxis : false;
 
+  /**
+   * @type {number|undefined}
+   */
+  var yLowerBound = options.yLowerBound;
+
 
   // Objects shared with the showPois function
   /**
@@ -268,6 +273,12 @@ ngeo.profile = function(options) {
           var yTarget2 = ratioXY * xResolution * height / 2;
           y.domain([yMean - yTarget2, yMean + yTarget2]);
         }
+      }
+
+      // Lower bound for y-axis
+      if (goog.isDef(yLowerBound) && y.domain()[0] < yLowerBound) {
+        var shift = yLowerBound - y.domain()[0];
+        y.domain([yLowerBound, y.domain()[1] - shift]);
       }
 
       // Update the area path.

--- a/src/d3-ext/profile.js
+++ b/src/d3-ext/profile.js
@@ -325,7 +325,7 @@ ngeo.profile = function(options) {
 
       g.select('.grid-y')
           .transition()
-          .call(yAxis.tickSize(-width, 0, 0).tickFormat(''))
+          .call(yAxis.tickSize(-width, 0).tickFormat(''))
           .selectAll('.tick line')
           .style('stroke', '#ccc')
           .style('opacity', 0.7);


### PR DESCRIPTION
For example, prevent displaying negative values with `yLowerBound = 0`.