### PR TITLE
Add public getFormattedArea and getFormattedLength functions

### DIFF
--- a/exports/ol-ext/interactions/measure.js
+++ b/exports/ol-ext/interactions/measure.js
@@ -1,9 +1,15 @@
+goog.require('ngeo.interaction.Measure');
 goog.require('ngeo.interaction.MeasureArea');
 goog.require('ngeo.interaction.MeasureAzimut');
 goog.require('ngeo.interaction.MeasureLength');
 
 
-goog.exportSymbol('ngeo.interaction.MeasureArea', ngeo.interaction.MeasureArea);
+goog.exportSymbol('ngeo.interaction.Measure.getFormattedArea',
+    ngeo.interaction.Measure.getFormattedArea);
+goog.exportSymbol('ngeo.interaction.Measure.getFormattedLength',
+    ngeo.interaction.Measure.getFormattedLength);
+goog.exportSymbol('ngeo.interaction.MeasureArea',
+    ngeo.interaction.MeasureArea);
 goog.exportSymbol('ngeo.interaction.MeasureAzimut',
     ngeo.interaction.MeasureAzimut);
 goog.exportSymbol('ngeo.interaction.MeasureLength',

--- a/src/ol-ext/interaction/measure.js
+++ b/src/ol-ext/interaction/measure.js
@@ -195,6 +195,57 @@ goog.inherits(ngeo.interaction.Measure, ol.interaction.Interaction);
 
 
 /**
+ * Calculate the area of the passed polygon and return a formatted string
+ * of the area.
+ * @param {ol.geom.Polygon} polygon Polygon.
+ * @param {ol.proj.Projection} projection Projection of the polygon coords.
+ * @return {string} Formatted string of the area.
+ */
+ngeo.interaction.Measure.getFormattedArea = function(polygon, projection) {
+  var geom = /** @type {ol.geom.Polygon} */ (
+      polygon.clone().transform(projection, 'EPSG:4326'));
+  var coordinates = geom.getLinearRing(0).getCoordinates();
+  var area = Math.abs(ol.sphere.WGS84.geodesicArea(coordinates));
+  var output;
+  if (area > 1000000) {
+    output = parseFloat((area / 1000000).toPrecision(3)) +
+        ' ' + 'km<sup>2</sup>';
+  } else {
+    output = parseFloat(area.toPrecision(3)) + ' ' + 'm<sup>2</sup>';
+  }
+  return output;
+};
+
+
+/**
+ * Calculate the length of the passed line string and return a formatted
+ * string of the length.
+ * @param {ol.geom.LineString} lineString Line string.
+ * @param {ol.proj.Projection} projection Projection of the line string coords.
+ * @return {string} Formatted string of length.
+ */
+ngeo.interaction.Measure.getFormattedLength =
+    function(lineString, projection) {
+  var length = 0;
+  var coordinates = lineString.getCoordinates();
+  for (var i = 0, ii = coordinates.length - 1; i < ii; ++i) {
+    var c1 = ol.proj.transform(coordinates[i], projection, 'EPSG:4326');
+    var c2 = ol.proj.transform(coordinates[i + 1], projection, 'EPSG:4326');
+    length += ol.sphere.WGS84.haversineDistance(c1, c2);
+  }
+  var output;
+  if (length > 1000) {
+    output = parseFloat((length / 1000).toPrecision(3)) +
+        ' ' + 'km';
+  } else {
+    output = parseFloat(length.toPrecision(3)) +
+        ' ' + 'm';
+  }
+  return output;
+};
+
+
+/**
  * Handle map browser event.
  * @param {ol.MapBrowserEvent} evt Map browser event.
  * @return {boolean} `false` if event propagation should be stopped.
@@ -371,34 +422,6 @@ ngeo.interaction.Measure.prototype.updateState_ = function() {
     this.removeMeasureTooltip_();
     this.removeHelpTooltip_();
   }
-};
-
-
-/**
- * Format measure output.
- * @param {ol.geom.LineString} line
- * @return {string}
- * @protected
- */
-ngeo.interaction.Measure.prototype.formatLength = function(line) {
-  var length = 0;
-  var map = this.getMap();
-  var sourceProj = map.getView().getProjection();
-  var coordinates = line.getCoordinates();
-  for (var i = 0, ii = coordinates.length - 1; i < ii; ++i) {
-    var c1 = ol.proj.transform(coordinates[i], sourceProj, 'EPSG:4326');
-    var c2 = ol.proj.transform(coordinates[i + 1], sourceProj, 'EPSG:4326');
-    length += ol.sphere.WGS84.haversineDistance(c1, c2);
-  }
-  var output;
-  if (length > 1000) {
-    output = parseFloat((length / 1000).toPrecision(3)) +
-        ' ' + 'km';
-  } else {
-    output = parseFloat(length.toPrecision(3)) +
-        ' ' + 'm';
-  }
-  return output;
 };
 
 

--- a/src/ol-ext/interaction/measurearea.js
+++ b/src/ol-ext/interaction/measurearea.js
@@ -58,35 +58,12 @@ ngeo.interaction.MeasureArea.prototype.getDrawInteraction = function(style,
 ngeo.interaction.MeasureArea.prototype.handleMeasure = function(callback) {
   var geom = /** @type {ol.geom.Polygon} */
       (this.sketchFeature.getGeometry());
-  var output = this.formatMeasure_(geom);
+  var proj = this.getMap().getView().getProjection();
+  var output = ngeo.interaction.Measure.getFormattedArea(geom, proj);
   var verticesCount = geom.getCoordinates()[0].length;
   var coord = null;
   if (verticesCount > 2) {
     coord = geom.getInteriorPoint().getCoordinates();
   }
   callback(output, coord);
-};
-
-
-/**
- * Format measure output.
- * @param {ol.geom.Polygon} polygon
- * @return {string}
- * @private
- */
-ngeo.interaction.MeasureArea.prototype.formatMeasure_ = function(polygon) {
-  var map = this.getMap();
-  var sourceProj = map.getView().getProjection();
-  var geom = /** @type {ol.geom.Polygon} */ (polygon.clone().transform(
-      sourceProj, 'EPSG:4326'));
-  var coordinates = geom.getLinearRing(0).getCoordinates();
-  var area = Math.abs(ol.sphere.WGS84.geodesicArea(coordinates));
-  var output;
-  if (area > 1000000) {
-    output = parseFloat((area / 1000000).toPrecision(3)) +
-        ' ' + 'km<sup>2</sup>';
-  } else {
-    output = parseFloat(area.toPrecision(3)) + ' ' + 'm<sup>2</sup>';
-  }
-  return output;
 };

--- a/src/ol-ext/interaction/measureazimut.js
+++ b/src/ol-ext/interaction/measureazimut.js
@@ -88,8 +88,8 @@ ngeo.interaction.MeasureAzimut.prototype.formatMeasure_ = function(line) {
   var factor = dx > 0 ? 1 : -1;
   var azimut = Math.round(factor * rad * 180 / Math.PI) % 360;
   var output = azimut + '°';
-
-  output += '<br/>' + this.formatLength(line);
+  var proj = this.getMap().getView().getProjection();
+  output += '<br/>' + ngeo.interaction.Measure.getFormattedLength(line, proj);
   return output;
 };
 

--- a/src/ol-ext/interaction/measurelength.js
+++ b/src/ol-ext/interaction/measurelength.js
@@ -57,18 +57,8 @@ ngeo.interaction.MeasureLength.prototype.getDrawInteraction = function(style,
 ngeo.interaction.MeasureLength.prototype.handleMeasure = function(callback) {
   var geom = /** @type {ol.geom.LineString} */
       (this.sketchFeature.getGeometry());
-  var output = this.formatMeasure_(geom);
+  var proj = this.getMap().getView().getProjection();
+  var output = ngeo.interaction.Measure.getFormattedLength(geom, proj);
   var coord = geom.getLastCoordinate();
   callback(output, coord);
-};
-
-
-/**
- * Format measure output.
- * @param {ol.geom.LineString} line
- * @return {string}
- * @private
- */
-ngeo.interaction.MeasureLength.prototype.formatMeasure_ = function(line) {
-  return this.formatLength(line);
 };


### PR DESCRIPTION
This PR refactors the measure interaction code to add `getFormattedArea` and `getFormattedLength` static function and make them public for use from outside.

Ready for review.