### PR TITLE
Add a setFeatures method to feature overlays

### DIFF
--- a/exports/services/featureoverlay.js
+++ b/exports/services/featureoverlay.js
@@ -33,5 +33,10 @@ goog.exportProperty(
 
 goog.exportProperty(
     ngeo.FeatureOverlay.prototype,
+    'setFeatures',
+    ngeo.FeatureOverlay.prototype.setFeatures);
+
+goog.exportProperty(
+    ngeo.FeatureOverlay.prototype,
     'setStyle',
     ngeo.FeatureOverlay.prototype.setStyle);

--- a/test/spec/services/featureoverlay.spec.js
+++ b/test/spec/services/featureoverlay.spec.js
@@ -82,4 +82,55 @@ describe('ngeo.FeatureOverlayMgr', function() {
     expect(styles.length).toEqual(1);
     expect(styles[0]).toBe(style2);
   });
+
+  describe('feature overlay configured with a feature collection', function() {
+    var overlay, features;
+
+    beforeEach(function() {
+      overlay = ngeoFeatureOverlayMgr.getFeatureOverlay();
+      var feature1 = new ol.Feature();
+      var feature2 = new ol.Feature();
+      features = new ol.Collection([feature1, feature2]);
+      overlay.setFeatures(features);
+    });
+
+    it('adds features to the overlay', function() {
+      expect(layer.getSource().getFeatures().length).toBe(2);
+    });
+
+    describe('add features to the collection', function() {
+      it('adds features to the overlay', function() {
+        features.push(new ol.Feature());
+        expect(layer.getSource().getFeatures().length).toBe(3);
+      });
+    });
+
+    describe('remove features from the collection', function() {
+      it('removes features from the overlay', function() {
+        features.clear();
+        expect(layer.getSource().getFeatures().length).toBe(0);
+      });
+    });
+
+    describe('remove the collection', function() {
+      it('removes the features from the collection', function() {
+        overlay.setFeatures(null);
+        expect(layer.getSource().getFeatures().length).toBe(0);
+      });
+    });
+
+    describe('replace the collection by another one', function() {
+      it('uses the new collection and ignores the old one', function() {
+        var newFeatures = new ol.Collection();
+        overlay.setFeatures(newFeatures);
+        expect(layer.getSource().getFeatures().length).toBe(0);
+        newFeatures.push(new ol.Feature());
+        expect(layer.getSource().getFeatures().length).toBe(1);
+        features.push(new ol.Feature());
+        expect(layer.getSource().getFeatures().length).toBe(1);
+      });
+    });
+
+  });
+
 });


### PR DESCRIPTION
This PR adds the possibility to configure an ngeo feature overlay with a feature collection (`ol.Collection.<ol.Feature>`).

This makes it possible to bind a drawing tool to an feature overlay:

```js
var features = new ol.Collection();

var overlay = ngeoFeatureOverlayMgr.getFeatureOverlay();
overlay.setStyle(myStyle);
overlay.setFeatures(features);

var draw = new ol.interaction.Draw({
  type: 'point',
  features: features
});
```

With this features drawn with the draw interaction are added to the ngeo feature overlay.