### PR TITLE
Fix menu animation on Safari (mobile application)

### DIFF
--- a/contribs/gmf/src/directives/mobilenav.js
+++ b/contribs/gmf/src/directives/mobilenav.js
@@ -144,7 +144,19 @@ gmf.mobileNavDirective = function() {
             // one is properly deactivated. This prevents weird animation
             // effects.
             window.setTimeout(function() {
-              nav.addClass('active');
+              // fix for safari: the following 3 lines force that the position
+              // of the newly inserted element is calculated.
+              // see http://stackoverflow.com/a/3485654/119937
+              nav.css('display', 'none');
+              nav.offset();
+              nav.css('display', '');
+
+              window.setTimeout(function() {
+                // fix: calling `position()` makes sure that the animation
+                // is always run
+                nav.position();
+                nav.addClass('active');
+              }, 0);
             }, 0);
           }
 


### PR DESCRIPTION
In a sidebar, when clicking on a link in the main menu (e.g. "Background"), the title bar turned white during the animation on Safari.

The problem is that the newly inserted element did not have the right position after insertion. The "fix" forces Safari to calculate the position.

Closes https://github.com/camptocamp/c2cgeoportal/issues/1987