### PR TITLE
Make ngeo.Print#encodeLayer public

### DIFF
--- a/exports/services/print.js
+++ b/exports/services/print.js
@@ -10,6 +10,10 @@ goog.exportProperty(
     ngeo.Print.prototype.createSpec);
 goog.exportProperty(
     ngeo.Print.prototype,
+    'encodeLayer',
+    ngeo.Print.prototype.encodeLayer);
+goog.exportProperty(
+    ngeo.Print.prototype,
     'getReportUrl',
     ngeo.Print.prototype.getReportUrl);
 goog.exportProperty(

--- a/src/services/print.js
+++ b/src/services/print.js
@@ -174,7 +174,7 @@ ngeo.Print.prototype.encodeMap_ = function(map, scale, object) {
        */
       function(layer, idx, layers) {
         goog.asserts.assert(goog.isDef(viewResolution));
-        this.encodeLayer_(object.layers, layer, viewResolution);
+        this.encodeLayer(object.layers, layer, viewResolution);
       }, this);
 };
 
@@ -183,9 +183,8 @@ ngeo.Print.prototype.encodeMap_ = function(map, scale, object) {
  * @param {Array.<MapFishPrintLayer>} arr Array.
  * @param {ol.layer.Base} layer Layer.
  * @param {number} resolution Resolution.
- * @private
  */
-ngeo.Print.prototype.encodeLayer_ = function(arr, layer, resolution) {
+ngeo.Print.prototype.encodeLayer = function(arr, layer, resolution) {
   if (layer instanceof ol.layer.Image) {
     this.encodeImageLayer_(arr, layer);
   } else if (layer instanceof ol.layer.Tile) {


### PR DESCRIPTION
This commit makes `ngeo.Print#encodeLayer` public. This, for example, makes it possible to applications to print "unmanaged" vector layers.