### PR TITLE
Latest jquery-1.9.js externs file is broken

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ $(EXTERNS_ANGULAR_HTTP_PROMISE):
 
 $(EXTERNS_JQUERY):
 	mkdir -p $(dir $@)
-	wget -O $@ https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/jquery-1.9.js
+	wget -O $@ https://raw.githubusercontent.com/google/closure-compiler/b27aa3b/contrib/externs/jquery-1.9.js
 	touch $@
 
 .build/python-venv:


### PR DESCRIPTION
We get a compile error with the latest jquery-1.9.js externs file:

```
ERR! compile .build/externs/jquery-1.9.js:94: ERROR - accessing name jQuery in externs has no effect. Perhaps you forgot to add a var keyword?
ERR! compile var $ = jQuery;
ERR! compile         ^
ERR! compile
ERR! compile
ERR! compile 1 error(s), 0 warning(s)
ERR! compile
ERR! Process exited with non-zero status, see log for more detail: 1
```

This commit fixes the problem by fetching the jquery-1.9.js file from a specific commit.


This is a temporary fix, until we (or someone) really fix the actual problem.