### PR TITLE
Separate same type of layers by some groups

### DIFF
--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -147,7 +147,20 @@ gmf.LayertreeController = function($http, $sce, ngeoCreatePopup,
    */
   this.openLinksInNewWindow = this['openLinksInNewWindowFn']() === true ?
       true : false;
+
+  /**
+   * @type {ol.layer.Group}
+   * @private
+   */
+  this.dataLayerGroup_ = this.layerHelper_.getGroupFromMap(this.map,
+        gmf.LayertreeController.DATALAYERGROUP_NAME);
 };
+
+
+/**
+ * @const
+ */
+gmf.LayertreeController.DATALAYERGROUP_NAME = 'data';
 
 
 /**
@@ -261,10 +274,8 @@ gmf.LayertreeController.prototype.getLayer = function(node, opt_depth,
   if (goog.isDefAndNotNull(layer)) {
     layer.set('querySourceId', node.id);
     layer.set('layerName', node.name);
-    // The layer must be upper than the background
-    layer.setZIndex(1);
-    // Add the new layer on the map but behind (before) others layers
-    this.map.getLayerGroup().getLayers().insertAt(0, layer);
+
+    this.dataLayerGroup_.getLayers().insertAt(0, layer);
 
     // If layer is 'unchecked', set it to invisible.
     var metadata = node.metadata;
@@ -408,16 +419,18 @@ gmf.LayertreeController.prototype.retrieveFirstParentTree_ = function(treeCtrl) 
 
 
 /**
- * Remove layer from map on a ngeo layertree destroy event.
+ * Remove layer from this component's layergroup (and then, from the map) on
+ * a ngeo layertree destroy event.
  * @param {angular.Scope} scope treeCtrl scope.
  * @param {ngeo.LayertreeController} treeCtrl ngeo layertree controller, from
  *     the current node.
  * @export
  */
 gmf.LayertreeController.prototype.listeners = function(scope, treeCtrl) {
+  var dataLayerGroup = this.dataLayerGroup_;
   scope.$on('$destroy', angular.bind(treeCtrl, function() {
-    // Remove treeCtrl.layer from map.
-    treeCtrl.map.removeLayer(treeCtrl.layer);
+    // Remove the layer from the map.
+    dataLayerGroup.getLayers().remove(treeCtrl.layer);
   }));
 };
 

--- a/src/services/layerHelper.js
+++ b/src/services/layerHelper.js
@@ -36,6 +36,12 @@ ngeo.LayerHelper = function($q, $http) {
 
 
 /**
+ * @const
+ */
+ngeo.LayerHelper.GROUP_KEY = 'groupName';
+
+
+/**
  * Create and return a basic WMS layer with only a source URL and a dot
  * separated layers names (see {@link ol.source.ImageWMS}).
  * @param {string} sourceURL The source URL.
@@ -112,6 +118,30 @@ ngeo.LayerHelper.prototype.createBasicGroup = function(opt_layers) {
   if (goog.isDefAndNotNull(opt_layers)) {
     group.setLayers(opt_layers);
   }
+  return group;
+};
+
+
+/**
+ * Retrieve (or create if it doesn't exist) and return a group of layer from
+ * the base array of layers of a map. The given name is used as unique
+ * identifier. If the group is created, it will be automatically added to
+ * the map.
+ * @param {ol.Map} map A map.
+ * @param {string} groupName The name of the group.
+ * @return {ol.layer.Group} The group corresponding to the given name.
+ * @export
+ */
+ngeo.LayerHelper.prototype.getGroupFromMap = function(map, groupName) {
+  var groups = map.getLayerGroup().getLayers();
+  groups.forEach(function(group) {
+    if (group.get(ngeo.LayerHelper.GROUP_KEY) === groupName) {
+      return group;
+    }
+  });
+  var group = this.createBasicGroup();
+  group.set(ngeo.LayerHelper.GROUP_KEY, groupName);
+  map.addLayer(group);
   return group;
 };
 


### PR DESCRIPTION
To fix: https://github.com/camptocamp/ngeo/issues/673

Example: https://ger-benjamin.github.io/ngeo/master/examples/contribs/gmf/apps/mobile/index.html

That can (and should probably) be improved by implementing the same system in the ngeo background manager (cause it can only manage one background for now). But this can be done later.