### PR TITLE
Add ngeo.Location#getParamKeys

### DIFF
--- a/exports/services/location.js
+++ b/exports/services/location.js
@@ -10,6 +10,10 @@ goog.exportProperty(
     ngeo.Location.prototype.getParam);
 goog.exportProperty(
     ngeo.Location.prototype,
+    'getParamKeys',
+    ngeo.Location.prototype.getParamKeys);
+goog.exportProperty(
+    ngeo.Location.prototype,
     'getPath',
     ngeo.Location.prototype.getPath);
 goog.exportProperty(

--- a/exports/services/location.js
+++ b/exports/services/location.js
@@ -10,6 +10,10 @@ goog.exportProperty(
     ngeo.Location.prototype.getParam);
 goog.exportProperty(
     ngeo.Location.prototype,
+    'getPath',
+    ngeo.Location.prototype.getPath);
+goog.exportProperty(
+    ngeo.Location.prototype,
     'hasParam',
     ngeo.Location.prototype.hasParam);
 goog.exportProperty(
@@ -24,3 +28,7 @@ goog.exportProperty(
     ngeo.Location.prototype,
     'refresh',
     ngeo.Location.prototype.refresh);
+goog.exportProperty(
+    ngeo.Location.prototype,
+    'setPath',
+    ngeo.Location.prototype.setPath);

--- a/exports/services/location.js
+++ b/exports/services/location.js
@@ -10,6 +10,10 @@ goog.exportProperty(
     ngeo.Location.prototype.getParam);
 goog.exportProperty(
     ngeo.Location.prototype,
+    'hasParam',
+    ngeo.Location.prototype.hasParam);
+goog.exportProperty(
+    ngeo.Location.prototype,
     'updateParams',
     ngeo.Location.prototype.updateParams);
 goog.exportProperty(

--- a/src/services/location.js
+++ b/src/services/location.js
@@ -96,6 +96,14 @@ ngeo.Location.prototype.getParam = function(key) {
 
 
 /**
+ * @return {Array.<string>} Param keys.
+ */
+ngeo.Location.prototype.getParamKeys = function() {
+  return this.uri_.getQueryData().getKeys();
+};
+
+
+/**
  * @param {Object.<string, string>} params
  */
 ngeo.Location.prototype.updateParams = function(params) {

--- a/test/spec/services/location.spec.js
+++ b/test/spec/services/location.spec.js
@@ -45,6 +45,13 @@ describe('ngeo.Location', function() {
     });
   });
 
+  describe('#getParamKeys', function() {
+    it('returns the param keys', function() {
+      var keys = ngeoLocation.getParamKeys();
+      expect(keys).toEqual(['some']);
+    });
+  });
+
   describe('#deleteParam', function() {
     it('delete the params', function() {
       ngeoLocation.deleteParam('some');


### PR DESCRIPTION
This PR adds the `ngeo.Location#getParamKeys` method. It also adds exports for the `hasParam`, `getPath` and `setPath` methods that were recently added.