### PR TITLE
Fix GMF theme json example - human readable

### DIFF
--- a/contribs/gmf/examples/data/themes.json
+++ b/contribs/gmf/examples/data/themes.json
@@ -1,1 +1,647 @@
-{"themes": [{"name": "Enseignement", "functionalities": {}, "id": 38, "icon": "https://geomapfish-demo.camptocamp.net/1.6/wsgi/project/8143d12d42d5431baf576b39d32f18e5/img/enseignement.jpeg", "children": [{"metadata": {}, "children": [{"layers": "bus_stop", "name": "bus_stop", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 101, "imageType": "image/jpeg", "metadata": {"identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "Arr\u00eats de bus"}}, {"layers": "information", "name": "information", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 98, "imageType": "image/jpeg", "metadata": {"is_checked": "true", "identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "Informations"}}], "id": 35, "name": "Enseignement"}], "metadata": {}}, {"name": "Transport", "functionalities": {}, "id": 37, "icon": "https://geomapfish-demo.camptocamp.net/1.6/wsgi/project/8143d12d42d5431baf576b39d32f18e5/img/transports.jpeg", "children": [{"metadata": {}, "children": [{"layers": "fuel", "name": "fuel", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 124, "imageType": "image/jpeg", "metadata": {"is_checked": "true", "identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "Stations service"}}, {"layers": "parking", "name": "parking", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 103, "imageType": "image/jpeg", "metadata": {"identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "Parkings"}}, {"layers": "bus_stop", "name": "bus_stop", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 101, "imageType": "image/jpeg", "metadata": {"identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "Arr\u00eats de bus"}}], "id": 36, "name": "Transport"}], "metadata": {}}, {"name": "Cadastre", "functionalities": {}, "id": 29, "icon": "https://geomapfish-demo.camptocamp.net/1.6/wsgi/project/8143d12d42d5431baf576b39d32f18e5/img/cadastre.jpeg", "children": [{"metadata": {}, "children": [{"layers": "ch.swisstopo.dreiecksvermaschung", "name": "ch.swisstopo.dreiecksvermaschung", "url": "http://wms.geo.admin.ch?lang=fr", "isSingleTile": false, "type": "external WMS", "id": 115, "imageType": "image/jpeg", "metadata": {"legend": "true", "disclaimer": "<a href=\"http://www.geo.admin.ch/\">Donn\u00e9es publiques de l'infrastructure f\u00e9d\u00e9rale de donn\u00e9es g\u00e9ographiques (IFDG)</a>"}}, {"layers": "ch.swisstopo.geologie-gravimetrischer_atlas", "name": "ch.swisstopo.geologie-gravimetrischer_atlas", "url": "http://wms.geo.admin.ch?lang=fr", "isSingleTile": false, "type": "external WMS", "id": 116, "imageType": "image/jpeg", "metadata": {"legend": "true", "disclaimer": "<a href=\"http://www.geo.admin.ch/\">Donn\u00e9es publiques de l'infrastructure f\u00e9d\u00e9rale de donn\u00e9es g\u00e9ographiques (IFDG)</a>"}}, {"layers": "ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen", "name": "ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen", "url": "http://wms.geo.admin.ch?lang=fr", "isSingleTile": false, "type": "external WMS", "id": 117, "imageType": "image/jpeg", "metadata": {"is_checked": "true", "legend": "true", "disclaimer": "<a href=\"http://www.geo.admin.ch/\">Donn\u00e9es publiques de l'infrastructure f\u00e9d\u00e9rale de donn\u00e9es g\u00e9ographiques (IFDG)</a>"}}, {"layers": "ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung", "name": "ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung", "url": "http://wms.geo.admin.ch?lang=fr", "isSingleTile": false, "type": "external WMS", "id": 118, "imageType": "image/jpeg", "metadata": {"legend": "true", "disclaimer": "<a href=\"http://www.geo.admin.ch/\">Donn\u00e9es publiques de l'infrastructure f\u00e9d\u00e9rale de donn\u00e9es g\u00e9ographiques (IFDG)</a>"}}, {"name": "ch.are.alpenkonvention", "url": "http://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml?lang=fr", "dimensions": {}, "type": "WMTS", "id": 119, "imageType": "image/jpeg", "metadata": {"max_resolution": "1000.0", "legend": "true", "disclaimer": "<a href=\"http://www.geo.admin.ch/\">Donn\u00e9es publiques de l'infrastructure f\u00e9d\u00e9rale de donn\u00e9es g\u00e9ographiques (IFDG)</a>", "min_resolution": "100.0"}}, {"style": "ch.astra.ausnahmetransportrouten", "name": "ch.astra.ausnahmetransportrouten", "url": "http://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml?lang=fr", "matrixSet": "21781_26", "dimensions": {"Time": "20141003"}, "type": "WMTS", "id": 120, "imageType": "image/jpeg", "metadata": {"legend": "true", "disclaimer": "<a href=\"http://www.geo.admin.ch/\">Donn\u00e9es publiques de l'infrastructure f\u00e9d\u00e9rale de donn\u00e9es g\u00e9ographiques (IFDG)</a>"}}], "id": 30, "name": "Cadastre"}], "metadata": {}}, {"name": "OSM", "functionalities": {}, "id": 64, "icon": "https://geomapfish-demo.camptocamp.net/1.6/wsgi/project/8143d12d42d5431baf576b39d32f18e5/img/osm.png", "children": [{"metadata": {}, "children": [{"layers": "osm", "name": "osm", "queryable": 0, "childLayers": [{"name": "fuel", "queryable": 1}, {"name": "hotel", "queryable": 1}, {"name": "information", "queryable": 1}, {"name": "cinema", "queryable": 1}, {"name": "alpine_hut", "queryable": 1}, {"name": "bank", "queryable": 1}, {"name": "bus_stop", "queryable": 1}, {"name": "cafe", "queryable": 1}, {"name": "parking", "queryable": 1}, {"name": "place_of_worship", "queryable": 1}, {"name": "police", "queryable": 1}, {"name": "post_office", "queryable": 1}, {"name": "restaurant", "queryable": 1}, {"name": "zoo", "queryable": 1}], "type": "internal WMS", "id": 109, "imageType": "image/jpeg", "metadata": {"identifier_attribute_field": "display_name", "legend": "true", "is_legend_expanded": "true", "disclaimer": "\u00a9 les contributeurs d\u2019OSM"}}], "id": 66, "name": "Group"}, {"metadata": {}, "children": [{"layers": "osm_time", "name": "osm_time", "queryable": 1, "childLayers": [], "time": {"widget": "slider", "interval": [0, 1, 0, 0], "maxValue": "2013-12-31T00:00:00Z", "minValue": "2006-01-01T00:00:00Z", "maxDefValue": null, "minDefValue": null, "resolution": "day", "mode": "range"}, "type": "internal WMS", "id": 110, "imageType": "image/jpeg", "metadata": {"is_checked": "true", "identifier_attribute_field": "name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "Dans les temps"}}, {"layers": "osm_scale", "minResolutionHint": 0.53, "name": "osm_scale", "queryable": 1, "childLayers": [], "maxResolutionHint": 1.41, "type": "internal WMS", "id": 114, "imageType": "image/jpeg", "metadata": {"is_checked": "true", "identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "OSM"}}], "id": 68, "name": "OSM function"}, {"metadata": {}, "children": [{"layers": "hotel", "name": "hotel", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 97, "imageType": "image/jpeg", "metadata": {"is_checked": "true", "identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "H\u00f4tels"}}, {"name": "ch.are.alpenkonvention", "url": "http://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml?lang=fr", "dimensions": {}, "type": "WMTS", "id": 119, "imageType": "image/jpeg", "metadata": {"max_resolution": "1000.0", "legend": "true", "disclaimer": "<a href=\"http://www.geo.admin.ch/\">Donn\u00e9es publiques de l'infrastructure f\u00e9d\u00e9rale de donn\u00e9es g\u00e9ographiques (IFDG)</a>", "min_resolution": "100.0"}}, {"layers": "cinema", "name": "cinema", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 99, "imageType": "image/jpeg", "metadata": {"is_checked": "true", "identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "Cin\u00e9mas"}}, {"layers": "police", "name": "police", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 105, "imageType": "image/jpeg", "metadata": {"is_checked": "true", "identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "Postes de police"}}, {"layers": "post_office", "name": "post_office", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 106, "imageType": "image/jpeg", "metadata": {"is_checked": "true", "identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "Offices de poste"}}, {"layers": "osm_time", "name": "osm_time", "queryable": 1, "childLayers": [], "time": {"widget": "datepicker", "interval": [0, 1, 0, 0], "maxValue": "2013-12-31T00:00:00Z", "minValue": "2006-01-01T00:00:00Z", "maxDefValue": null, "minDefValue": null, "resolution": "day", "mode": "range"}, "type": "internal WMS", "id": 126, "imageType": "image/jpeg", "metadata": {"identifier_attribute_field": "name", "legend": "true", "legend_rule": "Dans les temps"}}, {"metadata": {}, "children": [{"layers": "restaurant", "name": "restaurant", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 107, "imageType": "image/jpeg", "metadata": {"is_checked": "true", "identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "Restaurants"}}], "id": 137, "name": "Restauration"}], "id": 63, "name": "Layers"}], "metadata": {}}, {"name": "Edit", "functionalities": {}, "id": 73, "icon": "https://geomapfish-demo.camptocamp.net/1.6/wsgi/project/8143d12d42d5431baf576b39d32f18e5/img/edit.png", "children": [{"metadata": {}, "children": [{"layers": "line", "name": "line", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 111, "imageType": null, "metadata": {"is_checked": "true", "identifier_attribute_field": "name", "legend": "true", "legend_rule": "Line"}}, {"layers": "polygon", "name": "polygon", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 112, "imageType": null, "metadata": {"is_checked": "true", "identifier_attribute_field": "name", "legend": "true", "legend_rule": "Polygon"}}, {"layers": "point", "name": "point", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 113, "imageType": "image/jpeg", "metadata": {"is_checked": "true", "metadata_url": "http://example.com/camptocamp", "identifier_attribute_field": "name", "legend": "true", "legend_rule": "Point"}}], "id": 72, "name": "Edit"}], "metadata": {}}, {"name": "Enseignement", "functionalities": {}, "id": 92, "icon": "https://geomapfish-demo.camptocamp.net/1.6/wsgi/project/8143d12d42d5431baf576b39d32f18e5/img/enseignement2.jpeg", "children": [{"metadata": {}, "children": [{"layers": "bus_stop", "name": "bus_stop", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 101, "imageType": "image/jpeg", "metadata": {"identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "Arr\u00eats de bus"}}, {"layers": "information", "name": "information", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 98, "imageType": "image/jpeg", "metadata": {"is_checked": "true", "identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "Informations"}}], "id": 35, "name": "Enseignement"}], "metadata": {}}, {"name": "Patrimoine", "functionalities": {}, "id": 4, "icon": "https://geomapfish-demo.camptocamp.net/1.6/wsgi/project/8143d12d42d5431baf576b39d32f18e5/img/patrimoine.jpeg", "children": [{"metadata": {}, "children": [{"layers": "bank", "name": "bank", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 100, "imageType": "image/jpeg", "metadata": {"is_checked": "true", "identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "Banques"}}, {"layers": "place_of_worship", "name": "place_of_worship", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 104, "imageType": "image/jpeg", "metadata": {"is_checked": "true", "identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "Lieux de culte"}}], "id": 7, "name": "Patrimoine"}], "metadata": {}}, {"name": "Gestion des eaux", "functionalities": {}, "id": 3, "icon": "https://geomapfish-demo.camptocamp.net/1.6/wsgi/project/8143d12d42d5431baf576b39d32f18e5/img/gestion_eaux.jpeg", "children": [{"metadata": {}, "children": [{"layers": "zoo", "name": "zoo", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 108, "imageType": "image/jpeg", "metadata": {"is_checked": "true", "identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "Zoos"}}, {"layers": "fuel", "name": "fuel", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 124, "imageType": "image/jpeg", "metadata": {"is_checked": "true", "identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "Stations service"}}], "id": 8, "name": "Gestion des eaux"}], "metadata": {}}, {"name": "Paysage", "functionalities": {}, "id": 2, "icon": "https://geomapfish-demo.camptocamp.net/1.6/wsgi/project/8143d12d42d5431baf576b39d32f18e5/img/paysage.jpeg", "children": [{"metadata": {}, "children": [{"layers": "alpine_hut", "name": "alpine_hut", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 123, "imageType": "image/jpeg", "metadata": {"is_checked": "true", "identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "Cabanes alpines"}}, {"layers": "zoo", "name": "zoo", "queryable": 1, "childLayers": [], "type": "internal WMS", "id": 108, "imageType": "image/jpeg", "metadata": {"is_checked": "true", "identifier_attribute_field": "display_name", "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap", "legend": "true", "legend_rule": "Zoos"}}], "id": 9, "name": "Paysage"}], "metadata": {}}], "errors": []}
+{
+  "themes": [{
+    "name": "Enseignement",
+    "functionalities": {},
+    "id": 38,
+    "icon": "https://geomapfish-demo.camptocamp.net/1.6/wsgi/project/8143d12d42d5431baf576b39d32f18e5/img/enseignement.jpeg",
+    "children": [{
+      "metadata": {},
+      "children": [{
+        "layers": "bus_stop",
+        "name": "bus_stop",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 101,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "identifier_attribute_field": "display_name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "Arr\u00eats de bus"
+        }
+      }, {
+        "layers": "information",
+        "name": "information",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 98,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "is_checked": "true",
+          "identifier_attribute_field": "display_name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "Informations"
+        }
+      }],
+      "id": 35,
+      "name": "Enseignement"
+    }],
+    "metadata": {}
+  }, {
+    "name": "Transport",
+    "functionalities": {},
+    "id": 37,
+    "icon": "https://geomapfish-demo.camptocamp.net/1.6/wsgi/project/8143d12d42d5431baf576b39d32f18e5/img/transports.jpeg",
+    "children": [{
+      "metadata": {},
+      "children": [{
+        "layers": "fuel",
+        "name": "fuel",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 124,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "is_checked": "true",
+          "identifier_attribute_field": "display_name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "Stations service"
+        }
+      }, {
+        "layers": "parking",
+        "name": "parking",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 103,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "identifier_attribute_field": "display_name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "Parkings"
+        }
+      }, {
+        "layers": "bus_stop",
+        "name": "bus_stop",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 101,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "identifier_attribute_field": "display_name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "Arr\u00eats de bus"
+        }
+      }],
+      "id": 36,
+      "name": "Transport"
+    }],
+    "metadata": {}
+  }, {
+    "name": "Cadastre",
+    "functionalities": {},
+    "id": 29,
+    "icon": "https://geomapfish-demo.camptocamp.net/1.6/wsgi/project/8143d12d42d5431baf576b39d32f18e5/img/cadastre.jpeg",
+    "children": [{
+      "metadata": {},
+      "children": [{
+        "layers": "ch.swisstopo.dreiecksvermaschung",
+        "name": "ch.swisstopo.dreiecksvermaschung",
+        "url": "http://wms.geo.admin.ch?lang=fr",
+        "isSingleTile": false,
+        "type": "external WMS",
+        "id": 115,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "legend": "true",
+          "disclaimer": "<a href=\"http://www.geo.admin.ch/\">Donn\u00e9es publiques de l'infrastructure f\u00e9d\u00e9rale de donn\u00e9es g\u00e9ographiques (IFDG)</a>"
+        }
+      }, {
+        "layers": "ch.swisstopo.geologie-gravimetrischer_atlas",
+        "name": "ch.swisstopo.geologie-gravimetrischer_atlas",
+        "url": "http://wms.geo.admin.ch?lang=fr",
+        "isSingleTile": false,
+        "type": "external WMS",
+        "id": 116,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "legend": "true",
+          "disclaimer": "<a href=\"http://www.geo.admin.ch/\">Donn\u00e9es publiques de l'infrastructure f\u00e9d\u00e9rale de donn\u00e9es g\u00e9ographiques (IFDG)</a>"
+        }
+      }, {
+        "layers": "ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen",
+        "name": "ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen",
+        "url": "http://wms.geo.admin.ch?lang=fr",
+        "isSingleTile": false,
+        "type": "external WMS",
+        "id": 117,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "is_checked": "true",
+          "legend": "true",
+          "disclaimer": "<a href=\"http://www.geo.admin.ch/\">Donn\u00e9es publiques de l'infrastructure f\u00e9d\u00e9rale de donn\u00e9es g\u00e9ographiques (IFDG)</a>"
+        }
+      }, {
+        "layers": "ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung",
+        "name": "ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung",
+        "url": "http://wms.geo.admin.ch?lang=fr",
+        "isSingleTile": false,
+        "type": "external WMS",
+        "id": 118,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "legend": "true",
+          "disclaimer": "<a href=\"http://www.geo.admin.ch/\">Donn\u00e9es publiques de l'infrastructure f\u00e9d\u00e9rale de donn\u00e9es g\u00e9ographiques (IFDG)</a>"
+        }
+      }, {
+        "name": "ch.are.alpenkonvention",
+        "url": "http://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml?lang=fr",
+        "dimensions": {},
+        "type": "WMTS",
+        "id": 119,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "max_resolution": "1000.0",
+          "legend": "true",
+          "disclaimer": "<a href=\"http://www.geo.admin.ch/\">Donn\u00e9es publiques de l'infrastructure f\u00e9d\u00e9rale de donn\u00e9es g\u00e9ographiques (IFDG)</a>",
+          "min_resolution": "100.0"
+        }
+      }, {
+        "style": "ch.astra.ausnahmetransportrouten",
+        "name": "ch.astra.ausnahmetransportrouten",
+        "url": "http://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml?lang=fr",
+        "matrixSet": "21781_26",
+        "dimensions": {
+          "Time": "20141003"
+        },
+        "type": "WMTS",
+        "id": 120,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "legend": "true",
+          "disclaimer": "<a href=\"http://www.geo.admin.ch/\">Donn\u00e9es publiques de l'infrastructure f\u00e9d\u00e9rale de donn\u00e9es g\u00e9ographiques (IFDG)</a>"
+        }
+      }],
+      "id": 30,
+      "name": "Cadastre"
+    }],
+    "metadata": {}
+  }, {
+    "name": "OSM",
+    "functionalities": {},
+    "id": 64,
+    "icon": "https://geomapfish-demo.camptocamp.net/1.6/wsgi/project/8143d12d42d5431baf576b39d32f18e5/img/osm.png",
+    "children": [{
+      "metadata": {},
+      "children": [{
+        "layers": "osm",
+        "name": "osm",
+        "queryable": 0,
+        "childLayers": [{
+          "name": "fuel",
+          "queryable": 1
+        }, {
+          "name": "hotel",
+          "queryable": 1
+        }, {
+          "name": "information",
+          "queryable": 1
+        }, {
+          "name": "cinema",
+          "queryable": 1
+        }, {
+          "name": "alpine_hut",
+          "queryable": 1
+        }, {
+          "name": "bank",
+          "queryable": 1
+        }, {
+          "name": "bus_stop",
+          "queryable": 1
+        }, {
+          "name": "cafe",
+          "queryable": 1
+        }, {
+          "name": "parking",
+          "queryable": 1
+        }, {
+          "name": "place_of_worship",
+          "queryable": 1
+        }, {
+          "name": "police",
+          "queryable": 1
+        }, {
+          "name": "post_office",
+          "queryable": 1
+        }, {
+          "name": "restaurant",
+          "queryable": 1
+        }, {
+          "name": "zoo",
+          "queryable": 1
+        }],
+        "type": "internal WMS",
+        "id": 109,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "identifier_attribute_field": "display_name",
+          "legend": "true",
+          "is_legend_expanded": "true",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OSM"
+        }
+      }],
+      "id": 66,
+      "name": "Group"
+    }, {
+      "metadata": {},
+      "children": [{
+        "layers": "osm_time",
+        "name": "osm_time",
+        "queryable": 1,
+        "childLayers": [],
+        "time": {
+          "widget": "slider",
+          "interval": [0, 1, 0, 0],
+          "maxValue": "2013-12-31T00:00:00Z",
+          "minValue": "2006-01-01T00:00:00Z",
+          "maxDefValue": null,
+          "minDefValue": null,
+          "resolution": "day",
+          "mode": "range"
+        },
+        "type": "internal WMS",
+        "id": 110,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "is_checked": "true",
+          "identifier_attribute_field": "name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "Dans les temps"
+        }
+      }, {
+        "layers": "osm_scale",
+        "minResolutionHint": 0.53,
+        "name": "osm_scale",
+        "queryable": 1,
+        "childLayers": [],
+        "maxResolutionHint": 1.41,
+        "type": "internal WMS",
+        "id": 114,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "is_checked": "true",
+          "identifier_attribute_field": "display_name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "OSM"
+        }
+      }],
+      "id": 68,
+      "name": "OSM function"
+    }, {
+      "metadata": {},
+      "children": [{
+        "layers": "hotel",
+        "name": "hotel",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 97,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "is_checked": "true",
+          "identifier_attribute_field": "display_name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "H\u00f4tels"
+        }
+      }, {
+        "name": "ch.are.alpenkonvention",
+        "url": "http://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml?lang=fr",
+        "dimensions": {},
+        "type": "WMTS",
+        "id": 119,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "max_resolution": "1000.0",
+          "legend": "true",
+          "disclaimer": "<a href=\"http://www.geo.admin.ch/\">Donn\u00e9es publiques de l'infrastructure f\u00e9d\u00e9rale de donn\u00e9es g\u00e9ographiques (IFDG)</a>",
+          "min_resolution": "100.0"
+        }
+      }, {
+        "layers": "cinema",
+        "name": "cinema",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 99,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "is_checked": "true",
+          "identifier_attribute_field": "display_name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "Cin\u00e9mas"
+        }
+      }, {
+        "layers": "police",
+        "name": "police",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 105,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "is_checked": "true",
+          "identifier_attribute_field": "display_name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "Postes de police"
+        }
+      }, {
+        "layers": "post_office",
+        "name": "post_office",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 106,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "is_checked": "true",
+          "identifier_attribute_field": "display_name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "Offices de poste"
+        }
+      }, {
+        "layers": "osm_time",
+        "name": "osm_time",
+        "queryable": 1,
+        "childLayers": [],
+        "time": {
+          "widget": "datepicker",
+          "interval": [0, 1, 0, 0],
+          "maxValue": "2013-12-31T00:00:00Z",
+          "minValue": "2006-01-01T00:00:00Z",
+          "maxDefValue": null,
+          "minDefValue": null,
+          "resolution": "day",
+          "mode": "range"
+        },
+        "type": "internal WMS",
+        "id": 126,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "identifier_attribute_field": "name",
+          "legend": "true",
+          "legend_rule": "Dans les temps"
+        }
+      }, {
+        "metadata": {},
+        "children": [{
+          "layers": "restaurant",
+          "name": "restaurant",
+          "queryable": 1,
+          "childLayers": [],
+          "type": "internal WMS",
+          "id": 107,
+          "imageType": "image/jpeg",
+          "metadata": {
+            "is_checked": "true",
+            "identifier_attribute_field": "display_name",
+            "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+            "legend": "true",
+            "legend_rule": "Restaurants"
+          }
+        }],
+        "id": 137,
+        "name": "Restauration"
+      }],
+      "id": 63,
+      "name": "Layers"
+    }],
+    "metadata": {}
+  }, {
+    "name": "Edit",
+    "functionalities": {},
+    "id": 73,
+    "icon": "https://geomapfish-demo.camptocamp.net/1.6/wsgi/project/8143d12d42d5431baf576b39d32f18e5/img/edit.png",
+    "children": [{
+      "metadata": {},
+      "children": [{
+        "layers": "line",
+        "name": "line",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 111,
+        "imageType": null,
+        "metadata": {
+          "is_checked": "true",
+          "identifier_attribute_field": "name",
+          "legend": "true",
+          "legend_rule": "Line"
+        }
+      }, {
+        "layers": "polygon",
+        "name": "polygon",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 112,
+        "imageType": null,
+        "metadata": {
+          "is_checked": "true",
+          "identifier_attribute_field": "name",
+          "legend": "true",
+          "legend_rule": "Polygon"
+        }
+      }, {
+        "layers": "point",
+        "name": "point",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 113,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "is_checked": "true",
+          "metadata_url": "http://example.com/camptocamp",
+          "identifier_attribute_field": "name",
+          "legend": "true",
+          "legend_rule": "Point"
+        }
+      }],
+      "id": 72,
+      "name": "Edit"
+    }],
+    "metadata": {}
+  }, {
+    "name": "Enseignement",
+    "functionalities": {},
+    "id": 92,
+    "icon": "https://geomapfish-demo.camptocamp.net/1.6/wsgi/project/8143d12d42d5431baf576b39d32f18e5/img/enseignement2.jpeg",
+    "children": [{
+      "metadata": {},
+      "children": [{
+        "layers": "bus_stop",
+        "name": "bus_stop",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 101,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "identifier_attribute_field": "display_name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "Arr\u00eats de bus"
+        }
+      }, {
+        "layers": "information",
+        "name": "information",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 98,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "is_checked": "true",
+          "identifier_attribute_field": "display_name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "Informations"
+        }
+      }],
+      "id": 35,
+      "name": "Enseignement"
+    }],
+    "metadata": {}
+  }, {
+    "name": "Patrimoine",
+    "functionalities": {},
+    "id": 4,
+    "icon": "https://geomapfish-demo.camptocamp.net/1.6/wsgi/project/8143d12d42d5431baf576b39d32f18e5/img/patrimoine.jpeg",
+    "children": [{
+      "metadata": {},
+      "children": [{
+        "layers": "bank",
+        "name": "bank",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 100,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "is_checked": "true",
+          "identifier_attribute_field": "display_name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "Banques"
+        }
+      }, {
+        "layers": "place_of_worship",
+        "name": "place_of_worship",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 104,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "is_checked": "true",
+          "identifier_attribute_field": "display_name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "Lieux de culte"
+        }
+      }],
+      "id": 7,
+      "name": "Patrimoine"
+    }],
+    "metadata": {}
+  }, {
+    "name": "Gestion des eaux",
+    "functionalities": {},
+    "id": 3,
+    "icon": "https://geomapfish-demo.camptocamp.net/1.6/wsgi/project/8143d12d42d5431baf576b39d32f18e5/img/gestion_eaux.jpeg",
+    "children": [{
+      "metadata": {},
+      "children": [{
+        "layers": "zoo",
+        "name": "zoo",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 108,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "is_checked": "true",
+          "identifier_attribute_field": "display_name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "Zoos"
+        }
+      }, {
+        "layers": "fuel",
+        "name": "fuel",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 124,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "is_checked": "true",
+          "identifier_attribute_field": "display_name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "Stations service"
+        }
+      }],
+      "id": 8,
+      "name": "Gestion des eaux"
+    }],
+    "metadata": {}
+  }, {
+    "name": "Paysage",
+    "functionalities": {},
+    "id": 2,
+    "icon": "https://geomapfish-demo.camptocamp.net/1.6/wsgi/project/8143d12d42d5431baf576b39d32f18e5/img/paysage.jpeg",
+    "children": [{
+      "metadata": {},
+      "children": [{
+        "layers": "alpine_hut",
+        "name": "alpine_hut",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 123,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "is_checked": "true",
+          "identifier_attribute_field": "display_name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "Cabanes alpines"
+        }
+      }, {
+        "layers": "zoo",
+        "name": "zoo",
+        "queryable": 1,
+        "childLayers": [],
+        "type": "internal WMS",
+        "id": 108,
+        "imageType": "image/jpeg",
+        "metadata": {
+          "is_checked": "true",
+          "identifier_attribute_field": "display_name",
+          "disclaimer": "\u00a9 les contributeurs d\u2019OpenStreetMap",
+          "legend": "true",
+          "legend_rule": "Zoos"
+        }
+      }],
+      "id": 9,
+      "name": "Paysage"
+    }],
+    "metadata": {}
+  }],
+  "errors": []
+}


### PR DESCRIPTION
This simple PR makes the theme json in the GMF example human readable.  In addition, it allows modifications to be more easily merged.  I got conflicts while rebasing and it took a short while to understand what was different.  Having the file like this would have avoided the conflict.