### PR TITLE
Add css for gmf mobile fullscreen popups

### DIFF
--- a/contribs/gmf/apps/mobile/less/main.less
+++ b/contribs/gmf/apps/mobile/less/main.less
@@ -1,2 +1,3 @@
 @import '../../../less/layertree.less';
+@import '../../../less/fullscreenpopup.less';
 @import '../../../less/mobile.less';

--- a/contribs/gmf/less/fullscreenpopup.less
+++ b/contribs/gmf/less/fullscreenpopup.less
@@ -1,0 +1,55 @@
+[ngeo-popup] {
+  &.popover {
+    position: fixed;
+    top: 0;
+    left: auto;
+    right: auto;
+    max-width: 96%;
+    width: 96%;
+    height: 96%;
+    max-height: 96%;
+    margin: 2%;
+    border-radius: 0;
+  }
+  .popover-title {
+    background-color: @nav-bg;
+    border-bottom-color: @color2;
+    color: @color2;
+    .close {
+      color: @color2;
+      line-height: 0.8;
+      opacity: 1;
+    }
+  }
+  .popover-content {
+    /*
+     * popup's height - popover-title's height
+     * should be computed using bootstrap variables
+     */
+    max-height: 90%;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+@media (min-width: @screen-sm-min) {
+  [ngeo-popup] {
+    &.popover {
+      top: 20px;
+      max-width: 350px;
+      width: 350px;
+      margin-left: -175px;
+      left: 50%;
+      right: 50%;
+      max-height: 400px;
+      position: fixed;
+    }
+    .popover-content {
+      overflow: auto;
+      /*
+       * popup's height - popover-title's height
+       * should be computed using bootstrap variables
+       */
+      max-height: calc(400px - 38px);
+    }
+  }
+}


### PR DESCRIPTION
Ref to camptocamp/c2cgeoportal#1707

Example: https://ger-benjamin.github.io/ngeo/master/examples/contribs/gmf/apps/mobile/index.html
(watch it in theme `edit`, layer `point` (button metadata (`i`)))

Css for classic popups. Used to display metadata url popup from layertree (But not used in this the app mobile layertree because current demo uses an option to open links in a new page).