### PR TITLE
Use polyfill to shim ES5 'bind' (not supported by PhantomJS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ EXAMPLE_HOSTED_REQUIREMENTS = .build/examples-hosted/lib/ngeo.js \
 	.build/examples-hosted/lib/watchwatchers.js \
 	.build/examples-hosted/lib/typeahead.bundle.min.js \
 	.build/examples-hosted/lib/proj4.js \
+	.build/examples-hosted/lib/Function.prototype.bind.js \
 	.build/examples-hosted/partials \
 	.build/examples-hosted/data
 
@@ -278,6 +279,10 @@ dist/gmf.js: buildtools/gmf.json \
 	mkdir -p $(dir $@)
 	cp $< $@
 
+.build/examples-hosted/lib/Function.prototype.bind.js: node_modules/polyfill/es5/Function.prototype.bind.js
+	mkdir -p $(dir $@)
+	cp $< $@
+
 .build/examples-hosted/partials: examples/partials
 	mkdir -p $@
 	cp $</* $@
@@ -319,6 +324,7 @@ node_modules/angular/angular.min.js: .build/node_modules.timestamp
 		-e 's|/@?main=$*.js|$*.js|' \
 		-e '/default\.js/d' \
 		-e 's|\.\./utils/watchwatchers.js|lib/watchwatchers.js|' \
+		-e '/$*.js/i\    <script src="lib/Function.prototype.bind.js"></script>' \
 		-e '/$*.js/i\    <script src="lib/ngeo.js"></script>' $< > $@
 
 .PRECIOUS: .build/examples-hosted/contribs/gmf/%.html
@@ -336,6 +342,7 @@ node_modules/angular/angular.min.js: .build/node_modules.timestamp
 		-e 's|/@?main=$*\.js|$*.js|' \
 		-e '/default\.js/d' \
 		-e 's|\.\./utils/watchwatchers\.js|lib/watchwatchers.js|' \
+		-e '/$*.js/i\    <script src="../../lib/Function.prototype.bind.js"></script>' \
 		-e '/$*.js/i\    <script src="../../lib/gmf.js"></script>' $< > $@
 
 .PRECIOUS: .build/examples-hosted/contribs/gmf/apps/mobile/index.html
@@ -349,7 +356,8 @@ node_modules/angular/angular.min.js: .build/node_modules.timestamp
 		-e '/\/node_modules\//d' \
 		-e '/default\.js/d' \
 		-e 's|utils/watchwatchers\.js|lib/watchwatchers.js|' \
-		-e 's|/@?main=mobile/js/mobile\.js|../../build/mobile.js|' $< > $@
+		-e 's|/@?main=mobile/js/mobile\.js|../../build/mobile.js|' \
+		-e '/mobile.js/i\    <script src="../../../../lib/Function.prototype.bind.js"></script>' $< > $@
 
 .PRECIOUS: .build/examples-hosted/%.js
 .build/examples-hosted/%.js: examples/%.js

--- a/karma-conf.js
+++ b/karma-conf.js
@@ -29,6 +29,7 @@ module.exports = function(config) {
       'node_modules/angular/angular.js',
       'node_modules/angular-gettext/dist/angular-gettext.js',
       'node_modules/angular-mocks/angular-mocks.js',
+      'node_modules/polyfill/es5/Function.prototype.bind.js',
       'test/spec/beforeeach.js',
       'test/spec/data/*.js',
       'test/spec/**/*.spec.js',

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "nomnom": "1.6.2",
     "openlayers": "openlayers/ol3#master",
     "phantomjs": "1.9.19",
+    "polyfill": "0.1.0",
     "proj4": "2.3.6",
     "svg2ttf": "2.1.1",
     "temp": "0.7.0",


### PR DESCRIPTION
As stated by @tsauerwein:
> Because ngeo does not use a specifc version of ol3, it gets the current master of ol3. A PR related to .bind was merged 3 days ago. PhantomJS does not support .bind, you will have to use a shim, see:
https://github.com/openlayers/ol3/blob/db3ad70a3d7598254cbf11b7a6540b9fba3773ab/config/examples/example.html#L14