### PR TITLE
Avoid overlapping y ticks in profile

### DIFF
--- a/src/d3-ext/profile.js
+++ b/src/d3-ext/profile.js
@@ -318,6 +318,11 @@ ngeo.profile = function(options) {
           .style('fill', 'grey')
           .style('shape-rendering', 'crispEdges');
 
+        // Avoid too much lines with overlapping labels in small profiles
+        if (height / 15 < 10) {
+          yAxis.ticks(height / 15);
+        }
+
         g.select('.y.axis')
           .transition()
           .call(yAxis);


### PR DESCRIPTION
The value '15' is empirical and roughly represent the height in pixels
between two ticks. '10' is the  default number of ticks of d3.