### PR TITLE
Makefile osx compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ SRC_JS_FILES := $(shell find src -type f -name '*.js')
 NGEO_DIRECTIVES_PARTIALS_FILES := $(shell ls -1 src/directives/partials/*.html)
 GMF_DIRECTIVES_PARTIALS_FILES := $(shell ls -1 contribs/gmf/src/directives/partials/*.html)
 
+OS := $(shell uname)
+
 EXPORTS_JS_FILES := $(shell find exports -type f -name '*.js')
 
 EXAMPLES_JS_FILES := $(shell find examples -maxdepth 1 -type f -name '*.js')

--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,7 @@ node_modules/angular/angular.min.js: .build/node_modules.timestamp
 		-e 's|/@?main=$*.js|$*.js|' \
 		-e '/default\.js/d' \
 		-e 's|\.\./utils/watchwatchers.js|lib/watchwatchers.js|' \
-		-e '/$*.js/i\    <script src="lib/ngeo.js"></script>' $< > $@
+		-e '/$*.js/i\'$$'\n    <script src="lib/ngeo.js"></script>'$$'\n' $< > $@
 
 .PRECIOUS: .build/examples-hosted/contribs/gmf/%.html
 .build/examples-hosted/contribs/gmf/%.html: contribs/gmf/examples/%.html
@@ -399,7 +399,7 @@ node_modules/angular/angular.min.js: .build/node_modules.timestamp
 		-e 's|/@?main=$*\.js|$*.js|' \
 		-e '/default\.js/d' \
 		-e 's|\.\./utils/watchwatchers\.js|lib/watchwatchers.js|' \
-		-e '/$*.js/i\    <script src="../../lib/gmf.js"></script>' $< > $@
+		-e '/$*.js/i\'$$'\n    <script src="../../lib/gmf.js"></script>'$$'\n' $< > $@
 
 .PRECIOUS: .build/examples-hosted/contribs/gmf/apps/%/index.html
 .build/examples-hosted/contribs/gmf/apps/%/index.html: contribs/gmf/apps/%/index.html \

--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,9 @@ L10N_PO_FILES = $(addprefix c2cgeoportal/locale/,$(addsuffix /LC_MESSAGES/c2cgeo
 LANGUAGES = en $(L10N_LANGUAGES)
 TX_GIT_BRANCH ?= master
 ifeq (,$(wildcard $(HOME)/.transifexrc))
-TOUCHBACK_TXRC = touch --date "$(shell date --iso-8601=seconds)" $(HOME)/.transifexrc
+TOUCHBACK_TXRC = $(TOUCH_DATE) "$(shell date --iso-8601=seconds)" $(HOME)/.transifexrc
 else
-TOUCHBACK_TXRC = touch --date "$(shell stat -c '%y' $(HOME)/.transifexrc)" $(HOME)/.transifexrc
+TOUCHBACK_TXRC = $(TOUCH_DATE) "$(shell $(STAT_LAST_MODIFIED) $(HOME)/.transifexrc)" $(HOME)/.transifexrc
 endif
 
 NGEO_JS_FILES = $(shell find src -type f -name '*.js')
@@ -81,9 +81,13 @@ EXTERNS_FILES = $(EXTERNS_ANGULAR) $(EXTERNS_ANGULAR_Q) $(EXTERNS_ANGULAR_HTTP_P
 ifeq ($(OS),Darwin)
 	STAT_COMPRESSED = stat -f '  compressed: %z bytes'
 	STAT_UNCOMPRESSED = stat -f 'uncompressed: %z bytes'
+	STAT_LAST_MODIFIED = stat -f '%m'
+	TOUCH_DATE = touch -t
 else
 	STAT_COMPRESSED = stat -c '  compressed: %s bytes'
 	STAT_UNCOMPRESSED = stat -c 'uncompressed: %s bytes'
+	STAT_LAST_MODIFIED = stat -c '%y'
+	TOUCH_DATE = touch --date
 endif
 
 # Disabling Make built-in rules to speed up execution time


### PR DESCRIPTION
With this pull request I'm addressing compatibility issue that happen when running make targets on OSX due mainly to differences between the options available for `sed`, `touch`, and `stat` commands.

For the `sed` command, it took me a while and here's a very nice resource:
http://stackoverflow.com/questions/14846304/sed-command-error-on-macos-x

This hasn't been tested on linux yet since I am having issues with gflags python package not installing.