### PR TITLE
[WIP] - Add a directive to extend the main controller

### DIFF
--- a/contribs/gmf/apps/mobile/js/mobile.js
+++ b/contribs/gmf/apps/mobile/js/mobile.js
@@ -11,21 +11,7 @@ goog.provide('app.MobileController');
 goog.provide('app_mobile');
 
 goog.require('app');
-goog.require('gmf.mapDirective');
-goog.require('gmf.mobileNavDirective');
-goog.require('gmf.proj.EPSG21781');
-goog.require('gmf.searchDirective');
-goog.require('ngeo.FeatureOverlayMgr');
-goog.require('ngeo.mobileGeolocationDirective');
-goog.require('ol.Map');
-goog.require('ol.View');
-goog.require('ol.control.ScaleLine');
-goog.require('ol.control.Zoom');
-goog.require('ol.layer.Tile');
-goog.require('ol.source.OSM');
-
-
-gmfModule.constant('isMobile', true);
+goog.require('gmf.AbstractMobileController');
 
 
 
@@ -34,137 +20,14 @@ gmfModule.constant('isMobile', true);
  *     overlay manager service.
  * @param {Object} serverVars vars from GMF
  * @constructor
+ * @extends {gmf.AbstractMobileController}
  * @ngInject
  * @export
  */
 app.MobileController = function(ngeoFeatureOverlayMgr, serverVars) {
-
-  /**
-   * @type {Array.<gmfx.SearchDirectiveDatasource>}
-   * @export
-   */
-  this.searchDatasources = [{
-    datasetTitle: 'Internal',
-    labelKey: 'label',
-    groupsKey: 'layer_name',
-    groupValues: ['osm'],
-    projection: 'EPSG:21781',
-    url: serverVars['serviceUrls']['fulltextsearch']
-  }];
-
-  /**
-   * @type {boolean}
-   * @export
-   */
-  this.leftNavVisible = false;
-
-  /**
-   * @type {boolean}
-   * @export
-   */
-  this.rightNavVisible = false;
-
-  var positionFeatureStyle = new ol.style.Style({
-    image: new ol.style.Circle({
-      radius: 6,
-      fill: new ol.style.Fill({color: 'rgba(230, 100, 100, 1)'}),
-      stroke: new ol.style.Stroke({color: 'rgba(230, 40, 40, 1)', width: 2})
-    })
-  });
-
-  var accuracyFeatureStyle = new ol.style.Style({
-    fill: new ol.style.Fill({color: 'rgba(100, 100, 230, 0.3)'}),
-    stroke: new ol.style.Stroke({color: 'rgba(40, 40, 230, 1)', width: 2})
-  });
-
-  /**
-   * @type {ngeox.MobileGeolocationDirectiveOptions}
-   * @export
-   */
-  this.mobileGeolocationOptions = {
-    positionFeatureStyle: positionFeatureStyle,
-    accuracyFeatureStyle: accuracyFeatureStyle,
-    zoom: 17
-  };
-
-  /**
-   * @type {ol.Map}
-   * @export
-   */
-  this.map = new ol.Map({
-    layers: [
-      new ol.layer.Tile({
-        source: new ol.source.OSM()
-      })
-    ],
-    view: new ol.View({
-      center: [0, 0],
-      zoom: 2
-    }),
-    controls: [
-      new ol.control.ScaleLine(),
-      new ol.control.Zoom()
-    ]
-  });
-
-  ngeoFeatureOverlayMgr.init(this.map);
-
+  goog.base(this, ngeoFeatureOverlayMgr, serverVars);
 };
-
-
-/**
- * @export
- */
-app.MobileController.prototype.toggleLeftNavVisibility = function() {
-  this.leftNavVisible = !this.leftNavVisible;
-};
-
-
-/**
- * @export
- */
-app.MobileController.prototype.toggleRightNavVisibility = function() {
-  this.rightNavVisible = !this.rightNavVisible;
-};
-
-
-/**
- * Hide both navigation menus.
- * @export
- */
-app.MobileController.prototype.hideNav = function() {
-  this.leftNavVisible = this.rightNavVisible = false;
-};
-
-
-/**
- * @return {boolean} Return true if one of the navigation menus is visible,
- * otherwise false.
- * @export
- */
-app.MobileController.prototype.navIsVisible = function() {
-  return this.leftNavVisible || this.rightNavVisible;
-};
-
-
-/**
- * @return {boolean} Return true if the left navigation menus is visible,
- * otherwise false.
- * @export
- */
-app.MobileController.prototype.leftNavIsVisible = function() {
-  return this.leftNavVisible;
-};
-
-
-/**
- * @return {boolean} Return true if the right navigation menus is visible,
- * otherwise false.
- * @export
- */
-app.MobileController.prototype.rightNavIsVisible = function() {
-  return this.rightNavVisible;
-};
+goog.inherits(app.MobileController, gmf.AbstractMobileController);
 
 
 appModule.controller('MobileController', app.MobileController);

--- a/contribs/gmf/src/controllers/abstractmobile.js
+++ b/contribs/gmf/src/controllers/abstractmobile.js
@@ -1,0 +1,173 @@
+/**
+ * @fileoverview Application entry point.
+ *
+ * This file defines the "app_mobile" Closure namespace, which is be used as the
+ * Closure entry point (see "closure_entry_point" in the "build.json" file).
+ *
+ * This file includes `goog.require`'s for all the components/directives used
+ * by the HTML page and the controller to provide the configuration.
+ */
+goog.provide('gmf.AbstractMobileController');
+
+goog.require('gmf');
+goog.require('gmf.mapDirective');
+goog.require('gmf.mobileNavDirective');
+goog.require('gmf.proj.EPSG21781');
+goog.require('gmf.searchDirective');
+goog.require('ngeo.FeatureOverlayMgr');
+goog.require('ngeo.mobileGeolocationDirective');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.control.ScaleLine');
+goog.require('ol.control.Zoom');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+goog.require('ol.style.Circle');
+goog.require('ol.style.Fill');
+goog.require('ol.style.Stroke');
+goog.require('ol.style.Style');
+
+
+gmfModule.constant('isMobile', true);
+
+
+
+/**
+ * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
+ *     overlay manager service.
+ * @param {Object} serverVars vars from GMF
+ * @constructor
+ * @ngInject
+ * @export
+ */
+gmf.AbstractMobileController = function(ngeoFeatureOverlayMgr, serverVars) {
+
+  /**
+   * @type {Array.<gmfx.SearchDirectiveDatasource>}
+   * @export
+   */
+  this.searchDatasources = [{
+    datasetTitle: 'Internal',
+    labelKey: 'label',
+    groupsKey: 'layer_name',
+    groupValues: ['osm'],
+    projection: 'EPSG:21781',
+    url: serverVars['serviceUrls']['fulltextsearch']
+  }];
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.leftNavVisible = false;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.rightNavVisible = false;
+
+  var positionFeatureStyle = new ol.style.Style({
+    image: new ol.style.Circle({
+      radius: 6,
+      fill: new ol.style.Fill({color: 'rgba(230, 100, 100, 1)'}),
+      stroke: new ol.style.Stroke({color: 'rgba(230, 40, 40, 1)', width: 2})
+    })
+  });
+
+  var accuracyFeatureStyle = new ol.style.Style({
+    fill: new ol.style.Fill({color: 'rgba(100, 100, 230, 0.3)'}),
+    stroke: new ol.style.Stroke({color: 'rgba(40, 40, 230, 1)', width: 2})
+  });
+
+  /**
+   * @type {ngeox.MobileGeolocationDirectiveOptions}
+   * @export
+   */
+  this.mobileGeolocationOptions = {
+    positionFeatureStyle: positionFeatureStyle,
+    accuracyFeatureStyle: accuracyFeatureStyle,
+    zoom: 17
+  };
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      })
+    ],
+    view: new ol.View({
+      center: [0, 0],
+      zoom: 2
+    }),
+    controls: [
+      new ol.control.ScaleLine(),
+      new ol.control.Zoom()
+    ]
+  });
+
+  ngeoFeatureOverlayMgr.init(this.map);
+
+};
+
+
+/**
+ * @export
+ */
+gmf.AbstractMobileController.prototype.toggleLeftNavVisibility = function() {
+  this.leftNavVisible = !this.leftNavVisible;
+};
+
+
+/**
+ * @export
+ */
+gmf.AbstractMobileController.prototype.toggleRightNavVisibility = function() {
+  this.rightNavVisible = !this.rightNavVisible;
+};
+
+
+/**
+ * Hide both navigation menus.
+ * @export
+ */
+gmf.AbstractMobileController.prototype.hideNav = function() {
+  this.leftNavVisible = this.rightNavVisible = false;
+};
+
+
+/**
+ * @return {boolean} Return true if one of the navigation menus is visible,
+ * otherwise false.
+ * @export
+ */
+gmf.AbstractMobileController.prototype.navIsVisible = function() {
+  return this.leftNavVisible || this.rightNavVisible;
+};
+
+
+/**
+ * @return {boolean} Return true if the left navigation menus is visible,
+ * otherwise false.
+ * @export
+ */
+gmf.AbstractMobileController.prototype.leftNavIsVisible = function() {
+  return this.leftNavVisible;
+};
+
+
+/**
+ * @return {boolean} Return true if the right navigation menus is visible,
+ * otherwise false.
+ * @export
+ */
+gmf.AbstractMobileController.prototype.rightNavIsVisible = function() {
+  return this.rightNavVisible;
+};
+
+
+gmfModule.controller('AbstractMobileController', gmf.AbstractMobileController);


### PR DESCRIPTION
This PR suggests an architecture to override main controllers.

For maintenance purpose, we don't want to have customization in the `mainController` file itself.
This PR moves all shared code of the `MobileController` to an `AbstractMobileController`.

The `AbstractMobileController` class contains all the generic code of all gmf instances main controller.
It's moved to the `gmf` folder, and will be part of the library.

The new `MobileController` is just now an empty Controller, inheriting from `AbstractMobileController`.
This one is called from the template, and will be copied in all gmf instances.

It could be customised for each instance to override the main controller.

Same work will be done for destkop controllers.