### PR TITLE
Add an ngeoFilereader directive

### DIFF
--- a/examples/importfeatures.html
+++ b/examples/importfeatures.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>Import features example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
+    <style>
+      #map {
+        width: 600px;
+        height: 400px;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <div id="map" ngeo-map="ctrl.map"></div>
+    <input id="export" type="file" ngeo-filereader="ctrl.fileContent" ngeo-filereader-supported="ctrl.fileReaderSupported" />
+    <p ng-hide="::ctrl.fileReaderSupported">Your browser doesn't support the <code>FileReader</code> API! IE 9?</p>
+    <p id="desc">This example shows how to use the <code>ngeo-filereader</code> directive to import features from a KML file read from the user's file system.</p>
+    <p>You can download and use the <a href="http://openlayers.org/en/master/examples/data/kml/2012-02-10.kml">2012-02-10.kml file</a> from the OpenLayers examples for testing.</p>
+    <script src="../node_modules/angular/angular.js"></script>
+    <script src="/@?main=importfeatures.js"></script>
+    <script src="../utils/watchwatchers.js"></script>
+  </body>
+</html>

--- a/examples/importfeatures.js
+++ b/examples/importfeatures.js
@@ -1,0 +1,103 @@
+goog.provide('importfeatures');
+
+goog.require('ngeo.filereaderDirective');
+goog.require('ngeo.mapDirective');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.extent');
+goog.require('ol.format.KML');
+goog.require('ol.layer.Tile');
+goog.require('ol.layer.Vector');
+goog.require('ol.source.OSM');
+goog.require('ol.source.Vector');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['ngeo']);
+
+
+
+/**
+ * @constructor
+ * @param {angular.Scope} $scope Scope.
+ * @export
+ * @ngInject
+ */
+app.MainController = function($scope) {
+
+  /**
+   * @private
+   * @type {ol.format.KML}
+   */
+  this.kmlFormat_ = new ol.format.KML();
+
+  /**
+   * @private
+   * @type {ol.source.Vector}
+   */
+  this.vectorSource_ = new ol.source.Vector();
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      }),
+      new ol.layer.Vector({
+        source: this.vectorSource_
+      })
+    ],
+    view: new ol.View({
+      center: [0, 0],
+      zoom: 2
+    })
+  });
+
+
+  /**
+   * @type {boolean|undefined}
+   * @export
+   */
+  this.fileReaderSupported = undefined;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.fileContent = '';
+
+  $scope.$watch(angular.bind(this, function() {
+    return this.fileContent;
+  }), angular.bind(this, this.importKml_));
+
+};
+
+
+/**
+ * @param {string} kml KML document.
+ * @private
+ */
+app.MainController.prototype.importKml_ = function(kml) {
+  var map = this.map;
+  var vectorSource = this.vectorSource_;
+  var features = this.kmlFormat_.readFeatures(kml, {
+    featureProjection: 'EPSG:3857'
+  });
+  vectorSource.clear(true);
+  vectorSource.addFeatures(features);
+  var extent = vectorSource.getExtent();
+  var mapSize = map.getSize();
+  if (mapSize && !ol.extent.isEmpty(extent)) {
+    map.getView().fit(extent, mapSize);
+  }
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/src/directives/filereader.js
+++ b/src/directives/filereader.js
@@ -1,0 +1,57 @@
+goog.provide('ngeo.filereaderDirective');
+
+goog.require('ngeo');
+
+
+/**
+ * This directive is to used on an input file element. When a file is selected
+ * the directive uses the browser `FileReader` API to read the file. The file
+ * content is provided to the directive user through the assignable expression.
+ * Only works for text file (`readAsText` used for reading the file).
+ *
+ * @example
+ * <input type="file" ngeo-filereader="ctrl.fileContent" />
+ *
+ * @param {angular.$window} $window The Angular $window service.
+ * @return {angular.Directive} Directive Definition Object.
+ * @ngInject
+ */
+ngeo.filereaderDirective = function($window) {
+  return {
+    restrict: 'A',
+    scope: {
+      'fileContent': '=ngeoFilereader',
+      'supported': '=ngeoFilereaderSupported'
+    },
+    link:
+        /**
+         * @param {angular.Scope} scope Scope.
+         * @param {angular.JQLite} element Element.
+         * @param {angular.Attributes} attrs Attributes.
+         */
+        function(scope, element, attrs) {
+          var supported = 'FileReader' in $window;
+          scope['supported'] = supported;
+          if (!supported) {
+            return;
+          }
+          element.bind('change', function(changeEvent) {
+            /** @type {!FileReader} */
+            var fileReader = new $window.FileReader();
+            fileReader.onload = (
+                /**
+                 * @param {!ProgressEvent} evt Event.
+                 */
+                function(evt) {
+                  scope.$apply(function() {
+                    scope['fileContent'] = evt.target.result;
+                  });
+                });
+            fileReader.readAsText(changeEvent.target.files[0]);
+          });
+        }
+  };
+};
+
+
+ngeoModule.directive('ngeoFilereader', ngeo.filereaderDirective);

--- a/src/directives/filereader.js
+++ b/src/directives/filereader.js
@@ -7,10 +7,12 @@ goog.require('ngeo');
  * This directive is to used on an input file element. When a file is selected
  * the directive uses the browser `FileReader` API to read the file. The file
  * content is provided to the directive user through the assignable expression.
- * Only works for text file (`readAsText` used for reading the file).
+ * Only works for text files (`readAsText` used for reading the file). And does
+ * not work in Internet Explorer 9.
  *
  * @example
- * <input type="file" ngeo-filereader="ctrl.fileContent" />
+ * <input type="file" ngeo-filereader="ctrl.fileContent"
+ *        ngeo-filereader-supported="ctrl.supported"/>
  *
  * @param {angular.$window} $window The Angular $window service.
  * @return {angular.Directive} Directive Definition Object.

--- a/test/spec/directives/filereader.spec.js
+++ b/test/spec/directives/filereader.spec.js
@@ -1,0 +1,38 @@
+goog.require('ngeo.filereaderDirective');
+
+describe('ngeo.filereaderDirective', function() {
+  var element, rootScope;
+
+  beforeEach(function() {
+    element = angular.element(
+      '<input type="file" ngeo-filereader="fileContent" />');
+
+    module(function($provide) {
+      var FileReader = function() {};
+      FileReader.prototype.readAsText = function(file) {
+        var progressEvent = {
+          target: {
+            result: '<kml></kml>'
+          }
+        };
+        this.onload(progressEvent);
+      };
+      $provide.value('$window', {FileReader: FileReader});
+    });
+
+    inject(function($rootScope, $compile) {
+      $compile(element)($rootScope);
+      $rootScope.$digest();
+      rootScope = $rootScope;
+    });
+  });
+
+  it('sets the file content onto the scope', function() {
+    var input = element[0];
+    var customEvent = document.createEvent('CustomEvent');
+    customEvent.initCustomEvent('change');
+    input.dispatchEvent(customEvent);
+    expect(rootScope.fileContent).toBe('<kml></kml>');
+  });
+
+});


### PR DESCRIPTION
This PR adds an `ngeoFilereader`  directive and an example showing how to use that directive to import features from a KML document read from the user's file system.

The directive is based on the [FileReader](https://developer.mozilla.org/en-US/docs/Web/API/FileReader) object, itself being part of the [File API](https://w3c.github.io/FileAPI/#FileReader-interface).

Works in Chrome, Firefox, Safari and IE > 9.