### PR TITLE
Send layer opacity to MapFish Print

### DIFF
--- a/externs/mapfish-print-v3.js
+++ b/externs/mapfish-print-v3.js
@@ -99,6 +99,12 @@ var MapFishPrintLayer = function() {};
 MapFishPrintLayer.prototype.type;
 
 
+/**
+ * @type {number}
+ */
+MapFishPrintLayer.prototype.opacity;
+
+
 
 /**
  * @constructor
@@ -155,12 +161,6 @@ MapFishPrintWmsLayer.prototype.customParams;
  * @type {Array.<string>}
  */
 MapFishPrintWmsLayer.prototype.layers;
-
-
-/**
- * @type {number}
- */
-MapFishPrintWmsLayer.prototype.opacity;
 
 
 /**

--- a/src/services/print.js
+++ b/src/services/print.js
@@ -437,6 +437,7 @@ ngeo.Print.prototype.encodeVectorLayer_ = function(arr, layer, resolution) {
     });
     var object = /** @type {MapFishPrintVectorLayer} */ ({
       geoJson: geojsonFeatureCollection,
+      opacity: layer.getOpacity(),
       style: mapfishStyleObject,
       type: 'geojson'
     });

--- a/src/services/print.js
+++ b/src/services/print.js
@@ -341,6 +341,7 @@ ngeo.Print.prototype.encodeTileWmtsLayer_ = function(arr, layer) {
     layer: source.getLayer(),
     matrices: matrices,
     matrixSet: source.getMatrixSet(),
+    opacity: layer.getOpacity(),
     requestEncoding: /** @type {string} */ (source.getRequestEncoding()),
     style: source.getStyle(),
     type: 'WMTS',

--- a/src/services/print.js
+++ b/src/services/print.js
@@ -250,9 +250,8 @@ ngeo.Print.prototype.encodeImageWmsLayer_ = function(arr, layer) {
   goog.asserts.assertInstanceof(layer, ol.layer.Image);
   goog.asserts.assertInstanceof(source, ol.source.ImageWMS);
 
-  var url = source.getUrl();
-  var params = source.getParams();
-  this.encodeWmsLayer_(arr, layer.getOpacity(), url, params);
+  this.encodeWmsLayer_(
+      arr, layer.getOpacity(), source.getUrl(), source.getParams());
 };
 
 
@@ -363,9 +362,8 @@ ngeo.Print.prototype.encodeTileWmsLayer_ = function(arr, layer) {
   goog.asserts.assertInstanceof(layer, ol.layer.Tile);
   goog.asserts.assertInstanceof(source, ol.source.TileWMS);
 
-  var url = source.getUrls()[0];
-  var params = source.getParams();
-  this.encodeWmsLayer_(arr, layer.getOpacity(), url, params);
+  this.encodeWmsLayer_(
+      arr, layer.getOpacity(), source.getUrls()[0], source.getParams());
 };
 
 

--- a/test/spec/services/print.spec.js
+++ b/test/spec/services/print.spec.js
@@ -356,6 +356,7 @@ describe('ngeo.CreatePrint', function() {
         };
 
         map.addLayer(new ol.layer.Vector({
+          opacity: 0.8,
           source: new ol.source.Vector({
             features: [feature0, feature1, feature2, feature3]
           }),
@@ -485,6 +486,7 @@ describe('ngeo.CreatePrint', function() {
                     properties: properties3
                   }]
                 },
+                opacity: 0.8,
                 style: expectedStyle,
                 type: 'geojson'
               }]

--- a/test/spec/services/print.spec.js
+++ b/test/spec/services/print.spec.js
@@ -178,6 +178,7 @@ describe('ngeo.CreatePrint', function() {
       beforeEach(function() {
         var projection = ol.proj.get('EPSG:3857');
         map.addLayer(new ol.layer.Tile({
+          opacity: 0.5,
           source: new ol.source.WMTS({
             dimensions: {'TIME': 'time'},
             format: 'image/jpeg',
@@ -246,6 +247,7 @@ describe('ngeo.CreatePrint', function() {
                   matrixSize: [4, 4]
                 }],
                 matrixSet: 'matrixset',
+                opacity: 0.5,
                 requestEncoding: 'REST',
                 style: 'style',
                 type: 'WMTS',


### PR DESCRIPTION
Currently, the opacity of WMTS and Vector layers are not set in the print specs sent to MapFish Print. This PR fixes that.

Please review.