### PR TITLE
ngTouch is required for gmf thus for desktop as well

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -96,6 +96,7 @@
     <script src="../../../../node_modules/jquery/dist/jquery.js"></script>
     <script src="../../../../node_modules/angular/angular.js"></script>
     <script src="../../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../../node_modules/angular-touch/angular-touch.js"></script>
     <script src="../../../../node_modules/typeahead.js/dist/typeahead.bundle.js"></script>
     <script src="../../../../node_modules/proj4/dist/proj4-src.js" type="text/javascript"></script>
     <script src="../../../../node_modules/angular-gettext/dist/angular-gettext.js" type="text/javascript"></script>


### PR DESCRIPTION
Currently desktop app doesn't load correctly.
`angular-touch.js` needs to be loaded for desktop app since it's required by the `gmf` module.

Please review.