### PR TITLE
CSS cleanup

### DIFF
--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -6,12 +6,16 @@
 @import 'map.less';
 @import 'layertree.less';
 @import 'icons.less';
+@import 'search.less';
 
-@data-width: 320px;
-/* size of the links bar */
-@topbar-height: 50px;
-/* width for the vertical toolbar */
-@toolbar-width: 40px;
+@map-tools-size: 3rem;
+@button-size: 4rem;
+@left-panel-width: 32rem;
+@right-panel-width: 25rem;
+@topbar-height: @button-size;
+@toolbar-width: @button-size;
+@border-color: darken(@brand-primary, @standard-variation);
+@search-width: 8 * @map-tools-size;
 
 html, body {
   position: relative;
@@ -29,7 +33,6 @@ header {
   left: 0;
   height: @topbar-height;
   z-index: @zindex-navbar-fixed;
-
   .box-shadow(0px 2px 6px -1px rgba(0, 0, 0, 0.5));
 }
 
@@ -54,98 +57,42 @@ main {
     left: 0;
   }
 }
+
 .search {
   position: absolute;
-  top: @app-margin;
-  left: @app-margin + 50px;
-  z-index: @content-index;
+  width: @search-width;
+
+  .clear-button {
+    top: 0;
+  }
 
   span.twitter-typeahead {
-    &:after {
+    &:before {
       // magnifier
-      content: '\f002';
-      font-family: FontAwesome;
-      color: grey;
-      position: absolute;
-      top: 0;
-      left: .5em;
-      line-height: @input-height-base;
-    }
-
-    input {
-      padding-left: 2em;
-    }
-
-    & + span.clear-button {
-      position: absolute;
-      line-height: @input-height-base;
-      top: 0;
-      right: .5em;;
-      display: block;
-      cursor: pointer;
-      color: white;
-      opacity: 0.5;
-      &:after{
-        // cross
-        content: '\f00d';
-        color: grey;
-        font-family: FontAwesome;
-      }
-      &:hover {
-        opacity: 1;
-      }
-    }
-    .form-control {
-      position: relative;
-      padding-right: 20px;
-      width: auto;
+      font-size: 1.5rem;
     }
 
     .tt-menu {
-      min-width: 250px;
-      margin: 2px 0 0;
-      background-color: #ffffff;
-      border: 1px solid rgba(0, 0, 0, 0.15);
-      border-radius: 4px;
-      box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-      background-clip: padding-box;
-      // border radius will clip content
-      overflow: hidden;
+      position: relative!important;
+      top: 0!important;
+      left: -@app-margin!important;
+      border: 1px solid @color;
+      border-radius: @half-app-margin;
+      width: @search-width;
 
       .search-header {
+        padding: @app-margin;
+        padding-left: @app-margin + 2rem + @app-margin;
+        display:block;
         font-size: 0.9em;
         background-color: #eee;
         text-transform: uppercase;
         color: #666;
       }
 
-      .search-header,
-      .search-datum {
-        padding: 8px 10px;
-      }
-      .search-datum:not(:last-child) {
-        border-bottom: solid 1px #eee;
-      }
-      .search-datum {
-        font-weight: 600;
-
-        &.tt-cursor,
-        &:hover,
-        &:focus {
-          cursor: pointer;
-          background-color: @onhover-color;
-        }
-
-        p {
-          margin-bottom: 0;
-        }
-        .search-label {
-          color: @map-tools-color;
-        }
-        .search-group {
+      .search-group {
           display: none;
         }
-      }
     }
   }
 }
@@ -159,7 +106,7 @@ main {
   display: block;
   float: left;
   background-color: @brand-secondary;
-  width: @data-width;
+  width: @left-panel-width;
   height: 100%;
   display: flex;
   flex-flow: column;
@@ -171,19 +118,24 @@ main {
   .content {
     flex: 1 1 auto;
     overflow-y: auto;
-    margin: 5px;
+    margin: @app-margin;
   }
 
   gmf-themeselector {
-    width: 500px;
+    width: 2 * @left-panel-width;
+    margin: 0;
+    padding: @app-margin;
+    padding-right: 0;
     .gmf-theme-selector li {
+      padding-right: @app-margin;
       float: left;
+      width: 50%;
     }
   }
 }
 
 gmf-layertree ul .treenode {
-  padding-top: 5px;
+  padding-top: @app-margin;
 }
 
 
@@ -193,9 +145,9 @@ gmf-layertree ul .treenode {
   background-color: @brand-secondary;
 
   .tools-content {
-    padding: 10px;
-    width: 250px;
-    margin-right: -250px + @toolbar-width;
+    padding: @app-margin;
+    width: @right-panel-width;
+    margin-right: -@right-panel-width + @toolbar-width;
     transition: margin-right 0.2s ease;
 
     &.active {
@@ -204,20 +156,18 @@ gmf-layertree ul .treenode {
 
     .close {
       padding: 0;
-      line-height: 0.5em;
-      margin-bottom: 10px;
+      line-height: @half-app-margin;
+      margin-bottom: @app-margin;
     }
 
     .tools-content-heading {
-      @color: lighten(@text-color, 30%);
+      @color: lighten(@text-color, @standard-variation);
       color: @color;
-      padding-bottom: 10px;
-      margin-bottom: 10px;
+      padding-bottom: @app-margin;
+      margin-bottom: @app-margin;
       border-bottom: 1px solid @color;
     }
   }
-
-  @border-color: darken(@brand-primary, 10%);
 
   .bar {
     background-color: @brand-primary;
@@ -241,7 +191,7 @@ gmf-layertree ul .treenode {
       border-color: @border-color;
 
       &:hover {
-        background-color: lighten(@brand-primary, 10%);
+        background-color: lighten(@brand-primary, @standard-variation);
       }
 
       &.active,
@@ -265,16 +215,16 @@ gmf-layertree ul .treenode {
 
 
 ::-webkit-scrollbar-track {
-    -webkit-border-radius: 10px;
-    border-radius: 10px;
-    background: #eee;
+    -webkit-border-radius: @app-margin;
+    border-radius: @app-margin;
+    background: @main-bg-color;
 }
 
 ::-webkit-scrollbar {
-    width: 5px;
+    width: @half-app-margin;
 }
 ::-webkit-scrollbar-thumb {
-    -webkit-border-radius: 10px;
-    border-radius: 10px;
+    -webkit-border-radius: @app-margin;
+    border-radius: @app-margin;
     background: @brand-primary;
 }

--- a/contribs/gmf/less/fullscreenpopup.less
+++ b/contribs/gmf/less/fullscreenpopup.less
@@ -4,19 +4,19 @@
     top: 0;
     left: auto;
     right: auto;
-    max-width: 96%;
-    width: 96%;
-    height: 96%;
-    max-height: 96%;
-    margin: 2%;
+    max-width: calc(~"100vw -" 2 * @app-margin);
+    width: calc(~"100vw -" 2 * @app-margin);
+    height: calc(~"100vh -" 2 * @app-margin);
+    max-height: calc(~"100vh -" 2 * @app-margin);
+    margin: @app-margin;
     border-radius: 0;
   }
   .popover-title {
     background-color: @nav-bg;
-    border-bottom-color: @color2;
-    color: @color2;
+    border-bottom-color: @color;
+    color: @color;
     .close {
-      color: @color2;
+      color: @color;
       line-height: 0.8;
       opacity: 1;
     }
@@ -26,21 +26,22 @@
      * popup's height - popover-title's height
      * should be computed using bootstrap variables
      */
-    max-height: 90%;
+    max-height: 90vh;
     -webkit-overflow-scrolling: touch;
   }
 }
 
 @media (min-width: @screen-sm-min) {
+  @fullscreenpopup-tablet-width: 8 * @map-tools-size;
   [ngeo-popup] {
     &.popover {
-      top: 20px;
-      max-width: 350px;
-      width: 350px;
-      margin-left: -175px;
+      top: @app-margin + @map-tools-size;
+      max-width: @fullscreenpopup-tablet-width;
+      width: @fullscreenpopup-tablet-width;
+      margin-left: - @fullscreenpopup-tablet-width / 2;
       left: 50%;
       right: 50%;
-      max-height: 400px;
+      max-height: @fullscreenpopup-tablet-width + @map-tools-size;
       position: fixed;
     }
     .popover-content {
@@ -49,7 +50,7 @@
        * popup's height - popover-title's height
        * should be computed using bootstrap variables
        */
-      max-height: calc(400px - 38px);
+      max-height: @fullscreenpopup-tablet-width;
     }
   }
 }

--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -1,10 +1,10 @@
 gmf-layertree div {
-  margin-right: 10px;
+  margin-right: @app-margin;
 }
 gmf-layertree ul .treenode {
-  padding-top: 10px;
+  padding-top: @app-margin;
   a {
-    color: black;
+    color: @color;
     display: inline;
     line-height: inherit;
     padding-left: 0;
@@ -15,13 +15,13 @@ gmf-layertree ul .treenode {
   }
   .rightButtons *::after {
     background: none;
-    color: black;
+    color: @map-tools-color;
     display: inline;
     font-family: FontAwesome;
   }
   .state {
     font-family: gmf-icons;
-    color: @color2;
+    color: @color;
   }
   .on .state {
     color: @special-link;
@@ -42,8 +42,8 @@ gmf-layertree ul .treenode {
   }
   .layerIcon {
     display: inline-flex;
-    height: 10px;
-    width: 20px;
+    height: @app-margin;
+    width: 2 * @app-margin;
   }
   .name {
     white-space: normal;
@@ -108,7 +108,7 @@ gmf-layertree ul .treenode {
      display: none;
     }
     img {
-      padding-left: 15px;
+      padding-left: @app-margin + @half-app-margin;
     }
   }
 }

--- a/contribs/gmf/less/map.less
+++ b/contribs/gmf/less/map.less
@@ -6,11 +6,11 @@
   padding: 0;
   button {
     margin: 0;
-    margin-bottom: 3px;
+    margin-bottom: @micro-app-margin;
     height: @map-tools-size;
     width: @map-tools-size;
     background-color: @map-tools-bg-color;
-    border: solid 1px @map-tools-color;
+    border: solid 1px @border-color;
     color: @map-tools-color;
     &:hover {
       background-color: @onhover-color;
@@ -48,53 +48,54 @@
 
 .ol-scale-line, .ol-scale-line-inner {
   background-color: @map-tools-bg-color;
-  border-color: @map-tools-color;
+  border-color: @border-color;
   border-width: 2px;
   color: @map-tools-color;
 }
 
 button[ngeo-mobile-geolocation] {
   background-color: @map-tools-bg-color;
-  border: solid 1px @map-tools-color;
+  border: solid 1px @border-color;
   color: @map-tools-color;
-  right: 13px;
-  top: 135px;
+  .fa {
+    font-size: 2rem;
+  }
 }
 
 .gmf-theme-selector,
 .gmf-mobile-backgroundlayerselector {
   list-style: none;
-  margin: 0;
-  padding: 0;
 
   li {
+    width: 100%;
     cursor: pointer;
-    margin-bottom: 10px;
+    padding: @app-margin 0;
+    color: @color;
   }
 
   .gmf-check,
-  .gmf-text,
-  .gmf-thumb {
+  .gmf-text {
     float: left;
   }
 
   .gmf-check {
-    height: 20px;
-    margin: 15px 5px 0 0;
-    width: 20px;
+    position: relative;
+    height: 1px; // ::after needs a height different of 0
+    top: 1rem;
+    width: 2rem;
   }
 
   .gmf-text {
-    margin: 15px 10px 0 0;
+    margin: @app-margin @app-margin @app-margin 0;
     overflow: hidden;
     text-overflow: ellipsis;
-    width: 140px;
     white-space: nowrap;
   }
 
   .gmf-thumb {
-    height: 60px;
-    width: 60px;
+    height: auto;
+    width: 2 * @map-tools-size;
+    float: right;
   }
 
   .gmf-eol {

--- a/contribs/gmf/less/mobile-nav.less
+++ b/contribs/gmf/less/mobile-nav.less
@@ -1,11 +1,15 @@
 /**
  * Styles for mobile navigation menus (side menus).
  */
-@duration: .3s;
+
+@duration: 0.3s;
+@nav-bar-height: @map-tools-size + @app-margin;
+@menu-item-height: @nav-bar-height;
+
 main {
   position: fixed;
-  background-color: @color3;
-  box-shadow: 0px 0px 15px black;
+  background-color: @main-bg-color;
+  box-shadow: 0 0 @app-margin black;
   width: 100%;
   height: 100%;
   z-index: @content-index;
@@ -30,7 +34,7 @@ main {
     top: 0;
     left: 0;
     cursor: pointer;
-    background-color: fade(@color2, 40%);
+    background-color: fade(@color, 40%);
     visibility: hidden;
     opacity: 0;
 
@@ -43,8 +47,6 @@ main {
     }
   }
 }
-
-@nav-bar-height: 50px;
 
 .nav-left-is-visible nav.nav-right,
 .nav-right-is-visible nav.nav-left  {
@@ -84,7 +86,7 @@ nav.nav-right {
       opacity: 0;
       visibility: hidden;
       height: @nav-bar-height;
-      width: 30px;
+      width: @map-tools-size;
 
       &.active {
         opacity: 1;
@@ -93,7 +95,7 @@ nav.nav-right {
 
       &::before, &::after {
         transform-origin: 1px 50%;
-        left: 10px;
+        left: @app-margin;
       }
     }
 
@@ -134,7 +136,7 @@ nav.nav-right {
 
   a[data-toggle] {
     position: relative;
-    padding-right: 40px;
+    padding-right: @map-tools-size;
 
     &::before, &::after {
       /* arrow goes on the right side - children navigation */
@@ -153,8 +155,8 @@ nav.nav-right {
       margin-top: -1px;
       display: inline-block;
       height: 2px;
-      width: 10px;
-      background: darken(@nav-bg, 20%);
+      width: @app-margin;
+      background: darken(@nav-bg, @standard-variation);
       .backface-visibility(hidden);
     }
 
@@ -166,7 +168,6 @@ nav.nav-right {
     }
   }
 
-  @menu-item-height: @nav-bar-height;
   ul a[data-toggle=slide-in] {
     display: block;
     height: @menu-item-height;
@@ -186,7 +187,7 @@ nav.nav-right {
     will-change: transform, opacity;
     opacity: 0;
     overflow-y: auto;
-    padding: 10px;
+    padding: @app-margin;
 
     &.active {
       transform: translateX(0%);
@@ -215,21 +216,22 @@ nav.nav-right {
   top: @app-margin;
   background: white;
   z-index: @above-content-index;
-  height: ~"calc("@map-tools-size ~" - 3px)";
-  margin-top: 2px;
-  border: none;
+  height: @map-tools-size;
+  border: 1px solid @border-color;
   .fa, .gmf-icon {
-    font-size: 1.5em;
+    font-size: 2rem;
   }
 }
 
 .nav-left-trigger {
-  left: calc(@app-margin ~" + 1px");
+  left: @app-margin;
+  border-right: none;
   box-shadow: 3px 0 5px -2px #bbb;
 }
 
 .nav-right-trigger {
-  right: calc(@app-margin ~" + 1px");
+  right: @app-margin;
+  border-left: none;
   box-shadow: -3px 0 5px -2px #bbb;
 }
 
@@ -244,9 +246,9 @@ nav.nav-right {
     top: @app-margin;
     margin: 0;
     background-color: @map-tools-bg-color;
-    border: solid 1px @map-tools-color;
+    border: solid 1px @border-color;
     box-shadow: none;
-    height: 3em;
+    height: @map-tools-size;
   }
 
   .nav-left-trigger {

--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -11,8 +11,10 @@
 @import 'icons.less';
 @import 'mobiledisplayqueries.less';
 
-@map-tools-size: 3em;
-@app-margin: 1em;
+/**
+ * Mobile specific css only !
+ * Please, use shared less files to describe desktop-mobile shared css
+ */
 
 main>* {
   position: absolute;
@@ -37,9 +39,9 @@ gmf-map {
 #measure-tools {
   .measure-tools-button {
     display: block;
-    padding: 5px 0;
-    margin: 5px 0;
-    color: @color2;
+    padding: @half-app-margin 0;
+    margin: @half-app-margin 0;
+    color: @color;
     &:hover {
       cursor: pointer;
       text-decoration: none;
@@ -48,17 +50,22 @@ gmf-map {
 }
 
 .measure-tools-control {
-  bottom: 1em;
-  right: 1em;
+  bottom: @app-margin;
+  right: @app-margin;
+  a {
+    display: block;
+    float: left;
+    margin-left: @micro-app-margin;
+  }
 }
 
 gmf-map {
   .tooltip {
     position: relative;
     background: rgba(0, 0, 0, 0.5);
-    border-radius: 4px;
+    border-radius: @half-app-margin;
     color: white;
-    padding: 4px 8px;
+    padding: @half-app-margin @app-margin;
     opacity: 0.7;
     white-space: nowrap;
   }
@@ -68,18 +75,18 @@ gmf-map {
   }
   .tooltip-static {
     background-color: #ffcc33;
-    color: black;
+    color: @color;
     border: 1px solid white;
   }
   .tooltip-measure:before,
   .tooltip-static:before {
-    border-top: 6px solid rgba(0, 0, 0, 0.5);
-    border-right: 6px solid transparent;
-    border-left: 6px solid transparent;
+    border-top: @half-app-margin solid @border-color;
+    border-right: @half-app-margin solid transparent;
+    border-left: @half-app-margin solid transparent;
     content: "";
     position: absolute;
-    bottom: -6px;
-    margin-left: -7px;
+    bottom: -@half-app-margin;
+    margin-left: -@half-app-margin;
     left: 50%;
   }
   .tooltip-static:before {
@@ -88,52 +95,50 @@ gmf-map {
 }
 
 .ol-zoom {
-  top: 5em;
+  top: @app-margin + @map-tools-size + @app-margin;
   right: @app-margin;
   left: auto;
   .ol-zoom-in, .ol-zoom-out {
-    font-size: 1.5em;
+    font-size: 2rem;
     border-radius: 0;
-    height: 42px;
-    width: 42px;
-  }
-}
-button[ngeo-mobile-geolocation] {
-  right: @app-margin;
-  top: 11.5em;
-  .fa {
-    font-size: 1.5em;
   }
 }
 
-//mobile styles for the theme and background selector
+.ol-scale-line {
+  bottom: @app-margin;
+  left: @app-margin;
+}
+
+button[ngeo-mobile-geolocation] {
+  right: @app-margin;
+  top: calc(3 * @map-tools-size + 2 * @app-margin + 2 * @micro-app-margin);
+}
+
 .gmf-theme-selector,
 .gmf-mobile-backgroundlayerselector {
-  .gmf-icon-check:after {
-    font-size: 1.2rem;
-    position: relative;
-    bottom: 0.8rem;
+  .gmf-check {
+    top: 0.5rem;
   }
   .gmf-text {
-    margin: 3% 10px 0 0;
+    margin: @half-app-margin @app-margin 0 0;
+    width: calc(~"100% -" @app-margin + 2 * @map-tools-size);
   }
   .gmf-thumb {
-    height: auto;
     width: 25%;
   }
 }
 
 // Overrides for tablet devices
 @media (min-width: @screen-sm-min) {
+  .measure-tools-control {
+    right: 2 * @app-margin + @map-tools-size;
+  }
   .ol-zoom {
     top: auto;
-    bottom: 8.5em;
+    bottom: @app-margin + @map-tools-size;
   }
   button[ngeo-mobile-geolocation] {
     top: auto;
-    bottom: 5.5em;
-    & button:after {
-      content: 'b'
-    }
+    bottom: @app-margin;
   }
 }

--- a/contribs/gmf/less/mobiledisplayqueries.less
+++ b/contribs/gmf/less/mobiledisplayqueries.less
@@ -5,17 +5,17 @@
   right: 50%;
   left: 50%;
   bottom: 0;
-  max-height: 400px;
+  max-height: 10 * @map-tools-size;
   position: fixed;
   z-index: @above-menus-index;
   .collapse-button {
     background-color: @nav-bg;
-    border: solid 1px black;
+    border: solid 1px @border-color;
     border-bottom-width: 0;
-    border-radius: 4px 4px 0 0;
+    border-radius: @half-app-margin @half-app-margin 0 0;
     line-height: 0.5;
-    height: 28px;
-    width: 48px;
+    height: @map-tools-size;
+    width: @map-tools-size + @map-tools-size * 2/3;
     &.up:after {
       content: "\f077";
     }
@@ -25,20 +25,21 @@
   }
   .displayqueries-container {
     background-color: @nav-bg;
-    border: solid 1px black;
+    border: solid 1px @border-color;
   }
   .animation-container {
     position: relative;
     overflow: hidden;
-    height: 60px;
-    margin: 0 5px;
+    // height with 2em: 1em per text (title, subtitle)
+    height: calc(3 * @app-margin + @half-app-margin ~"+ 2em");
+    margin: 0;
     transition: 0.3s ease-in all;
     &.detailed {
-      height: 170px;
+      height: 33vh;
     }
     .slide-animation {
       height: 100%;
-      padding: 5px 5px 0;
+      padding: @app-margin @app-margin 0;
       text-align: left;
       white-space: nowrap;
       overflow: hidden;
@@ -82,24 +83,27 @@
       font-weight: bold;
     }
     .subtitle {
-     margin-left: 10px;
-     height: 2ex;
+     margin-left: @app-margin;
+     min-height: 1em;
+    }
+    p {
+      margin-bottom: @app-margin
     }
   }
   .details {
     height: 65%;
     overflow-x: hidden;
     overflow-y: auto;
-    margin-left: 10px;
-    padding-bottom: 10px;
+    margin-left: @app-margin;
+    padding-bottom: @app-margin;
     table {
-      font-size: 0.9em;
+      font-size: 90%;
     }
     .key {
-      padding-right: 5px;
+      padding-right: @app-margin;
       /** prevent glitch for swipe animation **/
-      min-width: ~"calc(30vw - 30px)";
-      max-width: ~"calc(30vw - 30px)";
+      min-width: calc(~"30vw -" 2 * @app-margin);
+      max-width: calc(~"30vw -" 2 * @app-margin);
       overflow-x: hidden;
       text-overflow: ellipsis;
     }
@@ -107,18 +111,18 @@
       white-space: pre-wrap;
       word-break: break-all;
       /** prevent glitch for swipe animation **/
-      min-width: ~"calc(70vw - 30px)";
-      max-width: ~"calc(70vw - 30px)";
+      min-width: calc(~"70vw -" 2 * @app-margin);
+      max-width: calc(~"70vw -" 2 * @app-margin);
     }
     .slide-animation.ng-enter-active .details .value {
       white-space: nowrap;
     }
   }
   .navigate {
-    border-top: solid 1px black;
+    border-top: solid 1px @border-color;
     text-align: center;
-    padding-top: 5px;
-    height: 32px;
+    padding-top: @app-margin;
+    height: @map-tools-size;
     .previous {
       float: left;
       &:after {
@@ -137,15 +141,15 @@
     border: none;
     font-family: FontAwesome;
     height: initial;
-    width: 32px;
+    width: @map-tools-size;
     &:hover {
       background-color: @nav-bg;
     }
     &.close {
       z-index: @above-content-index;
       position: absolute;
-      top: calc(28px + 1px + 5px);
-      right: 5px;
+      top: @map-tools-size + @app-margin;
+      right: 0;
       &:after {
         content: "\f00d";
       }
@@ -153,22 +157,23 @@
   }
 }
 @media (min-width: @screen-sm-min) {
+  @mobiledisplayqueries-tablet-width: 8 * @map-tools-size;
   .mobiledisplayqueries {
-    width: 350px;
-    max-width: 350px;
-    margin-left: -175px;
-    right: calc(1em + 3.1em + 1em ~"+ 2px");
+    width: @mobiledisplayqueries-tablet-width;
+    max-width: @mobiledisplayqueries-tablet-width;
+    margin-left: -@mobiledisplayqueries-tablet-width / 2;
+    right: @app-margin + @map-tools-size + @app-margin;
     left: initial;
-    bottom: 5px;
+    bottom: @app-margin;
     /** prevent glitch for swipe animation **/
     .details table {
       .key {
-        min-width: calc(325px * 0.34);
-        max-width: calc(325px * 0.34);
+        min-width: @mobiledisplayqueries-tablet-width * 0.3 - @app-margin;
+        max-width: @mobiledisplayqueries-tablet-width * 0.3 - @app-margin;
       }
       .value {
-        min-width: calc(325px * 0.67);
-        max-width: calc(335px * 0.67);
+        min-width: @mobiledisplayqueries-tablet-width * 0.7 - @app-margin;
+        max-width: @mobiledisplayqueries-tablet-width * 0.7 - @app-margin;
       }
     }
   }

--- a/contribs/gmf/less/search.less
+++ b/contribs/gmf/less/search.less
@@ -1,18 +1,17 @@
-@search-elements-spacing: 10px;
-
 .search {
   top: @app-margin;
   height: @map-tools-size;
   left: 0;
   right: 0;
-  margin-left: @app-margin;
-  margin-right: @app-margin;
-  padding: 0 @search-elements-spacing;
+  margin: 0 @app-margin + @map-tools-size;
+  padding: 0 @app-margin;
   background-color: @map-tools-bg-color;
-  border: solid 1px @map-tools-color;
+  border: solid 0 @border-color;
+  border-width: 1px 0;
   z-index: @content-index;
   input {
     height: @map-tools-size;
+    font-size: 1.4rem!important;
   }
   // hide the native "clear x" in Edge
   input::-ms-clear {
@@ -20,16 +19,20 @@
   }
   .clear-button {
     position: absolute;
-    top: 0;
-    right: 3.5em;
+    top: @half-app-margin;
+    right: @app-margin;
     height: @map-tools-size;
+    opacity: 0.5;
     &:after {
+      position: absolute;
       content: '\f00d';
-      color: @color2;
+      color: @map-tools-color;
       font-family: FontAwesome;
-      font-size: 2em;
+      font-size: 2rem;
+      right: 0;
     }
     &:hover {
+      opacity: 1;
       cursor: pointer;
     }
   }
@@ -49,26 +52,27 @@
 }
 
 span.twitter-typeahead input {
-  padding-left: 3em;
+  padding-left: @app-margin;
 }
 
+/** Some "!important" notation because some rules are in typeahead's html */
 .tt-menu {
   position: fixed!important;
   left: 0;
   right: 0;
-  top: 5em !important;
+  top: @app-margin + @map-tools-size + @app-margin !important;
   bottom: 0;
   overflow-x: hidden;
   overflow-y: auto;
   background-color: @map-tools-bg-color;
-  border: solid 1px black;
+  border: solid 1px @border-color;
   .search-header {
     display: none;
   }
   .search-datum {
-    border-bottom: solid 1px black;
-    padding: @search-elements-spacing @app-margin;
-    padding-left: 2.5em;
+    border-bottom: solid 1px @border-color;
+    padding: @app-margin;
+    padding-left: @app-margin + 2rem + @app-margin;
     text-align: left;
     &:hover {
       cursor: pointer;
@@ -78,47 +82,52 @@ span.twitter-typeahead input {
       margin: 0;
     }
     .search-label {
-      color: @map-tools-color;
+      color: @color;
     }
     .search-group {
-      color: @color2;
-      font-size: 0.8em;
+      color: @color-light;
+      font-size: 80%;
     }
   }
 }
 
 // Overrides for tablet devices
 @media (min-width: @screen-sm-min) {
+  @search-width: 6 * @map-tools-size;
   .search {
-    left: 4em;
-    width: 18em;
+    margin: 0;
+    left: calc(2 * @app-margin + @map-tools-size);
+    width: @search-width;
+    border-width: 1px;
     .clear-button {
-      margin-right: @search-elements-spacing;
+      margin-right: @app-margin;
       right: 0;
     }
   }
+
+  /** Some "!important" notation because some rules are in typeahead's html */
   .tt-menu {
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
     border-top: inherit;
     border-bottom: inherit;
-    top: 4em !important;
-    left: 5em !important;
+    top: @app-margin + @map-tools-size !important;
+    left: @app-margin + @map-tools-size + @app-margin !important;
     bottom: auto;
-    width: 18em;
+    width: @search-width;
   }
   span.twitter-typeahead {
-    &:after {
+    &:before {
       content: '\f002';
       font-family: FontAwesome;
-      color: @color2;
+      color: @color;
       position: absolute;
-      top: 0.3em;
       left: 0;
-      font-size: 1.4em;
+      font-size: 2rem;
+      top: @half-app-margin;
     }
     input {
-      width: 14em;
-      padding-left: @search-elements-spacing;
-      left: 1em;
+      width: @search-width - @app-margin;
+      padding-left: 2rem + @app-margin;
     }
   }
 }

--- a/contribs/gmf/less/vars.less
+++ b/contribs/gmf/less/vars.less
@@ -1,14 +1,18 @@
-@app-margin: 13px;
+@app-margin: 1rem;
+@half-app-margin: 0.5rem;
+@micro-app-margin: 0.2rem;
+@standard-variation: 15%;
 @nav-bg: white;
-@color2: #555; // grey
-@color3: #e2e3df; // grey light
+@color: #555;
+@color-light: lighten(@color, @standard-variation);
 @nav-header-bg: darken(@nav-bg, 50%);
-@nav-links: darken(@nav-bg, 50%);
+@nav-links: @special-link;
 @map-tools-bg-color: white;
 @map-tools-color: black;
-@map-tools-size: 29px;
-@onhover-color: darken(@nav-bg, 20%);
+@map-tools-size: 4rem;
+@onhover-color: darken(@nav-bg, @standard-variation);
 @special-link: hsv(hue(@brand-primary), 40%, 60%);
+@main-bg-color: #e2e3df; // grey light
 
 // Z-indexes
 @below-content-index: 1;
@@ -16,10 +20,11 @@
 @above-content-index: 3;
 @above-menus-index: 4;
 
-@nav-width: 260px;
+@nav-width: 26rem;
 
 @border-radius-base: 0;
-@input-border-focus: darken(@brand-primary, 10%);
+@border-color: black;
+@input-border-focus: darken(@brand-primary, @standard-variation);
 
 @brand-primary: #b1c2b5;
 @brand-secondary: #d3e5d7;


### PR DESCRIPTION
Fix: https://github.com/camptocamp/ngeo/issues/794

Example: 
 - https://ger-benjamin.github.io/ngeo/cleanup_css/examples/contribs/gmf/apps/mobile
 - https://ger-benjamin.github.io/ngeo/cleanup_css/examples/contribs/gmf/apps/desktop

To compare with:
- https://camptocamp.github.io/ngeo/master/examples/contribs/gmf/apps/mobile
- https://camptocamp.github.io/ngeo/master/examples/contribs/gmf/apps/desktop

I've taken some liberty to standardize all the stuff.
Please tell me what to change if you disagree. (the bigger change is the color of the menu links, we used strange shades of browngrey before. But you can set it easily by set the `@nav-links` value in the `contribs/gmf/less/vars.less` file)

