### PR TITLE
Changes for the gmf search directive

### DIFF
--- a/contribs/gmf/examples/search.js
+++ b/contribs/gmf/examples/search.js
@@ -22,7 +22,6 @@ app.module = angular.module('app', ['gmf']);
  * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *     overlay manager service.
  * @constructor
- * @export
  * @ngInject
  */
 app.MainController = function(ngeoFeatureOverlayMgr) {

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -222,9 +222,14 @@ gmf.SearchController.prototype.createDataset_ = function(config, opt_filter) {
  * @private
  */
 gmf.SearchController.prototype.filterLayername_ = function(layername) {
-  return function(feature) {
-    return (feature['properties']['layer_name'] === layername);
-  };
+  return (
+      /**
+       * @param {GeoJSONFeature} feature
+       * @return {boolean}
+       */
+      function(feature) {
+        return (feature['properties']['layer_name'] === layername);
+      });
 };
 
 

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -10,6 +10,10 @@
  * <gmf-search gmf-search-map="ctrl.map"
  *             gmf-search-datasources="ctrl.searchDatasources">
  * </gmf-search>
+ *
+ * This directive uses the ngeoFeatureOverlayMgr to create a feature overlay
+ * for drawing features on the map. The application is responsible to
+ * initialize the ngeoFeatureOverlayMgr with the map.
  */
 goog.provide('gmf.searchDirective');
 

--- a/exports/services/featureoverlay.js
+++ b/exports/services/featureoverlay.js
@@ -1,0 +1,37 @@
+goog.require('ngeo.FeatureOverlay');
+goog.require('ngeo.FeatureOverlayMgr');
+
+goog.exportProperty(
+    ngeo.FeatureOverlayMgr.prototype,
+    'init',
+    ngeo.FeatureOverlayMgr.prototype.init);
+
+goog.exportProperty(
+    ngeo.FeatureOverlayMgr.prototype,
+    'getLayer',
+    ngeo.FeatureOverlayMgr.prototype.getLayer);
+
+goog.exportProperty(
+    ngeo.FeatureOverlayMgr.prototype,
+    'getFeatureOverlay',
+    ngeo.FeatureOverlayMgr.prototype.getFeatureOverlay);
+
+goog.exportProperty(
+    ngeo.FeatureOverlay.prototype,
+    'addFeature',
+    ngeo.FeatureOverlay.prototype.addFeature);
+
+goog.exportProperty(
+    ngeo.FeatureOverlay.prototype,
+    'removeFeature',
+    ngeo.FeatureOverlay.prototype.removeFeature);
+
+goog.exportProperty(
+    ngeo.FeatureOverlay.prototype,
+    'clear',
+    ngeo.FeatureOverlay.prototype.clear);
+
+goog.exportProperty(
+    ngeo.FeatureOverlay.prototype,
+    'setStyle',
+    ngeo.FeatureOverlay.prototype.setStyle);


### PR DESCRIPTION
This PR makes a few changes related to the GMF search directive.

The exports for `ngeoFeatureOverlayMgr` and `ngeoFeatureOverlay` are necessary for non-compiled applications (our examples on github.io for example).

@ger-benjamin, could you please review this?