### PR TITLE
Go back to map after successful login

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -46,7 +46,7 @@
       <div class="tools" ngeo-resizemap="mainCtrl.map"
         ngeo-resizemap-state="mainCtrl.toolsActive">
         <div ngeo-btn-group class="bar btn-group-vertical" ngeo-btn-group-active="mainCtrl.toolsActive">
-          <button ngeo-btn class="btn btn-default" ng-model="loginActive"
+          <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.loginActive"
             data-toggle="tooltip" data-placement="left" data-original-title="{{'Login'|translate}}">
             <span class="fa fa-user"></span>
           </button>
@@ -60,8 +60,8 @@
           </button>
         </div>
         <div class="tools-content" ng-class="{active: mainCtrl.toolsActive}">
-          <div ng-show="loginActive">
-            <a class="btn close" ng-click="loginActive = false">&times;</a>
+          <div ng-show="mainCtrl.loginActive">
+            <a class="btn close" ng-click="mainCtrl.loginActive = false">&times;</a>
             <div class="tools-content-heading">
               Login
             </div>

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -101,6 +101,21 @@ gmf.AbstractController = function(config, $scope, $injector) {
   this.measureLengthActive = false;
 
   /**
+   * @type {gmf.User}
+   * @export
+   */
+  this.gmfUser = $injector.get('gmfUser');
+
+  // close right nave on successful login
+  $scope.$watch(function() {
+    return this.gmfUser.username;
+  }.bind(this), function(newVal) {
+    if (newVal !== null && this.navIsVisible) {
+      this.rightNavVisible = false;
+    }
+  }.bind(this));
+
+  /**
    * @type {ngeo.GetBrowserLanguage}
    */
   this.getBrowserLanguage = $injector.get('ngeoGetBrowserLanguage');

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -59,6 +59,12 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
    * @type {boolean}
    * @export
    */
+  this.loginActive = false;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
   this.toolsActive = false;
 
   // initialize tooltips
@@ -68,6 +74,15 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
 
   goog.base(
       this, config, $scope, $injector);
+
+  // close the login panel on successful login
+  $scope.$watch(function() {
+    return this.gmfUser.username;
+  }.bind(this), function(newVal) {
+    if (newVal !== null && this.loginActive) {
+      this.loginActive = false;
+    }
+  }.bind(this));
 
 };
 goog.inherits(gmf.AbstractDesktopController, gmf.AbstractController);


### PR DESCRIPTION
This PR introduces the following behaviour: in the desktop and mobile applications, when the user successfully logs in, the panels are closed to show back the map.

Fix: #780

Tasks:

 * [x] mobile app, close right nav on login success
 * [x] desktop app, close login panel on login success
 * [x] apply the patch to the `2.0` branch
 * [ ] code review
 * [x] travis build

Live demos:

 * (mobile) https://adube.github.io/ngeo/gmf-back2map-login/examples/contribs/gmf/apps/mobile/
 * (desktop) https://adube.github.io/ngeo/gmf-back2map-login/examples/contribs/gmf/apps/desktop/index.html?lang=fr