### PR TITLE
Remove the init method in themesService

### DIFF
--- a/contribs/gmf/src/services/themesservice.js
+++ b/contribs/gmf/src/services/themesservice.js
@@ -34,19 +34,14 @@ gmf.ThemesEventType = {
  * @constructor
  * @extends {goog.events.EventTarget}
  * @param {angular.$http} $http Angular http service.
+ * @param {string} gmfTtreeUrl URL to "themes" web service.
  * @ngInject
  * @ngdoc service
  * @ngname gmfThemes
  */
-gmf.Themes = function($http) {
+gmf.Themes = function($http, gmfTtreeUrl) {
 
   goog.base(this);
-
-  /**
-   * @type {boolean}
-   * @private
-   */
-  this.initialized_ = false;
 
   /**
    * @type {angular.$http}
@@ -58,7 +53,7 @@ gmf.Themes = function($http) {
    * @type {string}
    * @private
    */
-  this.treeUrl_ = '';
+  this.treeUrl_ = gmfTtreeUrl;
 
   /**
    * @type {?angular.$q.Promise}
@@ -67,19 +62,6 @@ gmf.Themes = function($http) {
   this.promise_ = null;
 };
 goog.inherits(gmf.Themes, goog.events.EventTarget);
-
-
-/**
- * Init the service.
- * @param {string} treeUrl URL to "themes" web service.
- * @export
- */
-gmf.Themes.prototype.init = function(treeUrl) {
-  if (!this.initialized_) {
-    this.treeUrl_ = treeUrl;
-    this.initialized_ = true;
-  }
-};
 
 
 /**

--- a/contribs/gmf/test/spec/beforeeach.js
+++ b/contribs/gmf/test/spec/beforeeach.js
@@ -1,3 +1,5 @@
 beforeEach(function() {
-  module('gmf');
+  module('gmf', function($provide) {
+    $provide.value('gmfTtreeUrl', 'http://fake/gmf/themes');
+  });
 });

--- a/contribs/gmf/test/spec/services/themesservice.spec.js
+++ b/contribs/gmf/test/spec/services/themesservice.spec.js
@@ -4,12 +4,12 @@ goog.require('gmf.test.data.themes');
 
 describe('gmf.Themes', function() {
   var gmfThemes;
-  var treeUrl = 'http://fake/gmf/themes';
+  var treeUrl;
 
   beforeEach(function() {
     inject(function($injector) {
       gmfThemes = $injector.get('gmfThemes');
-      gmfThemes.init(treeUrl);
+      treeUrl = $injector.get('gmfTtreeUrl');
       $httpBackend = $injector.get('$httpBackend');
       $httpBackend.when('GET', treeUrl).respond(themes);
     });


### PR DESCRIPTION
I prefer to have a `module.value` to manage the url to the themes service, and that this url is directly available in the angular `themesservice`.

I renamed the angular value to `gmfTreeUrl` and updated tests.