### PR TITLE
Use htmlmin in templatecache.mako.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,7 +373,7 @@ $(EXTERNS_JQUERY):
 # is done so ngeo.js works for the examples on github.io. If another key
 # pattern is needed this should be changed.
 .build/templatecache.js: buildtools/templatecache.mako.js .build/python-venv/bin/mako-render
-	.build/python-venv/bin/mako-render --var "partials=$(addprefix ../,$(SRC_DIRECTIVES_PARTIALS_FILES))" --var "basedir=src" $< > $@
+	PYTHONIOENCODING=UTF-8 .build/python-venv/bin/mako-render --var "partials=$(addprefix ../,$(SRC_DIRECTIVES_PARTIALS_FILES))" --var "basedir=src" $< > $@
 
 .build/apidoc-%: .build/node_modules.timestamp jsdoc.json $(SRC_JS_FILES)
 	rm -rf $@

--- a/Makefile
+++ b/Makefile
@@ -348,7 +348,7 @@ $(EXTERNS_JQUERY):
 	touch $@
 
 .build/python-venv/bin/mako-render: .build/python-venv
-	.build/python-venv/bin/pip install "Mako==1.0.0"
+	.build/python-venv/bin/pip install "Mako==1.0.0" "htmlmin==0.1.10"
 	touch $@
 
 .build/beautifulsoup4.timestamp: .build/python-venv

--- a/buildtools/templatecache.mako.js
+++ b/buildtools/templatecache.mako.js
@@ -7,16 +7,15 @@
 <%
   import re
   import os
+  import htmlmin
   _partials = {}
   basedirparts = basedir.split('/')
   for p in partials.split(' '):
       parts = basedirparts + [p]
       f = file(os.path.join(*parts))
       content = unicode(f.read().decode('utf8'))
-      content = re.sub(r'>\s*<' , '><', content)
-      content = re.sub(r'\s\s+', ' ', content)
-      content = re.sub(r'\n', '', content)
       content = re.sub(r"'", "\\'", content)
+      content = htmlmin.minify(content, remove_comments=True)
       _partials[p] = content
 %>\
 /**


### PR DESCRIPTION
`templatecache.mako.js` currently removes spaces and line breaks between HTML elements. This is not correct, and it may break the user's HTML code. This commit fixes the problem by using the `htmlmin` tool instead of minifying the HTML ourselves.

This is WIP in progress at the moment (being tested in https://github.com/Geoportail-Luxembourg/geoportailv3/pull/929).