### PR TITLE
[Mobile/Tablet] Layout details fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -664,7 +664,7 @@ contribs/gmf/build/gmf-%.json: .build/locale/%/LC_MESSAGES/gmf.po .build/node_mo
 	node buildtools/compile-catalog $< > $@
 
 .PHONY: generate-gmf-fonts
-gmf-icons-generate: contribs/gmf/fonts/gmf-icons.ttf contribs/gmf/fonts/gmf-icons.eot contribs/gmf/fonts/gmf-icons.woff
+generate-gmf-fonts: contribs/gmf/fonts/gmf-icons.ttf contribs/gmf/fonts/gmf-icons.eot contribs/gmf/fonts/gmf-icons.woff
 
 contribs/gmf/fonts/gmf-icons.ttf: contribs/gmf/fonts/gmf-icons.svg .build/node_modules.timestamp
 	node_modules/svg2ttf/svg2ttf.js $< $@

--- a/Makefile
+++ b/Makefile
@@ -451,7 +451,6 @@ node_modules/angular/angular.min.js: .build/node_modules.timestamp
 	touch $@
 
 node_modules/font-awesome/fonts/fontawesome-webfont.%: .build/node_modules.timestamp
-	touch --no-create $@
 
 contribs/gmf/fonts/fontawesome-webfont.%: node_modules/font-awesome/fonts/fontawesome-webfont.%
 	mkdir -p $(dir $@)

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -2,6 +2,7 @@
  * Entry point for all styles required for the desktop application.
  */
 @import 'font.less';
+@import 'mixins.less';
 @import 'base.less';
 @import 'map.less';
 @import 'layertree.less';
@@ -99,6 +100,9 @@ main {
       position: relative;
       padding-right: 20px;
       width: auto;
+      &:focus {
+        .noshadow();
+      }
     }
 
     .tt-menu {

--- a/contribs/gmf/less/font.less
+++ b/contribs/gmf/less/font.less
@@ -14,3 +14,11 @@
 
 @import "../../../node_modules/font-awesome/less/font-awesome.less";
 @fa-font-path: "../fonts";
+
+.fa-wrench,
+.fa-location-arrow {
+  &:after,
+  &:before {
+    font-size: 2.4rem;
+  }
+}

--- a/contribs/gmf/less/icons.less
+++ b/contribs/gmf/less/icons.less
@@ -8,6 +8,7 @@
     font-size: inherit;
     text-rendering: auto;
     -webkit-font-smoothing: antialiased;
+    font-size: 2.4rem;
   }
 
   &.gmf-icon-layers:after {

--- a/contribs/gmf/less/map.less
+++ b/contribs/gmf/less/map.less
@@ -7,8 +7,10 @@
   button {
     margin: 0;
     margin-bottom: 3px;
-    height: @map-tools-size;
-    width: @map-tools-size;
+    // height: @map-tools-size;
+    // width: @map-tools-size;
+    width: 1.75em;
+    height: 1.75em;
     background-color: @map-tools-bg-color;
     border: solid 1px @map-tools-color;
     color: @map-tools-color;

--- a/contribs/gmf/less/mixins.less
+++ b/contribs/gmf/less/mixins.less
@@ -1,0 +1,5 @@
+.noshadow() {
+  -webkit-box-shadow: none;
+	-moz-box-shadow: none;
+	box-shadow: none;
+}

--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -2,6 +2,7 @@
  * Entry point for all styles required for the mobile application.
  */
 @import 'font.less';
+@import 'mixins.less';
 @import 'base.less';
 @import 'map.less';
 @import 'layertree.less';
@@ -13,6 +14,7 @@
 @app-margin: 1em;
 
 @search-input-size: 200px;
+@search-input-width: ceil(@search-input-size + 9);
 
 main>* {
   position: absolute;
@@ -38,6 +40,7 @@ gmf-map {
  * Search (typeahead)
  */
 span.twitter-typeahead {
+  //left: -2em;
   &:after {
     content: '\f002';
     font-family: FontAwesome;
@@ -49,7 +52,9 @@ span.twitter-typeahead {
   }
 
   input {
-    padding-left: 1.5em;
+    //padding-left: 1.5em;
+    padding-left: 0.3em;
+    margin-left: 0px;
   }
 }
 .tt-menu {
@@ -70,6 +75,7 @@ span.twitter-typeahead {
     border-bottom: solid 1px black;
     margin: 0;
     padding: 10px @app-margin;
+    padding-left: 2em;
     text-align: left;
     &:hover {
       cursor: pointer;
@@ -124,11 +130,27 @@ span.twitter-typeahead {
       cursor: pointer;
     }
   }
+  .form-control {
+    .noshadow();
+    background: initial !important;
+    border: none;
+    outline: none;
+    &:focus {
+      .noshadow();
+    }
+    &.ng-pristine.ng-untouched.ng-valid.tt-hint {
+        left: 1em !important;
+    }
+  }
 }
 
-//For tablet only
+//For tablet only >= 768px
 @media (min-width: @screen-sm-min) {
   @search-width: 18em;
+
+  span.twitter-typeahead {
+    left: -1.6em;
+  }
   .tt-menu {
     top: 4em !important;
     width: @search-width;
@@ -145,7 +167,8 @@ span.twitter-typeahead {
     input {
       margin: 0;
       border: none;
-      width: ~"calc(" @search-width ~" - 2px)";
+      width: ~"calc(" @search-width ~" - 4.7em)";
+      left: 15px;
     }
     .clear-button {
       right: 0;

--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -131,20 +131,13 @@ span.twitter-typeahead {
     }
   }
   .form-control {
-    .noshadow();
     background: initial !important;
     border: none;
     outline: none;
-    &:focus {
-      .noshadow();
-    }
-    &.ng-pristine.ng-untouched.ng-valid.tt-hint {
-        left: 1em !important;
-    }
   }
 }
 
-//For tablet only >= 768px
+//For view ports >= 768px width
 @media (min-width: @screen-sm-min) {
   @search-width: 18em;
 
@@ -174,6 +167,15 @@ span.twitter-typeahead {
       right: 0;
       left: auto;
     }
+    .form-control {
+      .noshadow();
+      &:focus {
+        .noshadow();
+      }
+      &.ng-pristine.ng-untouched.ng-valid.tt-hint {
+        left: 1em !important;
+      }
+    }
   }
 }
 
@@ -183,9 +185,24 @@ span.twitter-typeahead {
     &:after {
       content: none !important;
     }
-
     input {
       padding: 0 5px !important;
+    }
+    .search {
+      .form-control {
+        //.noshadow();
+        &:focus {
+          .noshadow();
+        }
+        &.ng-pristine.ng-untouched.ng-valid.tt-hint {
+          left: 0 !important;
+        }
+      }
+    }
+  }
+  .tt-menu {
+    .search-datum {
+      padding-left: 1em;
     }
   }
 }

--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -46,14 +46,14 @@ span.twitter-typeahead {
     font-family: FontAwesome;
     color: grey;
     position: absolute;
-    top: 0;
-    left: .25em;
-    line-height: 2.8em;
+    top: 0.3em;
+    left: 0rem;
+    font-size: 1.4em;
   }
 
   input {
     //padding-left: 1.5em;
-    padding-left: 0.3em;
+    padding-left: 1em;
     margin-left: 0px;
   }
 }
@@ -75,7 +75,7 @@ span.twitter-typeahead {
     border-bottom: solid 1px black;
     margin: 0;
     padding: 10px @app-margin;
-    padding-left: 2em;
+    padding-left: 4rem;
     text-align: left;
     &:hover {
       cursor: pointer;
@@ -124,7 +124,7 @@ span.twitter-typeahead {
       content: '\f00d';
       color: grey;
       font-family: FontAwesome;
-      font-size: 1.5em;
+      font-size: 2em;
     }
     &:hover {
       cursor: pointer;
@@ -149,7 +149,7 @@ span.twitter-typeahead {
   @search-width: 18em;
 
   span.twitter-typeahead {
-    left: -1.6em;
+    left: -2.2rem;
   }
   .tt-menu {
     top: 4em !important;

--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -41,7 +41,7 @@ gmf-map {
  */
 span.twitter-typeahead {
   //left: -2em;
-  &:after {
+  &:after { // magnifying glass in search input
     content: '\f002';
     font-family: FontAwesome;
     color: grey;
@@ -192,7 +192,8 @@ span.twitter-typeahead {
 
 .ol-control button,
 .ol-touch .ol-control button {
-  font-size: 1em;
+  font-size: 2.4rem;//1em;
+  padding-bottom: 0.3rem;
 }
 .ol-zoom {
   top: 5em;
@@ -218,9 +219,26 @@ button[ngeo-mobile-geolocation] {
   }
   button[ngeo-mobile-geolocation] {
     top: auto;
-    bottom: 5.5em;
+    bottom: 4.7em;
     & button:after {
       content: 'b'
     }
+  }
+}
+
+//mobile styles for the theme and background selector
+.gmf-theme-selector,
+.gmf-mobile-background-layer-selector {
+  .gmf-icon-check:after {
+    font-size: 1.2rem;
+    position: relative;
+    bottom: 0.8rem;
+  }
+  .gmf-text {
+      margin: 3% 10px 0 0;
+  }
+  .gmf-thumb {
+    height: auto;
+    width: 25%;
   }
 }


### PR DESCRIPTION
* The magnifier search icon has now same space to outer border than the cross icon.
* Search field width is now changed to prevent the text of being displayed below the cross icon.

* Button sizes globally increased to 2.4rem (24px)
* Geolocation icon adjusted
* Space between zoom buttons and geolocation icon increased

* Background / Themes thumbnails adjusted to be displayed as rectangle in mobile view.

* Size of magnifying glass and "delete cross" adjusted
* Corresponding spaces adjusted

* fixes for mobile view

see: #614 