### PR TITLE
Add query to gmf mobile app

### DIFF
--- a/contribs/gmf/apps/desktop/js/controller.js
+++ b/contribs/gmf/apps/desktop/js/controller.js
@@ -25,6 +25,11 @@ appModule.constant(
     'https://geomapfish-demo.camptocamp.net/2.0/wsgi');
 
 
+appModule.constant('ngeoQueryOptions', {
+  'limit': 20
+});
+
+
 
 /**
  * @param {string} defaultLang The default language.
@@ -37,6 +42,8 @@ appModule.constant(
  *     overlay manager service.
  * @param {gmf.Themes} gmfThemes Themes service.
  * @param {string} fulltextsearchUrl url to a gmf fulltextsearch service.
+ * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr The ngeo ToolActivate
+ * @param {gmf.QueryManager} gmfQueryManager The gmf query manager service.
  * @constructor
  * @extends {gmf.AbstractDesktopController}
  * @ngInject
@@ -45,7 +52,8 @@ appModule.constant(
 app.DesktopController = function(
     defaultLang, langUrls, gettextCatalog, ngeoGetBrowserLanguage,
     $scope, ngeoStateManager, ngeoFeatureOverlayMgr,
-    gmfThemes, fulltextsearchUrl) {
+    gmfThemes, fulltextsearchUrl, ngeoToolActivateMgr,
+    gmfQueryManager) {
   goog.base(
       this, {
         srid: 21781,
@@ -56,7 +64,8 @@ app.DesktopController = function(
         }
       }, defaultLang, langUrls, gettextCatalog, ngeoGetBrowserLanguage,
       $scope, ngeoStateManager, ngeoFeatureOverlayMgr,
-      gmfThemes, fulltextsearchUrl);
+      gmfThemes, fulltextsearchUrl, ngeoToolActivateMgr,
+      gmfQueryManager);
 };
 goog.inherits(app.DesktopController, gmf.AbstractDesktopController);
 

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -12,6 +12,11 @@
                    'nav-right-is-visible': mainCtrl.rightNavIsVisible()}">
     <main>
       <gmf-map gmf-map-map="mainCtrl.map"></gmf-map>
+      <span
+        ngeo-mobile-query=""
+        ngeo-mobile-query-map="::mainCtrl.map"
+        ngeo-mobile-query-active="::mainCtrl.queryActive">
+      </span>
       <button class="nav-trigger nav-left-trigger"
         ng-click="mainCtrl.toggleLeftNavVisibility()">
         <span class="gmf-icon gmf-icon-layers"></span>

--- a/contribs/gmf/apps/mobile/js/controller.js
+++ b/contribs/gmf/apps/mobile/js/controller.js
@@ -21,6 +21,11 @@ goog.require('gmf.proj.EPSG21781');
 goog.require('ngeo.mobileGeolocationDirective');
 
 
+appModule.constant('ngeoQueryOptions', {
+  'limit': 20
+});
+
+
 
 /**
  * @param {string} defaultLang The default language.
@@ -33,6 +38,8 @@ goog.require('ngeo.mobileGeolocationDirective');
  *     overlay manager service.
  * @param {gmf.Themes} gmfThemes Themes service.
  * @param {string} fulltextsearchUrl url to a gmf fulltextsearch service.
+ * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr The ngeo ToolActivate
+ * @param {gmf.QueryManager} gmfQueryManager The gmf query manager service.
  * @constructor
  * @extends {gmf.AbstractMobileController}
  * @ngInject
@@ -41,7 +48,8 @@ goog.require('ngeo.mobileGeolocationDirective');
 app.MobileController = function(
     defaultLang, langUrls, gettextCatalog, ngeoGetBrowserLanguage,
     $scope, ngeoStateManager, ngeoFeatureOverlayMgr,
-    gmfThemes, fulltextsearchUrl) {
+    gmfThemes, fulltextsearchUrl, ngeoToolActivateMgr,
+    gmfQueryManager) {
   goog.base(
       this, {
         srid: 21781,
@@ -52,7 +60,8 @@ app.MobileController = function(
         }
       }, defaultLang, langUrls, gettextCatalog, ngeoGetBrowserLanguage,
       $scope, ngeoStateManager, ngeoFeatureOverlayMgr,
-      gmfThemes, fulltextsearchUrl);
+      gmfThemes, fulltextsearchUrl, ngeoToolActivateMgr,
+      gmfQueryManager);
 };
 goog.inherits(app.MobileController, gmf.AbstractMobileController);
 

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -1,6 +1,7 @@
 goog.provide('gmf.AbstractController');
 
 goog.require('gmf');
+goog.require('gmf.QueryManager');
 /** @suppress {extraRequire} */
 goog.require('gmf.Themes');
 /** @suppress {extraRequire} */
@@ -14,6 +15,8 @@ goog.require('gmf.themeselectorDirective');
 goog.require('ngeo.FeatureOverlayMgr');
 goog.require('ngeo.GetBrowserLanguage');
 goog.require('ngeo.StateManager');
+goog.require('ngeo.ToolActivate');
+goog.require('ngeo.ToolActivateMgr');
 
 
 
@@ -34,6 +37,8 @@ goog.require('ngeo.StateManager');
  *     overlay manager service.
  * @param {gmf.Themes} gmfThemes Themes service.
  * @param {string} fulltextsearchUrl url to a gmf fulltextsearch service.
+ * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr The ngeo ToolActivate
+ * @param {gmf.QueryManager} gmfQueryManager The gmf query manager service.
  * @constructor
  * @ngInject
  * @export
@@ -41,7 +46,8 @@ goog.require('ngeo.StateManager');
 gmf.AbstractController = function(
     config, defaultLang, langUrls, gettextCatalog, ngeoGetBrowserLanguage,
     $scope, ngeoStateManager, ngeoFeatureOverlayMgr,
-    gmfThemes, fulltextsearchUrl) {
+    gmfThemes, fulltextsearchUrl, ngeoToolActivateMgr,
+    gmfQueryManager) {
 
   /**
    * A reference to the current theme
@@ -76,6 +82,13 @@ gmf.AbstractController = function(
    * @export
    */
   this.rightNavVisible = false;
+
+  /**
+   * The active state of the ngeo query directive.
+   * @type {boolean}
+   * @export
+   */
+  this.queryActive = true;
 
   /**
    * @type {ngeo.GetBrowserLanguage}
@@ -113,6 +126,9 @@ gmf.AbstractController = function(
   this.initLanguage();
 
   ngeoFeatureOverlayMgr.init(this.map);
+
+  var queryToolActivate = new ngeo.ToolActivate(this, 'queryActive');
+  ngeoToolActivateMgr.registerTool('mapTools', queryToolActivate, true);
 
 };
 

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -38,6 +38,8 @@ gmfModule.constant('isDesktop', true);
  *     overlay manager service.
  * @param {gmf.Themes} gmfThemes Themes service.
  * @param {string} fulltextsearchUrl url to a gmf fulltextsearch service.
+ * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr The ngeo ToolActivate
+ * @param {gmf.QueryManager} gmfQueryManager The gmf query manager service.
  * @constructor
  * @extends {gmf.AbstractController}
  * @ngInject
@@ -46,12 +48,14 @@ gmfModule.constant('isDesktop', true);
 gmf.AbstractDesktopController = function(
     config, defaultLang, langUrls, gettextCatalog, ngeoGetBrowserLanguage,
     $scope, ngeoStateManager, ngeoFeatureOverlayMgr,
-    gmfThemes, fulltextsearchUrl) {
+    gmfThemes, fulltextsearchUrl, ngeoToolActivateMgr,
+    gmfQueryManager) {
   goog.base(
       this, config, defaultLang, langUrls, gettextCatalog,
       ngeoGetBrowserLanguage,
       $scope, ngeoStateManager, ngeoFeatureOverlayMgr,
-      gmfThemes, fulltextsearchUrl);
+      gmfThemes, fulltextsearchUrl, ngeoToolActivateMgr,
+      gmfQueryManager);
 
   var viewConfig = {
     projection: ol.proj.get('epsg:' + (config.srid || 21781))

--- a/contribs/gmf/src/controllers/abstractmobile.js
+++ b/contribs/gmf/src/controllers/abstractmobile.js
@@ -9,6 +9,8 @@ goog.require('gmf.mobileNavDirective');
 goog.require('ngeo.FeatureOverlayMgr');
 goog.require('ngeo.GetBrowserLanguage');
 goog.require('ngeo.StateManager');
+/** @suppress {extraRequire} */
+goog.require('ngeo.mobileQueryDirective');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.control.ScaleLine');
@@ -40,6 +42,8 @@ gmfModule.constant('isMobile', true);
  *     overlay manager service.
  * @param {gmf.Themes} gmfThemes Themes service.
  * @param {string} fulltextsearchUrl url to a gmf fulltextsearch service.
+ * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr The ngeo ToolActivate
+ * @param {gmf.QueryManager} gmfQueryManager The gmf query manager service.
  * @constructor
  * @extends {gmf.AbstractController}
  * @ngInject
@@ -48,12 +52,14 @@ gmfModule.constant('isMobile', true);
 gmf.AbstractMobileController = function(
     config, defaultLang, langUrls, gettextCatalog, ngeoGetBrowserLanguage,
     $scope, ngeoStateManager, ngeoFeatureOverlayMgr,
-    gmfThemes, fulltextsearchUrl) {
+    gmfThemes, fulltextsearchUrl, ngeoToolActivateMgr,
+    gmfQueryManager) {
   goog.base(
       this, config, defaultLang, langUrls, gettextCatalog,
       ngeoGetBrowserLanguage,
       $scope, ngeoStateManager, ngeoFeatureOverlayMgr,
-      gmfThemes, fulltextsearchUrl);
+      gmfThemes, fulltextsearchUrl, ngeoToolActivateMgr,
+      gmfQueryManager);
 
   /**
    * @type {boolean}

--- a/src/services/query.js
+++ b/src/services/query.js
@@ -3,6 +3,7 @@ goog.provide('ngeo.Query');
 goog.require('ngeo');
 goog.require('ol.format.WMSGetFeatureInfo');
 goog.require('ol.source.ImageWMS');
+goog.require('ol.source.TileWMS');
 
 
 /**
@@ -160,7 +161,8 @@ ngeo.Query.prototype.addSource = function(source) {
       if (wmsSource &&
           (wmsSource instanceof ol.source.ImageWMS ||
            wmsSource instanceof ol.source.TileWMS)) {
-        source.wmsSource = wmsSource;
+        source.wmsSource =
+            /** @type {ol.source.ImageWMS|ol.source.TileWMS} */ (wmsSource);
       }
     } else {
       var url = source.url;


### PR DESCRIPTION
This PR adds the mobile query directive inside the GMF mobile application.

When any click is made inside the application, one or more request occurs.  At this stage, there's nowhere the result is put, yet.

The ToolActiveManager of ngeo is also added in there as well, with only the query tool being bound to it.  The query tool is also the "default" tool that has to remain active if no other tool is active.

Please, review.