### PR TITLE
Copy ngeo-debug.js to examples/lib on github.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,7 @@ node_modules/angular/angular.min.js: .build/node_modules.timestamp
 .build/%.check.timestamp: .build/examples-hosted/%.html \
 	    .build/examples-hosted/%.js \
 	    .build/examples-hosted/lib/ngeo.js \
+	    .build/examples-hosted/lib/ngeo-debug.js \
 	    .build/examples-hosted/lib/ngeo.css \
 	    .build/examples-hosted/lib/gmf.js \
 	    .build/examples-hosted/lib/angular.min.js \


### PR DESCRIPTION
Right now only ngeo.js is available on camptocamp.github.io. This adds ngeo-debug.js.