### PR TITLE
Add gmf-permalink

### DIFF
--- a/contribs/gmf/examples/permalink.html
+++ b/contribs/gmf/examples/permalink.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>GeoMapFish Permalink example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../../../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/font-awesome/css/font-awesome.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+    <style>
+      gmf-map > div {
+        width: 600px;
+        height: 400px;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+
+    <gmf-map gmf-map-map="ctrl.map"></gmf-map>
+
+    <p id="desc">
+      This example demonstrates the use of the <code>ngeo-permalink</code>
+      service.
+    </p>
+
+    <script src="../../../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../../../node_modules/angular/angular.js"></script>
+    <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="../../../node_modules/proj4/dist/proj4.js"></script>
+    <script src="/@?main=permalink.js"></script>
+    <script src="default.js"></script>
+    <script src="../../../utils/watchwatchers.js"></script>
+  </body>
+</html>

--- a/contribs/gmf/examples/permalink.js
+++ b/contribs/gmf/examples/permalink.js
@@ -1,0 +1,54 @@
+goog.provide('gmf-permalink');
+
+goog.require('gmf.Permalink');
+goog.require('gmf.mapDirective');
+goog.require('gmf.proj.EPSG21781');
+goog.require('ngeo');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.proj');
+goog.require('ol.source.OSM');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['gmf']);
+
+
+
+/**
+ * @constructor
+ * @param {gmf.Permalink} gmfPermalink The gmf permalink service.
+ */
+app.MainController = function(gmfPermalink) {
+
+  var projection = ol.proj.get('EPSG:21781');
+  projection.setExtent([485869.5728, 76443.1884, 837076.5648, 299941.7864]);
+
+  var center = gmfPermalink.getMapCenter() || [537635, 152640];
+  var zoom = gmfPermalink.getMapZoom() || 3;
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      })
+    ],
+    view: new ol.View({
+      projection: projection,
+      resolutions: [200, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5],
+      center: center,
+      zoom: zoom
+    })
+  });
+};
+
+app.module.controller('MainController', app.MainController);

--- a/contribs/gmf/src/directives/map.js
+++ b/contribs/gmf/src/directives/map.js
@@ -2,9 +2,8 @@ goog.provide('gmf.MapController');
 goog.provide('gmf.mapDirective');
 
 goog.require('gmf');
+goog.require('gmf.Permalink');
 goog.require('goog.asserts');
-goog.require('ngeo.Debounce');
-goog.require('ngeo.Location');
 /**
  * This goog.require is needed because it provides 'ngeo-map' used in
  * the template.
@@ -42,14 +41,13 @@ gmf.module.directive('gmfMap', gmf.mapDirective);
 
 /**
  * @param {angular.Scope} $scope The directive's scope.
- * @param {ngeo.Location} ngeoLocation ngeo Location service.
- * @param {ngeo.Debounce} ngeoDebounce ngeo Debounce service.
+ * @param {gmf.Permalink} gmfPermalink The gmf permalink service.
  * @constructor
  * @ngInject
  * @ngdoc controller
  * @ngname GmfMapController
  */
-gmf.MapController = function($scope, ngeoLocation, ngeoDebounce) {
+gmf.MapController = function($scope, gmfPermalink) {
 
   var map = $scope['getMapFn']();
   goog.asserts.assertInstanceof(map, ol.Map);
@@ -60,29 +58,8 @@ gmf.MapController = function($scope, ngeoLocation, ngeoDebounce) {
    */
   this.map = map;
 
-  var view = map.getView();
-  goog.asserts.assert(!goog.isNull(view));
+  gmfPermalink.setMap(this.map);
 
-  var x = ngeoLocation.getParam('map_x');
-  var y = ngeoLocation.getParam('map_y');
-  var zoom = ngeoLocation.getParam('map_zoom');
-
-  if (goog.isDef(x) && goog.isDef(y)) {
-    view.setCenter([+x, +y]);
-  }
-  if (goog.isDef(zoom)) {
-    view.setZoom(+zoom);
-  }
-
-  view.on('propertychange', ngeoDebounce(function() {
-    var center = view.getCenter();
-    var zoom = view.getZoom();
-    ngeoLocation.updateParams({
-      'map_zoom': zoom,
-      'map_x': Math.round(center[0]),
-      'map_y': Math.round(center[1])
-    });
-  }, 300, /* invokeApply */ true));
 };
 
 gmf.module.controller('GmfMapController', gmf.MapController);

--- a/contribs/gmf/src/directives/mobilebackgroundlayerselector.js
+++ b/contribs/gmf/src/directives/mobilebackgroundlayerselector.js
@@ -2,6 +2,7 @@ goog.provide('gmf.MobileBackgroundLayerSelectorController');
 goog.provide('gmf.mobileBackgroundLayerSelectorDirective');
 
 goog.require('gmf');
+goog.require('gmf.Permalink');
 goog.require('gmf.Themes');
 goog.require('ngeo.BackgroundEventType');
 goog.require('ngeo.BackgroundLayerMgr');
@@ -58,6 +59,7 @@ gmf.module.directive('gmfMobileBackgroundLayerSelector',
  * @constructor
  * @param {ngeo.BackgroundLayerMgr} ngeoBackgroundLayerMgr Background layer
  *     manager.
+ * @param {gmf.Permalink} gmfPermalink The gmf permalink service.
  * @param {gmf.Themes} gmfThemes Themes service.
  * @export
  * @ngInject
@@ -65,7 +67,7 @@ gmf.module.directive('gmfMobileBackgroundLayerSelector',
  * @ngname GmfMobileBackgroundLayerSelectorController
  */
 gmf.MobileBackgroundLayerSelectorController = function(
-    ngeoBackgroundLayerMgr, gmfThemes) {
+    ngeoBackgroundLayerMgr, gmfPermalink, gmfThemes) {
 
   /**
    * @type {ol.Map}
@@ -90,6 +92,13 @@ gmf.MobileBackgroundLayerSelectorController = function(
    * @private
    */
   this.backgroundLayerMgr_ = ngeoBackgroundLayerMgr;
+
+  /**
+   * @type {gmf.Permalink}
+   * @private
+   */
+  this.gmfPermalink_ = gmfPermalink;
+
   gmfThemes.getBgLayers().then(goog.bind(
       /**
        * @param {Array.<ol.layer.Base>} bgLayers Array of background
@@ -97,11 +106,15 @@ gmf.MobileBackgroundLayerSelectorController = function(
        */
       function(bgLayers) {
         this.bgLayers = bgLayers;
+        // try to get default bgLayer from permalink service, otherwise
         // set default bgLayer to the second one (if defined), the first
         // being the blank layer
-        this.bgLayer = this.bgLayers[1] !== undefined ?
-            this.bgLayers[1] : this.bgLayers[0];
-        this.setLayer(this.bgLayer);
+        var defaultBgLayer = this.gmfPermalink_.getBackgroundLayer(bgLayers);
+        if (!defaultBgLayer) {
+          defaultBgLayer = this.bgLayers[1] !== undefined ?
+              this.bgLayers[1] : this.bgLayers[0];
+        }
+        this.setLayer(defaultBgLayer);
       }, this));
 
   ol.events.listen(

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -1,0 +1,233 @@
+goog.provide('gmf.Permalink');
+
+goog.require('gmf');
+goog.require('ngeo.BackgroundEventType');
+goog.require('ngeo.BackgroundLayerMgr');
+goog.require('ngeo.Debounce');
+goog.require('ngeo.StateManager');
+
+
+/**
+ * @enum {string}
+ */
+gmf.PermalinkParam = {
+  BG_LAYER: 'baselayer_ref',
+  MAP_X: 'map_x',
+  MAP_Y: 'map_y',
+  MAP_Z: 'map_zoom'
+};
+
+
+
+/**
+ * The Permalink service for GMF, which uses the `ngeo.StateManager` to manage
+ * the GMF application state. Here's the list of states are are managed:
+ *
+ * - the map center and zoom level
+ * - the current background layer selected
+ *
+ * @constructor
+ * @param {ngeo.BackgroundLayerMgr} ngeoBackgroundLayerMgr Background layer
+ *     manager.
+ * @param {ngeo.Debounce} ngeoDebounce ngeo Debounce service.
+ * @param {ngeo.StateManager} ngeoStateManager The ngeo StateManager service.
+ * @ngInject
+ * @ngdoc service
+ * @ngname gmfPermalink
+ */
+gmf.Permalink = function(ngeoBackgroundLayerMgr, ngeoDebounce,
+    ngeoStateManager) {
+
+  /**
+   * @type {ngeo.BackgroundLayerMgr}
+   * @private
+   */
+  this.ngeoBackgroundLayerMgr_ = ngeoBackgroundLayerMgr;
+
+  /**
+   * @type {ngeo.Debounce}
+   * @private
+   */
+  this.ngeoDebounce_ = ngeoDebounce;
+
+  /**
+   * @type {ngeo.StateManager}
+   * @private
+   */
+  this.ngeoStateManager_ = ngeoStateManager;
+
+  /**
+   * @type {?ol.Map}
+   * @private
+   */
+  this.map_ = null;
+
+
+  // == event listeners ==
+
+  ol.events.listen(
+      this.ngeoBackgroundLayerMgr_,
+      ngeo.BackgroundEventType.CHANGE,
+      this.handleBackgroundLayerManagerChange_,
+      this);
+
+
+  // == listener keys ==
+
+  /**
+   * The key for map view 'propertychange' event.
+   * @type {?ol.events.Key}
+   * @private
+   */
+  this.mapViewPropertyChangeEventKey_ = null;
+
+};
+
+// === Map X, Y, Z ===
+
+
+/**
+ * Get the coordinate to use to initialize the map view from the state manager.
+ * @return {?ol.Coordinate} The coordinate for the map view center.
+ * @export
+ */
+gmf.Permalink.prototype.getMapCenter = function() {
+  var center = null;
+  var x = this.ngeoStateManager_.getInitialValue(gmf.PermalinkParam.MAP_X);
+  var y = this.ngeoStateManager_.getInitialValue(gmf.PermalinkParam.MAP_Y);
+  if (x !== undefined && y !== undefined) {
+    center = [+x, +y];
+  }
+  return center;
+};
+
+
+/**
+ * Get the zoom level to use to initialize the map view from the state manager.
+ * @return {?number} The zoom for the map view.
+ * @export
+ */
+gmf.Permalink.prototype.getMapZoom = function() {
+  var zoom = null;
+  var z = this.ngeoStateManager_.getInitialValue(gmf.PermalinkParam.MAP_Z);
+  if (z !== undefined) {
+    zoom = +z;
+  }
+  return zoom;
+};
+
+
+/**
+ * Bind an ol3 map object to this service. The service will, from there on,
+ * listen to the properties changed within the map view and update the following
+ * state properties: map_x, map_y and map_zoom.
+ *
+ * If the service is already bound to a map, those events are unlistened first.
+ *
+ * @param {?ol.Map} map The ol3 map object.
+ * @export
+ */
+gmf.Permalink.prototype.setMap = function(map) {
+
+  if (map === this.map_) {
+    return;
+  }
+
+  if (this.map_) {
+    this.unregisterMap_();
+    this.map_ = null;
+  }
+
+  if (map) {
+    this.registerMap_(map);
+    this.map_ = map;
+  }
+
+};
+
+
+/**
+ * Listen to the map view property change and update the state accordingly.
+ * @param {ol.Map} map The ol3 map object.
+ * @private
+ */
+gmf.Permalink.prototype.registerMap_ = function(map) {
+  var view = map.getView();
+  this.mapViewPropertyChangeEventKey_ = ol.events.listen(
+      view,
+      'propertychange',
+      this.ngeoDebounce_(function() {
+        var center = view.getCenter();
+        var zoom = view.getZoom();
+        var object = {};
+        object[gmf.PermalinkParam.MAP_X] = Math.round(center[0]);
+        object[gmf.PermalinkParam.MAP_Y] = Math.round(center[1]);
+        object[gmf.PermalinkParam.MAP_Z] = zoom;
+        this.ngeoStateManager_.updateState(object);
+      }.bind(this), 300, /* invokeApply */ true),
+      this);
+};
+
+
+/**
+ * Remove any event listeners from the current map.
+ * @private
+ */
+gmf.Permalink.prototype.unregisterMap_ = function() {
+  goog.asserts.assert(
+      this.mapViewPropertyChangeEventKey_, 'Key should be thruthy');
+  ol.events.unlistenByKey(this.mapViewPropertyChangeEventKey_);
+  this.mapViewPropertyChangeEventKey_ = null;
+};
+
+
+// === Background layer ===
+
+
+/**
+ * Get the background layer object to use to initialize the map from the
+ * state manager.
+ * @param {Array.<ol.layer.Base>} layers Array of background layer objects.
+ * @return {?ol.layer.Base}
+ * @export
+ */
+gmf.Permalink.prototype.getBackgroundLayer = function(layers) {
+  var layer = null;
+  var layerName = this.ngeoStateManager_.getInitialValue(
+      gmf.PermalinkParam.BG_LAYER);
+  if (layerName !== undefined) {
+    for (var i = 0, len = layers.length; i < len; i++) {
+      if (layers[i].get('label') === layerName) {
+        layer = layers[i];
+        break;
+      }
+    }
+  }
+  return layer;
+};
+
+
+/**
+ * Called when the background layer changes. Update the state using the
+ * background layer label, i.e. its name.
+ * @private
+ */
+gmf.Permalink.prototype.handleBackgroundLayerManagerChange_ = function() {
+  if (!this.map_) {
+    return;
+  }
+
+  // get layer label, i.e its name
+  var layer = this.ngeoBackgroundLayerMgr_.get(this.map_);
+  var layerName = layer.get('label');
+  goog.asserts.assertString(layerName);
+
+  // set it in state
+  var object = {};
+  object[gmf.PermalinkParam.BG_LAYER] = layerName;
+  this.ngeoStateManager_.updateState(object);
+};
+
+
+
+gmf.module.service('gmfPermalink', gmf.Permalink);


### PR DESCRIPTION
This PR introduces the `gmf-permalink` service.  Here's the todo list.

* [x] manage the `map_x`, `map_y` and `map_zoom` parameters
* [x] manage the `baselayer_ref` parameter
* [x] remove `ngeo.Location` to get the params.  Use `ngeo.StateManager` instead.
* [x] fix travis issue
* [x] review

Live demo:

 * (map x, y, z only) - http://adube.github.io/ngeo/permalink/examples/contribs/gmf/permalink.html
 * (background layer, map x, y, z) - https://adube.github.io/ngeo/permalink/examples/contribs/gmf/mobilebackgroundlayerselector.html?baselayer_ref=map