### PR TITLE
Use version 20150920 of Closure Compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ $(EXTERNS_ANGULAR_HTTP_PROMISE):
 
 $(EXTERNS_JQUERY):
 	mkdir -p $(dir $@)
-	wget -O $@ https://raw.githubusercontent.com/google/closure-compiler/b27aa3b/contrib/externs/jquery-1.9.js
+	wget -O $@ https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/jquery-1.9.js
 	touch $@
 
 .build/python-venv:

--- a/buildtools/example.json
+++ b/buildtools/example.json
@@ -44,7 +44,6 @@
       "ambiguousFunctionDecl",
       "checkEventfulObjectDisposal",
       "checkRegExp",
-      "checkStructDictInheritance",
       "checkTypes",
       "checkVars",
       "const",

--- a/buildtools/examples-all.json
+++ b/buildtools/examples-all.json
@@ -44,7 +44,6 @@
       "ambiguousFunctionDecl",
       "checkEventfulObjectDisposal",
       "checkRegExp",
-      "checkStructDictInheritance",
       "checkTypes",
       "checkVars",
       "const",

--- a/buildtools/gmf.json
+++ b/buildtools/gmf.json
@@ -41,7 +41,6 @@
       "ambiguousFunctionDecl",
       "checkEventfulObjectDisposal",
       "checkRegExp",
-      "checkStructDictInheritance",
       "checkTypes",
       "checkVars",
       "const",

--- a/buildtools/ngeo.json
+++ b/buildtools/ngeo.json
@@ -39,7 +39,6 @@
       "ambiguousFunctionDecl",
       "checkEventfulObjectDisposal",
       "checkRegExp",
-      "checkStructDictInheritance",
       "checkTypes",
       "checkVars",
       "const",

--- a/externs/closure-compiler.js
+++ b/externs/closure-compiler.js
@@ -7,12 +7,6 @@
 
 
 /**
- * @type {Array.<string>}
- */
-Navigator.prototype.languages;
-
-
-/**
  * @type {string}
  */
 Navigator.prototype.systemLanguage;


### PR DESCRIPTION
OpenLayers now uses version 20150920 of Closure Compiler. This PR updates ngeo to

* use the `master` version of the jquery-1.9.js externs again
* remove the `checkStructDictInheritance` option which does no longer exist
* remove the definition of `Navigator.prototype.languages`