### PR TITLE
Update gmf layertree icons

### DIFF
--- a/contribs/gmf/examples/layertree.html
+++ b/contribs/gmf/examples/layertree.html
@@ -67,13 +67,13 @@
         font-family: FontAwesome;
         font-weight: lighter;
       }
-      .treenode .state.on:before {
+      .treenode .on .state:before {
         content: "\f14a";
       }
-      .treenode .state.off:before {
+      .treenode .off .state:before {
         content: "\f096";
       }
-      .treenode .state.indeterminate:before {
+      .treenode .indeterminate .state:before {
         content: "\f147";
       }
       [ngeo-popup] {

--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -13,32 +13,29 @@ gmf-layertree ul .treenode {
       display:none;
     }
   }
-  .state, .rightButtons *::after {
+  .rightButtons *::after {
     background: none;
     color: black;
     display: inline;
     font-family: FontAwesome;
   }
-  .leaf .state {
-    &.on::after {
-      content: "\f058";
-    }
-    &.off::after {
-      content: "\f1db";
-    }
+  .state {
+    font-family: gmf-icons;
+    color: @color2;
   }
-  .group .state {
-    &.on::after {
-      content: "\f14a";
-    }
-    &.off::after {
-      content: "\f096";
-    }
-    &.indeterminate::after {
-      content: "\f147";
-    }
+  .on .state {
+    color: @special-link;
+  }
+  .off, .off .legend img {
+    opacity: 0.5;
+  }
+  .leaf .state::after {
+    content: "\e603";
   }
   .group {
+    .state::after {
+      content: "\e600";
+    }
     .layerIcon {
       display: none;
     }
@@ -85,7 +82,6 @@ gmf-layertree ul .treenode {
     }
   }
   .outOfResolution {
-    opacity: 0.6;
     .rightButtons {
       .zoom {
         display: inline;
@@ -93,6 +89,9 @@ gmf-layertree ul .treenode {
       .legendButton {
         display: none;
       }
+    }
+    &.leaf .state::after {
+      content: "\e604";
     }
   }
   .legendButton {

--- a/contribs/gmf/less/vars.less
+++ b/contribs/gmf/less/vars.less
@@ -9,6 +9,7 @@
 @map-tools-size: 29px;
 @onhover-color: darken(@nav-bg, 20%);
 @search-result-font-color: black;
+@special-link: hsv(hue(@brand-primary), 40%, 60%);
 
 // Z-indexes
 @below-content-index: 1;

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -1,9 +1,9 @@
-<span ng-if="::!layertreeCtrl.isRoot" id="node-{{::layertreeCtrl.uid}}" ng-class="[layertreeCtrl.node.children ? 'group' : 'leaf', 'depth-' + layertreeCtrl.depth, gmfLayertreeCtrl.getResolutionStyle(layertreeCtrl.node), gmfLayertreeCtrl.getNoSourceStyle(layertreeCtrl)]">
+<span ng-if="::!layertreeCtrl.isRoot" id="node-{{::layertreeCtrl.uid}}" ng-class="[layertreeCtrl.node.children ? 'group' : 'leaf', 'depth-' + layertreeCtrl.depth, gmfLayertreeCtrl.getResolutionStyle(layertreeCtrl.node), gmfLayertreeCtrl.getNoSourceStyle(layertreeCtrl), gmfLayertreeCtrl.getNodeState(layertreeCtrl)]">
   <a href ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)">
     <span class="layerIcon">
       <img ng-src="{{::gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl)}}"></img>
     </span>
-    <span class="state" ng-class="[gmfLayertreeCtrl.getNodeState(layertreeCtrl)]"></span>
+    <span class="state"></span>
     <span class="name">{{::layertreeCtrl.node.name}}</span>
   </a>
   <span class="rightButtons">


### PR DESCRIPTION
Fix: https://github.com/camptocamp/ngeo/issues/644

Example: https://ger-benjamin.github.io/ngeo/gmf_layertree_icons/examples/contribs/gmf/apps/mobile

If we want that this example matches exactly with the example in the design document, I must create a new, plain, "node group" icon. For now, I just play with color's brightness.