### PR TITLE
Make sortable directive use getOptions

### DIFF
--- a/src/directives/sortable.js
+++ b/src/directives/sortable.js
@@ -65,7 +65,8 @@ ngeo.sortableDirective = function($timeout) {
               (scope.$eval(attrs['ngeoSortable']));
           goog.asserts.assert(goog.isArray(sortable));
 
-          var options = scope.$eval(attrs['ngeoSortableOptions']);
+          var optionsObject = scope.$eval(attrs['ngeoSortableOptions']);
+          var options = getOptions(optionsObject);
 
           /**
            * @type {goog.fx.DragListGroup}


### PR DESCRIPTION
Make the `sortable` directive use the `getOptions` function. Calling that function is necessary to get the default handle class name when it's not specified by the user.