### PR TITLE
Don't display the geolocation point at an invalid position

### DIFF
--- a/src/directives/desktopgeolocation.js
+++ b/src/directives/desktopgeolocation.js
@@ -92,7 +92,7 @@ ngeo.DesktopGeolocationController = function($scope, $element,
    * @type {ol.Feature}
    * @private
    */
-  this.positionFeature_ = new ol.Feature(new ol.geom.Point([0, 0]));
+  this.positionFeature_ = new ol.Feature();
 
   if (options.positionFeatureStyle) {
     this.positionFeature_.setStyle(options.positionFeatureStyle);
@@ -181,10 +181,9 @@ ngeo.DesktopGeolocationController.prototype.deactivate_ = function() {
  */
 ngeo.DesktopGeolocationController.prototype.setPosition_ = function(event) {
   var position = /** @type {ol.Coordinate} */ (this.geolocation_.getPosition());
-  var point = /** @type {ol.geom.Point} */
-      (this.positionFeature_.getGeometry());
+  var point = new ol.geom.Point(position);
 
-  point.setCoordinates(position);
+  this.positionFeature_.setGeometry(point);
   this.map_.getView().setCenter(position);
 
   if (this.zoom_ !== undefined) {

--- a/src/directives/mobilegeolocation.js
+++ b/src/directives/mobilegeolocation.js
@@ -90,7 +90,7 @@ ngeo.MobileGeolocationController = function($scope, $element,
    * @type {ol.Feature}
    * @private
    */
-  this.positionFeature_ = new ol.Feature(new ol.geom.Point([0, 0]));
+  this.positionFeature_ = new ol.Feature();
 
   if (options.positionFeatureStyle) {
     this.positionFeature_.setStyle(options.positionFeatureStyle);
@@ -221,10 +221,9 @@ ngeo.MobileGeolocationController.prototype.untrack_ = function() {
  */
 ngeo.MobileGeolocationController.prototype.setPosition_ = function(event) {
   var position = /** @type {ol.Coordinate} */ (this.geolocation_.getPosition());
-  var point = /** @type {ol.geom.Point} */
-      (this.positionFeature_.getGeometry());
+  var point = new ol.geom.Point(position);
 
-  point.setCoordinates(position);
+  this.positionFeature_.setGeometry(point);
 
   if (this.follow_) {
     this.viewChangedByMe_ = true;


### PR DESCRIPTION
To reproduce the issue:
 - http://camptocamp.github.io/ngeo/master/examples/contribs/gmf/apps/mobile/index.html
 - Click the geolocation button
 - The geolocation point is display at [0, 0]