### PR TITLE
Translate dropdown and placeholder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,10 @@ dist/gmf.js: buildtools/gmf.json \
 	mkdir -p $(dir $@)
 	cp $< $@
 
+.build/examples-hosted/lib/angular-gettext.min.js: node_modules/angular-gettext/dist/angular-gettext.min.js
+	mkdir -p $(dir $@)
+	cp $< $@
+
 .build/examples-hosted/lib/bootstrap.min.js: node_modules/bootstrap/dist/js/bootstrap.min.js
 	mkdir -p $(dir $@)
 	cp $< $@
@@ -247,6 +251,7 @@ node_modules/angular/angular.min.js: .build/node_modules.timestamp
 		-e 's|\.\./node_modules/jquery/dist/jquery.js|lib/jquery.min.js|' \
 		-e 's|\.\./node_modules/bootstrap/dist/js/bootstrap.js|lib/bootstrap.min.js|' \
 		-e 's|\.\./node_modules/angular/angular.js|lib/angular.min.js|' \
+		-e 's|\.\./node_modules/angular-gettext/dist/angular-gettext.js|lib/angular-gettext.min.js|' \
 		-e 's|\.\./node_modules/d3/d3.js|lib/d3.min.js|' \
 		-e 's|\.\./node_modules/typeahead.js/dist/typeahead.bundle.js|lib/typeahead.bundle.min.js|' \
 		-e 's|/@?main=$*.js|$*.js|' \
@@ -261,6 +266,7 @@ node_modules/angular/angular.min.js: .build/node_modules.timestamp
 		-e 's|\.\./node_modules/jquery/dist/jquery.js|lib/jquery.min.js|' \
 		-e 's|\.\./node_modules/bootstrap/dist/js/bootstrap.js|lib/bootstrap.min.js|' \
 		-e 's|\.\./node_modules/angular/angular.js|lib/angular.min.js|' \
+		-e 's|\.\./node_modules/angular-gettext/dist/angular-gettext.js|lib/angular-gettext.min.js|' \
 		-e 's|\.\./node_modules/d3/d3.js|lib/d3.min.js|' \
 		-e 's|\.\./node_modules/typeahead.js/dist/typeahead.bundle.js|lib/typeahead.bundle.min.js|' \
 		-e 's|/@?main=$*.js|$*.js|' \
@@ -308,6 +314,7 @@ node_modules/angular/angular.min.js: .build/node_modules.timestamp
 		.build/examples-hosted/lib/ngeo.css \
 		.build/examples-hosted/lib/gmf.js \
 		.build/examples-hosted/lib/angular.min.js \
+		.build/examples-hosted/lib/angular-gettext.min.js \
 		.build/examples-hosted/lib/bootstrap.min.js \
 		.build/examples-hosted/lib/bootstrap.min.css \
 		.build/examples-hosted/lib/jquery.min.js \

--- a/contribs/gmf/examples/asitvd.html
+++ b/contribs/gmf/examples/asitvd.html
@@ -21,6 +21,7 @@
       <a href="http://asitvd.ch/index.php?option=com_content&view=article&id=214&Itemid=154&lang=en">ASIT VD tile server</a>.
     </p>
     <script src="../../../node_modules/angular/angular.js"></script>
+    <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=asitvd.js"></script>
     <script src="../../../utils/watchwatchers.js"></script>
   </body>

--- a/contribs/gmf/examples/locationchooser.html
+++ b/contribs/gmf/examples/locationchooser.html
@@ -24,10 +24,11 @@
         </gmf-locationchooser>
     </div>
     <button ng-click="ctrl.selectedLocation = ctrl.locations[0]">Move to Europa</button>
-    <div>Selected location: {{ctrl.selectedLocation}}</div>
+    <div>Selected location: {{ctrl.selectedLocation.label}}</div>
     <gmf-map gmf-map-map="ctrl.map"></gmf-map>
     <p id="desc">This example shows how to use the <code>gmf-locationchooser</code> directive to jump between some predefined areas.</p>
     <script src="../../../node_modules/angular/angular.js"></script>
+    <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=locationchooser.js"></script>
     <script src="../../../utils/watchwatchers.js"></script>
   </body>

--- a/contribs/gmf/examples/locationchooser.js
+++ b/contribs/gmf/examples/locationchooser.js
@@ -63,7 +63,6 @@ app.MainController = function() {
       zoom: 4
     })
   });
-
 };
 
 

--- a/contribs/gmf/examples/search.html
+++ b/contribs/gmf/examples/search.html
@@ -113,6 +113,7 @@
     </div>
     <script src="../../../node_modules/jquery/dist/jquery.js"></script>
     <script src="../../../node_modules/angular/angular.js"></script>
+    <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="../../../node_modules/typeahead.js/dist/typeahead.bundle.js"></script>
     <script src="http://cdnjs.cloudflare.com/ajax/libs/proj4js/2.2.1/proj4.js" type="text/javascript"></script>
     <script src="/@?main=search.js"></script>

--- a/contribs/gmf/examples/simple.html
+++ b/contribs/gmf/examples/simple.html
@@ -18,6 +18,7 @@
     <gmf-map gmf-map-map="ctrl.map"></gmf-map>
     <p id="desc">This example shows how to use the <code>gmf-map</code> directive to insert an OpenLayers map in a GeoMapFish page.</p>
     <script src="../../../node_modules/angular/angular.js"></script>
+    <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=simple.js"></script>
     <script src="../../../utils/watchwatchers.js"></script>
   </body>

--- a/contribs/gmf/src/directives/locationchooser.js
+++ b/contribs/gmf/src/directives/locationchooser.js
@@ -31,9 +31,10 @@ gmf.locationchooserDirective = function() {
     bindToController: true,
     controller: 'gmfLocationchooserController',
     controllerAs: 'ctrl',
-    template: '<select ' +
-        'ng-model="ctrl.selectedLocation" ' +
-        'ng-options="location.label for location in ::ctrl.locations" ' +
+    template:
+        '<select ng-model="ctrl.selectedLocation" ' +
+        'ng-options="location as ctrl.translate(location.label) ' +
+        'for location in ctrl.locations" ' +
         'ng-change="ctrl.setLocation()">' +
         '</select>'
   };
@@ -44,6 +45,7 @@ gmfModule.directive('gmfLocationchooser', gmf.locationchooserDirective);
 
 
 /**
+ * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @param {angular.Scope} $scope The directive's scope.
  * @constructor
  * @export
@@ -51,7 +53,13 @@ gmfModule.directive('gmfLocationchooser', gmf.locationchooserDirective);
  * @ngdoc controller
  * @ngname gmfLocationchooserController
  */
-gmf.LocationchooserController = function($scope) {
+gmf.LocationchooserController = function(gettextCatalog, $scope) {
+
+  /**
+   * @type {angularGettext.Catalog}
+   * @private
+   */
+  this.gettextCatalog_ = gettextCatalog;
 
   var map = this['getMapFn']();
   goog.asserts.assertInstanceof(map, ol.Map);
@@ -98,4 +106,14 @@ gmf.LocationchooserController.prototype.setLocation = function() {
   var mapSize = this.map_.getSize();
   goog.asserts.assert(goog.isDefAndNotNull(mapSize));
   this.map_.getView().fit(this.selectedLocation.extent, mapSize);
+};
+
+
+/**
+ * @param {string} str String to translate.
+ * @return {string}
+ * @export
+ */
+gmf.LocationchooserController.prototype.translate = function(str) {
+  return this.gettextCatalog_.getString(str);
 };

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -16,12 +16,6 @@ goog.require('ol.proj');
  * It can search in multiple GeoJSON datasources.
  * It can filter and group results by a feature's property.
  *
- * FIXME: The 'placeholder' in the input field is hard-coded and can't currently
- * be internationalised.
- *
- * FIXME: The 'groupsKey' in each result is displayed "as is" and can't
- * currently be internationalised.
- *
  * This directive uses the ngeoFeatureOverlayMgr to create a feature overlay
  * for drawing features on the map. The application is responsible to
  * initialize the ngeoFeatureOverlayMgr with the map.
@@ -49,7 +43,7 @@ gmf.searchDirective = function() {
     controllerAs: 'ctrl',
     template:
         '<div class="gmf-search">' +
-        '<input type="text" placeholder="search…" ' +
+        '<input type="text" placeholder="{{\'search…\' | translate}}" ' +
         'ng-model="ctrl.input_value" ' +
         'ngeo-search="ctrl.options" ' +
         'ngeo-search-datasets="ctrl.datasets" ' +

--- a/contribs/gmf/src/gmf.js
+++ b/contribs/gmf/src/gmf.js
@@ -7,4 +7,4 @@ goog.require('ngeo');
 
 
 /** @type {!angular.Module} */
-var gmfModule = angular.module('gmf', [ngeoModule.name]);
+var gmfModule = angular.module('gmf', [ngeoModule.name, 'gettext']);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "angular": "1.4.7",
+    "angular-gettext": "2.1.0",
     "angular-jsdoc": "^1.2.1",
     "angular-mocks": "1.4.7",
     "bootstrap": "^3.3.0",


### PR DESCRIPTION
This is a WIP, open for discussions.

 1. First, I had to add the ``gettext`` provider. Else, It throws an error because it doesn't find a provider for the ``translate`` keyword.

 ~~2. For the **locationchooser**, I had to change how I create the dropdown. ng-options doesn't work with "on-the-flight translation". So I've used a ``ng-repeat`` instead the ``ng-options``. The consequence is that I can't use an object in the "value" of the options. So now, I must use the extent as a String.~~

 3. I've tried my changes in a GeoMapFish. For the **search**, I've saw that the project doesn't add the translation in the "pot" file. I had to add the same string as in the placeholder in a hidden markup in the html file.