### PR TITLE
Fix typo in twbootstrap externs file

### DIFF
--- a/externs/twbootstrap.js
+++ b/externs/twbootstrap.js
@@ -14,7 +14,7 @@ jQuery.prototype.alert = function(opt_action) {};
 
 /**
  * @param {string=} opt_action
- * @return {!angular.jQLite}
+ * @return {!angular.JQLite}
  */
 angular.JQLite.prototype.alert = function(opt_action) {};
 


### PR DESCRIPTION
This one was not caught by the ngeo build because this extern definition is not used in the ngeo code or in one of the examples.