### PR TITLE
[Full-text search] We should be able to hide the geometries

### DIFF
--- a/contribs/gmf/src/directives/partials/search.html
+++ b/contribs/gmf/src/directives/partials/search.html
@@ -6,5 +6,5 @@
         ngeo-search-listeners="ctrl.listeners">
 <div class="clear-button ng-hide"
         ng-hide="!ctrl.clearButton || ctrl.input_value == ''"
-        ng-click="ctrl.clear()"></div>
+        ng-click="ctrl.onClearButton()"></div>
 </div>

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -344,7 +344,9 @@ gmf.SearchController.select_ = function(event, feature, dataset) {
   var mapSize = /** @type {ol.Size} */ (this.map_.getSize());
   this.map_.getView().fit(fitArray, mapSize,
       /** @type {olx.view.FitOptions} */ ({maxZoom: 16}));
-  this.clear();
+  if (!this.clearButton) {
+    this.clear();
+  }
 };
 
 
@@ -354,7 +356,9 @@ gmf.SearchController.select_ = function(event, feature, dataset) {
  * @private
  */
 gmf.SearchController.close_ = function(event) {
-  this.setTTDropdownVisibility_();
+  if (!this.clearButton) {
+    this.setTTDropdownVisibility_();
+  }
 };
 
 

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -315,6 +315,15 @@ gmf.SearchController.prototype.setTTDropdownVisibility_ = function() {
 /**
  * @export
  */
+gmf.SearchController.prototype.onClearButton = function() {
+  this.featureOverlay_.clear();
+  this.clear();
+};
+
+
+/**
+ * @export
+ */
 gmf.SearchController.prototype.clear = function() {
   var typeahead = $('.twitter-typeahead');
   var ttmenu = typeahead.children('.tt-menu');


### PR DESCRIPTION
From the design proposal:
 - when an item is selected it:
  - hide the results div
  - highlight the geometry
  - recenter to the geometry
  - the input value is set to the selected item's title
  - a cross button is displayed in the input
  - FIXME: un-focus the input to hide the keyboard?
 - if the cross button is pressed it:
  - clear the input text
  - remove the highlighted geometry
  - hide the cross button

linked to: https://github.com/camptocamp/c2cgeoportal/issues/1656