### PR TITLE
iPad: Button icons now centered.

### DIFF
--- a/contribs/gmf/less/mobile-nav.less
+++ b/contribs/gmf/less/mobile-nav.less
@@ -5,7 +5,7 @@
 main {
   position: fixed;
   background-color: @color3;
-  box-shadow: 0px 0px 15px black;
+  box-shadow: 0 0 15px black;
   width: 100%;
   height: 100%;
   z-index: @content-index;
@@ -233,25 +233,21 @@ nav.nav-right {
 
 //For tablet only
 @media (min-width: @screen-sm-min) {
-  main button:hover{
-    background-color: @onhover-color;
-  }
-
   .nav-trigger {
     top: @app-margin;
     margin: 0;
-    background-color: @map-tools-bg-color;
-    border: solid 1px @map-tools-color;
+    background-color: inherit;
     box-shadow: none;
     height: 3em;
   }
 
   .nav-left-trigger {
-    left: @app-margin;
+    left: 0.6rem;
   }
 
   .nav-right-trigger {
     left: auto;
-    right: @app-margin;
+    right: 2.6rem;
+    top: 1.5rem;
   }
 }

--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -253,7 +253,7 @@ gmf-map {
 .fa:before,
 .gmf-icon:after,
 .gmf-icon:before {
-  font-size: 2.0rem;
+  font-size: 2rem;
 }
 
 .ol-zoom {
@@ -263,8 +263,8 @@ gmf-map {
     border-radius: 0;
   }
   button {
-    width: 2.1em;
-    height: 2.1em;
+    width: 4.2rem;
+    height: 4.2rem;
   }
 }
 button[ngeo-mobile-geolocation] {
@@ -308,6 +308,41 @@ button[ngeo-mobile-geolocation] {
     border-right: 1px solid black;
     border-bottom: inherit;
     border-left: 1px solid black;
+  }
+  .gmf-icon,
+  .fa-wrench {
+    &.gmf-icon-layers {
+      margin-left: -0.6rem;
+    }
+    &:before,
+    &:after {
+      padding: 1rem;
+      position: relative;
+      border: 1px solid black;
+      background-color: @map-tools-bg-color;
+    }
+    &:hover {
+      &::before,
+      &::after {
+        background-color: @onhover-color;
+      }
+    }
+    &.gmf-icon-check {
+      margin-left: 0;
+      &:before,
+      &:after {
+        padding: inherit;
+        position: relative;
+        border: inherit;
+        background-color: inherit;
+      }
+      &:hover {
+        &::before,
+        &::after {
+          background-color: inherit;
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
fixes #712 

Icons adjusted.

Example:
https://blattmann.github.io/ngeo/712_ipad_button_icons_not_centered/examples/contribs/gmf/apps/mobile/