### PR TITLE
Travis: test both 0.10 and 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,20 @@
-language: python
 sudo: false
+
+language: node_js
+
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+      - python-virtualenv
+
+node_js:
+- "4"
+- "0.10"
 
 cache:
   apt: true


### PR DESCRIPTION
Use node language instead of python.
Switch to a [trusty env](https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-%28or-io.js-v3%29-compiler-requirements) since newer versions of node require a C++11 compiler.