### PR TITLE
Make the goog.Uri object available in ngeoLocation

### DIFF
--- a/exports/services/location.js
+++ b/exports/services/location.js
@@ -6,6 +6,10 @@ goog.exportProperty(
     ngeo.Location.prototype.getUri);
 goog.exportProperty(
     ngeo.Location.prototype,
+    'getUriString',
+    ngeo.Location.prototype.getUriString);
+goog.exportProperty(
+    ngeo.Location.prototype,
     'getParam',
     ngeo.Location.prototype.getParam);
 goog.exportProperty(

--- a/src/services/location.js
+++ b/src/services/location.js
@@ -53,6 +53,15 @@ ngeo.Location = function(location, history) {
 
 
 /**
+ * Get the location's URI object.
+ * @return {!goog.Uri}
+ */
+ngeo.Location.prototype.getUri = function() {
+  return this.uri_;
+};
+
+
+/**
  * Get the location's current path.
  * @return {string} The path.
  */
@@ -65,7 +74,7 @@ ngeo.Location.prototype.getPath = function() {
  * @param {Object.<string, string>=} opt_params Params.
  * @return {string} The URI.
  */
-ngeo.Location.prototype.getUri = function(opt_params) {
+ngeo.Location.prototype.getUriString = function(opt_params) {
   var extendedUri;
   if (goog.isDef(opt_params)) {
     extendedUri = this.uri_.clone();
@@ -125,7 +134,7 @@ ngeo.Location.prototype.deleteParam = function(key) {
 /**
  */
 ngeo.Location.prototype.refresh = function() {
-  this.history_.replaceState(null, '', this.getUri());
+  this.history_.replaceState(null, '', this.getUriString());
 };
 
 
@@ -150,9 +159,9 @@ ngeo.LocationFactory = function($rootScope, $window) {
   var history = $window.history;
   var service = new ngeo.Location($window.location, $window.history);
 
-  var lastUri = service.getUri();
+  var lastUri = service.getUriString();
   $rootScope.$watch(function() {
-    var newUri = service.getUri();
+    var newUri = service.getUriString();
     if (lastUri !== newUri) {
       $rootScope.$evalAsync(function() {
         lastUri = newUri;

--- a/test/spec/services/location.spec.js
+++ b/test/spec/services/location.spec.js
@@ -18,13 +18,13 @@ describe('ngeo.Location', function() {
     });
   });
 
-  describe('#getUri', function() {
+  describe('#getUriString', function() {
     it('returns the URI', function() {
-      var uri = ngeoLocation.getUri();
+      var uri = ngeoLocation.getUriString();
       expect(uri).toBe('http://domain.com/some/path?some=param');
     });
     it('returns the URI with additional params', function() {
-      var uri = ngeoLocation.getUri({'another': 'param'});
+      var uri = ngeoLocation.getUriString({'another': 'param'});
       expect(uri).toBe('http://domain.com/some/path?some=param&another=param');
     });
   });
@@ -55,7 +55,7 @@ describe('ngeo.Location', function() {
   describe('#deleteParam', function() {
     it('delete the params', function() {
       ngeoLocation.deleteParam('some');
-      var uri = ngeoLocation.getUri();
+      var uri = ngeoLocation.getUriString();
       expect(uri).toBe('http://domain.com/some/path');
     });
   });


### PR DESCRIPTION
This change implies to rename getUri() to getUriString() in the projects using ngeoLocation. Is there a changelog to advertise this?