### PR TITLE
Gmf geolocation mobile

### DIFF
--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -30,6 +30,10 @@
         ng-click="mainCtrl.toggleRightNavVisibility()">
       </button>
       <div class="overlay" ng-click="mainCtrl.hideNav()"></div>
+      <button ngeo-mobile-geolocation=""
+        ngeo-mobile-geolocation-map="::mainCtrl.map"
+        ngeo-mobile-geolocation-options="::mainCtrl.mobileGeolocationOptions">
+      </button>
     </main>
     <nav class="nav-left" gmf-mobile-nav>
       <header>

--- a/contribs/gmf/apps/mobile/js/mobile.js
+++ b/contribs/gmf/apps/mobile/js/mobile.js
@@ -16,6 +16,7 @@ goog.require('gmf.mobileNavDirective');
 goog.require('gmf.proj.EPSG21781');
 goog.require('gmf.searchDirective');
 goog.require('ngeo.FeatureOverlayMgr');
+goog.require('ngeo.mobileGeolocationDirective');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.control.ScaleLine');
@@ -62,6 +63,29 @@ app.MobileController = function(ngeoFeatureOverlayMgr, serverVars) {
    * @export
    */
   this.rightNavVisible = false;
+
+  var positionFeatureStyle = new ol.style.Style({
+    image: new ol.style.Circle({
+      radius: 6,
+      fill: new ol.style.Fill({color: 'rgba(230, 100, 100, 1)'}),
+      stroke: new ol.style.Stroke({color: 'rgba(230, 40, 40, 1)', width: 2})
+    })
+  });
+
+  var accuracyFeatureStyle = new ol.style.Style({
+    fill: new ol.style.Fill({color: 'rgba(100, 100, 230, 0.3)'}),
+    stroke: new ol.style.Stroke({color: 'rgba(40, 40, 230, 1)', width: 2})
+  });
+
+  /**
+   * @type {ngeox.MobileGeolocationDirectiveOptions}
+   * @export
+   */
+  this.mobileGeolocationOptions = {
+    positionFeatureStyle: positionFeatureStyle,
+    accuracyFeatureStyle: accuracyFeatureStyle,
+    zoom: 17
+  };
 
   /**
    * @type {ol.Map}

--- a/contribs/gmf/less/map.less
+++ b/contribs/gmf/less/map.less
@@ -136,6 +136,14 @@ gmf-map {
   }
 }
 
+button[ngeo-mobile-geolocation] {
+  right: 13px;
+  top: 135px;
+  & button:after {
+    content: 'b'
+  }
+}
+
 //For tablet only
 @media (min-width: @screen-sm-min) {
   main button:hover{
@@ -189,5 +197,13 @@ gmf-map {
   .nav-right-trigger {
     left: auto;
     right: @app-margin;
+  }
+
+  button[ngeo-mobile-geolocation] {
+    bottom: 12px;
+    top: auto;
+    & button:after {
+      content: 'b'
+    }
   }
 }

--- a/examples/mobilegeolocation.html
+++ b/examples/mobilegeolocation.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>Mobile geolocation example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+    <style>
+      #map {
+        width: 600px;
+        height: 400px;
+      }
+      button[ngeo-mobile-geolocation]:after {
+        content: 'Toggle tracking'
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <div class="container-fluid">
+      <div id="map" ngeo-map="::ctrl.map"></div>
+      <button ngeo-mobile-geolocation=""
+        ngeo-mobile-geolocation-map="::ctrl.map"
+        ngeo-mobile-geolocation-options="::ctrl.mobileGeolocationOptions">
+      </button>
+      <p id="desc">
+        This example shows how to use the <code>ngeo-mobile-geolocation</code>
+        directive.
+      </p>
+    </div>
+    <script src="../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="/@?main=mobilegeolocation.js"></script>
+    <script src="../utils/watchwatchers.js"></script>
+  </body>
+</html>

--- a/examples/mobilegeolocation.js
+++ b/examples/mobilegeolocation.js
@@ -1,0 +1,72 @@
+goog.provide('ngeo-mobile-geolocation');
+
+goog.require('ngeo.FeatureOverlayMgr');
+goog.require('ngeo.mapDirective');
+goog.require('ngeo.mobileGeolocationDirective');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['ngeo']);
+
+
+
+/**
+ * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
+ *     overlay manager service.
+ * @constructor
+ * @ngInject
+ */
+app.MainController = function(ngeoFeatureOverlayMgr) {
+
+  var positionFeatureStyle = new ol.style.Style({
+    image: new ol.style.Circle({
+      radius: 6,
+      fill: new ol.style.Fill({color: 'rgba(230, 100, 100, 1)'}),
+      stroke: new ol.style.Stroke({color: 'rgba(230, 40, 40, 1)', width: 2})
+    })
+  });
+
+  var accuracyFeatureStyle = new ol.style.Style({
+    fill: new ol.style.Fill({color: 'rgba(100, 100, 230, 0.3)'}),
+    stroke: new ol.style.Stroke({color: 'rgba(40, 40, 230, 1)', width: 2})
+  });
+
+  /**
+   * @type {ngeox.MobileGeolocationDirectiveOptions}
+   * @export
+   */
+  this.mobileGeolocationOptions = {
+    positionFeatureStyle: positionFeatureStyle,
+    accuracyFeatureStyle: accuracyFeatureStyle,
+    zoom: 17
+  };
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      })
+    ],
+    view: new ol.View({
+      center: [0, 0],
+      zoom: 4
+    })
+  });
+
+  ngeoFeatureOverlayMgr.init(this.map);
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -327,6 +327,39 @@ ngeox.MeasureEvent.prototype.feature;
 
 
 /**
+ * Options for the mobile geolocations directive.
+ * @typedef {{
+ *    accuracyFeatureStyle: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined),
+ *    positionFeatureStyle: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined),
+ *    zoom: (number|undefined)
+ * }}
+ */
+ngeox.MobileGeolocationDirectiveOptions;
+
+
+/**
+ * The style to use to sketch the accuracy feature, which is a regular polygon.
+ * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined}
+ */
+ngeox.MobileGeolocationDirectiveOptions.prototype.accuracyFeatureStyle;
+
+
+/**
+ * The style to use to sketch the position feature, which is a point.
+ * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined}
+ */
+ngeox.MobileGeolocationDirectiveOptions.prototype.positionFeatureStyle;
+
+
+/**
+ * If set, in addition to recentering the map view at the location, determines
+ * the zoom level to set when obtaining a new position.
+ * @type {number|undefined}
+ */
+ngeox.MobileGeolocationDirectiveOptions.prototype.zoom;
+
+
+/**
  * @typedef {{
  *   open: (function()|undefined),
  *   close: (function()|undefined),

--- a/src/directives/mobilegeolocation.js
+++ b/src/directives/mobilegeolocation.js
@@ -1,0 +1,198 @@
+goog.provide('ngeo.MobileGeolocationController');
+goog.provide('ngeo.mobileGeolocationDirective');
+
+goog.require('ngeo');
+goog.require('ngeo.DecorateGeolocation');
+goog.require('ngeo.FeatureOverlay');
+goog.require('ngeo.FeatureOverlayMgr');
+goog.require('ol.Feature');
+goog.require('ol.Geolocation');
+goog.require('ol.Map');
+goog.require('ol.geom.Point');
+goog.require('ol.proj');
+
+
+/**
+ * Provide a "mobile geolocation" directive.
+ *
+ * @example
+ * <button ngeo-mobile-geolocation=""
+ *   ngeo-mobile-geolocation-map="ctrl.map"
+ *   ngeo-mobile-geolocation-options="ctrl.mobileGeolocationOptions">
+ * </button>
+ *
+ * @return {angular.Directive} The Directive Definition Object.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname ngeoMobileGeolocation
+ */
+ngeo.mobileGeolocationDirective = function() {
+  return {
+    restrict: 'A',
+    scope: {
+      'getMobileMapFn': '&ngeoMobileGeolocationMap',
+      'getMobileGeolocationOptionsFn': '&ngeoMobileGeolocationOptions'
+    },
+    controller: 'NgeoMobileGeolocationController',
+    controllerAs: 'ctrl'
+  };
+};
+
+
+ngeoModule.directive('ngeoMobileGeolocation', ngeo.mobileGeolocationDirective);
+
+
+
+/**
+ * @constructor
+ * @param {angular.Scope} $scope The directive's scope.
+ * @param {angular.JQLite} $element Element.
+ * @param {ngeo.DecorateGeolocation} ngeoDecorateGeolocation Decorate
+ *     Geolocation service.
+ * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
+ *     overlay manager service.
+ * @export
+ * @ngInject
+ * @ngdoc controller
+ * @ngname NgeoMobileGeolocationController
+ */
+ngeo.MobileGeolocationController = function($scope, $element,
+    ngeoDecorateGeolocation, ngeoFeatureOverlayMgr) {
+
+  $element.on('click', goog.bind(this.toggleTracking, this));
+
+  var map = $scope['getMobileMapFn']();
+  goog.asserts.assertInstanceof(map, ol.Map);
+
+  /**
+   * @type {!ol.Map}
+   * @private
+   */
+  this.map_ = map;
+
+  var options = $scope['getMobileGeolocationOptionsFn']() || {};
+  goog.asserts.assertObject(options);
+
+  /**
+   * @type {ngeo.FeatureOverlay}
+   * @private
+   */
+  this.featureOverlay_ = ngeoFeatureOverlayMgr.getFeatureOverlay();
+
+  /**
+   * @type {ol.Geolocation}
+   * @private
+   */
+  this.geolocation_ = new ol.Geolocation({
+    projection: map.getView().getProjection()
+  });
+
+  /**
+   * @type {ol.Feature}
+   * @private
+   */
+  this.positionFeature_ = new ol.Feature(new ol.geom.Point([0, 0]));
+
+  if (options.positionFeatureStyle) {
+    this.positionFeature_.setStyle(options.positionFeatureStyle);
+  }
+
+  /**
+   * @type {ol.Feature}
+   * @private
+   */
+  this.accuracyFeature_ = new ol.Feature();
+
+  if (options.accuracyFeatureStyle) {
+    this.accuracyFeature_.setStyle(options.accuracyFeatureStyle);
+  }
+
+  /**
+   * @type {number|undefined}
+   * @private
+   */
+  this.zoom_ = options.zoom;
+
+  goog.events.listen(
+      this.geolocation_,
+      ol.Object.getChangeEventType(ol.GeolocationProperty.ACCURACY_GEOMETRY),
+      function() {
+        this.accuracyFeature_.setGeometry(
+            this.geolocation_.getAccuracyGeometry());
+      },
+      false,
+      this);
+
+  goog.events.listen(
+      this.geolocation_,
+      ol.Object.getChangeEventType(ol.GeolocationProperty.POSITION),
+      function(e) {
+        this.setPosition_(e);
+      },
+      false,
+      this);
+
+  ngeoDecorateGeolocation(this.geolocation_);
+};
+
+
+/**
+ * @export
+ */
+ngeo.MobileGeolocationController.prototype.toggleTracking = function() {
+  if (this.geolocation_.getTracking()) {
+    // if map center is different than geolocation position, then track again
+    var currentPosition = this.geolocation_.getPosition();
+    var center = this.map_.getView().getCenter();
+    if (currentPosition[0] === center[0] &&
+        currentPosition[1] === center[1]) {
+      this.untrack_();
+    } else {
+      this.untrack_();
+      this.track_();
+    }
+  } else {
+    this.track_();
+  }
+};
+
+
+/**
+ * @private
+ */
+ngeo.MobileGeolocationController.prototype.track_ = function() {
+  this.featureOverlay_.addFeature(this.positionFeature_);
+  this.featureOverlay_.addFeature(this.accuracyFeature_);
+  this.geolocation_.setTracking(true);
+};
+
+
+/**
+ * @private
+ */
+ngeo.MobileGeolocationController.prototype.untrack_ = function() {
+  this.featureOverlay_.clear();
+  this.geolocation_.setTracking(false);
+};
+
+
+/**
+ * @param {ol.ObjectEvent} event Event.
+ * @private
+ */
+ngeo.MobileGeolocationController.prototype.setPosition_ = function(event) {
+  var position = /** @type {ol.Coordinate} */ (this.geolocation_.getPosition());
+  var point = /** @type {ol.geom.Point} */
+      (this.positionFeature_.getGeometry());
+
+  point.setCoordinates(position);
+  this.map_.getView().setCenter(position);
+
+  if (this.zoom_ !== undefined) {
+    this.map_.getView().setZoom(this.zoom_);
+  }
+};
+
+
+ngeoModule.controller('NgeoMobileGeolocationController',
+    ngeo.MobileGeolocationController);


### PR DESCRIPTION
This PR introduces the GMF mobile geolocation directive.  When clicked, if inactive, the inner geolocation gets activated.  A point feature is added on the map for the location and an other regular polygon feature is added for the precision.  If clicked again, if the position is at the center of the map, then the tracking is deactivated.  Otherwise, a new tracking position is obtained.

It also introduces an example in which it is featured.

It is possible to define 3 options:

 * `accuracyFeatureStyle`
 * `positionFeatureStyle`
 * `zoom`