### PR TITLE
Display the attributes in HTML attributes

### DIFF
--- a/jsdoc/plugin.js
+++ b/jsdoc/plugin.js
@@ -21,8 +21,10 @@ exports.defineTags = function(dictionary) {
           'type': {
               'names': type.type,
           },
-          'description': type.text
-
+          'description': type.text,
+          'optional': type.optional,
+          'nullable': type.nullable,
+          'variable': type.variable
       });
     }
   });


### PR DESCRIPTION
[#539]
Before: http://camptocamp.github.io/ngeo/master/apidoc/gmf.mobileBackgroundLayerSelectorDirective.html
After: http://camptocamp.github.io/ngeo/html-attributes/apidoc/gmf.mobileBackgroundLayerSelectorDirective.html