### PR TITLE
Use toolActivate without one-time binding in mobile apps

### DIFF
--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -14,7 +14,7 @@
       <gmf-map gmf-map-map="mainCtrl.map"
         ngeo-mobile-query=""
         ngeo-mobile-query-map="::mainCtrl.map"
-        ngeo-mobile-query-active="::mainCtrl.queryActive"></gmf-map>
+        ngeo-mobile-query-active="mainCtrl.queryActive"></gmf-map>
       <gmf-mobiledisplayqueries
         gmf-mobiledisplayqueries-featuresstyle="::mainCtrl.queryFeatureStyle">
       </gmf-mobiledisplayqueries>


### PR DESCRIPTION
Fix: https://github.com/camptocamp/ngeo/issues/753

https://ger-benjamin.github.io/ngeo/fix_753/examples/contribs/gmf/apps/mobile/?lang=en