### PR TITLE
Add requestEncoding to mapfish print externs

### DIFF
--- a/externs/mapfish-print-v3.js
+++ b/externs/mapfish-print-v3.js
@@ -226,6 +226,12 @@ MapFishPrintWmtsLayer.prototype.matrixSet;
 /**
  * @type {string}
  */
+MapFishPrintWmtsLayer.prototype.requestEncoding;
+
+
+/**
+ * @type {string}
+ */
 MapFishPrintWmtsLayer.prototype.style;
 
 


### PR DESCRIPTION
Add missing `requestEncoding` property to `MapFishPrintWmtsLayer` in the `mapfish-print-v3.js` externs file.

Please review.