### PR TITLE
Fix compile errors

### DIFF
--- a/buildtools/example.json
+++ b/buildtools/example.json
@@ -22,7 +22,6 @@
       ".build/externs/angular-1.3-q.js",
       ".build/externs/angular-1.3-http-promise.js",
       ".build/externs/jquery-1.9.js",
-      "externs/ngeox.js",
       "externs/d3.js",
       "externs/typeahead.js"
     ],
@@ -33,7 +32,8 @@
     "js": [
       "examples/{{example}}.js",
       "node_modules/openlayers/externs/olx.js",
-      "node_modules/openlayers/externs/oli.js"
+      "node_modules/openlayers/externs/oli.js",
+      "externs/ngeox.js"
     ],
     "jscomp_error": [
       "accessControls",

--- a/buildtools/example.json
+++ b/buildtools/example.json
@@ -58,7 +58,6 @@
       "missingGetCssName",
       "missingProperties",
       "missingProvide",
-      "missingRequire",
       "missingReturn",
       "newCheckTypes",
       "nonStandardJsDocs",
@@ -71,6 +70,7 @@
       "visibility"
     ],
     "jscomp_off": [
+      "missingRequire",
       "unknownDefines"
     ],
     "extra_annotation_name": [

--- a/buildtools/example.json
+++ b/buildtools/example.json
@@ -67,9 +67,11 @@
       "typeInvalidation",
       "undefinedNames",
       "undefinedVars",
-      "unknownDefines",
       "uselessCode",
       "visibility"
+    ],
+    "jscomp_off": [
+      "unknownDefines"
     ],
     "extra_annotation_name": [
       "api", "observable"

--- a/buildtools/examples-all.json
+++ b/buildtools/examples-all.json
@@ -21,7 +21,6 @@
       ".build/externs/angular-1.3-q.js",
       ".build/externs/angular-1.3-http-promise.js",
       ".build/externs/jquery-1.9.js",
-      "externs/ngeox.js",
       "externs/d3.js",
       "externs/typeahead.js"
     ],
@@ -31,6 +30,7 @@
     ],
     "js": [
       ".build/examples/all.js",
+      "externs/ngeox.js",
       "node_modules/openlayers/externs/olx.js",
       "node_modules/openlayers/externs/oli.js"
     ],

--- a/buildtools/examples-all.json
+++ b/buildtools/examples-all.json
@@ -57,7 +57,6 @@
       "missingGetCssName",
       "missingProperties",
       "missingProvide",
-      "missingRequire",
       "missingReturn",
       "newCheckTypes",
       "nonStandardJsDocs",
@@ -69,6 +68,9 @@
       "unknownDefines",
       "uselessCode",
       "visibility"
+    ],
+    "jscomp_off": [
+      "missingRequire"
     ],
     "extra_annotation_name": [
       "api", "observable"

--- a/examples/interactionbtngroup.js
+++ b/examples/interactionbtngroup.js
@@ -6,9 +6,16 @@ goog.require('ngeo.mapDirective');
 goog.require('ol.FeatureOverlay');
 goog.require('ol.Map');
 goog.require('ol.View');
+goog.require('ol.geom.Point');
 goog.require('ol.interaction.Draw');
 goog.require('ol.layer.Tile');
+goog.require('ol.layer.Vector');
 goog.require('ol.source.MapQuest');
+goog.require('ol.source.Vector');
+goog.require('ol.style.Circle');
+goog.require('ol.style.Fill');
+goog.require('ol.style.Stroke');
+goog.require('ol.style.Style');
 
 
 /** @const **/

--- a/examples/profile.js
+++ b/examples/profile.js
@@ -42,16 +42,18 @@ app.MainController = function($http, $scope) {
    * @return {function(Object): T}
    */
   var typedFunctionsFactory = function(type, key, opt_childKey) {
-    /**
-      * @param {Object} item
-      * @return {T}
-      */
-    return function(item) {
-      if (opt_childKey !== undefined) {
-        item = item[opt_childKey];
-      }
-      return item[key];
-    };
+    return (
+        /**
+         * @param {Object} item
+         * @return {T}
+         * @template T
+         */
+        function(item) {
+          if (opt_childKey !== undefined) {
+            item = item[opt_childKey];
+          }
+          return item[key];
+        });
   };
 
   var types = {

--- a/examples/profile.js
+++ b/examples/profile.js
@@ -1,4 +1,4 @@
-goog.provide('profile_example');
+goog.provide('profile');
 
 
 goog.require('ngeo');

--- a/src/ol-ext/interaction/measure.js
+++ b/src/ol-ext/interaction/measure.js
@@ -13,6 +13,8 @@ goog.require('ol.MapBrowserEvent');
 goog.require('ol.Observable');
 goog.require('ol.Overlay');
 goog.require('ol.interaction.Interaction');
+goog.require('ol.style.Fill');
+goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 
 

--- a/src/ol-ext/interaction/measureazimut.js
+++ b/src/ol-ext/interaction/measureazimut.js
@@ -7,6 +7,7 @@ goog.require('goog.events.Event');
 goog.require('ngeo.interaction.Measure');
 goog.require('ol.Collection');
 goog.require('ol.Coordinate');
+goog.require('ol.DrawEvent');
 goog.require('ol.Feature');
 goog.require('ol.FeatureOverlay');
 goog.require('ol.Map');


### PR DESCRIPTION
This PR fixes compile errors that we get because we now [use](https://github.com/openlayers/closure-util/pull/51) a more recent version of the compiler.

The new compiler is much more strict with respect to the presence/absence of `goog.provide` and `goog.require`.

And, unfortunately, I had to move `missingRequire` from `jscomp_error` to `jscomp_off` for the compilation of the examples. Otherwise we get compilation errors when `ngeox.js` is used as a source file rather than an externs file, which is what to do when compiling the application code. Indeed, `ngeox.js` cannot include `goog.provide`'s because it is used as an externs file for `ngeo.js`.

Please review.