### PR TITLE
Load x,y,z when registering map in permalink

### DIFF
--- a/contribs/gmf/examples/permalink.html
+++ b/contribs/gmf/examples/permalink.html
@@ -21,8 +21,8 @@
     <gmf-map gmf-map-map="ctrl.map"></gmf-map>
 
     <p id="desc">
-      This example demonstrates the use of the <code>ngeo-permalink</code>
-      service.
+      This example demonstrates the use of the <code>gmf-permalink</code>
+      service, which is injected inside the <code>gmf-map</code> directive.
     </p>
 
     <script src="../../../node_modules/jquery/dist/jquery.js"></script>

--- a/contribs/gmf/examples/permalink.js
+++ b/contribs/gmf/examples/permalink.js
@@ -1,6 +1,5 @@
 goog.provide('gmf-permalink');
 
-goog.require('gmf.Permalink');
 goog.require('gmf.mapDirective');
 goog.require('gmf.proj.EPSG21781');
 goog.require('ngeo');
@@ -21,15 +20,11 @@ app.module = angular.module('app', ['gmf']);
 
 /**
  * @constructor
- * @param {gmf.Permalink} gmfPermalink The gmf permalink service.
  */
-app.MainController = function(gmfPermalink) {
+app.MainController = function() {
 
   var projection = ol.proj.get('EPSG:21781');
   projection.setExtent([485869.5728, 76443.1884, 837076.5648, 299941.7864]);
-
-  var center = gmfPermalink.getMapCenter() || [537635, 152640];
-  var zoom = gmfPermalink.getMapZoom() || 3;
 
   /**
    * @type {ol.Map}
@@ -44,8 +39,8 @@ app.MainController = function(gmfPermalink) {
     view: new ol.View({
       projection: projection,
       resolutions: [200, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5],
-      center: center,
-      zoom: zoom
+      center: [537635, 152640],
+      zoom: 3
     })
   });
 };

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -151,7 +151,23 @@ gmf.Permalink.prototype.setMap = function(map) {
  * @private
  */
 gmf.Permalink.prototype.registerMap_ = function(map) {
+
   var view = map.getView();
+
+  // (1) Initialize the map view with the X, Y and Z available within the
+  //     permalink service, if availables
+  var center = this.getMapCenter();
+  if (center !== null) {
+    view.setCenter(center);
+  }
+  var zoom = this.getMapZoom();
+  if (zoom !== null) {
+    view.setZoom(zoom);
+  }
+
+
+  // (2) Listen to any property changes within the view and apply them to
+  //     the permalink service
   this.mapViewPropertyChangeEventKey_ = ol.events.listen(
       view,
       'propertychange',


### PR DESCRIPTION
This PR simplifies the initial loading and reading of the X, Y and Z values from the permalink.  It now occurs when registering the map in the permalink, which is done in the GMF map directive.

Live demos:

 * http://adube.github.io/ngeo/app-mobile-permalink/examples/contribs/gmf/permalink.html
 * https://adube.github.io/ngeo/app-mobile-permalink/examples/contribs/gmf/apps/mobile/index.html