### PR TITLE
Directive factories are not @constructor's

### DIFF
--- a/contribs/gmf/src/directives/locationchooser.js
+++ b/contribs/gmf/src/directives/locationchooser.js
@@ -5,7 +5,6 @@ goog.require('gmf');
 goog.require('ol.Map');
 
 
-
 /**
  * This file provides a directive that creates an option list.
  * The options serve to switch quickly between differents places on the map.
@@ -17,7 +16,6 @@ goog.require('ol.Map');
  * </gmf-locationchooser>
  *
  * @return {angular.Directive} The directive specs.
- * @constructor
  * @ngInject
  */
 gmf.locationchooserDirective = function() {

--- a/contribs/gmf/src/directives/map.js
+++ b/contribs/gmf/src/directives/map.js
@@ -9,7 +9,6 @@ goog.require('ngeo.mapDirective');
 goog.require('ol.Map');
 
 
-
 /**
  * This file provides the "map" directive for GeoMapFish
  * applications.
@@ -18,7 +17,6 @@ goog.require('ol.Map');
  * <gmf-map gmf-map-map="mainCtrl.map"></gmf-map>
  *
  * @return {angular.Directive} The Directive Definition Object.
- * @constructor
  * @ngInject
  */
 gmf.mapDirective = function() {

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -10,7 +10,6 @@ goog.require('ol.Map');
 goog.require('ol.proj');
 
 
-
 /**
  * This file provides the "search" directive and controller for
  * a GeoMapFish application.
@@ -28,7 +27,6 @@ goog.require('ol.proj');
  * </gmf-search>
  *
  * @return {angular.Directive} The Directive Definition Object.
- * @constructor
  * @ngInject
  */
 gmf.searchDirective = function() {

--- a/src/directives/btngroup.js
+++ b/src/directives/btngroup.js
@@ -5,7 +5,6 @@ goog.provide('ngeo.btngroupDirective');
 goog.require('ngeo');
 
 
-
 /**
  * Provides two directives: ngeo-btn-group and ngeo-btn.
  *
@@ -30,7 +29,6 @@ goog.require('ngeo');
  * This example is about creating a Bootstrap button that can pressed/depressed
  * to activate/deactivate an OpenLayers 3 interaction.
  *
- * @constructor
  * @return {angular.Directive} The directive specs.
  * @ngInject
  */

--- a/src/directives/control.js
+++ b/src/directives/control.js
@@ -6,7 +6,6 @@ goog.require('ol.Map');
 goog.require('ol.control.Control');
 
 
-
 /**
  * Provides a directive can be used to add a control to a DOM
  * element of the HTML page.
@@ -18,7 +17,6 @@ goog.require('ol.control.Control');
  * instance, and the expression passed to "ngeo-control-map" should
  * evaluate to a map instance.
  *
- * @constructor
  * @return {angular.Directive} The directive specs.
  * @ngInject
  */

--- a/src/directives/layertree.js
+++ b/src/directives/layertree.js
@@ -22,7 +22,6 @@ ngeoModule.value('ngeoLayertreeTemplateUrl',
     });
 
 
-
 /**
  * Provides the "ngeoLayertree" directive, a directive for
  * creating layer trees in application.
@@ -72,7 +71,6 @@ ngeoModule.value('ngeoLayertreeTemplateUrl',
  * controller: "layertreeCtrl". You can refer to that property in a custom
  * template for example.
  *
- * @constructor
  * @param {angular.$compile} $compile Angular compile service.
  * @param {string|function(!angular.JQLite=, !angular.Attributes=)}
  *     ngeoLayertreeTemplateUrl Template URL for the directive.

--- a/src/directives/map.js
+++ b/src/directives/map.js
@@ -5,7 +5,6 @@ goog.require('ngeo');
 goog.require('ol.Map');
 
 
-
 /**
  * Provides a directive used to insert a user-defined OpenLayers
  * map in the DOM. The directive does not create an isolate scope.
@@ -13,7 +12,6 @@ goog.require('ol.Map');
  * @example
  * <div ngeo-map="ctrl.map"></div>
  *
- * @constructor
  * @return {angular.Directive} Directive Definition Object.
  * @ngInject
  */

--- a/src/directives/modal.js
+++ b/src/directives/modal.js
@@ -1,8 +1,6 @@
-
 goog.provide('ngeo.modalDirective');
 
 goog.require('ngeo');
-
 
 
 /**
@@ -26,7 +24,6 @@ goog.require('ngeo');
  * Note: for z-indexing purpose, the modal DOM element is automatically moved
  * to document body element.
  *
- * @constructor
  * @param {angular.$parse} $parse Angular parse service.
  * @return {angular.Directive} The directive specs.
  * @ngInject

--- a/src/directives/popup.js
+++ b/src/directives/popup.js
@@ -13,7 +13,6 @@ ngeo.popupTemplateUrl = 'partials/popup.html';
 ngeoModule.value('ngeoPopupTemplateUrl', ngeo.popupTemplateUrl);
 
 
-
 /**
  * Provides a directive used to show a popup over the page with
  * a title and content.
@@ -29,7 +28,6 @@ ngeoModule.value('ngeoPopupTemplateUrl', ngeo.popupTemplateUrl);
  * - The directive doesn't create any scope but relies on its parent scope.
  *   Properties like 'content', 'title' or 'open' come from the parent scope.
  *
- * @constructor
  * @param {string} ngeoPopupTemplateUrl Url to popup template.
  * @return {angular.Directive} Directive Definition Object.
  * @ngInject

--- a/src/directives/profile.js
+++ b/src/directives/profile.js
@@ -5,7 +5,6 @@ goog.require('ngeo');
 goog.require('ngeo.profile');
 
 
-
 /**
  * Provides a directive used to insert an elevation profile chart
  * in the DOM.
@@ -21,7 +20,6 @@ goog.require('ngeo.profile');
  * processed by {@link ngeox.profile.ElevationExtractor} and
  * {@link ngeox.profile.PoiExtractor}.
  *
- * @constructor
  * @return {angular.Directive} Directive Definition Object.
  * @ngInject
  */

--- a/src/directives/resizemap.js
+++ b/src/directives/resizemap.js
@@ -6,7 +6,6 @@ goog.require('ngeo');
 goog.require('ol.Map');
 
 
-
 /**
  * Provides a directive that resizes the map in an animation loop
  * during 1 second when the value of "state" changes. This is especially useful
@@ -18,7 +17,6 @@ goog.require('ol.Map');
  *        ngeo-resizemap-state="open"><div>
  *   <input type="checkbox" ng-model="ctrl.open" />
  *
- * @constructor
  * @param {angular.$window} $window Angular window service.
  * @param {angular.$animate} $animate Angular animate service.
  * @return {angular.Directive} The directive specs.

--- a/src/directives/scaleselector.js
+++ b/src/directives/scaleselector.js
@@ -26,7 +26,6 @@ ngeoModule.value('ngeoScaleselectorTemplateUrl',
 ngeo.ScaleselectorOptions;
 
 
-
 /**
  * Provides the "ngeoScaleselector" directive, a widget for
  * selecting map scales.
@@ -64,7 +63,6 @@ ngeo.ScaleselectorOptions;
  * The directive doesn't create any watcher. In particular the object including
  * the scales information is now watched.
  *
- * @constructor
  * @param {string|function(!angular.JQLite=, !angular.Attributes=)}
  *     ngeoScaleselectorTemplateUrl Template URL for the directive.
  * @return {angular.Directive} Directive Definition Object.

--- a/src/directives/search.js
+++ b/src/directives/search.js
@@ -3,7 +3,6 @@ goog.provide('ngeo.searchDirective');
 goog.require('ngeo');
 
 
-
 /**
  * Provides the "ngeoSearch" directive, which uses Twitter's
  * typeahead component to change an input text into a search field.
@@ -14,7 +13,6 @@ goog.require('ngeo');
  *   ngeo-search-datasets="ctrl.typeaheadDatasets"
  *   ngeo-search-listeners="crtl.typeaheadListeners">
  *
- * @constructor
  * @return {angular.Directive} Directive Definition Object.
  * @ngInject
  */

--- a/src/directives/sortable.js
+++ b/src/directives/sortable.js
@@ -16,7 +16,6 @@ goog.require('ngeo');
 ngeo.SortableOptions;
 
 
-
 /**
  * Provides the "ngeoSortable" directive. This directive allows
  * drag-and-dropping DOM items between them. The directive also changes the
@@ -44,7 +43,6 @@ ngeo.SortableOptions;
  * if some outside code adds/removes elements to/from the "sortable" array,
  * the "ngeoSortable" directive will pick it up.
  *
- * @constructor
  * @param {angular.$timeout} $timeout Angular timeout service.
  * @return {angular.Directive} The directive specs.
  * @ngInject


### PR DESCRIPTION
The primary consumer of annotations is the Closure Compiler. Directive factories are not constructors. And I don't think we should make the Closure Compiler believe they are constructors.

I know this is going to cause problems on the apidoc side, but I think we should address that problem in a different way.