### PR TITLE
gmf-permalink - support map_crosshair & map_tooltip

### DIFF
--- a/contribs/gmf/examples/permalink.html
+++ b/contribs/gmf/examples/permalink.html
@@ -14,6 +14,12 @@
         width: 600px;
         height: 400px;
       }
+      .ngeo-popover .popover-content {
+        padding: 1px 2px;
+      }
+      .gmf-permalink-tooltip {
+        padding: 9px 14px;
+      }
     </style>
   </head>
   <body ng-controller="MainController as ctrl">
@@ -23,6 +29,26 @@
     <p id="desc">
       This example demonstrates the use of the <code>gmf-permalink</code>
       service, which is injected inside the <code>gmf-map</code> directive.
+      The following links demonstrate the different features:
+      <ul>
+        <li>
+          <a href="?map_crosshair=true">map_crosshair=true</a>
+          When set, a marker is added either at the location of the
+          <code>map_x</code> and <code>map_y</code> if those parameters
+          are set, otherwise it is added at the center of the map.
+        </li>
+        <li>
+          <a href="?map_tooltip=hello">map_tooltip=hello</a>
+          When set, a tooltip is added with the content equal to the value
+          set either at the location of the <code>map_x</code> and
+          <code>map_y</code> if those parameters are set, otherwise it is
+          added at the center of the map.
+        </li>
+        <li><a href="?">no param</a></li>
+      </ul>
+      This example also demonstrates the use of the
+      <code>gmfPermalinkOptions</code> to customize the permalink crosshair
+      feature style.
     </p>
 
     <script src="../../../node_modules/jquery/dist/jquery.js"></script>

--- a/contribs/gmf/examples/permalink.js
+++ b/contribs/gmf/examples/permalink.js
@@ -8,6 +8,9 @@ goog.require('ol.View');
 goog.require('ol.layer.Tile');
 goog.require('ol.proj');
 goog.require('ol.source.OSM');
+goog.require('ol.style.RegularShape');
+goog.require('ol.style.Stroke');
+goog.require('ol.style.Style');
 
 
 /** @const **/
@@ -17,6 +20,22 @@ var app = {};
 /** @type {!angular.Module} **/
 app.module = angular.module('app', ['gmf']);
 
+
+app.module.constant('gmfPermalinkOptions',
+    /** @type {gmfx.PermalinkOptions} */ ({
+      crosshairStyle: new ol.style.Style({
+        image: new ol.style.RegularShape({
+          stroke: new ol.style.Stroke({
+            color: 'rgba(0, 0, 255, 1)',
+            width: 2
+          }),
+          points: 4,
+          radius: 8,
+          radius2: 0,
+          angle: 0
+        })
+      })
+    }));
 
 /**
  * @constructor

--- a/contribs/gmf/externs/gmfx.js
+++ b/contribs/gmf/externs/gmfx.js
@@ -25,6 +25,23 @@ var gmfx;
  */
 gmfx.Config;
 
+
+/**
+ * Configuration options for the permalink service.
+ * @typedef {{
+ *     crosshairStyle: (Array<(null|ol.style.Style)>|null|ol.FeatureStyleFunction|ol.style.Style|undefined)
+ * }}
+ */
+gmfx.PermalinkOptions;
+
+
+/**
+ * An alternate style for the crosshair feature added by the permalink service.
+ * @type {Array<(null|ol.style.Style)>|null|ol.FeatureStyleFunction|ol.style.Style|undefined}
+ */
+gmfx.PermalinkOptions.prototype.crosshairStyle;
+
+
 /**
  * Datasource configuration options for the search directive.
  * @typedef {{

--- a/contribs/gmf/src/directives/map.js
+++ b/contribs/gmf/src/directives/map.js
@@ -4,6 +4,8 @@ goog.provide('gmf.mapDirective');
 goog.require('gmf');
 goog.require('gmf.Permalink');
 goog.require('goog.asserts');
+goog.require('ngeo.FeatureOverlayMgr');
+
 /**
  * This goog.require is needed because it provides 'ngeo-map' used in
  * the template.
@@ -42,13 +44,14 @@ gmf.module.directive('gmfMap', gmf.mapDirective);
 
 /**
  * @param {angular.Scope} $scope The directive's scope.
+ * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  * @param {gmf.Permalink} gmfPermalink The gmf permalink service.
  * @constructor
  * @ngInject
  * @ngdoc controller
  * @ngname GmfMapController
  */
-gmf.MapController = function($scope, gmfPermalink) {
+gmf.MapController = function($scope, ngeoFeatureOverlayMgr, gmfPermalink) {
 
   var map = $scope['getMapFn']();
   goog.asserts.assertInstanceof(map, ol.Map);
@@ -58,6 +61,8 @@ gmf.MapController = function($scope, gmfPermalink) {
    * @export
    */
   this.map = map;
+
+  ngeoFeatureOverlayMgr.init(this.map);
 
   gmfPermalink.setMap(this.map);
 

--- a/externs/twbootstrap.js
+++ b/externs/twbootstrap.js
@@ -48,6 +48,20 @@ angular.JQLite.prototype.modal = function(opt_options) {};
 
 
 /**
+ * @param {string|Object.<string,*>=} opt_option
+ * @return {!jQuery}
+ */
+jQuery.prototype.popover = function(opt_option) {};
+
+
+/**
+ * @param {(string|Object.<string,*>)=} opt_options
+ * @return {angular.JQLite}
+ */
+angular.JQLite.prototype.popover = function(opt_options) {};
+
+
+/**
  * @param {string} action
  * @return {!jQuery}
  */

--- a/src/ol-ext/popover.js
+++ b/src/ol-ext/popover.js
@@ -1,0 +1,113 @@
+goog.provide('ngeo.Popover');
+
+goog.require('ol.Overlay');
+goog.require('goog.events');
+
+
+/**
+ * @classdesc
+ * An openlayers overlay that uses bootstrap popover to produce a popup
+ * for maps.
+ *
+ * @constructor
+ * @extends {ol.Overlay}
+ * @param {olx.OverlayOptions=} opt_options Overlay options.
+ */
+ngeo.Popover = function(opt_options) {
+
+  var options = opt_options !== undefined ? opt_options : {};
+
+  /**
+   * The key for close button 'click' event
+   * @type {?goog.events.Key}
+   * @private
+   */
+  this.clickKey_ = null;
+
+  var originalEl;
+  if (options.element) {
+    originalEl = options.element;
+    delete options.element;
+  } else {
+    originalEl = $('<div />')[0];
+  }
+
+  /**
+   * @type {jQuery}
+   * @private
+   */
+  this.closeEl_ = $('<button>', {
+    'class': 'close',
+    'html': '&times;'
+  });
+
+  /**
+   * @type {jQuery}
+   * @private
+   */
+  this.contentEl_ = $('<div/>')
+    .append(this.closeEl_)
+    .append(originalEl);
+
+  options.element = $('<div />')[0];
+
+  goog.base(this, options);
+
+};
+goog.inherits(ngeo.Popover, ol.Overlay);
+
+
+/**
+ * @param {ol.Map|undefined} map Map.
+ * @export
+ */
+ngeo.Popover.prototype.setMap = function(map) {
+
+  var element = this.getElement();
+
+  var currentMap = this.getMap();
+  if (currentMap) {
+    if (this.clickKey_) {
+      goog.events.unlistenByKey(this.clickKey_);
+      this.clickKey_ = null;
+    }
+    $(element).popover('destroy');
+  }
+
+  goog.base(this, 'setMap', map);
+
+  if (map) {
+    var contentEl = this.contentEl_;
+    // wait for the overlay to be rendered in the map before poping over
+    window.setTimeout(function() {
+      $(element)
+        .popover({
+          'content': contentEl,
+          'html': true,
+          'placement': 'top',
+          'template': [
+            '<div class="popover ngeo-popover" role="tooltip">',
+            '  <div class="arrow"></div>',
+            '  <h3 class="popover-title"></h3>',
+            '  <div class="popover-content"></div>',
+            '</div>'
+          ].join('')
+        })
+        .popover('show');
+    }, 0);
+
+    this.clickKey_ = goog.events.listen(this.closeEl_[0],
+        goog.events.EventType.CLICK, this.handleCloseElClick_, false, this);
+  }
+};
+
+
+/**
+ * @private
+ */
+ngeo.Popover.prototype.handleCloseElClick_ = function() {
+  var map = this.getMap();
+  if (map) {
+    map.removeOverlay(this);
+  }
+};


### PR DESCRIPTION
This PR introduces the support of the `map_crosshair` and `map_tooltip` parameters for the `gmf-permalink` service.

Tasks to do:

 * [x] `map_crosshair`
 * [x] Define a default style for the map crosshair feature added
 * [x] Be able to define a custom style for the map crosshair feature added
 * [x] review `map_crosshair` code
 * [x] use ngeo.FeatureOverlayMgr instead of creating our own overlay
 * [x] `map_tooltip`
 * [x] use jQuery instead of native JavaScript for DOM manipulation
 * [x] review the current style of the popover
 * [x] enhance the CSS style of the popover
 * [x] use `&times;` instead of `x`
 * [x] review `map_tooltip` code
 * [x] merge into one commit
 * [x] travis passes

Live example:

 * http://adube.github.io/ngeo/gmf-permalink-map-crosshair-tooltip/examples/contribs/gmf/permalink.html