### PR TITLE
Add link to AngularJS documentation on AngularJS objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -441,10 +441,13 @@ $(EXTERNS_JQUERY):
 		--var "partials=$(addprefix ngeo:,$(NGEO_DIRECTIVES_PARTIALS_FILES)) \
 		$(addprefix gmf:,$(GMF_DIRECTIVES_PARTIALS_FILES))" $< > $@
 
+.build/jsdocAngularJS.js: jsdoc/get-angularjs-doc-ref.js .build/node_modules.timestamp
+	node $< > $@
+
 .build/jsdocOl3.js: jsdoc/get-ol3-doc-ref.js .build/node_modules.timestamp
 	node $< > $@
 
-.build/apidoc-%: jsdoc/config.json .build/node_modules.timestamp .build/jsdocOl3.js $(SRC_JS_FILES)
+.build/apidoc-%: jsdoc/config.json .build/node_modules.timestamp .build/jsdocAngularJS.js .build/jsdocOl3.js $(SRC_JS_FILES)
 	rm -rf $@
 	./node_modules/.bin/jsdoc -c $< --destination $@
 

--- a/jsdoc/get-angularjs-doc-ref.js
+++ b/jsdoc/get-angularjs-doc-ref.js
@@ -1,0 +1,33 @@
+var https = require("https");
+var data = "";
+
+https.get('https://docs.angularjs.org/js/search-data.json', function (result) {
+
+    result.setEncoding('utf8');
+
+    result.on('data', function(chunk) {
+        data += chunk;
+    });
+
+    result.on('end', function() {
+        var json = JSON.parse(data);
+        var i, ref;
+        console.log("exports.registerAngularJSLink = function(helper) {");
+        for (i = 0; i < json.length; i++) {
+            ref = json[i];
+            if(!ref['path'].match(/^error/)) {
+                console.log(
+                    "    helper.registerLink('angular." +
+                    ref['titleWords'] +
+                    "', 'https://docs.angularjs.org/" +
+                    ref['path'] +
+                    "');"
+                );
+            }
+        }
+        console.log("    helper.registerLink('angular.Scope', " +
+            "'https://docs.angularjs.org/guide/scope');");
+        console.log("}");
+    })
+
+});

--- a/jsdoc/template/publish.js
+++ b/jsdoc/template/publish.js
@@ -10,6 +10,7 @@ var taffy = require('taffydb').taffy;
 var template = require('jsdoc/template');
 var util = require('util');
 var jsdocType = require("jsdoc/tag/type")
+var jsdocAngularJS = require('../../.build/jsdocAngularJS.js');
 var jsdocOl3 = require('../../.build/jsdocOl3.js');
 
 var htmlsafe = helper.htmlsafe;
@@ -437,6 +438,7 @@ exports.publish = function(taffyData, opts, tutorials) {
     helper.registerLink('global', globalUrl);
 
     jsdocOl3.registerOl3Link(helper);
+    jsdocAngularJS.registerAngularJSLink(helper);
 
     // set up templating
     view.layout = conf.default.layoutFile ?


### PR DESCRIPTION
Example: http://ger-benjamin.github.io/ngeo/master/apidoc/gmf.MapController.html

(link to the ``angular.Scope`` is not really clean. But it's like an exception...)