### PR TITLE
Select print style type based on geometry type

### DIFF
--- a/src/services/print.js
+++ b/src/services/print.js
@@ -426,18 +426,23 @@ ngeo.Print.prototype.encodeVectorLayer_ = function(arr, layer, resolution) {
     }
   }
 
-  var geojsonFeatureCollection = /** @type {GeoJSONFeatureCollection} */ ({
-    type: 'FeatureCollection',
-    features: geojsonFeatures
-  });
+  // MapFish Print fails if there are no style rules, even if there are no
+  // features either. To work around this we just ignore the layer if the
+  // array of GeoJSON features is empty.
+  // See https://github.com/mapfish/mapfish-print/issues/279
 
-  var object = /** @type {MapFishPrintVectorLayer} */ ({
-    geoJson: geojsonFeatureCollection,
-    style: mapfishStyleObject,
-    type: 'geojson'
-  });
-
-  arr.push(object);
+  if (geojsonFeatures.length > 0) {
+    var geojsonFeatureCollection = /** @type {GeoJSONFeatureCollection} */ ({
+      type: 'FeatureCollection',
+      features: geojsonFeatures
+    });
+    var object = /** @type {MapFishPrintVectorLayer} */ ({
+      geoJson: geojsonFeatureCollection,
+      style: mapfishStyleObject,
+      type: 'geojson'
+    });
+    arr.push(object);
+  }
 };
 
 

--- a/src/services/print.js
+++ b/src/services/print.js
@@ -65,6 +65,36 @@ goog.require('ol.tilegrid.WMTS');
 ngeo.CreatePrint;
 
 
+/**
+ * @enum {string}
+ */
+ngeo.PrintStyleType = {
+  LINE_STRING: 'LineString',
+  POINT: 'Point',
+  POLYGON: 'Polygon'
+};
+
+
+/**
+ * @type {Object.<ol.geom.GeometryType, ngeo.PrintStyleType>}
+ * @private
+ */
+ngeo.PrintStyleTypes_ = {};
+
+ngeo.PrintStyleTypes_[ol.geom.GeometryType.LINE_STRING] =
+    ngeo.PrintStyleType.LINE_STRING;
+ngeo.PrintStyleTypes_[ol.geom.GeometryType.POINT] =
+    ngeo.PrintStyleType.POINT;
+ngeo.PrintStyleTypes_[ol.geom.GeometryType.POLYGON] =
+    ngeo.PrintStyleType.POLYGON;
+ngeo.PrintStyleTypes_[ol.geom.GeometryType.MULTI_LINE_STRING] =
+    ngeo.PrintStyleType.LINE_STRING;
+ngeo.PrintStyleTypes_[ol.geom.GeometryType.MULTI_POINT] =
+    ngeo.PrintStyleType.POINT;
+ngeo.PrintStyleTypes_[ol.geom.GeometryType.MULTI_POLYGON] =
+    ngeo.PrintStyleType.POLYGON;
+
+
 
 /**
  * @constructor
@@ -413,7 +443,7 @@ ngeo.Print.prototype.encodeVectorLayer_ = function(arr, layer, resolution) {
 
 /**
  * @param {MapFishPrintVectorStyle} object MapFish style object.
- * @param {string} geometryType Type of the GeoJSON geometry
+ * @param {ol.geom.GeometryType} geometryType Type of the GeoJSON geometry
  * @param {ol.style.Style} style Style.
  * @param {string} styleId Style id.
  * @param {string} featureStyleProp Feature style property name.
@@ -421,6 +451,11 @@ ngeo.Print.prototype.encodeVectorLayer_ = function(arr, layer, resolution) {
  */
 ngeo.Print.prototype.encodeVectorStyle_ =
     function(object, geometryType, style, styleId, featureStyleProp) {
+  if (!(geometryType in ngeo.PrintStyleTypes_)) {
+    // unsupported geometry type
+    return;
+  }
+  var styleType = ngeo.PrintStyleTypes_[geometryType];
   var key = '[' + featureStyleProp + ' = \'' + styleId + '\']';
   if (key in object) {
     // do nothing if we already have a style object for this CQL rule
@@ -434,17 +469,20 @@ ngeo.Print.prototype.encodeVectorStyle_ =
   var imageStyle = style.getImage();
   var strokeStyle = style.getStroke();
   var textStyle = style.getText();
-  var isLine = geometryType === ol.geom.GeometryType.LINE_STRING ||
-          geometryType === ol.geom.GeometryType.MULTI_LINE_STRING;
-  if (!goog.isNull(fillStyle) && !isLine) {
-    this.encodeVectorStylePolygon_(
-        styleObject.symbolizers, fillStyle, strokeStyle);
-  } else if (!goog.isNull(strokeStyle)) {
-    this.encodeVectorStyleLine_(styleObject.symbolizers, strokeStyle);
-  } else if (!goog.isNull(imageStyle)) {
-    this.encodeVectorStylePoint_(styleObject.symbolizers, imageStyle);
+  if (styleType == ngeo.PrintStyleType.POLYGON) {
+    if (!goog.isNull(fillStyle)) {
+      this.encodeVectorStylePolygon_(
+          styleObject.symbolizers, fillStyle, strokeStyle);
+    }
+  } else if (styleType == ngeo.PrintStyleType.LINE_STRING) {
+    if (!goog.isNull(strokeStyle)) {
+      this.encodeVectorStyleLine_(styleObject.symbolizers, strokeStyle);
+    }
+  } else if (styleType == ngeo.PrintStyleType.POINT) {
+    if (!goog.isNull(imageStyle)) {
+      this.encodeVectorStylePoint_(styleObject.symbolizers, imageStyle);
+    }
   }
-
   if (!goog.isNull(textStyle)) {
     this.encodeTextStyle_(styleObject.symbolizers, textStyle);
   }

--- a/test/spec/services/print.spec.js
+++ b/test/spec/services/print.spec.js
@@ -288,12 +288,19 @@ describe('ngeo.CreatePrint', function() {
         });
 
         style0 = new ol.style.Style({
+          fill: new ol.style.Fill({
+            color: [1, 1, 1, 0.1]
+          }),
           image: new ol.style.Circle({
             radius: 1,
             stroke: new ol.style.Stroke({
               width: 1,
               color: [1, 1, 1, 0.1]
             })
+          }),
+          stroke: new ol.style.Stroke({
+            width: 1,
+            color: [1, 1, 1, 0.1]
           })
         });
 
@@ -429,6 +436,7 @@ describe('ngeo.CreatePrint', function() {
           '_ngeo_style_0': styleId2
         };
 
+        // the expected properties of feature3
         var properties3 = {
           foo: '3',
           '_ngeo_style_0': styleId3


### PR DESCRIPTION
With this commint the vector style type used in the print spec is selected based on the geometry type, instead of being selected based on the properties found in the `ol.style.Style` object. Relying on the properties found in the `ol.style.Style` object is fragile, as a style object may be used for drawing different types of geometries.