### PR TITLE
Make check-example exit 1 on console errors

### DIFF
--- a/buildtools/check-example.js
+++ b/buildtools/check-example.js
@@ -30,4 +30,5 @@ page.open(examplePath, function(s) {
 });
 page.onConsoleMessage = function(msg) {
   console.log('console:', msg);
+  phantom.exit(msg.match(/error/i) ? 1 : 0);
 };


### PR DESCRIPTION
Currently exceptions thrown when checking the examples with the `check-example.js` PhantomJS script are not detected. This leads to PRs whose builds pass Travis but whose examples don't actually work on github.io. This PR aims to fix that by making `check-example` exit 1 when errors are detected on the console.