### PR TITLE
Gmf permalink added layers

### DIFF
--- a/contribs/gmf/examples/layertree.html
+++ b/contribs/gmf/examples/layertree.html
@@ -124,6 +124,15 @@
       #desc, #selections {
         margin-bottom: 20px;
       }
+      .treenode a.expand-node.fa {
+        display: inline-block;
+      }
+      .treenode a.expand-node.fa::before {
+          content: "\f054";
+      }
+      .treenode a.expand-node.fa[aria-expanded="true"]::before {
+          content: "\f078";
+      }
     </style>
   </head>
   <body ng-controller="MainController as ctrl">

--- a/contribs/gmf/examples/layertree.js
+++ b/contribs/gmf/examples/layertree.js
@@ -93,7 +93,7 @@ app.MainController = function(gmfThemes, gmfTreeManager) {
    * @type {string}
    * @export
    */
-  this.modeFlush = 'flush';
+  this.modeFlush = 'add';
 
   /**
    * @type {function()}
@@ -103,6 +103,8 @@ app.MainController = function(gmfThemes, gmfTreeManager) {
     var isModeFlush = this.modeFlush == 'flush' ? true : false;
     this.gmfTreeManager.setModeFlush(isModeFlush);
   }
+
+  this.setModeFlush();
 
   /**
    * @param {GmfThemesNode|undefined} value A theme or undefined to get Themes.

--- a/contribs/gmf/externs/gmf-themes.js
+++ b/contribs/gmf/externs/gmf-themes.js
@@ -82,3 +82,21 @@ GmfThemesNode.prototype.url;
  * @type {string|undefined}
  */
 GmfThemesNode.prototype.wmsUrl;
+
+
+/**
+ * @constructor
+ */
+var GmfThemesNodeCustom = function() {};
+
+
+/**
+ * @type {Array.<string>}
+ */
+GmfThemesNodeCustom.prototype.layers;
+
+
+/**
+ * @type {GmfThemesNode}
+ */
+GmfThemesNodeCustom.prototype.node;

--- a/contribs/gmf/src/services/themesservice.js
+++ b/contribs/gmf/src/services/themesservice.js
@@ -153,6 +153,30 @@ gmf.Themes.findThemeByName = function(themes, themeName) {
 
 
 /**
+ * Return a "type" that defines the node.
+ * @param {GmfThemesNode} node Layer tree node.
+ * @return {string} A type.
+ */
+gmf.Themes.getNodeType = function(node) {
+  var children = node.children;
+  var mixed = node.mixed;
+  if (node.children !== undefined && mixed) {
+    return gmf.Themes.NodeType.MIXED_GROUP;
+  }
+  if (children !== undefined && !mixed) {
+    return gmf.Themes.NodeType.NOT_MIXED_GROUP;
+  }
+  if (node.type === 'WMTS') {
+    return gmf.Themes.NodeType.WMTS;
+  }
+  if (goog.isDefAndNotNull(node.url)) {
+    return gmf.Themes.NodeType.EXTERNAL_WMS;
+  }
+  return gmf.Themes.NodeType.WMS;
+};
+
+
+/**
  * Get background layers.
  * @return {angular.$q.Promise} Promise.
  */
@@ -267,3 +291,15 @@ gmf.Themes.prototype.loadThemes = function(opt_roleId) {
 
 
 gmf.module.service('gmfThemes', gmf.Themes);
+
+
+/**
+ * @enum {string}
+ */
+gmf.Themes.NodeType = {
+  EXTERNAL_WMS: 'externalWMS',
+  MIXED_GROUP: 'MixedGroup',
+  NOT_MIXED_GROUP: 'NotMixedGroup',
+  WMTS: 'WMTS',
+  WMS: 'WMS'
+};


### PR DESCRIPTION
This PR introduces the support of layers that are not in the existing loaded theme inside the permalink. What the permalink does is this:

 * when a layer is added, it gets added in the state manager / url as well
 * upon loading the application, layers that are defined in the state manager are added using the gmf tree manager

To do:

 * [x] `getNodeType` in gmf.Themes (static method)
 * [x] review the code
 * [x] travis pass

Live example:

 * http://adube.github.io/ngeo/gmf-permalink-added-layers/examples/contribs/gmf/layertree.html