### PR TITLE
Set stopEvent to true in measure tooltip overlay

### DIFF
--- a/src/ol-ext/interaction/measure.js
+++ b/src/ol-ext/interaction/measure.js
@@ -333,7 +333,8 @@ ngeo.interaction.Measure.prototype.createMeasureTooltip_ = function() {
   this.measureTooltipOverlay_ = new ol.Overlay({
     element: this.measureTooltipElement_,
     offset: [0, -15],
-    positioning: 'bottom-center'
+    positioning: 'bottom-center',
+    stopEvent: false
   });
   this.getMap().addOverlay(this.measureTooltipOverlay_);
 };


### PR DESCRIPTION
This fixes a bug where the user cannot add a point under the measure tooltip.