### PR TITLE
Revert "Fix loading of mobile.js in local mode"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ node_modules/angular/angular.min.js: .build/node_modules.timestamp
 		-e '/\/node_modules\//d' \
 		-e '/default\.js/d' \
 		-e 's|utils/watchwatchers.js|lib/watchwatchers.js|' \
-		-e 's|/@?main=js/mobile.js|../../build/mobile.js|' $< > $@
+		-e 's|/@?main=mobile/js/mobile.js|../../build/mobile.js|' $< > $@
 
 .PRECIOUS: .build/examples-hosted/%.js
 .build/examples-hosted/%.js: examples/%.js

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -102,7 +102,7 @@
     <script src="../../../../node_modules/bootstrap/dist/js/bootstrap.js" type="text/javascript"></script>
     <script src="../../../../node_modules/d3/d3.min.js" type="text/javascript"></script>
     <script src="../../../../node_modules/less/dist/less.min.js"></script>
-    <script src="/@?main=js/mobile.js"></script>
+    <script src="/@?main=mobile/js/mobile.js"></script>
     <script src="default.js"></script>
     <script src="../../../../utils/watchwatchers.js"></script>
     <script>


### PR DESCRIPTION
This reverts commit 3777d51e2fe89f956168d88a661d812077a5fcf0.

Last week i had to make this change to make the mobile apps works in local mode, and now i have to revert it. Don't understand why, maybe i fixed it last week upon an old version.