### PR TITLE
Use `watch` in toolActivateMgr

### DIFF
--- a/examples/toolActivate.html
+++ b/examples/toolActivate.html
@@ -13,16 +13,14 @@
           width: 800px;
           height: 400px;
         }
-        .light {
-          opacity: 0.4;
-        }
     </style>
   </head>
   <body ng-controller="MainController as ctrl">
     <div id="map" ngeo-map="ctrl.map"></div>
     <div ngeo-btn-group>
-      <button ngeo-btn class="btn btn-primary" ng-model="ctrl.drawPoint.active" ng-class="ctrl.drawPoint.active ? '' : 'light'" ng-click="ctrl.togglePoint()">Point</button>
-      <button ngeo-btn class="btn btn-primary" ng-model="ctrl.drawPolygon.active" ng-class="ctrl.drawPolygon.active ? '' : 'light'" ng-click="ctrl.togglePolygon()">Polygon</button>
+      <button ngeo-btn class="btn btn-primary" ng-model="ctrl.drawPoint.active">Point</button>
+      <button ngeo-btn class="btn btn-primary" ng-model="ctrl.drawLine.active">Line</button>
+      <button ngeo-btn class="btn btn-primary" ng-model="ctrl.drawPolygon.active">Polygon</button>
     </div>
     <div id="popup-content"></div>
     <p id="desc">This example shows how to use <code>ngeo.ToolActivate</code> objects with the <code>ngeo.ToolActivateMgr</code>to active only one map control at once. If none draw control is choose, the click on the map is enabled.</p>

--- a/exports/services/toolActivateMgr.js
+++ b/exports/services/toolActivateMgr.js
@@ -27,8 +27,3 @@ goog.exportProperty(
     ngeo.ToolActivateMgr.prototype,
     'deactivateTool',
     ngeo.ToolActivateMgr.prototype.deactivateTool);
-
-goog.exportProperty(
-    ngeo.ToolActivateMgr.prototype,
-    'getGroups',
-    ngeo.ToolActivateMgr.prototype.getGroups);


### PR DESCRIPTION
This PR aims to simplify the usage of the `ngeo.ToolActivateMgr`. Now, the active state of a tool can be directly bound to the active property of an interaction (or any other object).

Example:

    this.drawPoint = new ol.interaction.Draw(...);
    ngeoDecorateInteraction(this.drawPoint);

    var drawPointTool = new ngeo.ToolActivate(this.drawPoint, 'active');
    ngeoToolActivateMgr.registerTool('mapTools', drawPointTool);

Closes https://github.com/camptocamp/ngeo/issues/577