### PR TITLE
Use new geomapfish server

### DIFF
--- a/examples/mapfishprint.js
+++ b/examples/mapfishprint.js
@@ -27,7 +27,7 @@ app.module = angular.module('app', ['ngeo']);
  * @const
  * @private
  */
-app.WMS_URL_ = 'http://geomapfish.demo-camptocamp.com/1.6/wsgi/' +
+app.WMS_URL_ = 'http://geomapfish-demo.camptocamp.net/1.6/wsgi/' +
     'mapserv_proxy';
 
 
@@ -35,7 +35,7 @@ app.WMS_URL_ = 'http://geomapfish.demo-camptocamp.com/1.6/wsgi/' +
  * @const
  * @private
  */
-app.PRINT_URL_ = 'http://geomapfish.demo-camptocamp.com/1.6/wsgi/' +
+app.PRINT_URL_ = 'http://geomapfish-demo.camptocamp.net/1.6/wsgi/' +
     'printproxy';
 
 


### PR DESCRIPTION
This changes the mapfishprint example to use the new geomapfish server as the previous one is not in service anymore.

But there still is a problem. The WMS layer works but print requests fail because of the CORS issue. This is the error I get in the console:

```
XMLHttpRequest cannot load http://geomapfish-demo.camptocamp.net/1.6/wsgi/printproxy/report.pdf. No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://localhost:3000' is therefore not allowed access. The response had HTTP status code 404.
```

@sbrunner, I think we need your help for this.