### PR TITLE
Don't touch the webfonts in fontawesome node module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -451,7 +451,6 @@ node_modules/angular/angular.min.js: .build/node_modules.timestamp
 	touch $@
 
 node_modules/font-awesome/fonts/fontawesome-webfont.%: .build/node_modules.timestamp
-	touch --no-create $@
 
 contribs/gmf/fonts/fontawesome-webfont.%: node_modules/font-awesome/fonts/fontawesome-webfont.%
 	mkdir -p $(dir $@)


### PR DESCRIPTION
Fixes issue with webfont files being removed when stopping (Ctrl-C) `make serve`.

```
^Cmake: *** [serve] Error 130
make: *** Deleting intermediate file `node_modules/font-awesome/fonts/fontawesome-webfont.woff'
make: *** Deleting intermediate file `node_modules/font-awesome/fonts/fontawesome-webfont.woff2'
make: *** Deleting intermediate file `node_modules/font-awesome/fonts/fontawesome-webfont.eot'
make: *** Deleting intermediate file `node_modules/font-awesome/fonts/fontawesome-webfont.ttf'
```
To be tested.