### PR TITLE
Check for undefined point in profile highlight

### DIFF
--- a/src/d3-ext/profile.js
+++ b/src/d3-ext/profile.js
@@ -421,6 +421,10 @@ ngeo.profile = function(options) {
   profile.highlight = function(distance) {
     var data = svg.datum();
     var i = bisectDistance(data, distance);
+    if (i >= data.length) {
+      return;
+    }
+
     var point = data[i];
 
     var extractor = elevationExtractor;


### PR DESCRIPTION
When the profile div is not perfectly aligned, the `distance` may be greater than the maximum distance from the data. In this case, `i` is out of range and `point` would be `undefined`.
This commit adds a test.