### PR TITLE
Query displayer above menu icons (very small screens)

### DIFF
--- a/contribs/gmf/less/mobiledisplayqueries.less
+++ b/contribs/gmf/less/mobiledisplayqueries.less
@@ -7,7 +7,7 @@
   bottom: 0;
   max-height: 400px;
   position: fixed;
-  z-index: @above-content-index;
+  z-index: @above-menus-index;
   .collapse-button {
     background-color: @nav-bg;
     border: solid 1px black;

--- a/contribs/gmf/less/vars.less
+++ b/contribs/gmf/less/vars.less
@@ -14,6 +14,7 @@
 @below-content-index: 1;
 @content-index: 2;
 @above-content-index: 3;
+@above-menus-index: 4;
 
 @nav-width: 260px;
 


### PR DESCRIPTION
Rel to https://github.com/camptocamp/ngeo/issues/670

Bug: On (very) small screen (or small screen, horizontal mode), query a feature. Then open completely the query displayer: Square menus buttons are above. My PR correct that. 

Example: https://ger-benjamin.github.io/ngeo/query_display_always_above/examples/contribs/gmf/apps/mobile