### PR TITLE
Display measurements even on touch devices

### DIFF
--- a/src/ol-ext/interaction/measurearea.js
+++ b/src/ol-ext/interaction/measurearea.js
@@ -25,9 +25,8 @@ ngeo.interaction.MeasureArea = function(opt_options) {
   /**
    * Message to show after the first point is clicked.
    * @type {Element}
-   * @private
    */
-  this.continueMsg_ = goog.isDef(options.continueMsg) ? options.continueMsg :
+  this.continueMsg = goog.isDef(options.continueMsg) ? options.continueMsg :
       goog.dom.createDom(goog.dom.TagName.SPAN, {},
           'Click to continue drawing the polygon.',
           goog.dom.createDom(goog.dom.TagName.BR),
@@ -61,12 +60,11 @@ ngeo.interaction.MeasureArea.prototype.handleMeasure = function(callback) {
       (this.sketchFeature.getGeometry());
   var output = this.formatMeasure_(geom);
   var verticesCount = geom.getCoordinates()[0].length;
-  var helpMsg = this.continueMsg_;
   var coord = null;
   if (verticesCount > 2) {
     coord = geom.getInteriorPoint().getCoordinates();
   }
-  callback(output, coord, helpMsg);
+  callback(output, coord);
 };
 
 

--- a/src/ol-ext/interaction/measureazimut.js
+++ b/src/ol-ext/interaction/measureazimut.js
@@ -44,9 +44,8 @@ ngeo.interaction.MeasureAzimut = function(opt_options) {
   /**
    * Message to show after the first point is clicked.
    * @type {Element}
-   * @private
    */
-  this.continueMsg_ = goog.isDef(options.continueMsg) ? options.continueMsg :
+  this.continueMsg = goog.isDef(options.continueMsg) ? options.continueMsg :
       goog.dom.createDom(goog.dom.TagName.SPAN, {}, 'Click to finish.');
 
 };
@@ -77,7 +76,7 @@ ngeo.interaction.MeasureAzimut.prototype.handleMeasure = function(callback) {
   var line = /** @type {ol.geom.LineString} */ (geom.getGeometries()[0]);
   var output = this.formatMeasure_(line);
   var coord = /** @type {ol.Coordinate} */ (line.getLastCoordinate());
-  callback(output, coord, this.continueMsg_);
+  callback(output, coord);
 };
 
 

--- a/src/ol-ext/interaction/measurelength.js
+++ b/src/ol-ext/interaction/measurelength.js
@@ -25,9 +25,8 @@ ngeo.interaction.MeasureLength = function(opt_options) {
   /**
    * Message to show after the first point is clicked.
    * @type {Element}
-   * @private
    */
-  this.continueMsg_ = goog.isDef(options.continueMsg) ? options.continueMsg :
+  this.continueMsg = goog.isDef(options.continueMsg) ? options.continueMsg :
       goog.dom.createDom(goog.dom.TagName.SPAN, {},
           'Click to continue drawing the line.',
           goog.dom.createDom(goog.dom.TagName.BR),
@@ -61,7 +60,7 @@ ngeo.interaction.MeasureLength.prototype.handleMeasure = function(callback) {
       (this.sketchFeature.getGeometry());
   var output = this.formatMeasure_(geom);
   var coord = geom.getLastCoordinate();
-  callback(output, coord, this.continueMsg_);
+  callback(output, coord);
 };
 
 


### PR DESCRIPTION
With this pull request, I make it so the measurement can be displayed even on touch devices.
Now the help tooltip is the only one to be shown on mousemove. The measurement tooltip displays and updates (content and position) as soon as the geometry is changed.
Please review.