### PR TITLE
Add a "properties" option to ngeo.format.FeatureHash

### DIFF
--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -13,17 +13,28 @@ ngeox.format;
 
 /**
  * @typedef {{
- *    accuracy: (number|undefined)
+ *    accuracy: (number|undefined),
+ *    properties: (function(ol.Feature): Object.<string, (string|undefined)>|undefined)
  * }}
  */
 ngeox.format.FeatureHashOptions;
 
 
 /**
- * The encoding and decoding accuracy.
+ * The encoding and decoding accuracy. Optional. Default value is 1.
  * @type {number|undefined}
  */
 ngeox.format.FeatureHashOptions.prototype.accuracy;
+
+
+/**
+ * A function that returns serializable properties for a feature. Optional. By
+ * default the feature properties (as returned by `feature.getProperties()`)
+ * are used. To be serializable the returned properties should be numbers or
+ * strings.
+ * @type {(function(ol.Feature): Object.<string, (string|undefined)>|undefined)}
+ */
+ngeox.format.FeatureHashOptions.prototype.properties;
 
 
 /**

--- a/src/ol-ext/format/featurehash.js
+++ b/src/ol-ext/format/featurehash.js
@@ -87,6 +87,13 @@ ngeo.format.FeatureHash = function(opt_options) {
       options.accuracy : ngeo.format.FeatureHash.ACCURACY_;
 
   /**
+   * @type {function(ol.Feature):Object.<string, (string|number)>}
+   * @private
+   */
+  this.propertiesFunction_ = goog.isDef(options.properties) ?
+      options.properties : ngeo.format.FeatureHash.defaultPropertiesFunction_;
+
+  /**
    * @type {number}
    * @private
    */
@@ -118,6 +125,17 @@ ngeo.format.FeatureHash.CHAR64_ =
  * @private
  */
 ngeo.format.FeatureHash.ACCURACY_ = 1;
+
+
+/**
+ * @param {ol.Feature} feature Feature.
+ * @return {Object.<string, (string|number)>} The feature properties to
+ * serialize.
+ * @private
+ */
+ngeo.format.FeatureHash.defaultPropertiesFunction_ = function(feature) {
+  return feature.getProperties();
+};
 
 
 /**
@@ -861,7 +879,7 @@ ngeo.format.FeatureHash.prototype.writeFeatureText =
   // encode properties
 
   var /** @type {Array.<string>} */ encodedProperties = [];
-  goog.object.forEach(feature.getProperties(), (
+  goog.object.forEach(this.propertiesFunction_(feature), (
       /**
        * @param {*} value Value.
        * @param {string} key Key.

--- a/test/spec/ol-ext/format/featurehash.spec.js
+++ b/test/spec/ol-ext/format/featurehash.spec.js
@@ -453,5 +453,20 @@ describe('ngeo.format.FeatureHash', function() {
       });
     });
 
+    describe('With a user-provided feature properties function', function() {
+      it('encodes feature properties as expected', function() {
+        fhFormat = new ngeo.format.FeatureHash({
+          properties: function(feature) {
+            return {foobar: feature.get('foo') + feature.get('bar')};
+          }
+        });
+        var feature = new ol.Feature(new ol.geom.Point([1, 1]));
+        feature.set('foo', 'foo');
+        feature.set('bar', 'bar');
+        var result = fhFormat.writeFeature(feature);
+        expect(result).toBe('p(__~foobar*foobar)');
+      });
+    });
+
   });
 });


### PR DESCRIPTION
This commit adds an optional "properties" option to the ngeo.format.FeatureHash constructor. Using this new option the user can provide a function that returns serializable properties for a feature. This can be used to filter out feature properties. This can also be used to add properties that are not set in the feature.