### PR TITLE
Remove ol.FeatureOverlay

### DIFF
--- a/examples/geolocation.js
+++ b/examples/geolocation.js
@@ -3,12 +3,13 @@ goog.provide('geolocation');
 goog.require('ngeo.DecorateGeolocation');
 goog.require('ngeo.mapDirective');
 goog.require('ol.Feature');
-goog.require('ol.FeatureOverlay');
 goog.require('ol.Geolocation');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Tile');
+goog.require('ol.layer.Vector');
 goog.require('ol.source.MapQuest');
+goog.require('ol.source.Vector');
 
 
 /** @const **/
@@ -65,10 +66,15 @@ app.MainController = function(ngeoDecorateGeolocation) {
     accuracyFeature.setGeometry(geolocation.getAccuracyGeometry());
   });
 
-  var featureOverlay = new ol.FeatureOverlay({
-    features: [positionFeature, accuracyFeature]
+  var vectorLayer = new ol.layer.Vector({
+    source: new ol.source.Vector({
+      features: [positionFeature, accuracyFeature]
+    })
   });
-  featureOverlay.setMap(map);
+
+  // Use vectorLayer.setMap(map) rather than map.addLayer(vectorLayer). This
+  // makes the vector layer "unmanaged", meaning that it is always on top.
+  vectorLayer.setMap(map);
 
   geolocation.on('change:position', function(e) {
     var position = /** @type {ol.Coordinate} */ (geolocation.getPosition());

--- a/examples/interactionbtngroup.js
+++ b/examples/interactionbtngroup.js
@@ -3,7 +3,6 @@ goog.provide('interactionbtngroup');
 goog.require('ngeo.DecorateInteraction');
 goog.require('ngeo.btngroupDirective');
 goog.require('ngeo.mapDirective');
-goog.require('ol.FeatureOverlay');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.geom.Point');

--- a/examples/interactiontoggle.js
+++ b/examples/interactiontoggle.js
@@ -2,12 +2,13 @@ goog.provide('interactiontoggle');
 
 goog.require('ngeo.DecorateInteraction');
 goog.require('ngeo.mapDirective');
-goog.require('ol.FeatureOverlay');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.interaction.Draw');
 goog.require('ol.layer.Tile');
+goog.require('ol.layer.Vector');
 goog.require('ol.source.MapQuest');
+goog.require('ol.source.Vector');
 
 
 /** @const **/
@@ -45,8 +46,13 @@ app.MainController = function(ngeoDecorateInteraction) {
 
   var map = this.map;
 
-  var featureOverlay = new ol.FeatureOverlay();
-  featureOverlay.setMap(map);
+  var vectorLayer = new ol.layer.Vector({
+    source: new ol.source.Vector()
+  });
+
+  // Use vectorLayer.setMap(map) rather than map.addLayer(vectorLayer). This
+  // makes the vector layer "unmanaged", meaning that it is always on top.
+  vectorLayer.setMap(map);
 
   /**
    * @type {ol.interaction.Draw}
@@ -55,7 +61,7 @@ app.MainController = function(ngeoDecorateInteraction) {
   this.interaction = new ol.interaction.Draw(
       /** @type {olx.interaction.DrawOptions} */ ({
         type: 'Point',
-        features: featureOverlay.getFeatures()
+        source: vectorLayer.getSource()
       }));
 
   var interaction = this.interaction;

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -7,7 +7,6 @@ goog.require('ngeo.interaction.MeasureArea');
 goog.require('ngeo.interaction.MeasureAzimut');
 goog.require('ngeo.interaction.MeasureLength');
 goog.require('ngeo.mapDirective');
-goog.require('ol.FeatureOverlay');
 goog.require('ol.Map');
 goog.require('ol.Observable');
 goog.require('ol.Overlay');

--- a/examples/profile.js
+++ b/examples/profile.js
@@ -7,15 +7,16 @@ goog.require('ngeo.profileDirective');
 goog.require('ol');
 goog.require('ol.Attribution');
 goog.require('ol.Feature');
-goog.require('ol.FeatureOverlay');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.geom.GeometryLayout');
 goog.require('ol.geom.LineString');
 goog.require('ol.layer.Image');
+goog.require('ol.layer.Vector');
 goog.require('ol.proj');
 goog.require('ol.proj.Projection');
 goog.require('ol.source.ImageWMS');
+goog.require('ol.source.Vector');
 
 
 /** @const **/
@@ -86,10 +87,16 @@ app.MainController = function($http, $scope) {
 
   var map = this.map;
 
-  var overlay = new ol.FeatureOverlay();
+  var vectorLayer = new ol.layer.Vector({
+    source: new ol.source.Vector()
+  });
+
   this.snappedPoint_ = new ol.Feature();
-  overlay.addFeature(this.snappedPoint_);
-  overlay.setMap(map);
+  vectorLayer.getSource().addFeature(this.snappedPoint_);
+
+  // Use vectorLayer.setMap(map) rather than map.addLayer(vectorLayer). This
+  // makes the vector layer "unmanaged", meaning that it is always on top.
+  vectorLayer.setMap(map);
 
   /**
    * @type {Array.<Object>}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "karma-jasmine": "^0.1.5",
     "karma-phantomjs-launcher": "^0.1.4",
     "nomnom": "~1.6.2",
-    "openlayers": "openlayers/ol3#v3.6.0",
+    "openlayers": "openlayers/ol3#master",
     "phantomjs": "~1.9.7-5",
     "temp": "~0.7.0",
     "typeahead.js": "~0.10.5",

--- a/src/ol-ext/interaction/measure.js
+++ b/src/ol-ext/interaction/measure.js
@@ -7,13 +7,14 @@ goog.require('goog.dom');
 goog.require('goog.dom.classlist');
 goog.require('goog.events');
 goog.require('ol.Feature');
-goog.require('ol.FeatureOverlay');
 goog.require('ol.MapBrowserEvent');
 goog.require('ol.Observable');
 goog.require('ol.Overlay');
 goog.require('ol.interaction.DrawEvent');
 goog.require('ol.interaction.DrawEventType');
 goog.require('ol.interaction.Interaction');
+goog.require('ol.layer.Vector');
+goog.require('ol.source.Vector');
 goog.require('ol.style.Fill');
 goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
@@ -165,14 +166,14 @@ ngeo.interaction.Measure = function(opt_options) {
       ];
 
   /**
-   * The draw overlay
-   * @type {ol.FeatureOverlay}
+   * The vector layer used to show final measure features.
+   * @type {ol.layer.Vector}
    * @private
    */
-  this.overlay_ = new ol.FeatureOverlay({
+  this.vectorLayer_ = new ol.layer.Vector({
+    source: new ol.source.Vector(),
     style: style
   });
-
 
   /**
    * The draw interaction to be used.
@@ -180,7 +181,7 @@ ngeo.interaction.Measure = function(opt_options) {
    * @private
    */
   this.drawInteraction_ = this.getDrawInteraction(options.sketchStyle,
-      this.overlay_);
+      this.vectorLayer_.getSource());
 
   goog.events.listen(this.drawInteraction_,
       ol.interaction.DrawEventType.DRAWSTART, this.onDrawStart_, false, this);
@@ -223,7 +224,7 @@ ngeo.interaction.Measure.handleEvent_ = function(evt) {
  * Creates the draw interaction.
  * @param {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined}
  *     style The sketchStyle used for the drawing interaction.
- * @param {ol.FeatureOverlay} overlay The feature overlay.
+ * @param {ol.source.Vector} source Vector source.
  * @return {ol.interaction.Draw|ngeo.interaction.DrawAzimut}
  * @protected
  */
@@ -236,7 +237,7 @@ ngeo.interaction.Measure.prototype.getDrawInteraction = goog.abstractMethod;
 ngeo.interaction.Measure.prototype.setMap = function(map) {
   goog.base(this, 'setMap', map);
 
-  this.overlay_.setMap(map);
+  this.vectorLayer_.setMap(map);
 
   var prevMap = this.drawInteraction_.getMap();
   if (!goog.isNull(prevMap)) {
@@ -256,7 +257,7 @@ ngeo.interaction.Measure.prototype.setMap = function(map) {
  */
 ngeo.interaction.Measure.prototype.onDrawStart_ = function(evt) {
   this.sketchFeature = evt.feature;
-  this.overlay_.getFeatures().clear();
+  this.vectorLayer_.getSource().clear(true);
   this.createMeasureTooltip_();
 
   var geometry = this.sketchFeature.getGeometry();
@@ -365,7 +366,7 @@ ngeo.interaction.Measure.prototype.updateState_ = function() {
     this.createMeasureTooltip_();
     this.createHelpTooltip_();
   } else {
-    this.overlay_.getFeatures().clear();
+    this.vectorLayer_.getSource().clear(true);
     this.getMap().removeOverlay(this.measureTooltipOverlay_);
     this.removeMeasureTooltip_();
     this.removeHelpTooltip_();

--- a/src/ol-ext/interaction/measurearea.js
+++ b/src/ol-ext/interaction/measurearea.js
@@ -40,12 +40,12 @@ goog.inherits(ngeo.interaction.MeasureArea, ngeo.interaction.Measure);
  * @inheritDoc
  */
 ngeo.interaction.MeasureArea.prototype.getDrawInteraction = function(style,
-    overlay) {
+    source) {
 
   return new ol.interaction.Draw(
       /** @type {olx.interaction.DrawOptions} */ ({
         type: 'Polygon',
-        features: overlay.getFeatures(),
+        source: source,
         style: style
       }));
 

--- a/src/ol-ext/interaction/measurelength.js
+++ b/src/ol-ext/interaction/measurelength.js
@@ -40,12 +40,12 @@ goog.inherits(ngeo.interaction.MeasureLength, ngeo.interaction.Measure);
  * @inheritDoc
  */
 ngeo.interaction.MeasureLength.prototype.getDrawInteraction = function(style,
-    overlay) {
+    source) {
 
   return new ol.interaction.Draw(
       /** @type {olx.interaction.DrawOptions} */ ({
         type: 'LineString',
-        features: overlay.getFeatures(),
+        source: source,
         style: style
       }));
 


### PR DESCRIPTION
This PR removes the use of `ol.FeatureOverlay`. Feature overlays are replaced by "unmanaged" vector layers, that is vector layers that are always on top.

Fixes #236.