### PR TITLE
Remove Angular externs from closure-compiler.js

### DIFF
--- a/externs/closure-compiler.js
+++ b/externs/closure-compiler.js
@@ -22,17 +22,3 @@ Navigator.prototype.systemLanguage;
  * @type {string}
  */
 Navigator.prototype.userLanguage;
-
-
-/**
- * @param {(string|function(!angular.Scope))=} opt_exp
- */
-angular.Scope.prototype.$applyAsync = function(opt_exp) {};
-
-
-/**
- * @param {string} event
- * @param {JQLiteSelector} container
- * @param {function(JQLiteSelector, string)} callback
- */
-angular.$animate.prototype.on = function(event, container, callback) {};


### PR DESCRIPTION
With https://github.com/google/closure-compiler/pull/1030 and https://github.com/google/closure-compiler/pull/1031 now closed we can remove these extern definitions.