### PR TITLE
Add externs definitions on angular.JQLite

### DIFF
--- a/externs/twbootstrap.js
+++ b/externs/twbootstrap.js
@@ -13,10 +13,24 @@ jQuery.prototype.alert = function(opt_action) {};
 
 
 /**
-* @param {(string|Object.<string,*>)=} opt_options
-* @return {jQuery}
-*/
+ * @param {string=} opt_action
+ * @return {!angular.jQLite}
+ */
+angular.JQLite.prototype.alert = function(opt_action) {};
+
+
+/**
+ * @param {(string|Object.<string,*>)=} opt_options
+ * @return {jQuery}
+ */
 jQuery.prototype.modal = function(opt_options) {};
+
+
+/**
+ * @param {(string|Object.<string,*>)=} opt_options
+ * @return {angular.JQLite}
+ */
+angular.JQLite.prototype.modal = function(opt_options) {};
 
 
 /**
@@ -24,3 +38,10 @@ jQuery.prototype.modal = function(opt_options) {};
  * @return {!jQuery}
  */
 jQuery.prototype.tab = function(action) {};
+
+
+/**
+ * @param {string} action
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.tab = function(action) {};

--- a/externs/typeahead.js
+++ b/externs/typeahead.js
@@ -162,3 +162,11 @@ var TypeaheadOptions;
  * @return {!jQuery}
  */
 jQuery.prototype.typeahead = function(options, var_dataset) {};
+
+
+/**
+ * @param {string|TypeaheadOptions} options
+ * @param {...TypeaheadDataset} var_dataset
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.typeahead = function(options, var_dataset) {};


### PR DESCRIPTION
`angular.JQLite` was de-typedef'ed in closure-compiler. See https://github.com/google/closure-compiler/commit/d785704f64e95e8764db5a9fb02809aaabf42c7e. Because of that we need to add externs definitions to `angular.JQLite`.