### PR TITLE
Create map in apps controller before calling parent controller

### DIFF
--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -32,6 +32,9 @@ goog.require('ngeo.ToolActivateMgr');
  */
 gmf.AbstractController = function(config, $scope, $injector) {
 
+
+  goog.asserts.assertInstanceof(this.map, ol.Map);
+
   /**
    * A reference to the current theme
    * @type {Object}

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -32,8 +32,6 @@ gmf.module.constant('isDesktop', true);
  * @export
  */
 gmf.AbstractDesktopController = function(config, $scope, $injector) {
-  goog.base(
-      this, config, $scope, $injector);
 
   var viewConfig = {
     projection: ol.proj.get('epsg:' + (config.srid || 21781))
@@ -67,6 +65,10 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
   $('[data-toggle="tooltip"]').tooltip({
     container: 'body'
   });
+
+  goog.base(
+      this, config, $scope, $injector);
+
 };
 goog.inherits(gmf.AbstractDesktopController, gmf.AbstractController);
 

--- a/contribs/gmf/src/controllers/abstractmobile.js
+++ b/contribs/gmf/src/controllers/abstractmobile.js
@@ -36,8 +36,6 @@ gmf.module.constant('isMobile', true);
  * @export
  */
 gmf.AbstractMobileController = function(config, $scope, $injector) {
-  goog.base(
-      this, config, $scope, $injector);
 
   /**
    * @type {boolean}
@@ -95,6 +93,10 @@ gmf.AbstractMobileController = function(config, $scope, $injector) {
         config.mapInteractions ||
         ol.interaction.defaults({pinchRotate: false})
   });
+
+  goog.base(
+      this, config, $scope, $injector);
+
 };
 goog.inherits(gmf.AbstractMobileController, gmf.AbstractController);
 


### PR DESCRIPTION
From `gmf.AbstractMobileController` and `gmf.AbstractDesktopController`, the map was created after we call the parent constructor.

In the parent constructor we need the map, for example for the `ngeoFeatureOverlayMgr.init(this.map);`

This PR fix this and add a check in abstract controller.