### PR TITLE
fix gmf layertree example (add missing require)

### DIFF
--- a/contribs/gmf/examples/layertree.js
+++ b/contribs/gmf/examples/layertree.js
@@ -1,5 +1,9 @@
 goog.provide('gmf-layertree');
 
+/** @suppress {extraRequire} */
+goog.require('gmf.Themes');
+/** @suppress {extraRequire} */
+goog.require('gmf.TreeManager');
 goog.require('gmf.layertreeDirective');
 goog.require('gmf.mapDirective');
 goog.require('ngeo.proj.EPSG21781');


### PR DESCRIPTION
This PR adds the missing require statements, which fixes the layer tree example in gmf.