### PR TITLE
Consistency on mobilegeolocation name

### DIFF
--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -50,9 +50,9 @@
         <i class="fa fa-wrench"></i>
       </button>
       <div class="overlay" ng-click="mainCtrl.hideNav()"></div>
-      <button ngeo-mobile-geolocation=""
-        ngeo-mobile-geolocation-map="::mainCtrl.map"
-        ngeo-mobile-geolocation-options="::mainCtrl.mobileGeolocationOptions">
+      <button ngeo-mobilegeolocation=""
+        ngeo-mobilegeolocation-map="::mainCtrl.map"
+        ngeo-mobilegeolocation-options="::mainCtrl.mobilegeolocationOptions">
         <span class="fa fa-location-arrow"></span>
       </button>
     </main>

--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -267,7 +267,7 @@ gmf-map {
     height: 2.1em;
   }
 }
-button[ngeo-mobile-geolocation] {
+button[ngeo-mobilegeolocation] {
   right: @app-margin;
   top: 11.5em;
 }
@@ -296,7 +296,7 @@ button[ngeo-mobile-geolocation] {
     top: auto;
     bottom: 8.5em;
   }
-  button[ngeo-mobile-geolocation] {
+  button[ngeo-mobilegeolocation] {
     top: auto;
     bottom: 5.5em;
     & button:after {

--- a/contribs/gmf/src/controllers/abstractmobile.js
+++ b/contribs/gmf/src/controllers/abstractmobile.js
@@ -94,10 +94,10 @@ gmf.AbstractMobileController = function(config, $scope, $injector) {
   });
 
   /**
-   * @type {ngeox.MobileGeolocationDirectiveOptions}
+   * @type {ngeox.MobilegeolocationDirectiveOptions}
    * @export
    */
-  this.mobileGeolocationOptions = {
+  this.mobilegeolocationOptions = {
     positionFeatureStyle: positionFeatureStyle,
     accuracyFeatureStyle: accuracyFeatureStyle,
     zoom: config.geolocationZoom || 9

--- a/examples/mobilegeolocation.html
+++ b/examples/mobilegeolocation.html
@@ -13,7 +13,7 @@
         width: 600px;
         height: 400px;
       }
-      button[ngeo-mobile-geolocation]:after {
+      button[ngeo-mobilegeolocation]:after {
         content: 'Toggle tracking'
       }
     </style>
@@ -21,12 +21,12 @@
   <body ng-controller="MainController as ctrl">
     <div class="container-fluid">
       <div id="map" ngeo-map="::ctrl.map"></div>
-      <button ngeo-mobile-geolocation=""
-        ngeo-mobile-geolocation-map="::ctrl.map"
-        ngeo-mobile-geolocation-options="::ctrl.mobileGeolocationOptions">
+      <button ngeo-mobilegeolocation=""
+        ngeo-mobilegeolocation-map="::ctrl.map"
+        ngeo-mobilegeolocation-options="::ctrl.mobilegeolocationOptions">
       </button>
       <p id="desc">
-        This example shows how to use the <code>ngeo-mobile-geolocation</code>
+        This example shows how to use the <code>ngeo-mobilegeolocation</code>
         directive.
       </p>
     </div>

--- a/examples/mobilegeolocation.js
+++ b/examples/mobilegeolocation.js
@@ -2,7 +2,7 @@ goog.provide('ngeo-mobile-geolocation');
 
 goog.require('ngeo.FeatureOverlayMgr');
 goog.require('ngeo.mapDirective');
-goog.require('ngeo.mobileGeolocationDirective');
+goog.require('ngeo.mobilegeolocationDirective');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Tile');
@@ -39,10 +39,10 @@ app.MainController = function(ngeoFeatureOverlayMgr) {
   });
 
   /**
-   * @type {ngeox.MobileGeolocationDirectiveOptions}
+   * @type {ngeox.MobilegeolocationDirectiveOptions}
    * @export
    */
-  this.mobileGeolocationOptions = {
+  this.mobilegeolocationOptions = {
     positionFeatureStyle: positionFeatureStyle,
     accuracyFeatureStyle: accuracyFeatureStyle,
     zoom: 17

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -542,21 +542,21 @@ ngeox.MeasureEvent.prototype.feature;
  *    zoom: (number|undefined)
  * }}
  */
-ngeox.MobileGeolocationDirectiveOptions;
+ngeox.MobilegeolocationDirectiveOptions;
 
 
 /**
  * The style to use to sketch the accuracy feature, which is a regular polygon.
  * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined}
  */
-ngeox.MobileGeolocationDirectiveOptions.prototype.accuracyFeatureStyle;
+ngeox.MobilegeolocationDirectiveOptions.prototype.accuracyFeatureStyle;
 
 
 /**
  * The style to use to sketch the position feature, which is a point.
  * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined}
  */
-ngeox.MobileGeolocationDirectiveOptions.prototype.positionFeatureStyle;
+ngeox.MobilegeolocationDirectiveOptions.prototype.positionFeatureStyle;
 
 
 /**
@@ -564,7 +564,7 @@ ngeox.MobileGeolocationDirectiveOptions.prototype.positionFeatureStyle;
  * the zoom level to set when obtaining a new position.
  * @type {number|undefined}
  */
-ngeox.MobileGeolocationDirectiveOptions.prototype.zoom;
+ngeox.MobilegeolocationDirectiveOptions.prototype.zoom;
 
 
 /**

--- a/src/directives/mobilegeolocation.js
+++ b/src/directives/mobilegeolocation.js
@@ -1,5 +1,5 @@
-goog.provide('ngeo.MobileGeolocationController');
-goog.provide('ngeo.mobileGeolocationDirective');
+goog.provide('ngeo.MobilegeolocationController');
+goog.provide('ngeo.mobilegeolocationDirective');
 
 goog.require('ngeo');
 goog.require('ngeo.DecorateGeolocation');
@@ -16,30 +16,30 @@ goog.require('ol.geom.Point');
  *
  * Example:
  *
- *      <button ngeo-mobile-geolocation=""
- *        ngeo-mobile-geolocation-map="ctrl.map"
- *        ngeo-mobile-geolocation-options="ctrl.mobileGeolocationOptions">
+ *      <button ngeo-mobilegeolocation=""
+ *        ngeo-mobilegeolocation-map="ctrl.map"
+ *        ngeo-mobilegeolocation-options="ctrl.mobilegeolocationOptions">
  *      </button>
  *
  * @return {angular.Directive} The Directive Definition Object.
  * @ngInject
  * @ngdoc directive
- * @ngname ngeoMobileGeolocation
+ * @ngname ngeoMobilegeolocation
  */
-ngeo.mobileGeolocationDirective = function() {
+ngeo.mobilegeolocationDirective = function() {
   return {
     restrict: 'A',
     scope: {
-      'getMobileMapFn': '&ngeoMobileGeolocationMap',
-      'getMobileGeolocationOptionsFn': '&ngeoMobileGeolocationOptions'
+      'getMobileMapFn': '&ngeoMobilegeolocationMap',
+      'getMobilegeolocationOptionsFn': '&ngeoMobilegeolocationOptions'
     },
-    controller: 'NgeoMobileGeolocationController',
+    controller: 'NgeoMobilegeolocationController',
     controllerAs: 'ctrl'
   };
 };
 
 
-ngeo.module.directive('ngeoMobileGeolocation', ngeo.mobileGeolocationDirective);
+ngeo.module.directive('ngeoMobilegeolocation', ngeo.mobilegeolocationDirective);
 
 
 /**
@@ -53,9 +53,9 @@ ngeo.module.directive('ngeoMobileGeolocation', ngeo.mobileGeolocationDirective);
  * @export
  * @ngInject
  * @ngdoc controller
- * @ngname NgeoMobileGeolocationController
+ * @ngname NgeoMobilegeolocationController
  */
-ngeo.MobileGeolocationController = function($scope, $element,
+ngeo.MobilegeolocationController = function($scope, $element,
     ngeoDecorateGeolocation, ngeoFeatureOverlayMgr) {
 
   $element.on('click', goog.bind(this.toggleTracking, this));
@@ -69,7 +69,7 @@ ngeo.MobileGeolocationController = function($scope, $element,
    */
   this.map_ = map;
 
-  var options = $scope['getMobileGeolocationOptionsFn']() || {};
+  var options = $scope['getMobilegeolocationOptionsFn']() || {};
   goog.asserts.assertObject(options);
 
   /**
@@ -171,7 +171,7 @@ ngeo.MobileGeolocationController = function($scope, $element,
 /**
  * @export
  */
-ngeo.MobileGeolocationController.prototype.toggleTracking = function() {
+ngeo.MobilegeolocationController.prototype.toggleTracking = function() {
   if (this.geolocation_.getTracking()) {
     // if map center is different than geolocation position, then track again
     var currentPosition = this.geolocation_.getPosition();
@@ -192,7 +192,7 @@ ngeo.MobileGeolocationController.prototype.toggleTracking = function() {
 /**
  * @private
  */
-ngeo.MobileGeolocationController.prototype.track_ = function() {
+ngeo.MobilegeolocationController.prototype.track_ = function() {
   this.featureOverlay_.addFeature(this.positionFeature_);
   this.featureOverlay_.addFeature(this.accuracyFeature_);
   this.follow_ = true;
@@ -203,7 +203,7 @@ ngeo.MobileGeolocationController.prototype.track_ = function() {
 /**
  * @private
  */
-ngeo.MobileGeolocationController.prototype.untrack_ = function() {
+ngeo.MobilegeolocationController.prototype.untrack_ = function() {
   this.featureOverlay_.clear();
   this.follow_ = false;
   this.geolocation_.setTracking(false);
@@ -214,7 +214,7 @@ ngeo.MobileGeolocationController.prototype.untrack_ = function() {
  * @param {ol.ObjectEvent} event Event.
  * @private
  */
-ngeo.MobileGeolocationController.prototype.setPosition_ = function(event) {
+ngeo.MobilegeolocationController.prototype.setPosition_ = function(event) {
   var position = /** @type {ol.Coordinate} */ (this.geolocation_.getPosition());
   var point = new ol.geom.Point(position);
 
@@ -235,12 +235,12 @@ ngeo.MobileGeolocationController.prototype.setPosition_ = function(event) {
  * @param {ol.ObjectEvent} event Event.
  * @private
  */
-ngeo.MobileGeolocationController.prototype.handleViewChange_ = function(event) {
+ngeo.MobilegeolocationController.prototype.handleViewChange_ = function(event) {
   if (this.follow_ && !this.viewChangedByMe_) {
     this.follow_ = false;
   }
 };
 
 
-ngeo.module.controller('NgeoMobileGeolocationController',
-    ngeo.MobileGeolocationController);
+ngeo.module.controller('NgeoMobilegeolocationController',
+    ngeo.MobilegeolocationController);


### PR DESCRIPTION
`MobileGeolocation` to `Mobilegeolocation` as in all others components.
Can be considered as relatif to #539

(Wait on https://github.com/camptocamp/ngeo/pull/718 discussions).