### PR TITLE
Fix scale order in scale selector

### DIFF
--- a/src/directives/partials/scaleselector.html
+++ b/src/directives/partials/scaleselector.html
@@ -3,8 +3,10 @@
     <span ng-bind-html="scaleselectorCtrl.currentScale"></span>&nbsp;<span class="caret"></span>
   </button>
   <ul class="dropdown-menu" role="menu">
-    <li ng-repeat="(zoom, scale) in ::scaleselectorCtrl.scales">
-      <a href ng-click="scaleselectorCtrl.changeZoom(zoom)" ng-bind-html="::scale"></a>
+    <li ng-repeat="zoomLevel in ::scaleselectorCtrl.zoomLevels">
+      <a href ng-click="scaleselectorCtrl.changeZoom(zoomLevel)"
+         ng-bind-html="scaleselectorCtrl.getScale(zoomLevel)">
+      </a>
     </li>
   </ul>
 </div>

--- a/src/directives/scaleselector.js
+++ b/src/directives/scaleselector.js
@@ -104,6 +104,14 @@ ngeo.ScaleselectorController = function($scope, $element, $attrs, $timeout) {
       ($scope.$eval(scalesExpr));
   goog.asserts.assert(goog.isDef(this['scales']));
 
+  var zoomLevels = goog.array.map(goog.object.getKeys(this['scales']), Number);
+  goog.array.sort(zoomLevels);
+
+  /**
+   * @type {Array.<number>}
+   */
+  this['zoomLevels'] = zoomLevels;
+
   var mapExpr = $attrs['ngeoScaleselectorMap'];
 
   /**
@@ -148,7 +156,7 @@ ngeo.ScaleselectorController = function($scope, $element, $attrs, $timeout) {
   if (!goog.isNull(view)) {
     var currentZoom = this.map_.getView().getZoom();
     if (goog.isDef(currentZoom)) {
-      this['currentScale'] = this['scales'][currentZoom.toString()];
+      this['currentScale'] = this.getScale(currentZoom);
     }
   }
 
@@ -182,7 +190,17 @@ ngeo.ScaleselectorController.getOptions_ = function(options) {
 
 
 /**
- * @param {string} zoom Zoom level.
+ * @param {number} zoom Zoom level.
+ * @return {string} Scale.
+ * @export
+ */
+ngeo.ScaleselectorController.prototype.getScale = function(zoom) {
+  return this['scales'][zoom.toString()];
+};
+
+
+/**
+ * @param {number} zoom Zoom level.
  * @export
  */
 ngeo.ScaleselectorController.prototype.changeZoom = function(zoom) {
@@ -191,7 +209,7 @@ ngeo.ScaleselectorController.prototype.changeZoom = function(zoom) {
   // and make sure that setZoom is called outside Angular context.
   var view = this.map_.getView();
   this.$timeout_(function() {
-    view.setZoom(+zoom);
+    view.setZoom(zoom);
   }, 0, false);
 };
 


### PR DESCRIPTION
With this commit scales are ordered by their zoom levels in the scale dropdown.