### PR TITLE
(wip) Fix query integration in GMF

### DIFF
--- a/contribs/gmf/examples/layertree.js
+++ b/contribs/gmf/examples/layertree.js
@@ -27,6 +27,11 @@ app.module.value('gmfWmsUrl',
     'https://geomapfish-demo.camptocamp.net/2.0/wsgi/mapserv_proxy');
 
 
+app.module.constant('ngeoQueryOptions', {
+  'limit': 20
+});
+
+
 /**
  * @constructor
  * @param {angular.$http} $http Angular's $http service.

--- a/contribs/gmf/examples/mobilequery.js
+++ b/contribs/gmf/examples/mobilequery.js
@@ -1,6 +1,5 @@
 goog.provide('gmf-mobilequery');
 
-goog.require('gmf.QueryManager');
 goog.require('gmf.Themes');
 goog.require('gmf.mobiledisplayqueriesDirective');
 goog.require('gmf.layertreeDirective');
@@ -92,12 +91,10 @@ app.module.controller('AppQueryresultController', app.QueryresultController);
 /**
  * @constructor
  * @param {gmf.Themes} gmfThemes The gme themes service.
- * @param {gmf.QueryManager} gmfQueryManager The gmf query manager service.
  * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *   overlay manager service.
  */
-app.MainController = function(gmfThemes, gmfQueryManager,
-    ngeoFeatureOverlayMgr) {
+app.MainController = function(gmfThemes, ngeoFeatureOverlayMgr) {
 
   gmfThemes.loadThemes();
 

--- a/contribs/gmf/src/services/querymanager.js
+++ b/contribs/gmf/src/services/querymanager.js
@@ -11,6 +11,15 @@ goog.require('ngeo.Query');
 
 
 /**
+ * DEPRECATED (for now)
+ *
+ * The QueryManager service uses the c2cgeoportal's themes to configure ngeo's
+ * query service with each layer found.
+ *
+ * This is currently no longer used.  The layertree directive has taken over
+ * the responsability to manage the addition of query source configurations
+ * to the query service.
+ *
  * @constructor
  * @param {ngeo.Query} ngeoQuery The ngeo Query service.
  * @param {gmf.Themes} gmfThemes The gmf Themes service.


### PR DESCRIPTION
This PR focuses on fixing the `ngeo.Query` integration in GMF.  The main idea is, for now, deprecate the `gmf.QueryManager` and move the configuration of the query sources directly inside the layer tree directive.

Work in progress:

 * [x] define the format object directly using all layer names
 * [ ] separate the results per layer name instead of per source, since we now have a single source for multiple layer names
 * [ ] manage the `identifierAttributeField` properly
 * [ ] review