### PR TITLE
Fix measureend @event annotation

### DIFF
--- a/src/ol-ext/interaction/measure.js
+++ b/src/ol-ext/interaction/measure.js
@@ -35,7 +35,7 @@ ngeo.interaction.MeasureBaseOptions;
 ngeo.MeasureEventType = {
   /**
    * Triggered upon feature draw end
-   * @event ol.MeasureEvent#measureend
+   * @event ngeo.MeasureEvent#measureend
    */
   MEASUREEND: 'measureend'
 };


### PR DESCRIPTION
This fixes a typo in the docs of `ngeo.MeasureEventType.MEASUREEND`.