### PR TITLE
Add a gmfExportFeatures service

### DIFF
--- a/contribs/gmf/externs/gmfx.js
+++ b/contribs/gmf/externs/gmfx.js
@@ -108,3 +108,18 @@ gmfx.LocationchooserLocation.prototype.label;
  * @type {Array.<number>}
  */
 gmfx.LocationchooserLocation.prototype.extent;
+
+
+/**
+ * @typedef {{
+ *     exportgpxkml: string
+ * }}
+ */
+gmfx.ServiceUrls;
+
+
+/**
+ * URL to the "exportgpxkml" service.
+ * @type {string}
+ */
+gmfx.ServiceUrls.prototype.exportgpxkml;

--- a/contribs/gmf/src/services/exportfeatures.js
+++ b/contribs/gmf/src/services/exportfeatures.js
@@ -1,0 +1,67 @@
+goog.provide('gmf.ExportFeatures');
+goog.provide('gmf.ExportFormat');
+
+goog.require('gmf');
+goog.require('goog.asserts');
+
+
+/**
+ * @enum {string}
+ */
+gmf.ExportFormat = {
+  GPX: 'gpx',
+  KML: 'kml'
+};
+
+
+/**
+ * @typedef {function(string, gmf.ExportFormat, string)}
+ */
+gmf.ExportFeatures;
+
+
+/**
+ * @param {Document} $document Angular $document service.
+ * @param {gmfx.ServiceUrls} gmfServiceUrls GMF URLs objects.
+ * @return {gmf.ExportFeatures} The "export features" function.
+ * @ngInject
+ * @private
+ */
+gmf.exportFeaturesFactory_ = function($document, gmfServiceUrls) {
+  goog.asserts.assert(gmfServiceUrls.exportgpxkml);
+  var exportgpxkmlUrl = gmfServiceUrls.exportgpxkml;
+
+  return (
+      /**
+       * @param {string} doc The document to export/download.
+       * @param {gmf.ExportFormat} format The document format.
+       * @param {string} filename File name for the exported document.
+       */
+      function exportFeatures(doc, format, filename) {
+        var formatInput = $('<input>').attr({
+          type: 'hidden',
+          name: 'format',
+          value: format
+        });
+        var nameInput = $('<input>').attr({
+          type: 'hidden',
+          name: 'name',
+          value: filename
+        });
+        var docInput = $('<input>').attr({
+          type: 'hidden',
+          name: 'doc',
+          value: doc
+        });
+        var form = $('<form>').attr({
+          method: 'POST',
+          action: exportgpxkmlUrl
+        });
+        form.append(formatInput, nameInput, docInput);
+        angular.element($document[0].body).append(form);
+        form[0].submit();
+        form.remove();
+      });
+};
+
+gmfModule.factory('gmfExportFeatures', gmf.exportFeaturesFactory_);


### PR DESCRIPTION
The `gmfExportFeatures` service is a function to be used for exporting a GPX or KML document. The service relies on GeoMapFish's `exportgpxkml` web service.

Providing an example would be good, but the `exportgpxkml` is not yet available on the GeoMapFish demo instance.