### PR TITLE
Update OpenLayers to current master

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "less": "2.6.0",
     "less-plugin-autoprefix": "1.5.1",
     "nomnom": "1.8.1",
-    "openlayers": "openlayers/ol3#ff1f447",
+    "openlayers": "openlayers/ol3#82f6fb9",
     "phantomjs-prebuilt": "2.1.4",
     "proj4": "2.3.12",
     "temp": "0.8.3",

--- a/src/ol-ext/format/featurehash.js
+++ b/src/ol-ext/format/featurehash.js
@@ -286,6 +286,7 @@ ngeo.format.FeatureHash.encodeStyleFill_ = function(fillStyle, encodedStyles, op
       opt_propertyName : 'fillColor';
   var fillColor = fillStyle.getColor();
   if (!goog.isNull(fillColor)) {
+    goog.asserts.assert(goog.isArray(fillColor), 'only supporting fill colors');
     var fillColorRgba = ol.color.asArray(fillColor);
     var fillColorHex = goog.color.rgbArrayToHex(fillColorRgba);
     if (encodedStyles.length > 0) {

--- a/src/services/print.js
+++ b/src/services/print.js
@@ -415,16 +415,24 @@ ngeo.Print.prototype.encodeVectorLayer_ = function(arr, layer, resolution) {
     var geometryType = geometry.getType();
     var geojsonFeature = geojsonFormat.writeFeatureObject(feature);
 
-    var styles = null;
+    var styleData = null;
     var styleFunction = feature.getStyleFunction();
     if (goog.isDef(styleFunction)) {
-      styles = styleFunction.call(feature, resolution);
+      styleData = styleFunction.call(feature, resolution);
     } else {
       styleFunction = layer.getStyleFunction();
       if (goog.isDef(styleFunction)) {
-        styles = styleFunction.call(layer, feature, resolution);
+        styleData = styleFunction.call(layer, feature, resolution);
       }
     }
+
+    /**
+     * @type {Array<ol.style.Style>}
+     */
+    var styles = (styleData !== null && !goog.isArray(styleData)) ?
+        [styleData] : styleData;
+    goog.asserts.assert(goog.isArray(styles));
+
     if (!goog.isNull(styles) && styles.length > 0) {
       geojsonFeatures.push(geojsonFeature);
       if (goog.isNull(geojsonFeature.properties)) {
@@ -516,6 +524,7 @@ ngeo.Print.prototype.encodeVectorStyle_ = function(object, geometryType, style, 
  */
 ngeo.Print.prototype.encodeVectorStyleFill_ = function(symbolizer, fillStyle) {
   var fillColor = fillStyle.getColor();
+  goog.asserts.assert(goog.isArray(fillColor), 'only supporting fill colors');
   if (!goog.isNull(fillColor)) {
     var fillColorRgba = ol.color.asArray(fillColor);
     symbolizer.fillColor = goog.color.rgbArrayToHex(fillColorRgba);
@@ -665,7 +674,10 @@ ngeo.Print.prototype.encodeTextStyle_ = function(symbolizers, textStyle) {
 
     var fillStyle = textStyle.getFill();
     if (!goog.isNull(fillStyle)) {
-      var fillColorRgba = ol.color.asArray(fillStyle.getColor());
+      var fillColor = fillStyle.getColor();
+      goog.asserts.assert(
+          goog.isArray(fillColor), 'only supporting fill colors');
+      var fillColorRgba = ol.color.asArray(fillColor);
       symbolizer.fontColor = goog.color.rgbArrayToHex(fillColorRgba);
     }
 


### PR DESCRIPTION
To follow the OpenLayers master a couple of small changes were required because:

 * a style function can now return a single style and not only an array of styles (see https://github.com/openlayers/ol3/pull/4401)
 * and because a fill style can now take a canvas gradient or pattern (see https://github.com/openlayers/ol3/pull/4632).