### PR TITLE
Make scope of query directive non-isolated

### DIFF
--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -11,12 +11,10 @@
                    'nav-left-is-visible': mainCtrl.leftNavIsVisible(),
                    'nav-right-is-visible': mainCtrl.rightNavIsVisible()}">
     <main>
-      <gmf-map gmf-map-map="mainCtrl.map"></gmf-map>
-      <span
+      <gmf-map gmf-map-map="mainCtrl.map"
         ngeo-mobile-query=""
         ngeo-mobile-query-map="::mainCtrl.map"
-        ngeo-mobile-query-active="::mainCtrl.queryActive">
-      </span>
+        ngeo-mobile-query-active="::mainCtrl.queryActive"></gmf-map>
       <gmf-mobiledisplayqueries
         gmf-mobiledisplayqueries-featuresstyle="::mainCtrl.queryFeatureStyle">
       </gmf-mobiledisplayqueries>

--- a/contribs/gmf/examples/mobilequery.html
+++ b/contribs/gmf/examples/mobilequery.html
@@ -235,7 +235,10 @@
   </head>
   <body ng-controller="MainController as ctrl">
 
-    <gmf-map gmf-map-map="ctrl.map"></gmf-map>
+    <gmf-map gmf-map-map="ctrl.map"
+        ngeo-mobile-query="" ngeo-mobile-query-map="::ctrl.map"
+        ngeo-mobile-query-active="ctrl.queryActive">
+    </gmf-map>
 
     <div id="tree-container">
       <div>
@@ -268,11 +271,8 @@
       display all selected features.</p>
     </p>
 
-    <span
-      ngeo-mobile-query=""
-      ngeo-mobile-query-map="::ctrl.map"
-      ngeo-mobile-query-active="::true">
-    </span>
+    <input type="checkbox"
+       ng-model="ctrl.queryActive" /> Query-Tool active
 
     <gmf-mobiledisplayqueries
       gmf-mobiledisplayqueries-featuresstyle="ctrl.featureStyle">

--- a/contribs/gmf/examples/mobilequery.js
+++ b/contribs/gmf/examples/mobilequery.js
@@ -148,6 +148,12 @@ app.MainController = function(gmfThemes, gmfQueryManager,
    */
   this.treeSource = undefined;
 
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.queryActive = true;
+
   gmfThemes.getThemesObject().then(function(themes) {
     if (themes) {
       this.themes = themes;

--- a/src/directives/mobilequery.js
+++ b/src/directives/mobilequery.js
@@ -1,4 +1,3 @@
-goog.provide('ngeo.MobileQueryController');
 goog.provide('ngeo.mobileQueryDirective');
 
 goog.require('ngeo');
@@ -24,113 +23,61 @@ goog.require('ngeo.Query');
  *        ngeo-mobile-query-active="ctrl.queryActive">
  *      </span>
  *
+ * @param {ngeo.Query} ngeoQuery The ngeo Query service.
  * @return {angular.Directive} The Directive Definition Object.
  * @ngInject
  * @ngdoc directive
  * @ngname ngeoMobileQuery
  */
-ngeo.mobileQueryDirective = function() {
+ngeo.mobileQueryDirective = function(ngeoQuery) {
   return {
     restrict: 'A',
-    scope: {
-      'active': '=ngeoMobileQueryActive',
-      'map': '=ngeoMobileQueryMap'
-    },
-    bindToController: true,
-    controller: 'NgeoMobileQueryController',
-    controllerAs: 'ctrl'
+    scope: false,
+    link: function(scope, elem, attrs) {
+      var map = scope.$eval(attrs['ngeoMobileQueryMap']);
+      var clickEventKey_ = null;
+
+      /**
+       * Called when the map is clicked while this controller is active. Issue
+       * a request to the query service using the coordinate that was clicked.
+       * @param {ol.MapBrowserEvent} evt The map browser event being fired.
+       */
+      var handleMapClick_ = function(evt) {
+        ngeoQuery.issue(map, evt.coordinate);
+      };
+
+      /**
+       * Listen to the map 'click' event.
+       */
+      var activate_ = function() {
+        clickEventKey_ = ol.events.listen(map,
+            ol.events.EventType.CLICK, handleMapClick_);
+      };
+
+
+      /**
+       * Unlisten the map 'click' event.
+       */
+      var deactivate_ = function() {
+        if (clickEventKey_ !== null) {
+          ol.events.unlistenByKey(clickEventKey_);
+          clickEventKey_ = null;
+        }
+        ngeoQuery.clear();
+      };
+
+      // watch 'active' property -> activate/deactivate accordingly
+      scope.$watch(attrs['ngeoMobileQueryActive'],
+          function(newVal, oldVal) {
+            if (newVal) {
+              activate_();
+            } else {
+              deactivate_();
+            }
+          }
+      );
+    }
   };
 };
 
-
 ngeo.module.directive('ngeoMobileQuery', ngeo.mobileQueryDirective);
-
-
-/**
- * @constructor
- * @param {angular.Scope} $scope Scope.
- * @param {ngeo.Query} ngeoQuery The ngeo Query service.
- * @export
- * @ngInject
- * @ngdoc controller
- * @ngname NgeoMobileQueryController
- */
-ngeo.MobileQueryController = function($scope, ngeoQuery) {
-
-  /**
-   * @type {ol.Map}
-   * @export
-   */
-  this.map;
-
-  /**
-   * @type {boolean}
-   * @export
-   */
-  this.active;
-
-  /**
-   * @type {ngeo.Query}
-   * @private
-   */
-  this.query_ = ngeoQuery;
-
-  /**
-   * The key for map click event.
-   * @type {?ol.events.Key}
-   * @private
-   */
-  this.clickEventKey_ = null;
-
-  // watch 'active' property -> activate/deactivate accordingly
-  $scope.$watch(
-      function() {
-        return this.active;
-      }.bind(this),
-      function() {
-        if (this.active) {
-          this.activate_();
-        } else {
-          this.deactivate_();
-        }
-      }.bind(this)
-  );
-
-};
-
-
-/**
- * Listen to the map 'click' event.
- * @private
- */
-ngeo.MobileQueryController.prototype.activate_ = function() {
-  this.clickEventKey_ = ol.events.listen(this.map,
-      ol.events.EventType.CLICK, this.handleMapClick_, this);
-};
-
-
-/**
- * Unlisten the map 'click' event.
- * @private
- */
-ngeo.MobileQueryController.prototype.deactivate_ = function() {
-  if (this.clickEventKey_ !== null) {
-    ol.events.unlistenByKey(this.clickEventKey_);
-    this.clickEventKey_ = null;
-  }
-  this.query_.clear();
-};
-
-
-/**
- * Called when the map is clicked while this controller is active. Issue
- * a request to the query service using the coordinate that was clicked.
- * @param {ol.MapBrowserEvent} evt The map browser event being fired.
- * @private
- */
-ngeo.MobileQueryController.prototype.handleMapClick_ = function(evt) {
-  this.query_.issue(this.map, evt.coordinate);
-};
-
-
-ngeo.module.controller('NgeoMobileQueryController', ngeo.MobileQueryController);


### PR DESCRIPTION
This allows to avoid one empty span element because the ngeo-mobile-query directive can be set on the gmf-map element.

Closes https://github.com/camptocamp/ngeo/issues/645