### PR TITLE
Add result label in mobile query result

### DIFF
--- a/contribs/gmf/src/directives/partials/mobiledisplayqueries.html
+++ b/contribs/gmf/src/directives/partials/mobiledisplayqueries.html
@@ -20,6 +20,7 @@
     </div>
     <div class="navigate">
       <button type="button" class="previous" ng-show="ctrl.getResultLength() - 1" ng-click="ctrl.previous()"></button>
+      <span>{{'Result' | translate}}</span>
       <span>{{ctrl.currentResult + 1}}</span>
       <span>/</span>
       <span>{{ctrl.getResultLength()}}</span>


### PR DESCRIPTION
Fixes #783 

Adds a label before the numbers in the mobile query result template.