### PR TITLE
(WIP) Gmf permalink - support layers

### DIFF
--- a/contribs/gmf/examples/mobilequery.html
+++ b/contribs/gmf/examples/mobilequery.html
@@ -198,7 +198,7 @@
       .treenode .outOfResolution .legend {
         display: none;
       }
-      .treenode .legend a:after {
+      .treenode .legendButton a:after {
         font-family: FontAwesome;
         content: "\f036";
       }
@@ -221,16 +221,60 @@
         font-family: FontAwesome;
         font-weight: lighter;
       }
-      .treenode .state.on:before {
+      .treenode .on .state:before {
         content: "\f14a";
       }
-      .treenode .state.off:before {
+      .treenode .off .state:before {
         content: "\f096";
       }
-      .treenode .state.indeterminate:before {
+      .treenode .indeterminate .state:before {
         content: "\f147";
       }
-
+      [ngeo-popup] {
+        top: 20px;
+        max-width: 350px;
+        width: 350px;
+        margin-left: -175px;
+        left: 50%;
+        right: 50%;
+        max-height: 400px;
+        position: fixed;
+      }
+      [ngeo-popup] .popover-content {
+        overflow: auto;
+        /*
+         * popup's height - popover-title's height
+         * should be computed using bootstrap variables
+         */
+        max-height: calc(400px - 38px);
+      }
+      @media (max-width: 768px) {
+        #map {
+          height: 200px;
+          width: 200px;
+        }
+        [ngeo-popup] {
+          position: fixed;
+          top: 0;
+          left: auto;
+          right: auto;
+          max-width: 100%;
+          width: calc(100% - 20px);
+          height: calc(100% - 20px);
+          max-height: none;
+          margin: 10px;
+        }
+      }
+      @media (max-width: 768px) {
+        [ngeo-popup] .popover-content {
+          /*
+           * popup's height - popover-title's height
+           * should be computed using bootstrap variables
+           */
+          max-height: calc(100% - 32px);
+          -webkit-overflow-scrolling: touch;
+        }
+      }
     </style>
   </head>
   <body ng-controller="MainController as ctrl">

--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -2,6 +2,7 @@ goog.provide('gmf.LayertreeController');
 goog.provide('gmf.layertreeDirective');
 
 goog.require('gmf');
+goog.require('gmf.Permalink');
 goog.require('ngeo.CreatePopup');
 goog.require('ngeo.LayerHelper');
 goog.require('ngeo.LayertreeController');
@@ -97,8 +98,10 @@ gmf.module.directive('gmfLayertree', gmf.layertreeDirective);
 /**
  * @param {angular.$http} $http Angular http service.
  * @param {angular.$sce} $sce Angular sce service.
+ * @param {!angular.Scope} $scope Angular scope.
  * @param {ngeo.CreatePopup} ngeoCreatePopup Popup service.
  * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
+ * @param {gmf.Permalink} gmfPermalink Gmf Permalink service.
  * @param {string} gmfWmsUrl URL to the wms service to use by default.
  * @constructor
  * @export
@@ -106,8 +109,8 @@ gmf.module.directive('gmfLayertree', gmf.layertreeDirective);
  * @ngdoc controller
  * @ngname gmfLayertreeController
  */
-gmf.LayertreeController = function($http, $sce, ngeoCreatePopup,
-    ngeoLayerHelper, gmfWmsUrl) {
+gmf.LayertreeController = function($http, $sce, $scope, ngeoCreatePopup,
+    ngeoLayerHelper, gmfPermalink, gmfWmsUrl) {
 
   /**
    * @private
@@ -163,14 +166,8 @@ gmf.LayertreeController = function($http, $sce, ngeoCreatePopup,
    * @private
    */
   this.dataLayerGroup_ = this.layerHelper_.getGroupFromMap(this.map,
-        gmf.LayertreeController.DATALAYERGROUP_NAME);
+        gmf.DATALAYERGROUP_NAME);
 };
-
-
-/**
- * @const
- */
-gmf.LayertreeController.DATALAYERGROUP_NAME = 'data';
 
 
 /**
@@ -285,6 +282,9 @@ gmf.LayertreeController.prototype.getLayer = function(node, opt_depth,
     var ids = this.getNodeIds_(node);
     layer.set('querySourceIds', ids);
     layer.set('layerName', node.name);
+
+    var isMerged = type === gmf.LayertreeController.TYPE_NOTMIXEDGROUP;
+    layer.set('isMerged', isMerged);
 
     this.dataLayerGroup_.getLayers().insertAt(0, layer);
 

--- a/contribs/gmf/src/gmf.js
+++ b/contribs/gmf/src/gmf.js
@@ -16,3 +16,9 @@ gmf.module = angular.module('gmf', [ngeo.module.name, 'gettext',
  * @type {string}
  */
 gmf.baseTemplateUrl = 'gmf';
+
+
+/**
+ * @const
+ */
+gmf.DATALAYERGROUP_NAME = 'data';

--- a/contribs/gmf/src/services/themesservice.js
+++ b/contribs/gmf/src/services/themesservice.js
@@ -24,7 +24,7 @@ gmf.ThemesResponse;
  * @constructor
  * @extends {ol.events.EventTarget}
  * @param {angular.$http} $http Angular http service.
- * @param {string} gmfTreeUrl URL to "themes" web service.
+ * @param {angular.$injector} $injector Main injector.
  * @param {angular.$q} $q Angular q service
  * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
@@ -32,7 +32,7 @@ gmf.ThemesResponse;
  * @ngdoc service
  * @ngname gmfThemes
  */
-gmf.Themes = function($http, gmfTreeUrl, $q, ngeoLayerHelper, gettextCatalog) {
+gmf.Themes = function($http, $injector, $q, ngeoLayerHelper, gettextCatalog) {
 
   goog.base(this);
 
@@ -49,10 +49,14 @@ gmf.Themes = function($http, gmfTreeUrl, $q, ngeoLayerHelper, gettextCatalog) {
   this.$http_ = $http;
 
   /**
-   * @type {string}
+   * @type {?string}
    * @private
    */
-  this.treeUrl_ = gmfTreeUrl;
+  this.treeUrl_ = null;
+
+  if ($injector.has('gmfTreeUrl')) {
+    this.treeUrl_ = $injector.get('gmfTreeUrl');
+  }
 
   /**
    * @type {ngeo.LayerHelper}
@@ -245,6 +249,8 @@ gmf.Themes.prototype.getThemesObject = function() {
  * @export
  */
 gmf.Themes.prototype.loadThemes = function(opt_roleId) {
+
+  goog.asserts.assert(this.treeUrl_, 'gmfTreeUrl should be defined.');
 
   var deferred = this.deferred_;
 

--- a/src/services/layerHelper.js
+++ b/src/services/layerHelper.js
@@ -186,4 +186,30 @@ ngeo.LayerHelper.prototype.getFlatLayers_ = function(layer, array) {
   return array;
 };
 
+
+/**
+ * Get a layer that has a `layerName` property equal to a given layer name from
+ * an array of layers. If one of the layers in the array is a group, then the
+ * layers contained in that group are searched as well.
+ * @param {string} layerName The name of the layer we're looking for.
+ * @param {Array.<ol.layer.Base>} layers Layers.
+ * @return {?ol.layer.Base} Layer.
+ * @export
+ */
+ngeo.LayerHelper.prototype.getLayerByName = function(layerName, layers) {
+  var found = null;
+  layers.some(function(layer) {
+    if (layer instanceof ol.layer.Group) {
+      var sublayers = layer.getLayers().getArray();
+      found = this.getLayerByName(layerName, sublayers);
+    } else if (layer.get('layerName') === layerName) {
+      found = layer;
+    }
+    return !!found;
+  }, this);
+
+  return found;
+};
+
+
 ngeo.module.service('ngeoLayerHelper', ngeo.LayerHelper);


### PR DESCRIPTION
This PR introduces the support of layers within the gmf permalink service.

Here's the things remaining to do (to my knowledge):

 * [x] Support `tree_group_layers_<group_name>` for layers that are merged
 * [x] Support `tree_enable_<layer_name>` for layers that are not merged
 * [x] Fix the issue that the tree doesn't refresh the state of the checkboxes (zooming in/out works)
 * [x] Deal with the `treeUrl` requirement, which is currently an issue
 * [x] Deal with the `data` group, which is in a constant defined in the layer tree
 * [x] Support layers like those in the 'Cadastre' theme
 * [x] Support themes with subgroups
 * [x] Remove the references to the `treeCtrl` if we end up not requiring it
 * [x] When switching theme, we should clean the groups
 * [x] Fix the layertree example - should use the gmf theme service instead of manually loading the url
 * [x] Use `$timeout` instead of `window.setTimeout` and remove the use of `$scope.$apply()`
 * [x] Code review
 * [x] Merge into one commit
 * [x] Travis build passes

**What is not covered by this PR**

This PR won't introduce the support of the `tree_groups` param.  The layer tree requires to be able to add new layers on the fly and this is not yet the case.  It is out of scope of this PR to make this possible.


**Live demo**

The following link demonstrates the loading of the `cafe` and `hotel` within the `Layers` group.

 * (currently broken) https://adube.github.io/ngeo/gmf-permalink-layers/examples/contribs/gmf/mobilequery.html?tree_group_layers_Layers=cafe%2Chotel&map_x=697900&map_y=218500&map_zoom=3

With new layertree example:

 * https://adube.github.io/ngeo/gmf-permalink-layers/examples/contribs/gmf/layertree.html