### PR TITLE
Ensure tooltips are dismissed even after click

### DIFF
--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -63,7 +63,8 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
 
   // initialize tooltips
   $('[data-toggle="tooltip"]').tooltip({
-    container: 'body'
+    container: 'body',
+    trigger: 'hover'
   });
 
   goog.base(


### PR DESCRIPTION
The default configuration for tooltip is "hover focus". With `focus`, the tooltip may stay displayed when clicking on a button until it looses focus.
This for example happen in the desktop application when clicking on a tool button on the right side bar.