### PR TITLE
Make it possible to pass $http options to print

### DIFF
--- a/examples/mapfishprint.js
+++ b/examples/mapfishprint.js
@@ -192,11 +192,12 @@ app.MainController.prototype.print = function() {
 
 
 /**
- * @param {MapFishPrintReportResponse} resp Response.
+ * @param {!angular.$http.Response} resp Response.
  * @private
  */
 app.MainController.prototype.handleCreateReportSuccess_ = function(resp) {
-  this.getStatus_(resp.ref);
+  var mfResp = /** @type {MapFishPrintReportResponse} */ (resp.data);
+  this.getStatus_(mfResp.ref);
 };
 
 
@@ -212,7 +213,7 @@ app.MainController.prototype.getStatus_ = function(ref) {
 
 
 /**
- * @param {MapFishPrintReportResponse} resp Response.
+ * @param {!angular.$http.Response} resp Response.
  * @private
  */
 app.MainController.prototype.handleCreateReportError_ = function(resp) {
@@ -222,11 +223,12 @@ app.MainController.prototype.handleCreateReportError_ = function(resp) {
 
 /**
  * @param {string} ref Ref.
- * @param {MapFishPrintStatusResponse} resp Response.
+ * @param {!angular.$http.Response} resp Response.
  * @private
  */
 app.MainController.prototype.handleGetStatusSuccess_ = function(ref, resp) {
-  var done = resp.done;
+  var mfResp = /** @type {MapFishPrintStatusResponse} */ (resp.data);
+  var done = mfResp.done;
   if (done) {
     // The report is ready. Open it by changing the window location.
     this.printState = '';
@@ -242,10 +244,10 @@ app.MainController.prototype.handleGetStatusSuccess_ = function(ref, resp) {
 
 
 /**
- * @param {Object} data Data.
+ * @param {!angular.$http.Response} resp Response.
  * @private
  */
-app.MainController.prototype.handleGetStatusError_ = function(data) {
+app.MainController.prototype.handleGetStatusError_ = function(resp) {
   this.printState = 'Print error';
 };
 

--- a/src/services/print.js
+++ b/src/services/print.js
@@ -273,56 +273,33 @@ ngeo.Print.prototype.getWmtsUrl_ = function(source) {
 /**
  * Send a create report request to the MapFish Print service.
  * @param {MapFishPrintSpec} printSpec Print specification.
- * @return {angular.$q.Promise} Promise.
+ * @param {angular.$http.Config=} opt_httpConfig $http config object.
+ * @return {angular.$http.HttpPromise} HTTP promise.
  */
-ngeo.Print.prototype.createReport = function(printSpec) {
+ngeo.Print.prototype.createReport = function(printSpec, opt_httpConfig) {
   var url = this.url_ + '/report.pdf';
-  var promise = this.$http_.post(url, printSpec, {
+  var httpConfig = /** @type {angular.$http.Config} */ ({
     headers: {
       'Content-Type': 'application/json; charset=UTF-8'
     }
   });
-  return promise.then(
-      /**
-       * @param {!angular.$http.Response} resp Response.
-       * @return {MapFishPrintReportResponse} MapFish Print report response.
-       */
-      function(resp) {
-        return /** @type {MapFishPrintReportResponse} */ (resp.data);
-      },
-      /**
-       * @param {!angular.$http.Response} resp Response.
-       * @return {!angular.$http.Response} Response.
-       */
-      function(resp) {
-        return resp;
-      });
+  goog.object.extend(httpConfig,
+      goog.isDef(opt_httpConfig) ? opt_httpConfig : {});
+  return this.$http_.post(url, printSpec, httpConfig);
 };
 
 
 /**
  * Get the status of a report.
  * @param {string} ref Print report reference.
- * @return {angular.$q.Promise} Promise.
+ * @param {angular.$http.Config=} opt_httpConfig $http config object.
+ * @return {angular.$http.HttpPromise} HTTP promise.
  */
-ngeo.Print.prototype.getStatus = function(ref) {
+ngeo.Print.prototype.getStatus = function(ref, opt_httpConfig) {
+  var httpConfig = goog.isDef(opt_httpConfig) ? opt_httpConfig :
+      /** @type {angular.$http.Config} */ ({});
   var url = this.url_ + '/status/' + ref + '.json';
-  var promise = this.$http_.get(url);
-  return promise.then(
-      /**
-       * @param {!angular.$http.Response} resp Response.
-       * @return {MapFishPrintStatusResponse} MapFish Print status response.
-       */
-      function(resp) {
-        return /** @type {MapFishPrintStatusResponse} */ (resp.data);
-      },
-      /**
-       * @param {!angular.$http.Response} resp Response.
-       * @return {!angular.$http.Response} Response.
-       */
-      function(resp) {
-        return resp;
-      });
+  return this.$http_.get(url, httpConfig);
 };
 
 

--- a/test/spec/services/print.spec.js
+++ b/test/spec/services/print.spec.js
@@ -273,11 +273,28 @@ describe('ngeo.CreatePrint', function() {
       $httpBackend.flush();
 
       expect(spy.calls.length).toBe(1);
-      expect(spy.mostRecentCall.args[0]).toEqual({
+      expect(spy.mostRecentCall.args[0].data).toEqual({
         ref: 'deadbeef',
         statusURL: '/print/status/deadbeef.json',
         downloadURL: '/print/report/deadbeef.json'
       });
+    });
+
+    describe('cancel report request', function() {
+
+      it('cancels the request', inject(function($q) {
+        $httpBackend.expectPOST('http://example.com/print/report.pdf');
+
+        var canceler = $q.defer();
+        var promise = print.createReport(spec, {
+          timeout: canceler.promise
+        });
+
+        canceler.resolve(); // abort the $http request
+
+        // We will get an "Unflushed requests: 1" error in afterEach when
+        // calling verifyNoOutstandingRequest if the aborting did not work.
+      }));
     });
 
   });
@@ -336,7 +353,7 @@ describe('ngeo.CreatePrint', function() {
       $httpBackend.flush();
 
       expect(spy.calls.length).toBe(1);
-      expect(spy.mostRecentCall.args[0]).toEqual({
+      expect(spy.mostRecentCall.args[0].data).toEqual({
         done: false,
         downloadURL: '/print/report/deadbeef.json'
       });


### PR DESCRIPTION
This commit does two things: (1) it allows passing `$http` options to `createReport` and `getStatus`, making it possible to pass a request canceler to `$http`, and (b) change the promise returned by `createReport` and `getStatus` to be an http promise instead of a regular promise, providing more flexibility and making it possible to be notified in case of HTTP errors.