### PR TITLE
Feature overlay configuration

### DIFF
--- a/src/services/featureoverlay.js
+++ b/src/services/featureoverlay.js
@@ -59,7 +59,9 @@ ngeo.FeatureOverlayMgr = function() {
    * @type {ol.source.Vector}
    * @private
    */
-  this.source_ = new ol.source.Vector();
+  this.source_ = new ol.source.Vector({
+    useSpatialIndex: false
+  });
 
   /**
    * @type {ol.layer.Vector}
@@ -67,8 +69,7 @@ ngeo.FeatureOverlayMgr = function() {
    */
   this.layer_ = new ol.layer.Vector({
     source: this.source_,
-    style: goog.bind(this.styleFunction_, this),
-    useSpatialgroupIndex: false
+    style: goog.bind(this.styleFunction_, this)
   });
 
 };

--- a/src/services/featureoverlay.js
+++ b/src/services/featureoverlay.js
@@ -69,7 +69,9 @@ ngeo.FeatureOverlayMgr = function() {
    */
   this.layer_ = new ol.layer.Vector({
     source: this.source_,
-    style: goog.bind(this.styleFunction_, this)
+    style: goog.bind(this.styleFunction_, this),
+    updateWhileAnimating: true,
+    updateWhileInteracting: true
   });
 
 };


### PR DESCRIPTION
This PR sets `useSpatialIndex` to `false` and `updateWhileAnimating` and `updateWhileInteracting` to `true` on feature overlays. See the commit messages for more details.

Please review.