### PR TITLE
Add ngeo.gmf.mapDirective

### DIFF
--- a/examples/gmf-simple.html
+++ b/examples/gmf-simple.html
@@ -1,0 +1,24 @@
+<!DOCTYPE>
+<html ng-app='app'>
+  <head>
+    <title>Simple GeoMapFish example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
+    <style>
+      ngeo-gmf-map > div {
+        width: 600px;
+        height: 400px;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <ngeo-gmf-map ngeo-gmf-map-map="::ctrl.map"></ngeo-gmf-map>
+    <p id="desc">This example shows how to use the <code>ngeo-gmf-map</code> directive to insert an OpenLayers map in a GeoMapFish page.</p>
+    <script src="../node_modules/angular/angular.js"></script>
+    <script src="/@?main=gmf-simple.js"></script>
+    <script src="../utils/watchwatchers.js"></script>
+  </body>
+</html>

--- a/examples/gmf-simple.js
+++ b/examples/gmf-simple.js
@@ -1,0 +1,42 @@
+goog.provide('gmf-simple');
+
+goog.require('ngeo.gmf.mapDirective');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['ngeo']);
+
+
+
+/**
+ * @constructor
+ */
+app.MainController = function() {
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      })
+    ],
+    view: new ol.View({
+      center: [0, 0],
+      zoom: 4
+    })
+  });
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/src/directives/gmf-map.js
+++ b/src/directives/gmf-map.js
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview This file provides the "map" directive
+ * for GeoMapFish applications.
+ *
+ * Example:
+ *
+ * <ngeo-gmf-map ngeo-gmf-map-map="::mainCtrl.map"></ngeo-gmf-map>
+ */
+goog.provide('ngeo.gmf.mapDirective');
+
+goog.require('goog.asserts');
+goog.require('ngeo.Debounce');
+goog.require('ngeo.Location');
+goog.require('ngeo.mapDirective');
+
+
+/**
+ * @return {angular.Directive} The Directive Definition Object.
+ * @ngInject
+ */
+ngeo.gmf.mapDirective = function() {
+  return {
+    scope: {},
+    bindToController: {
+      'map': '=ngeoGmfMapMap'
+    },
+    controller: 'NgeoGmfMapController',
+    controllerAs: 'ctrl',
+    template: '<div ngeo-map="ctrl.map"></div>'
+  };
+};
+
+ngeoModule.directive('ngeoGmfMap', ngeo.gmf.mapDirective);
+
+
+
+/**
+ * @param {ngeo.Location} ngeoLocation ngeo Location service.
+ * @param {ngeo.Debounce} ngeoDebounce ngeo Debounce service.
+ * @constructor
+ * @ngInject
+ */
+ngeo.gmf.MapController = function(ngeoLocation, ngeoDebounce) {
+
+  /**
+   * @type {!ol.Map}
+   */
+  var map = this['map'];
+  goog.asserts.assert(goog.isDef(map));
+  var view = map.getView();
+
+  var x = ngeoLocation.getParam('map_x');
+  var y = ngeoLocation.getParam('map_y');
+  var zoom = ngeoLocation.getParam('map_zoom');
+
+  if (goog.isDef(x) && goog.isDef(y)) {
+    view.setCenter([+x, +y]);
+  }
+  if (goog.isDef(zoom)) {
+    view.setZoom(+zoom);
+  }
+
+  view.on('propertychange', ngeoDebounce(function() {
+    var center = view.getCenter();
+    var zoom = view.getZoom();
+    ngeoLocation.updateParams({
+      'map_zoom': zoom,
+      'map_x': Math.round(center[0]),
+      'map_y': Math.round(center[1])
+    });
+  }, 300, /* invokeApply */ true));
+};
+
+ngeoModule.controller('NgeoGmfMapController', ngeo.gmf.MapController);


### PR DESCRIPTION
Port of https://github.com/camptocamp/c2cgeoportal/pull/1471

To be discussed:
* ~~the new ngeo.gmf directive/controller are in a dedicated ``directives/gmf/`` to make GMF directives apart (clearer?).~~
* ~~on the other hand the ``gmf-simple.html`` example is at the root of ``examples/``. If files are placed in a ``gmf/`` dir, the page complains that ``Main script not in manager paths: ...``. I also suspect troubles with the hosted examples deployment.~~
* ~~the map expands on the whole viewport, the explanation test being pushed ouside of the window, despite the "#map" style provided in the example page. Any idea?~~