### PR TITLE
Remove svg tag when there's no data

### DIFF
--- a/src/d3-ext/profile.js
+++ b/src/d3-ext/profile.js
@@ -194,6 +194,10 @@ ngeo.profile = function(options) {
 
   var profile = function(selection) {
     selection.each(function(data) {
+      if (!goog.isDef(data)) {
+        d3.select(this).selectAll('svg').remove();
+        return;
+      }
 
       var extractor = elevationExtractor;
 

--- a/src/directives/profile.js
+++ b/src/directives/profile.js
@@ -103,9 +103,11 @@ ngeo.profileDirective = function() {
               });
 
           function refreshData() {
-            if (goog.isDef(profile) && goog.isDef(elevationData)) {
+            if (goog.isDef(profile)) {
               selection.datum(elevationData).call(profile);
-              profile.showPois(poiData);
+              if (goog.isDef(elevationData)) {
+                profile.showPois(poiData);
+              }
             }
           }
         }


### PR DESCRIPTION
With this pull request the d3 component can receive `undefined` for data in which case the `svg` element is removed.
Please review.