### PR TITLE
Fix gh-pages-from-travis Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ gh-pages-from-travis: .build/ngeo-travis-gh-pages check-examples .build/examples
 	 git merge --ff-only origin/gh-pages && \
 	 git rm --ignore-unmatch -rqf master && \
 	 mkdir -p master && \
-	 cp -r ../examples-hosted/* $(GIT_BRANCH) && \
+	 cp -r ../examples-hosted/* master && \
 	 git config user.name "Travis" && \
 	 git config user.email "travis@travis-ci.org" && \
 	 git add -A . && \


### PR DESCRIPTION
12558b9 introduced a regression where `$(GIT_BRANCH)` is used instead of `master` in the `gh-pages-from-travis` target.