### PR TITLE
Desktop styling

### DIFF
--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -13,8 +13,6 @@
 /* width for the vertical toolbar */
 @toolbar-width: 40px;
 
-@brand-secondary: lighten(@brand-primary, 20%);
-
 html, body {
   position: relative;
   height: 100%;

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -220,8 +220,11 @@ gmf-layertree ul .treenode {
     }
   }
 
+  @border-color: darken(@brand-primary, 10%);
+
   .bar {
     background-color: @brand-primary;
+    border-left: 1px solid @border-color;
     width: @toolbar-width;
 
     float: right;
@@ -229,13 +232,16 @@ gmf-layertree ul .treenode {
     position: relative;
 
     > .btn + .btn {
-      margin-top: 0;
+      margin-top: -1px;
     }
 
     .btn {
       background-color: @brand-primary;
-      border: 0;
+      margin-left: 0;
+      border-right-width: 0;
+      border-left-width: 0;
       border-radius: 0 !important;
+      border-color: @border-color;
 
       &:hover {
         background-color: lighten(@brand-primary, 10%);
@@ -247,6 +253,8 @@ gmf-layertree ul .treenode {
       }
       &.active {
         background-color: @brand-secondary;
+        border-left: 1px solid @brand-secondary;
+        margin-left: -1px;
       }
     }
   }

--- a/contribs/gmf/less/vars.less
+++ b/contribs/gmf/less/vars.less
@@ -16,3 +16,9 @@
 @above-content-index: 3;
 
 @nav-width: 260px;
+
+@border-radius-base: 0;
+@input-border-focus: darken(@brand-primary, 10%);
+
+@brand-primary: #b1c2b5;
+@brand-secondary: #d3e5d7;


### PR DESCRIPTION
Here's a quick change to make the desktop look more coherent and with less "agressive", more neutral colors.

![screenshot from 2016-02-09 14 10 22](https://cloud.githubusercontent.com/assets/319774/12917097/9040107c-cf37-11e5-8a19-42a90f529d7b.png)

Mobile also takes advantage of the modifications.
![screenshot from 2016-02-09 14 16 25](https://cloud.githubusercontent.com/assets/319774/12917141/ecae5ed6-cf37-11e5-8262-63151fe27631.png)

Some work may still need to be done, but it's a good start with only a bit of CSS.