### PR TITLE
Add gmf-layertree in mobile app

### DIFF
--- a/contribs/gmf/apps/mobile/build.json
+++ b/contribs/gmf/apps/mobile/build.json
@@ -42,6 +42,7 @@
       "node_modules/openlayers/externs/olx.js",
       "node_modules/openlayers/externs/oli.js",
       "externs/ngeox.js",
+      "contribs/gmf/externs/gmf-themes.js",
       "contribs/gmf/externs/gmfx.js"
     ],
     "jscomp_error": [

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -61,6 +61,13 @@
           <li>
             <a href="#themes" data-toggle="slide-in">Themes</a>
           </li>
+          <li>
+            <gmf-layertree
+                gmf-layertree-source="mainCtrl.theme"
+                gmf-layertree-map="::mainCtrl.map"
+                gmf-layertree-openlinksinnewwindow="true">
+            </gmf-layertree>
+          </li>
         </ul>
       </div>
       <gmf-themeselector
@@ -115,9 +122,11 @@
              'de': '../../build/gmf-de.json'
            },
            serviceUrls: {
-             fulltextsearch: 'https://geomapfish-demo.camptocamp.net/2.0/wsgi/fulltextsearch?query=%QUERY'
+             fulltextsearch: 'https://geomapfish-demo.camptocamp.net/2.0/wsgi/fulltextsearch?query=%QUERY',
+             themes: 'https://geomapfish-demo.camptocamp.net/2.0/wsgi/themes?version=2'
            }
          });
+         module.constant('gmfWmsUrl', 'https://geomapfish-demo.camptocamp.net/2.0/wsgi/mapserv_proxy');
        })();
     </script>
   </body>

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -121,12 +121,11 @@
              'fr': '../../build/gmf-fr.json',
              'de': '../../build/gmf-de.json'
            },
-           serviceUrls: {
-             fulltextsearch: 'https://geomapfish-demo.camptocamp.net/2.0/wsgi/fulltextsearch?query=%QUERY',
-             themes: 'https://geomapfish-demo.camptocamp.net/2.0/wsgi/themes?version=2'
-           }
          });
+         module.constant('authenticationBaseUrl', 'https://geomapfish-demo.camptocamp.net/2.0/wsgi');
+         module.constant('fulltextsearchUrl', 'https://geomapfish-demo.camptocamp.net/2.0/wsgi/fulltextsearch?query=%QUERY');
          module.constant('gmfWmsUrl', 'https://geomapfish-demo.camptocamp.net/2.0/wsgi/mapserv_proxy');
+         module.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.0/wsgi/themes?version=2&background=background');
        })();
     </script>
   </body>

--- a/contribs/gmf/apps/mobile/js/mobile.js
+++ b/contribs/gmf/apps/mobile/js/mobile.js
@@ -25,32 +25,28 @@ goog.require('gmf.searchDirective');
 goog.require('ngeo.mobileGeolocationDirective');
 
 
-appModule.constant(
-    'authenticationBaseUrl',
-    'https://geomapfish-demo.camptocamp.net/2.0/wsgi');
-
-
 
 /**
  * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *     overlay manager service.
- * @param {Object} serverVars vars from GMF
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @param {ngeo.StateManager} ngeoStateManager the state manager.
  * @param {angular.Scope} $scope Scope.
  * @param {ngeo.GetBrowserLanguage} ngeoGetBrowserLanguage
  * @param {gmf.Themes} gmfThemes Themes service.
+ * @param {Object} serverVars vars from GMF
+ * @param {string} fulltextsearchUrl url to a gmf fulltextsearch service.
  * @constructor
  * @extends {gmf.AbstractMobileController}
  * @ngInject
  * @export
  */
 app.MobileController = function(
-    ngeoFeatureOverlayMgr, serverVars, gettextCatalog, ngeoStateManager, $scope,
-    ngeoGetBrowserLanguage, gmfThemes) {
+    ngeoFeatureOverlayMgr, gettextCatalog, ngeoStateManager, $scope,
+    ngeoGetBrowserLanguage, gmfThemes, serverVars, fulltextsearchUrl) {
   goog.base(
-      this, ngeoFeatureOverlayMgr, serverVars, gettextCatalog, ngeoStateManager,
-      $scope, ngeoGetBrowserLanguage, gmfThemes);
+      this, ngeoFeatureOverlayMgr, gettextCatalog, ngeoStateManager,
+      $scope, ngeoGetBrowserLanguage, gmfThemes, serverVars, fulltextsearchUrl);
 };
 goog.inherits(app.MobileController, gmf.AbstractMobileController);
 

--- a/contribs/gmf/apps/mobile/js/mobile.js
+++ b/contribs/gmf/apps/mobile/js/mobile.js
@@ -16,6 +16,8 @@ goog.require('gmf.Themes');
 /** @suppress {extraRequire} */
 goog.require('gmf.authenticationDirective');
 /** @suppress {extraRequire} */
+goog.require('gmf.layertreeDirective');
+/** @suppress {extraRequire} */
 goog.require('gmf.proj.EPSG21781');
 /** @suppress {extraRequire} */
 goog.require('gmf.searchDirective');

--- a/contribs/gmf/apps/mobile/less/mobile.less
+++ b/contribs/gmf/apps/mobile/less/mobile.less
@@ -1,2 +1,3 @@
+@import '../../../less/layertree.less';
 @import '../../../less/mobile.less';
 @import '../../../less/search.less';

--- a/contribs/gmf/examples/layertree.html
+++ b/contribs/gmf/examples/layertree.html
@@ -44,7 +44,7 @@
       .treenode .outOfResolution .legend {
         display: none;
       }
-      .treenode .legend a:after {
+      .treenode .legendButton a:after {
         font-family: FontAwesome;
         content: "\f036";
       }

--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -1,0 +1,115 @@
+gmf-layertree div {
+  margin-right: 10px;
+}
+nav.nav-left ul .treenode {
+  padding: 10px 0 0 10px;
+  a {
+    color: black;
+    display: inline;
+    line-height: inherit;
+    padding-left: 0;
+    text-decoration: none;
+    &::after {
+      display:none;
+    }
+  }
+  .state, .rightButtons *::after {
+    background: none;
+    color: black;
+    display: inline;
+    font-family: FontAwesome;
+  }
+  .leaf .state {
+    &.on::after {
+      content: "\f058";
+    }
+    &.off::after {
+      content: "\f1db";
+    }
+  }
+  .group .state {
+    &.on::after {
+      content: "\f14a";
+    }
+    &.off::after {
+      content: "\f096";
+    }
+    &.indeterminate::after {
+      content: "\f147";
+    }
+  }
+  .group {
+    .layerIcon {
+      display: none;
+    }
+  }
+  .layerIcon {
+    display: inline-flex;
+    height: 10px;
+    width: 20px;
+  }
+  .name {
+    white-space: normal;
+  }
+  .rightButtons {
+    float: right;
+    *::after, *::before {
+      background: none;
+      position: relative;
+      right: initial;
+    }
+  }
+  .metadata {
+    a {
+      padding: 0;
+      &::after {
+        content: "\f129";
+        display: inline;
+        font-family: FontAwesome;
+      }
+    }
+  }
+  .zoom {
+    display: none;
+    &:hover {
+      cursor: pointer;
+    }
+    &::after {
+      content: "\f18e";
+    }
+  }
+  .noSource {
+    opacity: 0.3;
+    &::after {
+      content: "(source not available)";
+    }
+  }
+  .outOfResolution {
+    opacity: 0.6;
+    .rightButtons {
+      .zoom {
+        display: inline;
+      }
+      .legendButton {
+        display: none;
+      }
+    }
+  }
+  .legendButton {
+    a {
+      padding: 0;
+      &::after {
+        content: "\f036";
+        transform: initial;
+      }
+    }
+  }
+  .legend {
+    a::before {
+     display: none;
+    }
+    img {
+      padding-left: 15px;
+    }
+  }
+}

--- a/contribs/gmf/src/controllers/abstractmobile.js
+++ b/contribs/gmf/src/controllers/abstractmobile.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Application entry point.
+* @fileoverview Application entry point.
  *
  * This file defines the "app_mobile" Closure namespace, which is be used as the
  * Closure entry point (see "closure_entry_point" in the "build.json" file).
@@ -12,6 +12,8 @@ goog.provide('gmf.AbstractMobileController');
 goog.require('gmf');
 /** @suppress {extraRequire} */
 goog.require('gmf.Themes');
+/** @suppress {extraRequire} */
+goog.require('gmf.layertreeDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.mapDirective');
 /** @suppress {extraRequire} */

--- a/contribs/gmf/src/controllers/abstractmobile.js
+++ b/contribs/gmf/src/controllers/abstractmobile.js
@@ -1,5 +1,5 @@
 /**
-* @fileoverview Application entry point.
+ * @fileoverview Application entry point.
  *
  * This file defines the "app_mobile" Closure namespace, which is be used as the
  * Closure entry point (see "closure_entry_point" in the "build.json" file).
@@ -41,29 +41,24 @@ goog.require('ol.style.Style');
 gmfModule.constant('isMobile', true);
 
 
-gmfModule.constant(
-    'gmfTreeUrl',
-    'https://geomapfish-demo.camptocamp.net/2.0/wsgi/themes?' +
-        'version=2&background=background');
-
-
 
 /**
  * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *     overlay manager service.
- * @param {Object} serverVars vars from GMF
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @param {ngeo.StateManager} ngeoStateManager the state manager.
  * @param {angular.Scope} $scope Scope.
  * @param {ngeo.GetBrowserLanguage} ngeoGetBrowserLanguage
  * @param {gmf.Themes} gmfThemes Themes service.
+ * @param {Object} serverVars vars from GMF
+ * @param {string} fulltextsearchUrl url to a gmf fulltextsearch service.
  * @constructor
  * @ngInject
  * @export
  */
 gmf.AbstractMobileController = function(
-    ngeoFeatureOverlayMgr, serverVars, gettextCatalog, ngeoStateManager, $scope,
-    ngeoGetBrowserLanguage, gmfThemes) {
+    ngeoFeatureOverlayMgr, gettextCatalog, ngeoStateManager, $scope,
+    ngeoGetBrowserLanguage, gmfThemes, serverVars, fulltextsearchUrl) {
 
   /**
    * A reference to the current theme
@@ -84,7 +79,7 @@ gmf.AbstractMobileController = function(
     groupsKey: 'layer_name',
     groupValues: ['osm'],
     projection: 'EPSG:21781',
-    url: serverVars['serviceUrls']['fulltextsearch']
+    url: fulltextsearchUrl
   }];
 
   /**

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -1,4 +1,4 @@
-<span ng-if="::!layertreeCtrl.isRoot" id="node-{{::layertreeCtrl.uid}}" ng-class="['depth-' + layertreeCtrl.depth, gmfLayertreeCtrl.getResolutionStyle(layertreeCtrl.node), gmfLayertreeCtrl.getNoSourceStyle(layertreeCtrl)]">
+<span ng-if="::!layertreeCtrl.isRoot" id="node-{{::layertreeCtrl.uid}}" ng-class="[layertreeCtrl.node.children ? 'group' : 'leaf', 'depth-' + layertreeCtrl.depth, gmfLayertreeCtrl.getResolutionStyle(layertreeCtrl.node), gmfLayertreeCtrl.getNoSourceStyle(layertreeCtrl)]">
   <a href ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)">
     <span class="layerIcon">
       <img ng-src="{{::gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl)}}"></img>
@@ -6,19 +6,25 @@
     <span class="state" ng-class="[gmfLayertreeCtrl.getNodeState(layertreeCtrl)]"></span>
     <span class="name">{{::layertreeCtrl.node.name}}</span>
   </a>
-  <span class="metadata" ng-if="::layertreeCtrl.node.metadata.metadataUrl">
-    <span ng-if="::gmfLayertreeCtrl.openLinksInNewWindow === true">
-      <a title="More informations" href="{{::layertreeCtrl.node.metadata.metadataUrl}}" target="blank_"></a>
+  <span class="rightButtons">
+    <span class="metadata" ng-if="::layertreeCtrl.node.metadata.metadataUrl">
+      <span ng-if="::gmfLayertreeCtrl.openLinksInNewWindow === true">
+        <a title="More informations" href="{{::layertreeCtrl.node.metadata.metadataUrl}}" target="blank_"></a>
+      </span>
+      <span ng-if="::gmfLayertreeCtrl.openLinksInNewWindow !== true">
+        <a title="More informations" href="" ng-click="gmfLayertreeCtrl.displayMetadata(layertreeCtrl)"></a>
+      </span>
     </span>
-    <span ng-if="::gmfLayertreeCtrl.openLinksInNewWindow !== true">
-      <a title="More informations" href="" ng-click="gmfLayertreeCtrl.displayMetadata(layertreeCtrl)"></a>
+    <span class="zoom" title="Zoom to a visible level" ng-click="::gmfLayertreeCtrl.zoomToResolution(layertreeCtrl.node)"></span>
+    <span class="legendButton" ng-if="::(gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend == 'true')">
+      <a title="Show/hide legend" data-toggle="collapse" href="#node-{{::layertreeCtrl.uid}}-legend"></a>
     </span>
   </span>
-  <span class="zoom" title="Zoom to a visible level" ng-click="::gmfLayertreeCtrl.zoomToResolution(layertreeCtrl.node)"></span>
-  <span class="legend" ng-if="::(gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend == 'true')">
-    <a data-toggle="collapse" href="#node-{{::layertreeCtrl.uid}}-legend"></a>
+  <span class="legend">
     <div id="node-{{::layertreeCtrl.uid}}-legend" class="collapse" ng-class="::[layertreeCtrl.node.metadata.isLegendExpanded == 'true' ? 'in' : '']">
-      <img ng-src="{{gmfLayertreeCtrl.getLegendURL(layertreeCtrl)}}"></img>
+      <a data-toggle="collapse" href="#node-{{::layertreeCtrl.uid}}-legend">
+        <img ng-src="{{gmfLayertreeCtrl.getLegendURL(layertreeCtrl)}}"></img>
+      </a>
     </div>
   </span>
 </span>


### PR DESCRIPTION
Ref to https://github.com/camptocamp/c2cgeoportal/issues/1707
Exemple: http://ger-benjamin.github.io/ngeo/master/examples/contribs/gmf/apps/mobile/index.html

Theme "Cadastre" looks really bad but I don't know what to do with a 15+-letters-without-space string.
Checkbox icons aren't definitive.