### PR TITLE
Disable map rotation behaviour

### DIFF
--- a/contribs/gmf/src/controllers/abstractmobile.js
+++ b/contribs/gmf/src/controllers/abstractmobile.js
@@ -113,7 +113,8 @@ gmf.AbstractMobileController = function(
     controls: [
       new ol.control.ScaleLine(),
       new ol.control.Zoom()
-    ]
+    ],
+    interactions: ol.interaction.defaults({pinchRotate: false})
   });
 
   /**


### PR DESCRIPTION
- disable the rotation feature for mobile
- temporary solution for https://github.com/camptocamp/c2cgeoportal/issues/1861
- example: https://marionb.github.io/ngeo/map-rotation/examples/contribs/gmf/apps/mobile