### PR TITLE
More options for tooltips externs

### DIFF
--- a/externs/twbootstrap.js
+++ b/externs/twbootstrap.js
@@ -60,16 +60,32 @@ jQuery.prototype.tab = function(action) {};
  */
 angular.JQLite.prototype.tab = function(action) {};
 
+/**
+ * @typedef {{
+   * animation: (boolean|undefined),
+   * container: (string|boolean|undefined),
+   * delay: (number|Object.<string,*>|undefined),
+   * html: (boolean|undefined),
+   * placement: (string|function(Element, Element)|undefined),
+   * selector: (string|undefined),
+   * template: (string|undefined),
+   * title: (string|function()|undefined),
+   * trigger: (string|undefined),
+   * viewport: (string|Object.<string,*>|function(Element)|undefined)
+ * }}
+ */
+var TooltipOptions;
+
 
 /**
- * @param {(string|Object.<string,*>)=} opt_options
+ * @param {(string|TooltipOptions)=} opt_options
  * @return {jQuery}
  */
 jQuery.prototype.tooltip = function(opt_options) {};
 
 
 /**
- * @param {(string|Object.<string,*>)=} opt_options
+ * @param {(string|TooltipOptions)=} opt_options
  * @return {angular.JQLite}
  */
 angular.JQLite.prototype.tooltip = function(opt_options) {};


### PR DESCRIPTION
Fixes issue with 'container: body' not taken into account when built