### PR TITLE
Fix layertree example

### DIFF
--- a/examples/layertree.js
+++ b/examples/layertree.js
@@ -79,10 +79,10 @@ app.module.directive('appLayertree', app.layertreeDirective);
 app.LayertreeController = function($http, $sce, appGetLayer, ngeoCreatePopup) {
 
   /**
-   * @type {Object}
+   * @type {Object|undefined}
    * @export
    */
-  this.tree = null;
+  this.tree = undefined;
 
   $http.get('data/tree.json').then(angular.bind(this, function(resp) {
     this.tree = resp.data;


### PR DESCRIPTION
This commit fixes #227, reported by @fgravin. The bug is related to Angular's one-time binding (correctly) considering `null` values as defined values. The fix involves using `undefined` instead of `null` as the initial value for the `tree` data model.

Fixes #227.