### PR TITLE
Formatter can be configured partially

### DIFF
--- a/src/d3-ext/profile.js
+++ b/src/d3-ext/profile.js
@@ -36,6 +36,8 @@
  */
 goog.provide('ngeo.profile');
 
+goog.require('goog.object');
+
 
 /**
  *
@@ -109,15 +111,30 @@ ngeo.profile = function(options) {
   /**
    * @type {ngeox.profile.ProfileFormatter}
    */
-  var formatter = goog.isDef(options.formatter) ?
-      options.formatter : {
-        xhover: function(dist, units) {
-          return parseFloat(dist.toPrecision(3)) + ' ' + units;
-        },
-        yhover: function(ele, units) { return Math.round(ele) + ' m'; },
-        xtick: function(dist, units) { return dist; },
-        ytick: function(ele, units) { return ele; }
-      };
+  var formatter = {
+    /**
+     * @return {string}
+     */
+    xhover: function(dist, units) {
+      return parseFloat(dist.toPrecision(3)) + ' ' + units;
+    },
+    /**
+     * @return {string}
+     */
+    yhover: function(ele, units) { return Math.round(ele) + ' m'; },
+    /**
+     * @return {string|number}
+     */
+    xtick: function(dist, units) { return dist; },
+    /**
+     * @return {string|number}
+     */
+    ytick: function(ele, units) { return ele; }
+  };
+
+  if (goog.isDef(options.formatter)) {
+    goog.object.extend(formatter, options.formatter);
+  }
 
   /**
    * @type {boolean}


### PR DESCRIPTION
I'm using `goog.object.extend` so that the user can configure only part of the `formatter`.
Please review.