### PR TITLE
Use language:python in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: ruby
+language: python
 sudo: false
 branches:
   only:
@@ -10,10 +10,6 @@ after_success:
 env:
   global:
   - secure: "WZWqYrRy5uhk3IgXT9HXAL1zrZfrmJbbglF4gwNpSnrZkLv63gFwpMj6bjxOPKPouU76p4K7x/fnZb/FWRl6/fEnJzLKNvbknQtvmC4dAoHLynFVpilYholmdscT2fo/SOmE3XKOA4EJTF7oxToCgT2+e68e/oH87izXUn4FvK8="
-addons:
-  apt:
-    packages:
-    - python-virtualenv
 cache:
   apt: true
   directories:


### PR DESCRIPTION
This is an attempt to use `language: python` in the Travis config. Not sure it works and makes sense really.