### PR TITLE
Set groupValues and groupActions in search example

### DIFF
--- a/contribs/gmf/examples/search.js
+++ b/contribs/gmf/examples/search.js
@@ -36,6 +36,8 @@ app.MainController = function(ngeoFeatureOverlayMgr, gmfThemes) {
    * @export
    */
   this.searchDatasources = [{
+    groupValues: ['osm', 'district'],
+    groupActions: [],
     labelKey: 'label',
     projection: 'EPSG:21781',
     url: 'https://geomapfish-demo.camptocamp.net/2.0/wsgi/fulltextsearch'


### PR DESCRIPTION
Don't allow to select theme search actions (add_theme, add_group or add_layer)