### PR TITLE
Remove duplicated translate keys

### DIFF
--- a/contribs/gmf/src/directives/partials/authentication.html
+++ b/contribs/gmf/src/directives/partials/authentication.html
@@ -153,7 +153,7 @@
         <span aria-hidden="true">&times;</span>
       </button>
       <h4 class="modal-title">
-        {{'Password Forgotten?' | translate}}
+        {{'Password forgotten?' | translate}}
       </h4>
     </div>
     <div class="modal-body">


### PR DESCRIPTION
We had `Password forgotten?` and `Password Forgotten?`
