### PR TITLE
Add a button to display metadata in gmf-layertree

### DIFF
--- a/contribs/gmf/examples/data/metadata.html
+++ b/contribs/gmf/examples/data/metadata.html
@@ -1,0 +1,9 @@
+<p>
+  Here's some metadata for the layers <em>with <b>some</b> html</em>
+</p>
+<p>
+Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+</p>
+<p>
+Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.
+</p>

--- a/contribs/gmf/examples/layertree.html
+++ b/contribs/gmf/examples/layertree.html
@@ -20,6 +20,11 @@
       .treenode a{
         color: black;
         text-decoration: none;
+        padding-right: 5px;
+      }
+      .treenode .metadata a:before {
+        font-family: FontAwesome;
+        content: "\f129";
       }
       .treenode .layerIcon {
         display: inline-flex;
@@ -71,6 +76,52 @@
       .treenode .state.indeterminate:before {
         content: "\f147";
       }
+      [ngeo-popup] {
+        top: 20px;
+        max-width: 350px;
+        width: 350px;
+        margin-left: -175px;
+        left: 50%;
+        right: 50%;
+        max-height: 400px;
+        position: fixed;
+      }
+      [ngeo-popup] .popover-content {
+        overflow: auto;
+        /*
+         * popup's height - popover-title's height
+         * should be computed using bootstrap variables
+         */
+        max-height: calc(400px - 38px);
+      }
+      @media (max-width: 768px) {
+        #map {
+          height: 200px;
+          width: 200px;
+        }
+        [ngeo-popup] {
+          position: fixed;
+          top: 0;
+          left: auto;
+          right: auto;
+          max-width: 100%;
+          width: calc(100% - 20px);
+          height: calc(100% - 20px);
+          max-height: none;
+          margin: 10px;
+        }
+      }
+      @media (max-width: 768px) {
+        [ngeo-popup] .popover-content {
+          /*
+           * popup's height - popover-title's height
+           * should be computed using bootstrap variables
+           */
+          max-height: calc(100% - 32px);
+          -webkit-overflow-scrolling: touch;
+        }
+      }
+
     </style>
   </head>
   <body ng-controller="MainController as ctrl">

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -6,6 +6,14 @@
     <span class="state" ng-class="[gmfLayertreeCtrl.getNodeState(layertreeCtrl)]"></span>
     <span class="name">{{::layertreeCtrl.node.name}}</span>
   </a>
+  <span class="metadata" ng-if="::layertreeCtrl.node.metadata.metadataUrl">
+    <span ng-if="::gmfLayertreeCtrl.openLinksInNewWindow === true">
+      <a title="More informations" href="{{::layertreeCtrl.node.metadata.metadataUrl}}" target="blank_"></a>
+    </span>
+    <span ng-if="::gmfLayertreeCtrl.openLinksInNewWindow !== true">
+      <a title="More informations" href="" ng-click="gmfLayertreeCtrl.displayMetadata(layertreeCtrl)"></a>
+    </span>
+  </span>
   <span class="zoom" title="Zoom to a visible level" ng-click="::gmfLayertreeCtrl.zoomToResolution(layertreeCtrl.node)"></span>
   <span class="legend" ng-if="::(gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend == 'true')">
     <a data-toggle="collapse" href="#node-{{::layertreeCtrl.uid}}-legend"></a>


### PR DESCRIPTION
Exemple :  http://ger-benjamin.github.io/ngeo/master/examples/contribs/gmf/layertree.html . **try it on theme `Edit`, layer `point`, the one with a `metadataUrl`** (mode 'popup' only but I have added an option to open link in a new window).
Relative to c2c issue: camptocamp/c2cgeoportal#1707