### PR TITLE
issue #845:

### DIFF
--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -3,6 +3,11 @@ gmf-layertree div {
 }
 gmf-layertree ul .treenode {
   padding-top: @app-margin;
+
+  ul ul {
+    padding-left: 20px;
+  }
+
   a {
     color: @color;
     display: inline;
@@ -32,6 +37,7 @@ gmf-layertree ul .treenode {
   .leaf .state::after {
     content: "\e603";
   }
+
   .group {
     .state::after {
       content: "\e600";
@@ -40,6 +46,7 @@ gmf-layertree ul .treenode {
       display: none;
     }
   }
+
   .layerIcon {
     display: inline-flex;
     height: @app-margin;


### PR DESCRIPTION
2 CSS rules added in layertree.less  to avoid subgroups of layers to be styled like root groups.
- padding-left added for nested ul on .treenode
- Different CSS style added for .group which are root compared to subgroups (e.g Restaurants) 

<img width="307" alt="capture d ecran 2016-03-15 a 10 14 34" src="https://cloud.githubusercontent.com/assets/8366681/13773416/66012c88-ea99-11e5-806e-05f4eb07b6ed.png">

As shown by the screenshot, Restaurants (subgroup of  layers) are not style as root group (e.g Couches) anymore. 