### PR TITLE
Drag drop

### DIFF
--- a/examples/layerorder.html
+++ b/examples/layerorder.html
@@ -15,13 +15,15 @@
         }
 
         ul {
-          width: 250px;
+          padding: 0;
         }
         li {
+          list-style: none;
           margin: 5px;
           background-color: white;
           border: 1px solid;
           padding: 5px;
+          width: 250px;
         }
         li:hover .sortable-handle {
           opacity: 1;
@@ -33,6 +35,10 @@
           cursor: -webkit-grab;
           cursor: grab;
         }
+        .sortable-dragger {
+          -webkit-box-shadow: 0px 2px 6px -1px rgba(0, 0, 0, 0.5);
+          box-shadow: 0px 2px 6px -1px rgba(0, 0, 0, 0.5);
+        }
     </style>
   </head>
   <body ng-controller="MainController as ctrl">
@@ -43,7 +49,7 @@
       <br>
       Hint: drag-drop elements using the handle.
     </p>
-    <ul ngeo-sortable="ctrl.selectedLayers" ngeo-sortable-options="{handleClassName: 'sortable-handle'}">
+    <ul ngeo-sortable="ctrl.selectedLayers" ngeo-sortable-options="{handleClassName: 'sortable-handle', draggerClassName: 'sortable-dragger'}">
       <li ng-repeat="layer in ctrl.selectedLayers">
         <span class="sortable-handle fa fa-reorder"></span>{{layer.get('name')}}
       </li>

--- a/src/directives/sortable.js
+++ b/src/directives/sortable.js
@@ -89,7 +89,7 @@ ngeo.sortableDirective = function($timeout) {
             }
 
             if (!goog.isNull(dragListGroup)) {
-              goog.events.removeAll(dragListGroup);
+              dragListGroup.dispose();
             }
 
             dragListGroup = new goog.fx.DragListGroup();

--- a/src/directives/sortable.js
+++ b/src/directives/sortable.js
@@ -37,7 +37,10 @@ goog.require('ngeo');
 
 
 /**
- * @typedef {{handleClassName: (string|undefined)}}
+ * @typedef {{
+ *     handleClassName: (string|undefined),
+ *     draggerClassName: (string|undefined)
+ * }}
  */
 ngeo.SortableOptions;
 
@@ -101,6 +104,10 @@ ngeo.sortableDirective = function($timeout) {
                   var className = options['handleClassName'];
                   return goog.dom.getElementByClass(className, dragItem);
                 });
+
+            if (goog.isDef(options['draggerClassName'])) {
+              dragListGroup.setDraggerElClass(options['draggerClassName']);
+            }
 
             /** @type {number} */
             var hoverNextItemIdx = -1;


### PR DESCRIPTION
With this pull request I let developer style the dragged element.

Also I'm using DragListGroup::dispose to remove any listener on the drag list group. Without doing that the number of listeners was growing each time the sortable was reset. This can easily seen by checking the dom inspector and looking for the clone(s) of the currently dragged item.
https://github.com/camptocamp/ngeo/commit/ae0e60074983010ac70d89863b71b87a5652b272

Please review.