### PR TITLE
Don't load less js, not required anymore

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -98,7 +98,6 @@
     <script src="../../../../node_modules/angular-gettext/dist/angular-gettext.js" type="text/javascript"></script>
     <script src="../../../../node_modules/bootstrap/dist/js/bootstrap.js" type="text/javascript"></script>
     <script src="../../../../node_modules/d3/d3.min.js" type="text/javascript"></script>
-    <script src="../../../../node_modules/less/dist/less.min.js"></script>
     <script src="/@?main=desktop/js/controller.js"></script>
     <script src="default.js"></script>
     <script src="../../../../utils/watchwatchers.js"></script>


### PR DESCRIPTION
Fixes #618 

After upgrading less to 2.6.0, the javascript compiler of less seem to hide the body when no less file is found.
We don't need to compile less in the browser so we don't need the less javascript file anymore.