### PR TITLE
Fix the themeselector example

### DIFF
--- a/contribs/gmf/examples/themeselector.html
+++ b/contribs/gmf/examples/themeselector.html
@@ -51,7 +51,6 @@
     <div class="container">
       <gmf-themeselector
               gmf-themeselector-defaulttheme="OSM"
-              gmf-themeselector-currenttheme="ctrl.theme"
               gmf-themeselector-filter="::ctrl.filter">
       </gmf-themeselector>
       <div> The theme selected is {{ctrl.theme['name']}}</div>

--- a/contribs/gmf/examples/themeselector.js
+++ b/contribs/gmf/examples/themeselector.js
@@ -1,6 +1,9 @@
 goog.provide('gmf-themeselector');
 
+/** @suppress {extraRequire} */
 goog.require('gmf.Themes');
+/** @suppress {extraRequire} */
+goog.require('gmf.TreeManager');
 goog.require('gmf.themeselectorDirective');
 
 
@@ -18,12 +21,13 @@ app.module.constant('gmfTreeUrl', 'data/themes.json');
  * @constructor
  * @param {angular.$http} $http Angular's $http service.
  * @param {gmf.Themes} gmfThemes Themes service.
+ * @param {gmf.TreeManager} gmfTreeManager gmf Tree Manager service.
  * @ngInject
  */
-app.MainController = function($http, gmfThemes) {
+app.MainController = function($http, gmfThemes, gmfTreeManager) {
 
   /**
-   * @param {Object} theme Theme.
+   * @param {GmfThemesNode} theme Theme.
    * @return {boolean} Theme is 'Enseignement'
    * @export
    */
@@ -32,10 +36,10 @@ app.MainController = function($http, gmfThemes) {
   };
 
   /**
-   * @type {Object|undefined}
+   * @type {GmfThemesNode}
    * @export
    */
-  this.theme = undefined;
+  this.theme = gmfTreeManager.tree;
 
   gmfThemes.loadThemes();
 };

--- a/contribs/gmf/src/directives/themeselector.js
+++ b/contribs/gmf/src/directives/themeselector.js
@@ -8,19 +8,18 @@ goog.require('ngeo.Location');
 
 
 /**
+ * Note that this directive works with the gmf TreeManager service. Set the
+ * theme will update the "tree" object of this TreeManager service.
  * Example:
  *
  *     <gmf-themeselector
  *         id="themes"
  *         class="slide"
  *         data-header-title="Themes"
- *         gmf-themeselector-currenttheme="mainCtrl.theme"
  *         gmf-themeselector-filter="::mainCtrl.filter">
  *     </gmf-themeselector>
  *
  * @htmlAttribute {string} gmf-themeselector-defaulttheme The default theme.
- * @htmlAttribute {GmfThemesNode} gmf-themeselector-currenttheme The selected
- *     theme.
  * @htmlAttribute {Function} gmf-themeselector-filter The themes filter.
  * @return {angular.Directive} The directive specs.
  * @ngInject
@@ -33,7 +32,6 @@ gmf.themeselectorDirective = function() {
     controller: 'gmfThemeselectorController',
     scope: {
       'defaultTheme': '@gmfThemeselectorDefaulttheme',
-      'currentTheme': '=gmfThemeselectorCurrenttheme',
       'filter': '=gmfThemeselectorFilter'
     },
     bindToController: true,
@@ -87,7 +85,7 @@ gmf.ThemeselectorController = function($scope, ngeoLocation, gmfTreeManager,
    * @type {Object}
    * @export
    */
-  this.currentTheme;
+  this.currentTheme = this.gmfTreeManager_.tree;
 
   /**
    * @type {string}


### PR DESCRIPTION
And remove a now useless directive attribute

Change usefull after this change: https://github.com/camptocamp/ngeo/commit/b5585de3a80e5c77bd00c501428b33a83ae72151#diff-9040305a49e3edd158509e27caa44d42R191 

Example: https://ger-benjamin.github.io/ngeo/fix_themeselector_example/examples/contribs/gmf/themeselector.html/