### PR TITLE
Allow the scales array to be refreshed

### DIFF
--- a/src/directives/scaleselector.js
+++ b/src/directives/scaleselector.js
@@ -117,12 +117,12 @@ ngeo.ScaleselectorController = function($scope, $element, $attrs) {
    */
   this.zoomLevels;
 
-  $scope.$watchCollection(goog.bind(function() {
-    return this.scales;
-  }, this), goog.bind(function(newNames) {
+  $scope.$watch(function() {
+    return Object.keys(this.scales).length;
+  }.bind(this), function(newLength) {
     this.zoomLevels = Object.keys(this.scales).map(Number);
     this.zoomLevels.sort(ol.array.numberSafeCompareFunction);
-  }, this));
+  }.bind(this));
 
   var mapExpr = $attrs['ngeoScaleselectorMap'];
 

--- a/src/directives/scaleselector.js
+++ b/src/directives/scaleselector.js
@@ -111,14 +111,18 @@ ngeo.ScaleselectorController = function($scope, $element, $attrs) {
       ($scope.$eval(scalesExpr));
   goog.asserts.assert(this.scales !== undefined);
 
-  var zoomLevels = Object.keys(this.scales).map(Number);
-  zoomLevels.sort(ol.array.numberSafeCompareFunction);
-
   /**
    * @type {Array.<number>}
    * @export
    */
-  this.zoomLevels = zoomLevels;
+  this.zoomLevels;
+
+  $scope.$watchCollection(goog.bind(function() {
+    return this.scales;
+  }, this), goog.bind(function(newNames) {
+    this.zoomLevels = Object.keys(this.scales).map(Number);
+    this.zoomLevels.sort(ol.array.numberSafeCompareFunction);
+  }, this));
 
   var mapExpr = $attrs['ngeoScaleselectorMap'];
 
@@ -243,6 +247,7 @@ ngeo.ScaleselectorController.prototype.handleResolutionChange_ = function(e) {
  */
 ngeo.ScaleselectorController.prototype.handleViewChange_ = function(e) {
   this.registerResolutionChangeListener_();
+  this.handleResolutionChange_(null);
 };
 
 


### PR DESCRIPTION
The goal of this PR is to allow to the list of scales to be refreshed.
The use case in our app is that the list of available scales is theme dependent. When a user switches the current theme, then the number of scales could vary.

My first thought was to listen on the maxzoom and minzoom property of the view and to limit the scales using these values. But none of both are observable. Therefore I've chosen this solution but I'm not sure, I've chosen the best way to achieve this. Could you please review and give advices.
