### PR TITLE
Use $applyAsync in scale selector directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ check-examples: $(BUILD_EXAMPLES_CHECK_TIMESTAMP_FILES)
 lint: .build/python-venv/bin/gjslint .build/node_modules.timestamp .build/gjslint.timestamp .build/jshint.timestamp
 
 .PHONY: test
-test: .build/ol-deps.js .build/ngeo-deps.js .build/node_modules.timestamp
+test: .build/ol-deps.js .build/ngeo-deps.js .build/templatecache.js .build/node_modules.timestamp
 	./node_modules/karma/bin/karma start karma-conf.js --single-run
 
 .PHONY: serve

--- a/karma-conf.js
+++ b/karma-conf.js
@@ -51,7 +51,8 @@ module.exports = function(config) {
         included: false,
         watched: true,
         served: true
-       }
+      },
+      '.build/templatecache.js'
     ],
 
 

--- a/test/spec/directives/scaleselector.spec.js
+++ b/test/spec/directives/scaleselector.spec.js
@@ -1,0 +1,66 @@
+goog.require('ol.Map');
+goog.require('ngeo.scaleselectorDirective');
+
+describe('ngeo.scaleselectorDirective', function() {
+
+  var element;
+  var map;
+  var scales;
+
+  beforeEach(function() {
+
+    ngeoModule.value('ngeoScaleselectorTemplateUrl',
+      '../src/directives/partials/scaleselector.html');
+
+    map = new ol.Map({
+      view: new ol.View({
+        center: [0, 0],
+        zoom: 0
+      })
+    });
+
+    element = angular.element(
+        '<div ngeo-scaleselector="scales"' +
+            'ngeo-scaleselector-map="map">' +
+        '</div>');
+
+    inject(function($rootScope, $compile, $sce) {
+      scales = {
+        '0': $sce.trustAsHtml('1&nbsp;:&nbsp;200\'000\'000'),
+        '1': $sce.trustAsHtml('1&nbsp;:&nbsp;100\'000\'000'),
+        '2': $sce.trustAsHtml('1&nbsp;:&nbsp;50\'000\'000'),
+        '3': $sce.trustAsHtml('1&nbsp;:&nbsp;25\'000\'000'),
+        '4': $sce.trustAsHtml('1&nbsp;:&nbsp;12\'000\'000')
+      };
+
+      $rootScope.map = map;
+      $rootScope.scales = scales;
+      $compile(element)($rootScope);
+      $rootScope.$digest();
+    });
+
+  });
+
+  it('creates an element with expected number of li elements', function() {
+    var lis = element.find('li');
+    expect(lis.length).toBe(5);
+  });
+
+  describe('calling setZoom in Angular context', function() {
+
+    it('does not throw', function() {
+      var scope = element.scope();
+
+      function test() {
+        scope.$apply(function() {
+          map.getView().setZoom(4);
+        });
+      }
+
+      expect(test).not.toThrow();
+      expect(scope.scaleselectorCtrl.currentScale).toBe(scales[4]);
+    });
+
+  });
+
+});


### PR DESCRIPTION
This PR changes the scale selector directive to use `$applyAsync` instead of `$apply` in the `change:resolution` listener. It is wrong to use `$apply` in a `change:resolution` listener, because it is not guaranteed that a `change:listener` will be executed outside Angular context.

The PR also adds tests for the scale selector directive. It also sets things up to be able to test directives with templates.

Please review.