### PR TITLE
Fix LayerHelper group creation

### DIFF
--- a/src/services/layerHelper.js
+++ b/src/services/layerHelper.js
@@ -134,14 +134,20 @@ ngeo.LayerHelper.prototype.createBasicGroup = function(opt_layers) {
  */
 ngeo.LayerHelper.prototype.getGroupFromMap = function(map, groupName) {
   var groups = map.getLayerGroup().getLayers();
-  groups.forEach(function(group) {
-    if (group.get(ngeo.LayerHelper.GROUP_KEY) === groupName) {
-      return group;
+  var group;
+  groups.getArray().some(function(exitingGroup) {
+    if (exitingGroup.get(ngeo.LayerHelper.GROUP_KEY) === groupName) {
+      group = /** @type {ol.layer.Group} */ (exitingGroup);
+      return true;
+    } else {
+      return false;
     }
   });
-  var group = this.createBasicGroup();
-  group.set(ngeo.LayerHelper.GROUP_KEY, groupName);
-  map.addLayer(group);
+  if (!group) {
+    group = this.createBasicGroup();
+    group.set(ngeo.LayerHelper.GROUP_KEY, groupName);
+    map.addLayer(group);
+  }
   return group;
 };
 


### PR DESCRIPTION
This PR fixes the ngeo LayerHelper `createBasicGroup` method, allowing it to actually use the already created groups and return them.  Inside a `forEach`, calling `return` didn't actually did the return of the `createBasicGroup` method, but rather the anonymous function used for the forEach.