### PR TITLE
Use export_local_property_definitions compile flag

### DIFF
--- a/buildtools/example.json
+++ b/buildtools/example.json
@@ -78,6 +78,7 @@
     ],
     "angular_pass": true,
     "compilation_level": "ADVANCED_OPTIMIZATIONS",
+    "export_local_property_definitions": true,
     "output_wrapper": "(function(){%output%})();",
     "use_types_for_optimization": true,
     "manage_closure_dependencies": true

--- a/buildtools/examples-all.json
+++ b/buildtools/examples-all.json
@@ -77,6 +77,7 @@
     ],
     "angular_pass": true,
     "compilation_level": "ADVANCED_OPTIMIZATIONS",
+    "export_local_property_definitions": true,
     "output_wrapper": "(function(){%output%})();",
     "use_types_for_optimization": true
   }

--- a/buildtools/ngeo.json
+++ b/buildtools/ngeo.json
@@ -72,6 +72,7 @@
     ],
     "angular_pass": true,
     "compilation_level": "ADVANCED_OPTIMIZATIONS",
+    "export_local_property_definitions": true,
     "generate_exports": true,
     "output_wrapper": "(function(){%output%})();",
     "use_types_for_optimization": true

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -67,6 +67,13 @@ Here is an example:
  * @export
  */
 app.MainController = function($scope) {
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.title = 'Addition';
+
   // …
 };
 
@@ -89,25 +96,29 @@ And this is the template:
 
 ```html
 <div ng-controller="MainController as ctrl">
+  <h2>{{ctrl.title}}</h2>
   <span>{{ctrl.add(2, 3)}}</span>
 </div>
 ```
 
-For this to work the `add` property must exist on the controller prototype.
-This is why the `app.MainController` and `add` functions are annotated with
-`@export`. The `@export` annotation tells Closure Compiler to generate exports
-in the build for the annotated functions.
+For this to work the `title` and `add` properties must exist on the controller
+object. This is why the `app.MainController` constructor, the `add` method, and
+the `title` property, are annotated with `@export`. The `@export` annotation
+tells Closure Compiler to generate exports in the build for the annotated
+functions, and to not rename the annotated properties.
 
-Note that compiler flag
+Note that the compiler flags
 
 ```
 "--generate_exports"
+"--export_local_property_definitions"
 ```
 
-is required for the Compiler to actually generate exports!
+are required for the Compiler to actually take the `@export` annotations into
+account.
 
 And remember to `@export` the constructor as well! If you just export the
-method this is the code the compiler will generate for the export:
+method (`add` here) this is the code the compiler will generate for the export:
 
 ```js
 t("app.MainController.prototype.add",cw.prototype.d)

--- a/examples/animation.js
+++ b/examples/animation.js
@@ -48,8 +48,11 @@ app.module.directive('appMap', app.mapDirective);
  * @constructor
  */
 app.MainController = function() {
-  /** @type {ol.Map} */
-  this['map'] = new ol.Map({
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
     layers: [
       new ol.layer.Tile({
         source: new ol.source.OSM()
@@ -61,7 +64,11 @@ app.MainController = function() {
     })
   });
 
-  this['open'] = false;
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.open = false;
 };
 
 

--- a/examples/backgroundlayer.js
+++ b/examples/backgroundlayer.js
@@ -59,11 +59,30 @@ app.module.directive('appBackgroundlayer', app.backgroundlayerDirective);
  * @ngInject
  */
 app.BackgroundlayerController = function($http, ngeoBackgroundLayerMgr) {
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
+
+  /**
+   * @type {Array.<Object>}
+   * @export
+   */
+  this.bgLayers = null;
+
+  /**
+   * @type {Object}
+   * @export
+   */
+  this.bgLayer = null;
+
   $http.get('data/backgroundlayers.json').then(
       angular.bind(this, function(resp) {
-        this['bgLayers'] = resp.data;
+        this.bgLayers = resp.data;
         // use the first layer by default
-        this['bgLayer'] = this['bgLayers'][0];
+        this.bgLayer = this.bgLayers[0];
       }));
 
   /**
@@ -81,9 +100,9 @@ app.BackgroundlayerController = function($http, ngeoBackgroundLayerMgr) {
  * @export
  */
 app.BackgroundlayerController.prototype.change = function() {
-  var layerSpec = this['bgLayer'];
+  var layerSpec = this.bgLayer;
   var layer = this.getLayer_(layerSpec['name']);
-  this.backgroundLayerMgr_.set(this['map'], layer);
+  this.backgroundLayerMgr_.set(this.map, layer);
 };
 
 
@@ -119,14 +138,14 @@ app.MainController = function($scope) {
 
   /**
    * @type {ol.Map}
+   * @export
    */
-  var map = new ol.Map({
+  this.map = new ol.Map({
     view: new ol.View({
       center: [-10635142.37, 4813698.29],
       zoom: 4
     })
   });
-  this['map'] = map;
 
   /**
    * An overlay layer.
@@ -140,7 +159,7 @@ app.MainController = function($scope) {
     })
   });
 
-  map.addLayer(overlay);
+  this.map.addLayer(overlay);
 
 };
 

--- a/examples/control.js
+++ b/examples/control.js
@@ -23,8 +23,11 @@ app.module = angular.module('app', ['ngeo']);
  */
 app.MainController = function() {
 
-  /** @type {ol.Map} */
-  this['map'] = new ol.Map({
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
     layers: [
       new ol.layer.Tile({
         source: new ol.source.OSM()
@@ -36,8 +39,11 @@ app.MainController = function() {
     })
   });
 
-  /** @type {ol.control.Control} */
-  this['control'] = new ol.control.MousePosition({
+  /**
+   * @type {ol.control.Control}
+   * @export
+   */
+  this.control = new ol.control.MousePosition({
     className: 'mouse-position'
   });
 };

--- a/examples/geolocation.js
+++ b/examples/geolocation.js
@@ -32,8 +32,11 @@ app.MainController = function(ngeoDecorateGeolocation) {
     zoom: 4
   });
 
-  /** @type {ol.Map} */
-  var map = new ol.Map({
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
     layers: [
       new ol.layer.Tile({
         source: new ol.source.OSM()
@@ -41,12 +44,18 @@ app.MainController = function(ngeoDecorateGeolocation) {
     ],
     view: view
   });
-  this['map'] = map;
 
-  var geolocation = new ol.Geolocation({
+  var map = this.map;
+
+  /**
+   * @type {ol.Geolocation}
+   * @export
+   */
+  this.geolocation = new ol.Geolocation({
     projection: view.getProjection()
   });
-  this['geolocation'] = geolocation;
+
+  var geolocation = this.geolocation;
 
   var positionPoint = new ol.geom.Point([0, 0]);
   var positionFeature = new ol.Feature(positionPoint);

--- a/examples/interactionbtngroup.js
+++ b/examples/interactionbtngroup.js
@@ -55,8 +55,11 @@ app.MainController = function(ngeoDecorateInteraction) {
     })
   });
 
-  /** @type {ol.Map} */
-  var map = new ol.Map({
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
     layers: [
       new ol.layer.Tile({
         source: new ol.source.MapQuest({layer: 'sat'})
@@ -68,40 +71,54 @@ app.MainController = function(ngeoDecorateInteraction) {
       zoom: 4
     })
   });
-  this['map'] = map;
 
-  /** @type {ol.interaction.Draw} */
-  var drawPolygon = new ol.interaction.Draw(
+  var map = this.map;
+
+  /**
+   * @type {ol.interaction.Draw}
+   * @export
+   */
+  this.drawPolygon = new ol.interaction.Draw(
       /** @type {olx.interaction.DrawOptions} */ ({
         type: 'Polygon',
         source: source
       }));
+
+  var drawPolygon = this.drawPolygon;
+
   drawPolygon.setActive(false);
   ngeoDecorateInteraction(drawPolygon);
   map.addInteraction(drawPolygon);
-  this['drawPolygon'] = drawPolygon;
 
-  /** @type {ol.interaction.Draw} */
-  var drawPoint = new ol.interaction.Draw(
+  /**
+   * @type {ol.interaction.Draw}
+   * @export
+   */
+  this.drawPoint = new ol.interaction.Draw(
       /** @type {olx.interaction.DrawOptions} */ ({
         type: 'Point',
         source: source
       }));
+
+  var drawPoint = this.drawPoint;
   drawPoint.setActive(false);
   ngeoDecorateInteraction(drawPoint);
   map.addInteraction(drawPoint);
-  this['drawPoint'] = drawPoint;
 
-  /** @type {ol.interaction.Draw} */
-  var drawLine = new ol.interaction.Draw(
+  /**
+   * @type {ol.interaction.Draw}
+   * @export
+   */
+  this.drawLine = new ol.interaction.Draw(
       /** @type {olx.interaction.DrawOptions} */ ({
         type: 'LineString',
         source: source
       }));
+
+  var drawLine = this.drawLine;
   drawLine.setActive(false);
   ngeoDecorateInteraction(drawLine);
   map.addInteraction(drawLine);
-  this['drawLine'] = drawLine;
 
 };
 

--- a/examples/interactiontoggle.js
+++ b/examples/interactiontoggle.js
@@ -27,8 +27,11 @@ var module = angular.module('app', ['ngeo']);
  */
 app.MainController = function(ngeoDecorateInteraction) {
 
-  /** @type {ol.Map} */
-  var map = new ol.Map({
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
     layers: [
       new ol.layer.Tile({
         source: new ol.source.MapQuest({layer: 'sat'})
@@ -39,21 +42,26 @@ app.MainController = function(ngeoDecorateInteraction) {
       zoom: 4
     })
   });
-  this['map'] = map;
+
+  var map = this.map;
 
   var featureOverlay = new ol.FeatureOverlay();
   featureOverlay.setMap(map);
 
-  /** @type {ol.interaction.Draw} */
-  var interaction = new ol.interaction.Draw(
+  /**
+   * @type {ol.interaction.Draw}
+   * @export
+   */
+  this.interaction = new ol.interaction.Draw(
       /** @type {olx.interaction.DrawOptions} */ ({
         type: 'Point',
         features: featureOverlay.getFeatures()
       }));
+
+  var interaction = this.interaction;
   interaction.setActive(false);
   map.addInteraction(interaction);
   ngeoDecorateInteraction(interaction);
-  this['interaction'] = interaction;
 
 };
 

--- a/examples/layeropacity.js
+++ b/examples/layeropacity.js
@@ -23,15 +23,22 @@ app.module = angular.module('app', ['ngeo']);
  * @ngInject
  */
 app.MainController = function(ngeoDecorateLayer) {
-  /** @type {ol.layer.Tile} */
-  var layer = new ol.layer.Tile({
+  /**
+   * @type {ol.layer.Tile}
+   * @export
+   */
+  this.layer = new ol.layer.Tile({
     source: new ol.source.OSM()
   });
-  ngeoDecorateLayer(layer);
-  this['layer'] = layer;
 
-  /** @type {ol.Map} */
-  this['map'] = new ol.Map({
+  var layer = this.layer;
+  ngeoDecorateLayer(layer);
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
     layers: [layer],
     view: new ol.View({
       center: [0, 0],

--- a/examples/layerorder.js
+++ b/examples/layerorder.js
@@ -67,8 +67,11 @@ app.MainController = function($scope, ngeoDecorateLayer, ngeoSyncArrays) {
   });
   cities.set('name', 'Cities');
 
-  /** @type {ol.Map} */
-  this['map'] = new ol.Map({
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
     layers: [
       mapquest,
       boundaries,
@@ -81,14 +84,7 @@ app.MainController = function($scope, ngeoDecorateLayer, ngeoSyncArrays) {
     })
   });
 
-  var map = this['map'];
-
-  /**
-   * @type {ol.Map}
-   * @private
-   * @const
-   */
-  this.map_ = map;
+  var map = this.map;
 
   /**
    * @type {ol.layer.Tile}
@@ -106,10 +102,12 @@ app.MainController = function($scope, ngeoDecorateLayer, ngeoSyncArrays) {
   /**
    * @type {Array.<ol.layer.Base>}
    * @const
+   * @export
    */
-  this['selectedLayers'] = [];
+  this.selectedLayers = [];
 
-  var selectedLayers = this['selectedLayers'];
+  var selectedLayers = this.selectedLayers;
+
   ngeoSyncArrays(map.getLayers().getArray(), selectedLayers, true, $scope,
       layerFilter);
 
@@ -143,12 +141,12 @@ app.MainController = function($scope, ngeoDecorateLayer, ngeoSyncArrays) {
  */
 app.MainController.prototype.toggleRoadsLayer = function(val) {
   if (!angular.isDefined(val)) {
-    return this.map_.getLayers().getArray().indexOf(this.roads_) >= 0;
+    return this.map.getLayers().getArray().indexOf(this.roads_) >= 0;
   } else {
     if (val) {
-      this.map_.addLayer(this.roads_);
+      this.map.addLayer(this.roads_);
     } else {
-      this.map_.removeLayer(this.roads_);
+      this.map.removeLayer(this.roads_);
     }
   }
 };

--- a/examples/layertree.js
+++ b/examples/layertree.js
@@ -77,8 +77,15 @@ app.module.directive('appLayertree', app.layertreeDirective);
  * @export
  */
 app.LayertreeController = function($http, $sce, appGetLayer, ngeoCreatePopup) {
+
+  /**
+   * @type {Object}
+   * @export
+   */
+  this.tree = null;
+
   $http.get('data/tree.json').then(angular.bind(this, function(resp) {
-    this['tree'] = resp.data;
+    this.tree = resp.data;
   }));
 
   /**
@@ -222,8 +229,12 @@ app.module.value('appGetLayer', app.getLayer);
  * @constructor
  */
 app.MainController = function() {
-  /** @type {ol.Map} */
-  this['map'] = new ol.Map({
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
     layers: [
       new ol.layer.Tile({
         source: new ol.source.OSM()

--- a/examples/layervisibility.js
+++ b/examples/layervisibility.js
@@ -25,8 +25,11 @@ app.module = angular.module('app', ['ngeo']);
  */
 app.MainController = function(ngeoDecorateLayer) {
 
-  /** @type {ol.layer.Tile} */
-  var wmsLayer = new ol.layer.Tile({
+  /**
+   * @type {ol.layer.Tile}
+   * @export
+   */
+  this.layer = new ol.layer.Tile({
     source: new ol.source.TileWMS({
       url: 'http://demo.opengeo.org/geoserver/wms',
       params: {'LAYERS': 'topp:states'},
@@ -34,11 +37,15 @@ app.MainController = function(ngeoDecorateLayer) {
       extent: [-13884991, 2870341, -7455066, 6338219]
     })
   });
-  ngeoDecorateLayer(wmsLayer);
-  this['layer'] = wmsLayer;
 
-  /** @type {ol.Map} */
-  this['map'] = new ol.Map({
+  var wmsLayer = this.layer;
+  ngeoDecorateLayer(wmsLayer);
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
     layers: [
       new ol.layer.Tile({
         source: new ol.source.MapQuest({layer: 'sat'})

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -62,6 +62,43 @@ app.module.directive('appMeasuretools', app.measuretoolsDirective);
 app.MeasuretoolsController = function($scope, $compile, $sce,
     ngeoDecorateInteraction) {
 
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.lang;
+
+  /**
+   * @type {Object}
+   * @export
+   */
+  this.measureStartMsg = null;
+
+  /**
+   * @type {Object}
+   * @export
+   */
+  this.measureLengthContinueMsg = null;
+
+
+  /**
+   * @type {Object}
+   * @export
+   */
+  this.measureAreaContinueMsg = null;
+
+  /**
+   * @type {Object}
+   * @export
+   */
+  this.measureAzimutContinueMsg = null;
+
   // Translations for the measure tools' tooltips.
   var measureStartMsgs = {
     'en': $sce.trustAsHtml('Click to start drawing.'),
@@ -101,12 +138,12 @@ app.MeasuretoolsController = function($scope, $compile, $sce,
   // Watch the "lang" property and update the toolip messages
   // based on the selected language.
   $scope.$watch(angular.bind(this, function() {
-    return this['lang'];
+    return this.lang;
   }), angular.bind(this, function(newVal) {
-    this['measureStartMsg'] = measureStartMsgs[newVal];
-    this['measureLengthContinueMsg'] = measureLengthContinueMsgs[newVal];
-    this['measureAreaContinueMsg'] = measureAreaContinueMsgs[newVal];
-    this['measureAzimutContinueMsg'] = measureAzimutContinueMsgs[newVal];
+    this.measureStartMsg = measureStartMsgs[newVal];
+    this.measureLengthContinueMsg = measureLengthContinueMsgs[newVal];
+    this.measureAreaContinueMsg = measureAreaContinueMsgs[newVal];
+    this.measureAzimutContinueMsg = measureAzimutContinueMsgs[newVal];
   }));
 
   var style = new ol.style.Style({
@@ -129,40 +166,52 @@ app.MeasuretoolsController = function($scope, $compile, $sce,
     })
   });
 
-  var map = this['map'];
+  var map = this.map;
 
-  /** @type {ngeo.interaction.MeasureLength} */
-  var measureLength = new ngeo.interaction.MeasureLength({
+  /**
+   * @type {ngeo.interaction.MeasureLength}
+   * @export
+   */
+  this.measureLength = new ngeo.interaction.MeasureLength({
     sketchStyle: style,
     startMsg: measureStartMsg[0],
     continueMsg: measureLengthContinueMsg[0]
   });
+
+  var measureLength = this.measureLength;
   measureLength.setActive(false);
   ngeoDecorateInteraction(measureLength);
   map.addInteraction(measureLength);
-  this['measureLength'] = measureLength;
 
-  /** @type {ngeo.interaction.MeasureArea} */
-  var measureArea = new ngeo.interaction.MeasureArea({
+  /**
+   * @type {ngeo.interaction.MeasureArea}
+   * @export
+   */
+  this.measureArea = new ngeo.interaction.MeasureArea({
     sketchStyle: style,
     startMsg: measureStartMsg[0],
     continueMsg: measureAreaContinueMsg[0]
   });
+
+  var measureArea = this.measureArea;
   measureArea.setActive(false);
   ngeoDecorateInteraction(measureArea);
   map.addInteraction(measureArea);
-  this['measureArea'] = measureArea;
 
-  /** @type {ngeo.interaction.MeasureAzimut} */
-  var measureAzimut = new ngeo.interaction.MeasureAzimut({
+  /**
+   * @type {ngeo.interaction.MeasureAzimut}
+   * @export
+   */
+  this.measureAzimut = new ngeo.interaction.MeasureAzimut({
     sketchStyle: style,
     startMsg: measureStartMsg[0],
     continueMsg: measureAzimutContinueMsg[0]
   });
+
+  var measureAzimut = this.measureAzimut;
   measureAzimut.setActive(false);
   ngeoDecorateInteraction(measureAzimut);
   map.addInteraction(measureAzimut);
-  this['measureAzimut'] = measureAzimut;
 
 
   // the following code shows how one can add additional information to the
@@ -183,11 +232,17 @@ app.module.controller('AppMeasuretoolsController', app.MeasuretoolsController);
  */
 app.MainController = function() {
 
-  /** @type {string} */
-  this['lang'] = 'en';
+  /**
+   * @type {string}
+   * @export
+   */
+  this.lang = 'en';
 
-  /** @type {ol.Map} */
-  var map = new ol.Map({
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
     layers: [
       new ol.layer.Tile({
         source: new ol.source.OSM()
@@ -198,10 +253,8 @@ app.MainController = function() {
       zoom: 15
     })
   });
-  this['map'] = map;
 
-  map.addControl(new ol.control.ScaleLine());
-
+  this.map.addControl(new ol.control.ScaleLine());
 };
 
 

--- a/examples/permalink.js
+++ b/examples/permalink.js
@@ -52,7 +52,13 @@ app.module.directive('appMap', app.mapDirective);
  * @ngInject
  */
 app.MapDirectiveController = function(ngeoLocation, ngeoDebounce) {
-  var map = this['map'];
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
+
+  var map = this.map;
   var view = map.getView();
 
   var zoom = ngeoLocation.getParam('z');
@@ -97,8 +103,12 @@ app.module.controller('AppMapController', app.MapDirectiveController);
  * @constructor
  */
 app.MainController = function() {
-  /** @type {ol.Map} */
-  this['map'] = new ol.Map({
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
     layers: [
       new ol.layer.Tile({
         source: new ol.source.OSM()

--- a/examples/profile.js
+++ b/examples/profile.js
@@ -34,6 +34,10 @@ app.module = angular.module('app', ['ngeo']);
  */
 app.MainController = function($http, $scope) {
 
+  /**
+   * @type {angular.Scope}
+   * @private
+   */
   this.scope_ = $scope;
 
   var projection = new ol.proj.Projection({
@@ -47,8 +51,9 @@ app.MainController = function($http, $scope) {
 
   /**
    * @type {ol.Map}
+   * @export
    */
-  var map = this['map'] = new ol.Map({
+  this.map = new ol.Map({
     layers: [
       new ol.layer.Image({
         source: new ol.source.ImageWMS({
@@ -79,19 +84,31 @@ app.MainController = function($http, $scope) {
     })
   });
 
+  var map = this.map;
+
   var overlay = new ol.FeatureOverlay();
   this.snappedPoint_ = new ol.Feature();
   overlay.addFeature(this.snappedPoint_);
   overlay.setMap(map);
 
-  this['profilePoisData'] = [
+  /**
+   * @type {Array.<Object>}
+   * @export
+   */
+  this.profilePoisData = [
     {sort: 1, dist: 1000, title: 'First POI', id: 12345},
     {sort: 2, dist: 3000, title: 'Second POI', id: 12346}
   ];
 
+  /**
+   * @type {Object|undefined}
+   * @export
+   */
+  this.profileData = undefined;
+
   $http.get('data/profile.json').then(angular.bind(this, function(resp) {
     var data = resp.data['profile'];
-    this['profileData'] = data;
+    this.profileData = data;
 
     var i;
     var len = data.length;
@@ -102,7 +119,9 @@ app.MainController = function($http, $scope) {
       lineString.appendCoordinate([p.x, p.y, p.dist]);
     }
     source.addFeature(new ol.Feature(lineString));
-    map.getView().fitExtent(source.getExtent(), this['map'].getSize());
+
+    map.getView().fitExtent(source.getExtent(),
+        /** @type {ol.Size} */ (this.map.getSize()));
   }));
 
 
@@ -186,25 +205,38 @@ app.MainController = function($http, $scope) {
    */
   var hoverCallback = function(point) {
     // An item in the list of points given to the profile.
-    that['point'] = point;
+    that.point = point;
     that.snappedPoint_.setGeometry(new ol.geom.Point([point.x, point.y]));
   };
 
   var outCallback = function() {
-    that['point'] = null;
+    that.point = null;
     that.snappedPoint_.setGeometry(null);
   };
 
 
-  this['profileOptions'] = {
+  /**
+   * @type {Object}
+   * @export
+   */
+  this.profileOptions = {
     elevationExtractor: elevationExtractor,
     poiExtractor: poiExtractor,
     hoverCallback: hoverCallback,
     outCallback: outCallback
   };
 
+  /**
+   * @type {Object}
+   * @export
+   */
+  this.point = null;
 
-  this['point'] = null;
+  /**
+   * @type {number|undefined}
+   * @export
+   */
+  this.profileHighlight = undefined;
 };
 
 
@@ -218,12 +250,12 @@ app.MainController.prototype.snapToGeometry = function(coordinate, geometry) {
   var dx = closestPoint[0] - coordinate[0];
   var dy = closestPoint[1] - coordinate[1];
   var dist = Math.sqrt(dx * dx + dy * dy);
-  var pixelDist = dist / this['map'].getView().getResolution();
+  var pixelDist = dist / this.map.getView().getResolution();
 
   if (pixelDist < 8) {
-    this['profileHighlight'] = closestPoint[2];
+    this.profileHighlight = closestPoint[2];
   } else {
-    this['profileHighlight'] = -1;
+    this.profileHighlight = -1;
   }
   this.scope_.$apply();
 };

--- a/examples/scaleselector.js
+++ b/examples/scaleselector.js
@@ -56,12 +56,19 @@ app.module.directive('appScaleselector', app.scaleselectorDirective);
 app.ScaleselectorController = function($sce) {
 
   /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
+
+  /**
    * The zoom level/scale map object for the ngeoScaleselector directive.
    * The values need to be trusted as HTML.
    * @type {Object.<string, string>}
    * @const
+   * @export
    */
-  this['scales'] = {
+  this.scales = {
     '0': $sce.trustAsHtml('1&nbsp;:&nbsp;200\'000\'000'),
     '1': $sce.trustAsHtml('1&nbsp;:&nbsp;100\'000\'000'),
     '2': $sce.trustAsHtml('1&nbsp;:&nbsp;50\'000\'000'),
@@ -72,8 +79,9 @@ app.ScaleselectorController = function($sce) {
   /**
    * Use the "dropup" variation of the Bootstrap dropdown.
    * @type {ngeo.ScaleselectorOptions}
+   * @export
    */
-  this['options'] = {
+  this.options = {
     'dropup': true
   };
 };
@@ -92,8 +100,9 @@ app.MainController = function($scope) {
 
   /**
    * @type {ol.Map}
+   * @export
    */
-  var map = new ol.Map({
+  this.map = new ol.Map({
     layers: [
       new ol.layer.Tile({
         source: new ol.source.OSM()
@@ -105,7 +114,6 @@ app.MainController = function($scope) {
       maxZoom: 4
     })
   });
-  this['map'] = map;
 
 };
 

--- a/examples/search.js
+++ b/examples/search.js
@@ -68,6 +68,12 @@ app.SearchController = function($rootScope, $compile,
     ngeoCreateGeoJSONBloodhound) {
 
   /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
+
+  /**
    * @type {ol.FeatureOverlay}
    * @private
    */
@@ -77,13 +83,21 @@ app.SearchController = function($rootScope, $compile,
   var bloodhoundEngine = this.createAndInitBloodhound_(
       ngeoCreateGeoJSONBloodhound);
 
-  /** @type {TypeaheadOptions} */
-  this['options'] = {
-    highlight: true
+  /**
+   * @type {TypeaheadOptions}
+   * @export
+   */
+  this.options = {
+    highlight: true,
+    hint: undefined,
+    minLength: undefined
   };
 
-  /** @type {Array.<TypeaheadDataset>} */
-  this['datasets'] = [{
+  /**
+   * @type {Array.<TypeaheadDataset>}
+   * @export
+   */
+  this.datasets = [{
     source: bloodhoundEngine.ttAdapter(),
     displayKey: function(suggestion) {
       var feature = /** @type {ol.Feature} */ (suggestion);
@@ -111,7 +125,11 @@ app.SearchController = function($rootScope, $compile,
     }
   }];
 
-  this['listeners'] = /** @type {ngeox.SearchDirectiveListeners} */ ({
+  /**
+   * @type {ngeox.SearchDirectiveListeners}
+   * @export
+   */
+  this.listeners = /** @type {ngeox.SearchDirectiveListeners} */ ({
     selected: angular.bind(this, app.SearchController.selected_)
   });
 
@@ -124,7 +142,7 @@ app.SearchController = function($rootScope, $compile,
  */
 app.SearchController.prototype.createFeatureOverlay_ = function() {
   var featureOverlay = new ol.FeatureOverlay();
-  featureOverlay.setMap(this['map']);
+  featureOverlay.setMap(this.map);
   return featureOverlay;
 };
 
@@ -152,7 +170,7 @@ app.SearchController.prototype.createAndInitBloodhound_ =
  * @private
  */
 app.SearchController.selected_ = function(event, suggestion, dataset) {
-  var map = /** @type {ol.Map} */ (this['map']);
+  var map = /** @type {ol.Map} */ (this.map);
   var feature = /** @type {ol.Feature} */ (suggestion);
   var features = this.featureOverlay_.getFeatures();
   var featureGeometry = /** @type {ol.geom.SimpleGeometry} */
@@ -175,8 +193,9 @@ app.module.controller('AppSearchController', app.SearchController);
 app.MainController = function() {
   /**
    * @type {ol.Map}
+   * @export
    */
-  this['map'] = new ol.Map({
+  this.map = new ol.Map({
     layers: [
       new ol.layer.Tile({
         source: new ol.source.OSM()

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -20,10 +20,12 @@ app.module = angular.module('app', ['ngeo']);
  * @constructor
  */
 app.MainController = function() {
+
   /**
    * @type {ol.Map}
+   * @export
    */
-  this['map'] = new ol.Map({
+  this.map = new ol.Map({
     layers: [
       new ol.layer.Tile({
         source: new ol.source.OSM()

--- a/src/directives/layertree.js
+++ b/src/directives/layertree.js
@@ -91,21 +91,47 @@ ngeo.NgeoLayertreeController = function($scope, $element, $attrs) {
 
   var treeExpr = $attrs['ngeoLayertree'];
   var tree = /** @type {Object} */ ($scope.$eval(treeExpr));
-  this['tree'] = tree;
+
+  /**
+   * @type {Object}
+   * @export
+   */
+  this.tree = tree;
 
   var mapExpr = $attrs['ngeoLayertreeMap'];
   var map = /** @type {ol.Map} */ ($scope.$eval(mapExpr));
-  this['map'] = map;
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = map;
 
   var nodelayerExpr = $attrs['ngeoLayertreeNodelayer'];
-  this['layerExpr'] = nodelayerExpr;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.layerExpr = nodelayerExpr;
 
   $scope.$watch(treeExpr, goog.bind(function(newVal, oldVal) {
-    this['tree'] = newVal;
+    this.tree = newVal;
   }, this));
 
-  $scope['uid'] = this['uid'] = goog.getUid(this);
-  $scope['depth'] = 0;
+  $scope['uid'] = goog.getUid(this);
+
+  /**
+   * @type {number}
+   * @export
+   */
+  this.uid = $scope['uid'];
+
+  /**
+   * @type {number}
+   * @export
+   */
+  $scope.depth = 0;
 
   $scope['layertreeCtrl'] = this;
 };

--- a/src/directives/layertreenode.js
+++ b/src/directives/layertreenode.js
@@ -118,24 +118,44 @@ ngeo.LayertreenodeController = function($scope, $element, $attrs) {
   var nodeExpr = $attrs['ngeoLayertreenode'];
   var node = /** @type {Object} */ ($scope.$eval(nodeExpr));
   goog.asserts.assert(goog.isDef(node));
-  this['node'] = node;
+
+  /**
+   * @type {Object}
+   * @export
+   */
+  this.node = node;
 
   var mapExpr = $attrs['ngeoLayertreenodeMap'];
   var map = /** @type {ol.Map} */ ($scope.$eval(mapExpr));
   goog.asserts.assert(goog.isDef(map));
-  this['map'] = map;
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = map;
 
   var layerexprExpr = $attrs['ngeoLayertreenodeLayerexpr'];
   var layerExpr = /** @type {string} */ ($scope.$eval(layerexprExpr));
   goog.asserts.assert(goog.isDef(layerExpr));
-  this['layerExpr'] = layerExpr;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.layerExpr = layerExpr;
 
   // The node is passed in the "locals" object (2nd arg to $eval). This
   // is to allow expressions like "ctrl.getLayer(node)".
   var layer = /** @type {ol.layer.Layer} */
       ($scope.$eval(layerExpr, {'node': node}));
   goog.asserts.assert(goog.isDef(layer));
-  this['layer'] = layer;
+
+  /**
+   * @type {ol.layer.Layer}
+   * @export
+   */
+  this.layer = layer;
 
   /**
    * @type {ol.Map}
@@ -151,15 +171,29 @@ ngeo.LayertreenodeController = function($scope, $element, $attrs) {
    */
   this.layer_ = layer;
 
-  this['parentUid'] = $scope.$parent['uid'];
-  this['uid'] = goog.getUid(this);
-  this['depth'] = $scope.$parent['depth'] + 1;
+  /**
+   * @type {number}
+   * @export
+   */
+  this.parentUid = $scope.$parent['uid'];
+
+  /**
+   * @type {number}
+   * @export
+   */
+  this.uid = goog.getUid(this);
+
+  /**
+   * @type {number}
+   * @export
+   */
+  this.depth = $scope.$parent['depth'] + 1;
 
   // We set 'uid' and 'depth' in the scope as well to access the parent values
   // in the inherited scopes. This is intended to be used in the javascript not
   // in the templates.
-  $scope['uid'] = this['uid'];
-  $scope['depth'] = this['depth'];
+  $scope['uid'] = this.uid;
+  $scope['depth'] = this.depth;
 
   $scope['layertreenodeCtrl'] = this;
 };

--- a/src/directives/scaleselector.js
+++ b/src/directives/scaleselector.js
@@ -98,8 +98,9 @@ ngeo.ScaleselectorController = function($scope, $element, $attrs) {
   /**
    * The zoom level/scale map object.
    * @type {Object.<string, string>}
+   * @export
    */
-  this['scales'] = /** @type {Object.<string, string>} */
+  this.scales = /** @type {Object.<string, string>} */
       ($scope.$eval(scalesExpr));
   goog.asserts.assert(goog.isDef(this['scales']));
 
@@ -108,8 +109,9 @@ ngeo.ScaleselectorController = function($scope, $element, $attrs) {
 
   /**
    * @type {Array.<number>}
+   * @export
    */
-  this['zoomLevels'] = zoomLevels;
+  this.zoomLevels = zoomLevels;
 
   var mapExpr = $attrs['ngeoScaleselectorMap'];
 
@@ -125,8 +127,9 @@ ngeo.ScaleselectorController = function($scope, $element, $attrs) {
 
   /**
    * @type {!ngeo.ScaleselectorOptions}
+   * @export
    */
-  this['options'] = ngeo.ScaleselectorController.getOptions_(options);
+  this.options = ngeo.ScaleselectorController.getOptions_(options);
 
   /**
    * @type {angular.Scope}
@@ -142,14 +145,15 @@ ngeo.ScaleselectorController = function($scope, $element, $attrs) {
 
   /**
    * @type {string|undefined}
+   * @export
    */
-  this['currentScale'] = undefined;
+  this.currentScale = undefined;
 
   var view = this.map_.getView();
   if (!goog.isNull(view)) {
     var currentZoom = this.map_.getView().getZoom();
     if (goog.isDef(currentZoom)) {
-      this['currentScale'] = this.getScale(currentZoom);
+      this.currentScale = this.getScale(currentZoom);
     }
   }
 
@@ -188,7 +192,7 @@ ngeo.ScaleselectorController.getOptions_ = function(options) {
  * @export
  */
 ngeo.ScaleselectorController.prototype.getScale = function(zoom) {
-  return this['scales'][zoom.toString()];
+  return this.scales[zoom.toString()];
 };
 
 
@@ -207,7 +211,7 @@ ngeo.ScaleselectorController.prototype.changeZoom = function(zoom) {
  */
 ngeo.ScaleselectorController.prototype.handleResolutionChange_ = function(e) {
   var view = this.map_.getView();
-  var currentScale = this['scales'][view.getZoom().toString()];
+  var currentScale = this.scales[view.getZoom().toString()];
 
   // handleResolutionChange_ is a change:resolution listener. The listener
   // may be executed outside the Angular context, for example when the user
@@ -223,7 +227,7 @@ ngeo.ScaleselectorController.prototype.handleResolutionChange_ = function(e) {
   this.$scope_.$applyAsync(
       /** @type {function(?)} */ (
       goog.bind(function() {
-        this['currentScale'] = currentScale;
+        this.currentScale = currentScale;
       }, this)));
 };
 


### PR DESCRIPTION
Use the new export_local_property_definitions compiler option. Using this option properties can be marked with `@export` in constructors. This means we can now use the following in controller constructors instead of using the square bracket notation:

```js
app.MyController = function() {

  /**
   * @type {Object}
   * @export
   */
  this.aProperty = {};

  // …
};
```