### PR TITLE
Add a tree manager service to manage source of layertree

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -86,7 +86,6 @@
         <div class="search">
           <gmf-search gmf-search-map="mainCtrl.map"
             gmf-search-datasources="mainCtrl.searchDatasources"
-            gmf-search-currenttheme="mainCtrl.theme"
             gmf-search-coordinatesprojections="mainCtrl.searchCoordinatesProjections"
             gmf-search-clearbutton="true">
           </gmf-search>
@@ -121,7 +120,7 @@
          module.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.0/wsgi/themes?version=2&background=background');
          module.constant('gmfSearchGroups', ['osm','district']);
          // Requires that the gmfSearchGroups is specified
-         module.constant('gmfSearchActions', ['add_theme', 'add_group']);
+         module.constant('gmfSearchActions', ['add_theme', 'add_group', 'add_layer']);
        })();
     </script>
   </body>

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -39,7 +39,6 @@
       <div class="search">
         <gmf-search gmf-search-map="mainCtrl.map"
           gmf-search-datasources="mainCtrl.searchDatasources"
-          gmf-search-currenttheme="mainCtrl.theme"
           gmf-search-clearbutton="true"
           gmf-search-coordinatesprojections="mainCtrl.searchCoordinatesProjections"
           gmf-search-listeners="::mainCtrl.searchListeners">

--- a/contribs/gmf/examples/layertree.html
+++ b/contribs/gmf/examples/layertree.html
@@ -121,17 +121,28 @@
           -webkit-overflow-scrolling: touch;
         }
       }
-
+      #desc, #selections {
+        margin-bottom: 20px;
+      }
     </style>
   </head>
   <body ng-controller="MainController as ctrl">
     <gmf-map gmf-map-map="ctrl.map"></gmf-map>
-    <div><span>Theme: <select ng-model="ctrl.treeSource" ng-options="theme.name for theme in ctrl.themes"></select></span></div>
+    <p id="desc">This example shows how to use the <code>gmf.Layertree</code> directive. This layertree needs a source object (that can change) that describes layers like the c2cgeoportal themes service. The wmsUrl is used by internals WMS layers but you can use WMS externals layers and WMTS layers too.</p>
+    <div id="selections">
+        <div>Mode:
+          Replace tree <input type="radio" ng-model="ctrl.modeFlush" ng-change="ctrl.setModeFlush()" value="flush">
+          Add tree <input type="radio" ng-model="ctrl.modeFlush" ng-change="ctrl.setModeFlush()" value="add">
+        </div>
+        <div>New Theme <select ng-model="ctrl.getSetTheme" ng-model-options="{getterSetter: true}" ng-options="theme.name for theme in ctrl.themes"><option value="">-- Choose a theme --</option></select></div>
+        <div>New Group <select ng-model="ctrl.getSetGroup" ng-model-options="{getterSetter: true}" ng-options="group.name for group in ctrl.groups"><option value="">-- Choose a group --</option></select></div>
+        <div>New Layer <select ng-model="ctrl.getSetLayers" ng-model-options="{getterSetter: true}" ng-options="layer.name for layer in ctrl.layers"> <option value="">-- Choose a layer --</option></select></div>
+        <div>Remove a tree <select ng-model="ctrl.getSetRemoveTree" ng-model-options="{getterSetter: true}" ng-options="tree.name for tree in ctrl.gmfTreeManager.tree.children"><option value="">-- Choose a tree --</option></select></div>
+    </div>
     <gmf-layertree
         gmf-layertree-source="ctrl.treeSource"
         gmf-layertree-map="::ctrl.map">
     </gmf-layertree>
-    <p id="desc">This example shows how to use the <code>gmf.Layertree</code> directive. This layertree needs a source object (that can change) that describes layers like the c2cgeoportal themes service. The wmsUrl is used by internals WMS layers but you can use WMS externals layers and WMTS layers too.</p>
     <script src="../../../node_modules/jquery/dist/jquery.js"></script>
     <script src="../../../node_modules/proj4/dist/proj4.js"></script>
     <script src="../../../node_modules/angular/angular.js"></script>

--- a/contribs/gmf/examples/layertree.js
+++ b/contribs/gmf/examples/layertree.js
@@ -18,15 +18,21 @@ var app = {};
 app.module = angular.module('app', ['gmf']);
 
 
+app.module.constant('gmfTreeUrl', 'data/themes.json');
+
+
 app.module.value('gmfWmsUrl',
     'https://geomapfish-demo.camptocamp.net/2.0/wsgi/mapserv_proxy');
 
 
 /**
  * @constructor
- * @param {angular.$http} $http Angular's $http service.
+ * @param {gmf.Themes} gmfThemes The gme themes service.
+ * @param {gmf.TreeManager} gmfTreeManager gmf Tree Manager service.
  */
-app.MainController = function($http) {
+app.MainController = function(gmfThemes, gmfTreeManager) {
+
+  gmfThemes.loadThemes();
 
   var projection = ol.proj.get('EPSG:21781');
   projection.setExtent([485869.5728, 76443.1884, 837076.5648, 299941.7864]);
@@ -50,10 +56,28 @@ app.MainController = function($http) {
   });
 
   /**
-   * @type {Array.<Object>|undefined}
-   * export
+   * @type {gmf.TreeManager}
+   * @export
    */
-  this.themes = undefined;
+  this.gmfTreeManager = gmfTreeManager;
+
+  /**
+   * @type {Array.<GmfThemesNode>}
+   * @export
+   */
+  this.themes = [];
+
+  /**
+   * @type {Array.<GmfThemesNode>}
+   * @export
+   */
+  this.groups = [];
+
+  /**
+   * @type {Array.<GmfThemesNode>}
+   * @export
+   */
+  this.layers = [];
 
   /**
    * @type {Object|undefined}
@@ -61,13 +85,119 @@ app.MainController = function($http) {
    */
   this.treeSource = undefined;
 
-  $http.get('data/themes.json').success(function(data) {
-    var themes = data['themes'];
+  /**
+   * @type {string}
+   * @export
+   */
+  this.modeFlush = 'flush';
+
+  /**
+   * @type {function()}
+   * @export
+   */
+  this.setModeFlush = function() {
+    var isModeFlush = this.modeFlush == 'flush' ? true : false;
+    this.gmfTreeManager.setModeFlush(isModeFlush);
+  }
+
+  /**
+   * @param {GmfThemesNode|undefined} value A theme or undefined to get Themes.
+   * @return {Array.<GmfThemesNode>} All themes.
+   * @export
+   */
+  this.getSetTheme = function(value) {
+    if (value !== undefined) {
+      this.gmfTreeManager.addTheme(value);
+    }
+    return this.themes;
+  }
+
+  /**
+   * @param {GmfThemesNode|undefined} value A group or undefined to get groups.
+   * @return {Array.<GmfThemesNode>} All groups in all themes.
+   * @export
+   */
+  this.getSetGroup = function(value) {
+    if (value !== undefined) {
+      this.gmfTreeManager.addGroups([value]);
+    }
+    return this.groups;
+  }
+
+  /**
+   * @param {GmfThemesNode|undefined} value A group or undefined to get groups.
+   * @return {Array.<GmfThemesNode>} All groups in all themes.
+   * @export
+   */
+  this.getSetLayers = function(value) {
+    if (value !== undefined) {
+      this.gmfTreeManager.addGroupByLayerName(value.name);
+    }
+    return this.layers;
+  }
+
+  /**
+   * @param {GmfThemesNode|undefined} value A Theme or group node, or undefined
+   *     to get the groups of the tree manager.
+   * @return {Array.<GmfThemesNode>} All groups in the tree manager.
+   * @export
+   */
+  this.getSetRemoveTree = function(value) {
+    if (value !== undefined) {
+      this.gmfTreeManager.removeGroup(value);
+    }
+    return this.gmfTreeManager.tree.children;
+  }
+
+  gmfThemes.getThemesObject().then(function(themes) {
     if (themes) {
       this.themes = themes;
-      this.treeSource = themes[3];
+
+      // Get an array with all nodes entities existing in "themes".
+      var flatNodes = [];
+      this.themes.forEach(function(theme) {
+        theme.children.forEach(function(group) {
+          this.groups.push(group); // get a list of all groups
+          this.getDistinctFlatNodes_(group, flatNodes);
+        }.bind(this));
+      }.bind(this));
+      flatNodes.forEach(function(node) {
+        // Get an array of all layers
+        if (node.children === undefined) {
+          this.layers.push(node);
+        }
+      }.bind(this));
+
+      //set arbitrarily a default theme
+      this.gmfTreeManager.addTheme(themes[0]);
+      this.treeSource = this.gmfTreeManager.tree;
     }
   }.bind(this));
+
+  /**
+   * Just for this example
+   * @param {GmfThemesNode} node A theme, group or layer node.
+   * @param {Array.<GmfThemesNode>} nodes An Array of nodes.
+   * @export
+   */
+  this.getDistinctFlatNodes_ = function(node, nodes) {
+    var i;
+    var children = node.children;
+    if (children !== undefined) {
+      for (i = 0; i < children.length; i++) {
+        this.getDistinctFlatNodes_(children[i], nodes);
+      }
+    }
+    var alreadyAdded = false;
+    nodes.some(function(n) {
+      if (n.id === node.id) {
+        return alreadyAdded = true;
+      }
+    });
+    if (!alreadyAdded) {
+      nodes.push(node);
+    }
+  }
 };
 
 app.module.controller('MainController', app.MainController);

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -4,6 +4,8 @@ goog.require('gmf');
 /** @suppress {extraRequire} */
 goog.require('gmf.QueryManager');
 /** @suppress {extraRequire} */
+goog.require('gmf.TreeManager');
+/** @suppress {extraRequire} */
 goog.require('gmf.Themes');
 /** @suppress {extraRequire} */
 goog.require('gmf.layertreeDirective');
@@ -38,12 +40,13 @@ gmf.AbstractController = function(config, $scope, $injector) {
 
   goog.asserts.assertInstanceof(this.map, ol.Map);
 
+  var gmfTreeManager = $injector.get('gmfTreeManager');
   /**
    * A reference to the current theme
-   * @type {Object}
+   * @type {GmfThemesNode}
    * @export
    */
-  this.theme;
+  this.theme = gmfTreeManager.tree;
 
   /**
    * Themes service

--- a/contribs/gmf/src/directives/partials/themeselector.html
+++ b/contribs/gmf/src/directives/partials/themeselector.html
@@ -1,7 +1,7 @@
 <ul class="gmf-theme-selector">
   <li
       ng-repeat="theme in tsCtrl.themes"
-      ng-click="tsCtrl.switchTheme(theme)">
+      ng-click="tsCtrl.setTheme(theme)">
     <div class="gmf-check">
       <span class="gmf-icon"
           ng-class="{'gmf-icon-check': tsCtrl.currentTheme['name'] == theme.name}">

--- a/contribs/gmf/src/services/treemanager.js
+++ b/contribs/gmf/src/services/treemanager.js
@@ -1,0 +1,193 @@
+goog.provide('gmf.TreeManager');
+
+goog.require('gmf');
+goog.require('gmf.Themes');
+
+/**
+ * Manage a tree with children. This service can be used in mode 'flush' or
+ * not (mode 'add'). In mode 'flush', each theme, group or group by layer that
+ * you add will replace the previous children's array. In mode 'add', children
+ * will be just pushed in this array.
+ * This service's theme is a GmfThemesNode with only children and a name.
+ * Thought to be the tree source of the gmf layertree directive.
+ * @constructor
+ * @param {gmf.Themes} gmfThemes gmf Themes service.
+ * @ngInject
+ * @ngdoc service
+ * @ngname gmfTreeManager
+ */
+gmf.TreeManager = function(gmfThemes) {
+
+  /**
+   * @type {gmf.Themes}
+   * @private
+   */
+  this.gmfThemes_ = gmfThemes;
+
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.modeFlush_ = true;
+
+  /**
+   * @type {GmfThemesNode}
+   * @export
+   */
+  this.tree = /** @type {GmfThemesNode} */ ({
+    children: [],
+    name: ''
+  });
+};
+
+
+/**
+ * Return the current 'mode' of this service.
+ * @return {boolean} True if the service is in 'flush' mode. False otherwise.
+ * @export
+ */
+gmf.TreeManager.prototype.isModeFlush = function() {
+  return this.modeFlush_
+};
+
+
+/**
+ * Set the 'mode' of this service. In mode 'flush', you'll replace previous
+ * tree's children with groups that you add. In mode 'add', you'll add them to
+ * the array.
+ * @param{boolean} value True to use the 'flush' mode. false to use the 'add'
+ *     one.
+ * @export
+ */
+gmf.TreeManager.prototype.setModeFlush = function(value) {
+  this.modeFlush_ = value;
+  this.tree.name = '';
+};
+
+
+/**
+ * Set the current theme name (mode 'flush' only) and add its children. Add
+ * only groups that are not already in the tree.
+ * @param{GmfThemesNode} theme A theme object.
+ * @export
+ */
+gmf.TreeManager.prototype.addTheme = function(theme) {
+  if (this.isModeFlush()) {
+    this.tree.name = theme.name;
+  }
+  this.addGroups(theme.children);
+};
+
+
+/**
+ * Add some groups as tree's children. If the service use mode 'flush', the
+ * previous tree's children will be removed. Add only groups that are not
+ * already in the tree.
+ * @param{Array.<GmfThemesNode>} groups An array of gmf theme nodes.
+ * @param{boolean=} opt_add if true, force to use the 'add' mode this time.
+ * @export
+ */
+gmf.TreeManager.prototype.addGroups = function(groups, opt_add) {
+  if (this.isModeFlush() && opt_add !== true) {
+    this.tree.children.length = 0;
+  }
+  groups.forEach(function(group) {
+    this.addGroup_(group);
+  }.bind(this));
+};
+
+
+/**
+ * Add a group as tree's children without consideration of this service 'mode'.
+ * Add it only if it's not already in the tree.
+ * @param{GmfThemesNode} group The group to add.
+ * @private
+ */
+gmf.TreeManager.prototype.addGroup_ = function(group) {
+  var children = this.tree.children;
+  var alreadyAdded = false;
+  children.some(function(child) {
+    if (group.id === child.id) {
+      // FIXME: display "this group is already loaded"
+      return alreadyAdded = true;
+    }
+  });
+  if (!alreadyAdded) {
+    children.push(group);
+  }
+};
+
+
+/**
+ * Retrieve a theme (first found) by its name and add in the tree. Do nothing
+ * if any corresponding theme is found.
+ * @param{string} themeName Name of the theme to add.
+ * @export
+ */
+gmf.TreeManager.prototype.addThemeByName = function(themeName) {
+  this.gmfThemes_.getThemesObject().then(function(themes) {
+    var theme = gmf.Themes.findThemeByName(themes, themeName);
+    if (theme) {
+      this.addTheme(theme);
+    }
+  }.bind(this));
+};
+
+
+/**
+ * Retrieve a group (first found) by its name and add in the tree. Do nothing
+ * if any corresponding group is found.
+ * @param{string} groupName Name of the group to add.
+ * @param{boolean=} opt_add if true, force to use the 'add' mode this time.
+ * @export
+ */
+gmf.TreeManager.prototype.addGroupByName = function(groupName, opt_add) {
+  this.gmfThemes_.getThemesObject().then(function(themes) {
+    var group = gmf.Themes.findGroupByName(themes, groupName);
+    if (group) {
+      this.addGroups([group], opt_add);
+    }
+  }.bind(this));
+};
+
+
+/**
+ * Retrieve a group by the name of a layer that is contained in this group
+ * (first found). This group will be added in the tree. Do nothing if any
+ * corresponding group is found.
+ * @param{string} layerName Name of the layer inside the group to add.
+ * @param{boolean=} opt_add if true, force to use the 'add' mode this time.
+ * @export
+ */
+gmf.TreeManager.prototype.addGroupByLayerName = function(layerName, opt_add) {
+  this.gmfThemes_.getThemesObject().then(function(themes) {
+    var group = gmf.Themes.findGroupByLayerName(themes, layerName);
+    if (group) {
+      this.addGroups([group], opt_add);
+      // FIXME: set the layer visible
+    }
+  }.bind(this));
+};
+
+
+/**
+ * Remove a group from this tree's children. The first group that is found (
+ * based on its name) will be removed. If any is found, nothing will append.
+ * @param{GmfThemesNode} group The group to remove.
+ * @export
+ */
+gmf.TreeManager.prototype.removeGroup = function(group) {
+  var children = this.tree.children;
+  var index = 0, found = false;
+  children.some(function(child) {
+    if (child.name === group.name) {
+      return found = true;
+    }
+    index++;
+  }.bind(this));
+  if (found) {
+    children.splice(index, 1);
+  }
+};
+
+gmf.module.service('gmfTreeManager', gmf.TreeManager);

--- a/contribs/gmf/test/spec/services/treemanager.spec.js
+++ b/contribs/gmf/test/spec/services/treemanager.spec.js
@@ -1,0 +1,112 @@
+goog.require('gmf.TreeManager');
+goog.require('gmf.test.data.themes');
+
+describe('gmf.TreeManager', function() {
+  var gmfTreeManager;
+  var gmfThemes;
+  var treeUrl;
+
+  beforeEach(function() {
+    inject(function($injector) {
+      gmfTreeManager = $injector.get('gmfTreeManager');
+      gmfThemes = $injector.get('gmfThemes');
+      treeUrl = $injector.get('gmfTreeUrl');
+      $httpBackend = $injector.get('$httpBackend');
+      $httpBackend.when('GET', treeUrl).respond(themes);
+      gmfTreeManager.setModeFlush(true);
+    });
+  });
+
+  it('Is mode flush', function() {
+    expect(gmfTreeManager.isModeFlush()).toBe(true);
+  });
+
+  it('Set mode flush', function() {
+    expect(gmfTreeManager.isModeFlush()).toBe(true);
+    gmfTreeManager.setModeFlush(false);
+    expect(gmfTreeManager.isModeFlush()).toBe(false);
+  });
+
+  it('Add some groups', function() {
+    var group0 = themes.themes[0].children[0];
+    var group1 = themes.themes[1].children[0];
+    // Add a group
+    gmfTreeManager.addGroups([group0]);
+    expect(gmfTreeManager.tree.children[0]).toEqual(group0);
+    // Add the same group, It won't be added.
+    gmfTreeManager.addGroups([group0]);
+    expect(gmfTreeManager.tree.children.length).toBe(1);
+    // Add another group, mode flush. It will replace the previous one.
+    gmfTreeManager.addGroups([group1]);
+    expect(gmfTreeManager.tree.children[0]).toEqual(group1);
+    expect(gmfTreeManager.tree.children.length).toBe(1);
+    // Add another group, mode add. It will be added in children array.
+    gmfTreeManager.setModeFlush(false);
+    gmfTreeManager.addGroups([group0]);
+    expect(gmfTreeManager.tree.children[1]).toEqual(group0);
+  });
+
+  it('Add a theme', function() {
+    var theme0 = themes.themes[0];
+    gmfTreeManager.addTheme(theme0);
+    expect(gmfTreeManager.tree.children).toEqual(theme0.children);
+    expect(gmfTreeManager.tree.name).toEqual(theme0.name);
+  });
+
+  it('Add a theme by name', function() {
+    var spy = jasmine.createSpy();
+    var theme0 = themes.themes[0];
+    gmfTreeManager.addThemeByName(theme0.name);
+
+    gmfThemes.getThemesObject().then(spy);
+    $httpBackend.expectGET(treeUrl);
+    gmfThemes.loadThemes();
+    $httpBackend.flush();
+
+    expect(spy.calls.count()).toBe(1);
+    expect(gmfTreeManager.tree.children).toEqual(theme0.children);
+    expect(gmfTreeManager.tree.name).toEqual(theme0.name);
+  });
+
+  it('Add a group by name', function() {
+    var spy = jasmine.createSpy();
+    var group0 = themes.themes[0].children[0];
+    var group1 = themes.themes[1].children[0];
+    gmfTreeManager.addGroupByName(group0.name);
+    gmfTreeManager.addGroupByName(group1.name, true);
+
+    gmfThemes.getThemesObject().then(spy);
+    $httpBackend.expectGET(treeUrl);
+    gmfThemes.loadThemes();
+    $httpBackend.flush();
+
+    expect(spy.calls.count()).toBe(1);
+    expect(gmfTreeManager.tree.children[0]).toEqual(group0);
+    expect(gmfTreeManager.tree.children[1]).toEqual(group1);
+  });
+
+  it('Add a group by layer name', function() {
+    var spy = jasmine.createSpy();
+    var group0 = themes.themes[0].children[0];
+    var group1 = themes.themes[1].children[0];
+    gmfTreeManager.addGroupByLayerName(group0.children[0].name);
+    gmfTreeManager.addGroupByLayerName(group1.children[0].name, true);
+
+    gmfThemes.getThemesObject().then(spy);
+    $httpBackend.expectGET(treeUrl);
+    gmfThemes.loadThemes();
+    $httpBackend.flush();
+
+    expect(spy.calls.count()).toBe(1);
+    expect(gmfTreeManager.tree.children[0]).toEqual(group0);
+    expect(gmfTreeManager.tree.children[1]).toEqual(group1);
+  });
+
+  it('Remove a group', function() {
+    var group0 = themes.themes[0].children[0];
+    var group1 = themes.themes[1].children[0];
+    gmfTreeManager.addGroups([group0, group1]);
+    gmfTreeManager.removeGroup(group0);
+    expect(gmfTreeManager.tree.children[0]).toEqual(group1);
+  });
+});


### PR DESCRIPTION
To add, replace or remove theme, group or group by layername.

Fix: https://github.com/camptocamp/ngeo/issues/779
Needed by: https://github.com/camptocamp/c2cgeoportal/issues/1710
Needed by: https://github.com/camptocamp/c2cgeoportal/issues/1657
Specs: https://github.com/camptocamp/c2cgeoportal/wiki/Spec-%231710-Theme-selector-(add)

Example: http://ger-benjamin.github.io/ngeo/add_theme_example/examples/contribs/gmf/layertree.html

Desktop example (try to search a group, a theme or a layer) (add theme mode: flush): http://ger-benjamin.github.io/ngeo/add_theme_example/examples/contribs/gmf/apps/desktop

Todo:
 * ~~Use treeManager (and "its tree") in each example with layertree (insteade of use directly the Theme as source)~~
 * ~~The gmf search should use the tree services to add and remove layers, groups, themes~~
 * ~~Add unit tests for the new services~~
 * ~~Add descriptions on methodes~~

Issues (can be resolved in others PR) : 
 * (New, mobile) Select a theme in the theme selector, menu didn't go back to "data" panel (to previous panel).
 * (Related) https://github.com/camptocamp/ngeo/issues/883