### PR TITLE
Set search's rateLimitWait to 50ms

### DIFF
--- a/src/services/creategeojsonbloodhound.js
+++ b/src/services/creategeojsonbloodhound.js
@@ -58,6 +58,7 @@ ngeo.createGeoJSONBloodhound = function(url, opt_filter, opt_featureProjection,
   var bloodhoundOptions = /** @type {BloodhoundOptions} */ ({
     remote: {
       url: url,
+      rateLimitWait: 50,
       prepare: function(query, settings) {
         settings.url = settings.url.replace('%QUERY', query);
         settings.dataType = 'jsonp';


### PR DESCRIPTION
Wait 50ms instead of the default 300ms on each request (~speedup the search).
https://github.com/twitter/typeahead.js/blob/master/doc/bloodhound.md#remote