### PR TITLE
Add an encodeStyles option to ngeo.format.FeatureHash

### DIFF
--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -14,6 +14,7 @@ ngeox.format;
 /**
  * @typedef {{
  *    accuracy: (number|undefined),
+ *    encodeStyles: (boolean|undefined),
  *    properties: (function(ol.Feature): Object.<string, (string|undefined)>|undefined)
  * }}
  */
@@ -25,6 +26,13 @@ ngeox.format.FeatureHashOptions;
  * @type {number|undefined}
  */
 ngeox.format.FeatureHashOptions.prototype.accuracy;
+
+
+/**
+ * Encode styles. Optional. Default is `true`.
+ * @type {boolean|undefined}
+ */
+ngeox.format.FeatureHashOptions.prototype.encodeStyles;
 
 
 /**

--- a/src/ol-ext/format/featurehash.js
+++ b/src/ol-ext/format/featurehash.js
@@ -87,6 +87,13 @@ ngeo.format.FeatureHash = function(opt_options) {
       options.accuracy : ngeo.format.FeatureHash.ACCURACY_;
 
   /**
+   * @type {boolean}
+   * @private
+   */
+  this.encodeStyles_ = goog.isDef(options.encodeStyles) ?
+      options.encodeStyles : true;
+
+  /**
    * @type {function(ol.Feature):Object.<string, (string|number)>}
    * @private
    */
@@ -903,16 +910,18 @@ ngeo.format.FeatureHash.prototype.writeFeatureText =
 
   // encode styles
 
-  var styleFunction = feature.getStyleFunction();
-  if (goog.isDef(styleFunction)) {
-    var styles = styleFunction.call(feature, 0);
-    if (!goog.isNull(styles)) {
-      var encodedStyles = [];
-      ngeo.format.FeatureHash.encodeStyles_(
-          styles, geometry.getType(), encodedStyles);
-      if (encodedStyles.length > 0) {
-        encodedParts.push('~');
-        Array.prototype.push.apply(encodedParts, encodedStyles);
+  if (this.encodeStyles_) {
+    var styleFunction = feature.getStyleFunction();
+    if (goog.isDef(styleFunction)) {
+      var styles = styleFunction.call(feature, 0);
+      if (!goog.isNull(styles)) {
+        var encodedStyles = [];
+        ngeo.format.FeatureHash.encodeStyles_(
+            styles, geometry.getType(), encodedStyles);
+        if (encodedStyles.length > 0) {
+          encodedParts.push('~');
+          Array.prototype.push.apply(encodedParts, encodedStyles);
+        }
       }
     }
   }


### PR DESCRIPTION
This PR adds an `encodeStyles` option to `ngeo.format.FeatureHash`. When set to `false` the format does not encode styles.

Please review.