### PR TITLE
Hide native "clear X" in Edge (mobile search)

### DIFF
--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -106,6 +106,10 @@ span.twitter-typeahead {
     border-radius: 0;
     height: @map-tools-size - .2em;
   }
+  // hide the native "clear x" in Edge
+  input::-ms-clear {
+    display: none;
+  }
   .clear-button {
     position: absolute;
     top: 0;


### PR DESCRIPTION
Closes https://github.com/camptocamp/c2cgeoportal/issues/1989