### PR TITLE
Separate sizes for map layout symbols

### DIFF
--- a/contribs/gmf/less/mobile-nav.less
+++ b/contribs/gmf/less/mobile-nav.less
@@ -218,6 +218,9 @@ nav.nav-right {
   height: ~"calc("@map-tools-size ~" - 3px)";
   margin-top: 2px;
   border: none;
+  .fa, .gmf-icon {
+    font-size: 1.5em;
+  }
 }
 
 .nav-left-trigger {

--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -87,31 +87,23 @@ gmf-map {
   }
 }
 
-.ol-control button,
-.ol-touch .ol-control button,
-.fa:after,
-.fa:before,
-.gmf-icon:after,
-.gmf-icon:before {
-  font-size: 2.0rem;
-}
-
 .ol-zoom {
   top: 5em;
   right: @app-margin;
   left: auto;
-  .ol-zoom-in,
-  .ol-zoom-out {
+  .ol-zoom-in, .ol-zoom-out {
+    font-size: 1.5em;
     border-radius: 0;
-  }
-  button {
-    width: 2.1em;
-    height: 2.1em;
+    height: 42px;
+    width: 42px;
   }
 }
 button[ngeo-mobile-geolocation] {
   right: @app-margin;
   top: 11.5em;
+  .fa {
+    font-size: 1.5em;
+  }
 }
 
 //mobile styles for the theme and background selector


### PR DESCRIPTION
Fix: https://github.com/camptocamp/ngeo/issues/737

Example : https://ger-benjamin.github.io/ngeo/separate-sizes-for-icons-buttons/examples/contribs/gmf/apps/mobile/