### PR TITLE
location chooser refactoring

### DIFF
--- a/examples/locationchooser.html
+++ b/examples/locationchooser.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>Location chooser example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../../../node_modules/openlayers/css/ol.css" type="text/css">
+    <style>
+      #map {
+        width: 600px;
+        height: 400px;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <div id="map" ngeo-map="ctrl.map"></div>
+    <p id="desc">This example shows how to use the <code>ngeo-recenter</code> directive to jump between some predefined areas.</p>
+
+    <span>Move to:</span>
+    <select ngeo-recenter ngeo-recenter-map="::ctrl.map">
+      <option ngeo-extent="[-1898084, 4676723, 3972279, 8590299]" translate>Europa</option>
+      <option ngeo-extent="[727681, 5784754, 1094579, 6029353]" translate>Switzerland</option>
+      <option ngeo-extent="[-2778639, 9133308, -1311048, 10111701]" translate>Iceland</option>
+      <option ngeo-extent="[12044030, -4921322, 17914393, -1007746]" translate>Australia</option>
+    </select>
+
+    <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="/@?main=locationchooser.js"></script>
+    <script src="../utils/watchwatchers.js"></script>
+  </body>
+</html>

--- a/examples/locationchooser.js
+++ b/examples/locationchooser.js
@@ -1,0 +1,43 @@
+goog.provide('locationchooser');
+
+goog.require('ngeo.mapDirective');
+goog.require('ngeo.recenterDirective');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['ngeo']);
+
+
+
+/**
+ * @constructor
+ */
+app.MainController = function() {
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      })
+    ],
+    view: new ol.View({
+      center: [0, 0],
+      zoom: 4
+    })
+  });
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/src/directives/recenter.js
+++ b/src/directives/recenter.js
@@ -1,0 +1,64 @@
+goog.provide('ngeo.recenterDirective');
+
+goog.require('ngeo');
+
+
+/**
+ * Provides the "ngeoRecenter" directive, a widget for recentering a map
+ * to a specific extent (by using `ngeo-extent`) or a specific zoom level
+ * (by using `ngeo-zoom`).
+ *
+ * Example:
+ *
+ *     <div ngeo-recenter ngeo-recenter-map="::ctrl.map">
+ *       <a href="#" ngeo-extent="[-1898084, 4676723, 3972279, 8590299]">A</a>
+ *       <a href="#" ngeo-extent="[727681, 5784754, 1094579, 6029353]">B</a>
+ *       <a href="#" ngeo-zoom="1">Zoom to level 1</a>
+ *     </div>
+ *
+ * Or with a select:
+ *
+ *     <select ngeo-locationchooser ngeo-locationchooser-map="::ctrl.map">
+ *       <option extent="[-1898084, 4676723, 3972279, 8590299]">A</option>
+ *       <option extent="[727681, 5784754, 1094579, 6029353]">B</option>
+ *     </select>
+ *
+ *
+ * @return {angular.Directive} Directive Definition Object.
+ * @ngdoc directive
+ * @ngname ngeoRecenter
+ */
+ngeo.recenterDirective = function() {
+  return {
+    restrict: 'A',
+    link: function($scope, $element, $attrs) {
+      var mapExpr = $attrs['ngeoRecenterMap'];
+      var map = /** @type {ol.Map} */ ($scope.$eval(mapExpr));
+
+      function recenter(element) {
+        var extent = element.attr('ngeo-extent');
+        if (extent !== undefined) {
+          var mapSize = /** @type {ol.Size} */ (map.getSize());
+          map.getView().fit($scope.$eval(extent), mapSize);
+        }
+        var zoom = element.attr('ngeo-zoom');
+        if (zoom !== undefined) {
+          map.getView().setZoom($scope.$eval(zoom));
+        }
+      }
+
+      // if the children is a link or button
+      $element.on('click', function(event) {
+        recenter(angular.element(event.target));
+      });
+
+      // if the children is an option inside a select
+      $element.on('change', function(event) {
+        var selected = event.target.options[event.target.selectedIndex];
+        recenter(angular.element(selected));
+      });
+
+    }
+  };
+};
+ngeoModule.directive('ngeoRecenter', ngeo.recenterDirective);


### PR DESCRIPTION
From a user perspective, using the location chooser directive could be something like:
```html
<select ngeo-locationchooser ngeo-locationchooser-map="ctrl.map">
  <option extent="[-1898084, 4676723, 3972279, 8590299]" translate>Europa</option>
  <option extent="[727681, 5784754, 1094579, 6029353]" translate>Switzerland</option>
</select>
```

Or (with `ng-options`):
```html
<select ngeo-locationchooser ngeo-locationchooser-map="ctrl.map"
            ng-options="location.label for location in mainCtrl.locations"></select>
```

handle `ng-change` events at `ngeo-locationchooser` level


Or (with simple links):
```html
<div ngeo-locationchooser ngeo-locationchooser-map="ctrl.map">
  <a href="#" extent="[-1898084, 4676723, 3972279, 8590299]" translate>Europa</a>
  <a href="#" extent="[727681, 5784754, 1094579, 6029353]" translate>Switzerland</a>
</div>
```

handle `ng-click` at `ngeo-locationchooser` level (event bubbling)

Or (with bootstrap):
```html
<div class="dropdown" ngeo-locationchooser ngeo-locationchooser-map="ctrl.map">
  <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
    Dropdown
    <span class="caret"></span>
  </button>
  <ul class="dropdown-menu">
    <li><a href="#" extent="[-1898084, 4676723, 3972279, 8590299]" translate>Europa</a></li>
    <li role="separator" class="divider"></li>
    <li><a href="#" extent="[727681, 5784754, 1094579, 6029353]" translate>Switzerland</a></li>
  </ul>
</div>
```


