### PR TITLE
Mobile: Search field for wide screen or landscape adjusted

### DIFF
--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -239,6 +239,20 @@ button[ngeo-mobile-geolocation] {
   right: @app-margin;
   left: auto;
 }
+
+//For mobile with wide viewport or landscape mode only (> 375px and < 768px)
+@media (min-width: (@screen-xs-min - 105)) {
+  .twitter-typeahead {
+    width: 100%;
+    margin-left: 2.5em;
+  }
+  .search .clear-button {
+    left: inherit;
+    margin-left: inherit;
+    right: 3em;
+  }
+}
+
 //For tablet only
 @media (min-width: @screen-sm-min) {
   .ol-zoom {


### PR DESCRIPTION
For mobile with a wide screen or mobile in landscape mode: Search input field is aligned left and clear button (cross) is aligned right.