### PR TITLE
Let MapFish Print choose WMS version

### DIFF
--- a/src/services/print.js
+++ b/src/services/print.js
@@ -271,6 +271,7 @@ ngeo.Print.prototype.encodeWmsLayer_ = function(arr, opacity, url, params) {
 
   goog.object.remove(customParams, 'LAYERS');
   goog.object.remove(customParams, 'FORMAT');
+  goog.object.remove(customParams, 'VERSION');
 
   var object = /** @type {MapFishPrintWmsLayer} */ ({
     baseURL: ngeo.Print.getAbsoluteUrl_(url),


### PR DESCRIPTION
For instance, we may pass VERSION=1.3.0, MapFish Print will add
VERSION=1.1.0 and the WMS server will use version 1.3.0 and print will
not work as required parameters for version 1.3.0 won't be passed.