### PR TITLE
Fix the gmf.js build

### DIFF
--- a/buildtools/gmf.json
+++ b/buildtools/gmf.json
@@ -4,7 +4,7 @@
     "node_modules/openlayers/src/**/*.js",
     "node_modules/openlayers/build/ol.ext/*.js",
     "src/**/*.js",
-    "contribs/gmf/src/*.js",
+    "contribs/gmf/src/**/*.js",
     "exports/**/*.js",
     ".build/templatecache.js"
   ],


### PR DESCRIPTION
The gmf simple example currently does not work on github.io. See http://camptocamp.github.io/ngeo/master/contribs/gmf/simple.html. This is because the `gmf.js` build does not include the `gmfMap` directive because of a mis-configuration in `gmf.json`. This PR fixes it.