### PR TITLE
Add an ngeo.PrintUtils#getOptimalResolution function

### DIFF
--- a/exports/services/printutils.js
+++ b/exports/services/printutils.js
@@ -6,5 +6,9 @@ goog.exportProperty(
     ngeo.PrintUtils.prototype.getOptimalScale);
 goog.exportProperty(
     ngeo.PrintUtils.prototype,
+    'getOptimalResolution',
+    ngeo.PrintUtils.prototype.getOptimalResolution);
+goog.exportProperty(
+    ngeo.PrintUtils.prototype,
     'createPrintMaskPostcompose',
     ngeo.PrintUtils.prototype.createPrintMaskPostcompose);

--- a/src/services/printutils.js
+++ b/src/services/printutils.js
@@ -130,4 +130,28 @@ ngeo.PrintUtils.prototype.getOptimalScale = function(
 };
 
 
+/**
+ * Get the optimal map resolution for a print scale and a map size.
+ * @param {ol.Size} mapSize Size of the map on the screen (px).
+ * @param {ol.Size} printMapSize Size of the map on the paper (dots).
+ * @param {number} printMapScale Map scale on the paper.
+ * @return {number} The optimal map resolution.
+ */
+ngeo.PrintUtils.prototype.getOptimalResolution = function(
+    mapSize, printMapSize, printMapScale) {
+
+  var dotsPerMeter =
+      ngeo.PrintUtils.DOTS_PER_INCH_ * ngeo.PrintUtils.INCHES_PER_METER_;
+
+  var resolutionX = (printMapSize[0] * printMapScale) /
+      (dotsPerMeter * mapSize[0]);
+  var resolutionY = (printMapSize[1] * printMapScale) /
+      (dotsPerMeter * mapSize[1]);
+
+  var optimalResolution = Math.max(resolutionX, resolutionY);
+
+  return optimalResolution;
+};
+
+
 ngeoModule.service('ngeoPrintUtils', ngeo.PrintUtils);

--- a/src/services/printutils.js
+++ b/src/services/printutils.js
@@ -95,7 +95,8 @@ ngeo.PrintUtils.prototype.createPrintMaskPostcompose =
 
 
 /**
- * Get the optimal print scale for a map.
+ * Get the optimal print scale for a map, the map being defined by its
+ * size (in pixels) and resolution (in map units per pixel).
  * @param {ol.Size} mapSize Size of the map on the screen (px).
  * @param {number} mapResolution Resolution of the map on the screen.
  * @param {ol.Size} printMapSize Size of the map on the paper (dots).

--- a/test/spec/services/printutils.spec.js
+++ b/test/spec/services/printutils.spec.js
@@ -1,0 +1,40 @@
+goog.require('ngeo.PrintUtils');
+
+describe('ngeo.PrintUtils', function() {
+
+  var ngeoPrintUtils;
+
+  beforeEach(function() {
+    inject(function($injector) {
+      printUtils = $injector.get('ngeoPrintUtils');
+    });
+  });
+
+  describe('#getOptimalResolution', function() {
+
+    var inchesPerMeter, dotsPerInch;
+
+    beforeEach(function() {
+      inchesPerMeter = ngeo.PrintUtils.INCHES_PER_METER_;
+      dotsPerInch = ngeo.PrintUtils.DOTS_PER_INCH_;
+
+      // consider 3200 dots per meter
+      ngeo.PrintUtils.INCHES_PER_METER_ = 40;
+      ngeo.PrintUtils.DOTS_PER_INCH_ = 80;
+    });
+
+    afterEach(function() {
+      ngeo.PrintUtils.INCHES_PER_METER_ = inchesPerMeter;
+      ngeo.PrintUtils.DOTS_PER_INCH_ = dotsPerInch;
+    });
+
+    it('returns the optimal resolution', function() {
+      var mapSize = [2, 1];  // px
+      var printMapSize = [640, 320];  // dots
+      var printScale = 10;  // scale denominator
+      var optimalResolution = printUtils.getOptimalResolution(
+          mapSize, printMapSize, printScale);
+      expect(optimalResolution).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a `getOptimalResolution` function to `ngeo.PrintUtils`. This function returns the optimal map resolution for a given print scale. The optimal map resolution is such that the print rectangle fits into the map view.

This is WIP at the moment.

TODOs:

- [x] Test in Luxembourg application
- [x] Add unit tests