### PR TITLE
(wip) Fix query service integration in GMF

### DIFF
--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -259,7 +259,8 @@ gmf.LayertreeController.prototype.getLayer = function(node, opt_depth,
   }
 
   if (goog.isDefAndNotNull(layer)) {
-    layer.set('querySourceId', node.id);
+    var ids = this.getNodeIds_(node);
+    layer.set('querySourceIds', ids);
     layer.set('layerName', node.name);
     // The layer must be upper than the background
     layer.setZIndex(1);
@@ -836,6 +837,26 @@ gmf.LayertreeController.prototype.zoomToResolution = function(node) {
   if (goog.isDef(resolution)) {
     view.setResolution(resolution);
   }
+};
+
+
+/**
+ * Collect and return all ids this node and all child nodes as well.
+ * @param {GmfThemesNode} node Layer tree node.
+ * @return {Array.<number|string>} Layer names.
+ * @private
+ */
+gmf.LayertreeController.prototype.getNodeIds_ = function(node) {
+  var ids = [];
+  var children = node.children || node;
+  if (children && children.length) {
+    children.forEach(function(childNode) {
+      ids = ids.concat(this.getNodeIds_(childNode));
+    }, this);
+  } else if (node.id !== undefined) {
+    ids.push(node.id);
+  }
+  return ids;
 };
 
 

--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -841,7 +841,7 @@ gmf.LayertreeController.prototype.zoomToResolution = function(node) {
 
 
 /**
- * Collect and return all ids this node and all child nodes as well.
+ * Collect and return all ids of this node and all child nodes as well.
  * @param {GmfThemesNode} node Layer tree node.
  * @return {Array.<number|string>} Layer names.
  * @private

--- a/contribs/gmf/src/services/querymanager.js
+++ b/contribs/gmf/src/services/querymanager.js
@@ -94,6 +94,21 @@ gmf.QueryManager.prototype.createSources_ = function(node) {
     }
   } else {
     if (!this.cache_[id]) {
+
+      // Some nodes have child layers, i.e. a list of layer names that are
+      // part of a group.  The name of the group itself can't be used 'as-is'
+      // as an identifier of the layers for this source.  For example, a
+      // group named 'osm' might result in returning 'restaurant' features.
+      // This override makes sure that those layer names are used instead of
+      // the original one.
+      if (node.childLayers) {
+        var childLayerNames = [];
+        node.childLayers.forEach(function(childLayer) {
+          childLayerNames.push(childLayer.name);
+        }, this);
+        layers = childLayerNames.join(',');
+      }
+
       var source = {
         'id': id,
         'identifierAttributeField': identifierAttributeField,

--- a/contribs/gmf/src/services/querymanager.js
+++ b/contribs/gmf/src/services/querymanager.js
@@ -96,12 +96,12 @@ gmf.QueryManager.prototype.createSources_ = function(node) {
     if (!this.cache_[id]) {
 
       // Some nodes have child layers, i.e. a list of layer names that are
-      // part of a group.  The name of the group itself can't be used 'as-is'
-      // as an identifier of the layers for this source.  For example, a
+      // part of a group. The name of the group itself can't be used 'as-is'
+      // as an identifier of the layers for this source. For example, a
       // group named 'osm' might result in returning 'restaurant' features.
       // This override makes sure that those layer names are used instead of
       // the original one.
-      if (node.childLayers) {
+      if (node.childLayers && node.childLayers.length) {
         var childLayerNames = [];
         node.childLayers.forEach(function(childLayer) {
           childLayerNames.push(childLayer.name);

--- a/contribs/gmf/src/services/querymanager.js
+++ b/contribs/gmf/src/services/querymanager.js
@@ -87,6 +87,7 @@ gmf.QueryManager.prototype.createSources_ = function(node) {
   var layers = meta['wmsLayers'] || meta['queryLayers'] || node.layers;
   var name = node.name;
   var url = meta['wmsUrl'] || node.url || this.gmfWmsUrl_;
+  var validateLayerParams = false;
 
   if (children) {
     for (var i = 0, len = children.length; i < len; i++) {
@@ -107,6 +108,8 @@ gmf.QueryManager.prototype.createSources_ = function(node) {
           childLayerNames.push(childLayer.name);
         }, this);
         layers = childLayerNames.join(',');
+      } else if (node.type === 'WMS') {
+        validateLayerParams = true;
       }
 
       var source = {
@@ -114,7 +117,8 @@ gmf.QueryManager.prototype.createSources_ = function(node) {
         'identifierAttributeField': identifierAttributeField,
         'label': name,
         'params': {'LAYERS': layers},
-        'url': url
+        'url': url,
+        'validateLayerParams': validateLayerParams
       };
       this.cache_[id] = source;
       this.sources_.push(source);

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -59,6 +59,7 @@ ngeox.QueryOptions.prototype.sourceIdsProperty;
  *     params: (Object.<string, *>|undefined),
  *     serverType: (string|undefined),
  *     url: (string|undefined),
+ *     validateLayerParams: (boolean|undefined),
  *     wmsSource: (ol.source.ImageWMS|ol.source.TileWMS|undefined)
  * }}
  */
@@ -131,6 +132,29 @@ ngeox.QuerySource.prototype.serverType;
  * @type {string|undefined}
  */
 ngeox.QuerySource.prototype.url;
+
+
+/**
+ * Whether to validate the LAYERS params of the layer currently being
+ * queried. Useful if the source configuration was not given a direct
+ * reference to the ol3 WMS source object, i.e. it was given an `url` and
+ * `params` properties instead, which resulted in the creation of an
+ * inner `ol.source.ImageWMS` object. If that source configuration is attached
+ * to a layer that also has an ol3 WMS source object, then the latter may
+ * contain more than one layer name within the LAYERS param. In that case,
+ * this `validateLayerParams` property, when enabled, will make the query
+ * service check if the layer name within its LAYERS params is currently inside
+ * the layer source LAYERS params. If it's not there, then the source should
+ * not be queried.
+ *
+ * When setting this option, you must not set the wmsSource or layer if
+ * it has an inner ol3 wms source object.
+ *
+ * Also, when using this option, your config `params` must also only have
+ * one layer name set in the LAYERS property.
+ * @type {boolean|undefined}
+ */
+ngeox.QuerySource.prototype.validateLayerParams;
 
 
 /**

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -13,7 +13,8 @@ var ngeox;
  * The options for the query service.
  * @typedef {{
  *     limit: (number|undefined),
- *     sourceIdProperty: (string|undefined)
+ *     sourceIdProperty: (string|undefined),
+ *     sourceIdsProperty: (string|undefined)
  * }}
  */
 ngeox.QueryOptions;
@@ -35,6 +36,15 @@ ngeox.QueryOptions.prototype.limit;
  * @type {string|undefined}
  */
 ngeox.QueryOptions.prototype.sourceIdProperty;
+
+
+/**
+ * Defines the name of the layer property that holds the ids of the sources.
+ * Use this if you have more than one source bound to a layer.  Defaults to
+ * `querySourceIds`.
+ * @type {string|undefined}
+ */
+ngeox.QueryOptions.prototype.sourceIdsProperty;
 
 
 /**

--- a/src/services/query.js
+++ b/src/services/query.js
@@ -318,12 +318,12 @@ ngeo.Query.prototype.issueWMSGetFeatureInfoRequests_ = function(
 
   map.getLayers().forEach(function(layer) {
 
-    // skip layers that are not visible
+    // Skip layers that are not visible
     if (!layer.getVisible()) {
       return;
     }
 
-    // skip layers that don't have one or more sources configured
+    // Skip layers that don't have one or more sources configured
     id = this.getLayerSourceId_(layer);
     ids = this.getLayerSourceIds_(layer);
     if ((!id || !this.cache_[id]) && !ids.length) {
@@ -339,7 +339,7 @@ ngeo.Query.prototype.issueWMSGetFeatureInfoRequests_ = function(
       item['resultSource'].pending = true;
       infoFormat = item.source.infoFormat;
 
-      // sources that use GML as info format are combined together if they
+      // Sources that use GML as info format are combined together if they
       // share the same server url
       if (infoFormat === ngeo.QueryInfoFormatType.GML) {
         url = item.source.wmsSource.getUrl();
@@ -433,7 +433,8 @@ ngeo.Query.prototype.getLayerSourceId_ = function(layer) {
 ngeo.Query.prototype.getLayerSourceIds_ = function(layer) {
   var ids = layer.get(this.sourceIdsProperty_) || [];
   goog.asserts.assertArray(ids);
-  return ids;
+  var clone = ids.slice()
+  return clone;
 };
 
 


### PR DESCRIPTION
This PR is an alternate solution to fix the issue in the Query tool.  I think it's much better than #691.

The main idea behind this approach is this: "A source for query needs to be bound to a single layer, i.e. a single server-side layer".  A source and its result NEED to be bound together, as the source has its own label (used for title) and also requires a way to define a sub-title.  The latter is directly bound the the feature properties themselves, which cannot be controlled at the level of the source if it was responsible of managing multiple layers.

The approach of this PR is to keep the `gmf.QueryManager` service while allowing a layer to define multiple query sources.  This is defined using the `querySourceIds` property of the layer, which has a list of source ids instead of just one.  When looping in the layers, that property is also checked to get the sources associated.  The rest stays "as-is".

 - [x] Restore the previous behaviour, fixing the query tool in GMF
 - [x] Support layer groups, i.e. the "osm" layer returns nothing
 - [x] Fix the bug that occurs with layers that combine multiple layer names
 - [x] Address reviewer's comments / required fixes
 - [x] Review

Live demo:

 * https://adube.github.io/ngeo/fix-query-service-2nd/examples/contribs/gmf/mobilequery.html