### PR TITLE
Add goog.provide's for constructors

### DIFF
--- a/contribs/gmf/src/directives/map.js
+++ b/contribs/gmf/src/directives/map.js
@@ -6,6 +6,7 @@
  *
  * <gmf-map gmf-map-map="mainCtrl.map"></gmf-map>
  */
+goog.provide('gmf.MapController');
 goog.provide('gmf.mapDirective');
 
 goog.require('gmf');

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -15,6 +15,7 @@
  * for drawing features on the map. The application is responsible to
  * initialize the ngeoFeatureOverlayMgr with the map.
  */
+goog.provide('gmf.SearchController');
 goog.provide('gmf.searchDirective');
 
 goog.require('gmf');

--- a/src/directives/btngroup.js
+++ b/src/directives/btngroup.js
@@ -25,6 +25,7 @@
  * to activate/deactivate an OpenLayers 3 interaction.
  */
 
+goog.provide('ngeo.BtnGroupController');
 goog.provide('ngeo.btnDirective');
 goog.provide('ngeo.btngroupDirective');
 

--- a/src/directives/scaleselector.js
+++ b/src/directives/scaleselector.js
@@ -36,6 +36,7 @@
  * The directive doesn't create any watcher. In particular the object including
  * the scales information is now watched.
  */
+goog.provide('ngeo.ScaleselectorController');
 goog.provide('ngeo.ScaleselectorOptions');
 goog.provide('ngeo.scaleselectorDirective');
 


### PR DESCRIPTION
Recent versions of the compiler require a goog.provide for every type defined as constructor.