### PR TITLE
Allow tiles from a TileWMS to be printed

### DIFF
--- a/src/services/print.js
+++ b/src/services/print.js
@@ -193,18 +193,30 @@ ngeo.Print.prototype.encodeImageLayer_ = function(arr, layer) {
 
 /**
  * @param {Array.<MapFishPrintLayer>} arr Array.
- * @param {ol.layer.Image} layer Layer.
+ * @param {ol.layer.Tile|ol.layer.Image} layer Layer.
  * @private
  */
 ngeo.Print.prototype.encodeImageWmsLayer_ = function(arr, layer) {
-  goog.asserts.assertInstanceof(layer, ol.layer.Image);
+  var url;
   var source = layer.getSource();
-  goog.asserts.assertInstanceof(source, ol.source.ImageWMS);
-  var url = source.getUrl();
+
+  if (source instanceof ol.source.ImageWMS) {
+    goog.asserts.assertInstanceof(layer, ol.layer.Image);
+    goog.asserts.assertInstanceof(source, ol.source.ImageWMS);
+    url = source.getUrl();
+  } else {
+    goog.asserts.assertInstanceof(layer, ol.layer.Tile);
+    goog.asserts.assertInstanceof(source, ol.source.TileWMS);
+    url = source.getUrls()[0];
+  }
+
   var params = source.getParams();
   var object = /** @type {MapFishPrintWmsLayer} */ ({
     baseURL: url,
     imageFormat: 'FORMAT' in params ? params['FORMAT'] : 'image/png',
+    customParams: {
+      transparent: true
+    },
     layers: params['LAYERS'].split(','),
     type: 'wms'
   });
@@ -222,6 +234,8 @@ ngeo.Print.prototype.encodeTileLayer_ = function(arr, layer) {
   var source = layer.getSource();
   if (source instanceof ol.source.WMTS) {
     this.encodeTileWmtsLayer_(arr, layer);
+  } else if (source instanceof ol.source.TileWMS) {
+    this.encodeImageWmsLayer_(arr, layer);
   }
 };
 

--- a/src/services/print.js
+++ b/src/services/print.js
@@ -215,13 +215,17 @@ ngeo.Print.prototype.encodeImageWmsLayer_ = function(arr, layer) {
  * @private
  */
 ngeo.Print.prototype.encodeWmsLayer_ = function(arr, url, params) {
+  var customParams = {'TRANSPARENT': true};
+  goog.object.extend(customParams, params);
+
+  goog.object.remove(customParams, 'LAYERS');
+  goog.object.remove(customParams, 'FORMAT');
+
   var object = /** @type {MapFishPrintWmsLayer} */ ({
     baseURL: url,
     imageFormat: 'FORMAT' in params ? params['FORMAT'] : 'image/png',
-    customParams: {
-      transparent: true
-    },
     layers: params['LAYERS'].split(','),
+    customParams: customParams,
     type: 'wms'
   });
   arr.push(object);

--- a/src/services/print.js
+++ b/src/services/print.js
@@ -193,24 +193,28 @@ ngeo.Print.prototype.encodeImageLayer_ = function(arr, layer) {
 
 /**
  * @param {Array.<MapFishPrintLayer>} arr Array.
- * @param {ol.layer.Tile|ol.layer.Image} layer Layer.
+ * @param {ol.layer.Image} layer Layer.
  * @private
  */
 ngeo.Print.prototype.encodeImageWmsLayer_ = function(arr, layer) {
-  var url;
   var source = layer.getSource();
 
-  if (source instanceof ol.source.ImageWMS) {
-    goog.asserts.assertInstanceof(layer, ol.layer.Image);
-    goog.asserts.assertInstanceof(source, ol.source.ImageWMS);
-    url = source.getUrl();
-  } else {
-    goog.asserts.assertInstanceof(layer, ol.layer.Tile);
-    goog.asserts.assertInstanceof(source, ol.source.TileWMS);
-    url = source.getUrls()[0];
-  }
+  goog.asserts.assertInstanceof(layer, ol.layer.Image);
+  goog.asserts.assertInstanceof(source, ol.source.ImageWMS);
 
+  var url = source.getUrl();
   var params = source.getParams();
+  this.encodeWmsLayer_(arr, url, params);
+};
+
+
+/**
+ * @param {Array.<MapFishPrintLayer>} arr Array.
+ * @param {string|undefined} url Url of the WMS server.
+ * @param {Object} params Url parameters
+ * @private
+ */
+ngeo.Print.prototype.encodeWmsLayer_ = function(arr, url, params) {
   var object = /** @type {MapFishPrintWmsLayer} */ ({
     baseURL: url,
     imageFormat: 'FORMAT' in params ? params['FORMAT'] : 'image/png',
@@ -235,7 +239,7 @@ ngeo.Print.prototype.encodeTileLayer_ = function(arr, layer) {
   if (source instanceof ol.source.WMTS) {
     this.encodeTileWmtsLayer_(arr, layer);
   } else if (source instanceof ol.source.TileWMS) {
-    this.encodeImageWmsLayer_(arr, layer);
+    this.encodeTileWmsLayer_(arr, layer);
   }
 };
 
@@ -291,6 +295,23 @@ ngeo.Print.prototype.encodeTileWmtsLayer_ = function(arr, layer) {
   });
 
   arr.push(object);
+};
+
+
+/**
+ * @param {Array.<MapFishPrintLayer>} arr Array.
+ * @param {ol.layer.Tile} layer Layer.
+ * @private
+ */
+ngeo.Print.prototype.encodeTileWmsLayer_ = function(arr, layer) {
+  var source = layer.getSource();
+
+  goog.asserts.assertInstanceof(layer, ol.layer.Tile);
+  goog.asserts.assertInstanceof(source, ol.source.TileWMS);
+
+  var url = source.getUrls()[0];
+  var params = source.getParams();
+  this.encodeWmsLayer_(arr, url, params);
 };
 
 

--- a/test/spec/services/print.spec.js
+++ b/test/spec/services/print.spec.js
@@ -79,11 +79,12 @@ describe('ngeo.CreatePrint', function() {
               center: [3000, 4000],
               projection: 'EPSG:3857',
               scale: 500,
+              rotation: 0,
               layers: [{
                 baseURL: 'http://example.com/wms',
                 imageFormat: 'image/jpeg',
                 customParams: {
-                  transparent: true
+                  TRANSPARENT: true
                 },
                 layers: ['foo', 'bar'],
                 type: 'wms'
@@ -129,11 +130,12 @@ describe('ngeo.CreatePrint', function() {
               center: [3000, 4000],
               projection: 'EPSG:3857',
               scale: 500,
+              rotation: 0,
               layers: [{
                 baseURL: 'http://example.com/wms',
                 imageFormat: 'image/jpeg',
                 customParams: {
-                  transparent: true
+                  TRANSPARENT: true
                 },
                 layers: ['foo', 'bar'],
                 type: 'wms'

--- a/test/spec/services/print.spec.js
+++ b/test/spec/services/print.spec.js
@@ -8,6 +8,7 @@ goog.require('ol.layer.Image');
 goog.require('ol.layer.Tile');
 goog.require('ol.layer.Vector');
 goog.require('ol.source.ImageWMS');
+goog.require('ol.source.TileWMS');
 goog.require('ol.source.Vector');
 goog.require('ol.source.WMTS');
 goog.require('ol.style.Circle');
@@ -81,6 +82,59 @@ describe('ngeo.CreatePrint', function() {
               layers: [{
                 baseURL: 'http://example.com/wms',
                 imageFormat: 'image/jpeg',
+                customParams: {
+                  transparent: true
+                },
+                layers: ['foo', 'bar'],
+                type: 'wms'
+              }]
+            },
+            foo: 'fooval',
+            bar: 'barval'
+          },
+          layout: 'foo layout'
+        });
+
+      });
+
+    });
+
+
+    describe('TileWMS', function() {
+
+      beforeEach(function() {
+        map.addLayer(new ol.layer.Tile({
+          source: new ol.source.TileWMS({
+            url: 'http://example.com/wms',
+            params: {
+              'LAYERS': 'foo,bar',
+              'FORMAT': 'image/jpeg'
+            }
+          })
+        }));
+      });
+
+      it('creates a valid spec object', function() {
+
+        var scale = 500;
+        var dpi = 72;
+        var layout = 'foo layout';
+        var customAttributes = {'foo': 'fooval', 'bar': 'barval'};
+
+        var spec = print.createSpec(map, scale, dpi, layout, customAttributes);
+        expect(spec).toEqual({
+          attributes: {
+            map: {
+              dpi: 72,
+              center: [3000, 4000],
+              projection: 'EPSG:3857',
+              scale: 500,
+              layers: [{
+                baseURL: 'http://example.com/wms',
+                imageFormat: 'image/jpeg',
+                customParams: {
+                  transparent: true
+                },
                 layers: ['foo', 'bar'],
                 type: 'wms'
               }]


### PR DESCRIPTION
- Use encodeImageWmsLayer to encode layer of type Tile and of source TileWMS
- Add a function to get the correct URL if the source is TileWMS and not
  ImageWMS
- Add a custom parameter in the object to get images with transparency