### PR TITLE
Strictly listen on container, not children

### DIFF
--- a/src/directives/resizemap.js
+++ b/src/directives/resizemap.js
@@ -55,10 +55,12 @@ ngeo.resizemapDirective = function($window, $animate) {
                 animationDelay.start();
               }, $window);
 
-          var animationCallback = function(element, phase) {
-            animationDelay.start();
-            if (phase == 'close') {
-              animationDelay.stop();
+          var animationCallback = function(target, phase) {
+            if (target == element) {
+              animationDelay.start();
+              if (phase == 'close') {
+                animationDelay.stop();
+              }
             }
           };
           $animate.on('addClass', element, animationCallback);


### PR DESCRIPTION
When we listen on $animate events, callbacks may be called even for children of the element we listen to. This pull request prevents this by ensuring that the target of the event is actually the element itself.
Please review.