### PR TITLE
Whiteout when search is active for mobile

### DIFF
--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -10,7 +10,7 @@
   <body ng-class="{'nav-is-visible': mainCtrl.navIsVisible(),
                    'nav-left-is-visible': mainCtrl.leftNavIsVisible(),
                    'nav-right-is-visible': mainCtrl.rightNavIsVisible()}">
-    <main>
+    <main ng-class="{'search-is-active': mainCtrl.searchOverlayVisible}">
       <gmf-map gmf-map-map="mainCtrl.map"
         ngeo-mobile-query=""
         ngeo-mobile-query-map="::mainCtrl.map"
@@ -40,7 +40,8 @@
         <gmf-search gmf-search-map="mainCtrl.map"
           gmf-search-datasources="mainCtrl.searchDatasources"
           gmf-search-currenttheme="mainCtrl.theme"
-          gmf-search-clearbutton="true">
+          gmf-search-clearbutton="true"
+          gmf-search-listeners="::mainCtrl.searchListeners">
         </gmf-search>
       </div>
       <button class="nav-trigger nav-right-trigger"
@@ -48,6 +49,7 @@
         <i class="fa fa-wrench"></i>
       </button>
       <div class="overlay" ng-click="mainCtrl.hideNav()"></div>
+      <div class="search-overlay" ng-click="mainCtrl.hideSearchOverlay()"></div>
       <button ngeo-mobile-geolocation=""
         ngeo-mobile-geolocation-map="::mainCtrl.map"
         ngeo-mobile-geolocation-options="::mainCtrl.mobileGeolocationOptions">

--- a/contribs/gmf/less/mobile-nav.less
+++ b/contribs/gmf/less/mobile-nav.less
@@ -24,9 +24,9 @@ main {
   .overlay {
     /* shadow layer visible when navigation is active */
     position: absolute;
-    z-index: @above-content-index;
-    height: 100%;
-    width: 100%;
+    z-index: @above-search-index;
+    height: 100vh;
+    width: 100vw;
     top: 0;
     left: 0;
     cursor: pointer;
@@ -38,6 +38,30 @@ main {
     .backface-visibility(hidden);
 
     .nav-is-visible & {
+      visibility: visible;
+      opacity: 1;
+    }
+  }
+}
+
+.search-overlay {
+  /* shadow layer visible when search is active */
+  position: absolute;
+  z-index: @above-menus-index;
+  height: 100vh;
+  width: 100vw;
+  top: 0;
+  left: 0;
+  cursor: pointer;
+  background-color: white;
+  visibility: hidden;
+  opacity: 0;
+
+  .transition(opacity @duration, visibility @duration;);
+  .backface-visibility(hidden);
+
+  @media (max-width: @screen-xs-max) {
+    .search-is-active & {
       visibility: visible;
       opacity: 1;
     }
@@ -214,7 +238,7 @@ nav.nav-right {
 .nav-trigger {
   top: @app-margin;
   background: white;
-  z-index: @above-content-index;
+  z-index: @above-search-index;
   height: ~"calc("@map-tools-size ~" - 3px)";
   margin-top: 2px;
   border: none;

--- a/contribs/gmf/less/search.less
+++ b/contribs/gmf/less/search.less
@@ -46,6 +46,10 @@
       display: none;
     }
   }
+
+  .search-is-active & {
+    z-index: @search-index;
+  }
 }
 
 span.twitter-typeahead input {

--- a/contribs/gmf/less/vars.less
+++ b/contribs/gmf/less/vars.less
@@ -15,6 +15,9 @@
 @content-index: 2;
 @above-content-index: 3;
 @above-menus-index: 4;
+@search-index: 5;
+@above-search-index: 6;
+
 
 @nav-width: 260px;
 

--- a/contribs/gmf/src/controllers/abstractmobile.js
+++ b/contribs/gmf/src/controllers/abstractmobile.js
@@ -61,6 +61,12 @@ gmf.AbstractMobileController = function(config, $scope, $injector) {
    */
   this.rightNavVisible = false;
 
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.searchOverlayVisible = false;
+
 
   var positionFeatureStyle = config.positionFeatureStyle || new ol.style.Style({
     image: new ol.style.Circle({
@@ -129,6 +135,19 @@ gmf.AbstractMobileController = function(config, $scope, $injector) {
     alert('Geo-location failed');
   }.bind(this));
 
+  /**
+   * @type {ngeox.SearchDirectiveListeners}
+   * @export
+   */
+  this.searchListeners = /** @type {ngeox.SearchDirectiveListeners} */ ({
+    open: function() {
+      this.searchOverlayVisible = true;
+    }.bind(this),
+    close: function() {
+      this.searchOverlayVisible = false;
+    }.bind(this)
+  });
+
   goog.base(
       this, config, $scope, $injector);
 };
@@ -167,6 +186,15 @@ gmf.AbstractMobileController.prototype.hideNav = function() {
  */
 gmf.AbstractMobileController.prototype.navIsVisible = function() {
   return this.leftNavVisible || this.rightNavVisible;
+};
+
+
+/**
+ * Hide search overlay.
+ * @export
+ */
+gmf.AbstractMobileController.prototype.hideSearchOverlay = function() {
+  this.searchOverlayVisible = false;
 };
 
 


### PR DESCRIPTION
Replace #789 

When the search field is active, hide anything else (for small screens).

Demo: https://tsauerwein.github.io/ngeo/search-overlay/examples/contribs/gmf/apps/mobile/

Closes https://github.com/camptocamp/ngeo/issues/778