### PR TITLE
[WIP] - Manage search feature style

### DIFF
--- a/contribs/gmf/examples/search.html
+++ b/contribs/gmf/examples/search.html
@@ -105,6 +105,7 @@
       <p>Search for « Laus » for example…<p>
       <gmf-search
         gmf-search-map="ctrl.map"
+        gmf-search-styles="ctrl.searchStyles"
         gmf-search-datasources="ctrl.searchDatasources"
         gmf-search-clearbutton="true">
       </gmf-search>

--- a/contribs/gmf/examples/search.js
+++ b/contribs/gmf/examples/search.js
@@ -7,6 +7,11 @@ goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Tile');
 goog.require('ol.source.OSM');
+goog.require('ol.style.Circle');
+goog.require('ol.style.Fill');
+goog.require('ol.style.RegularShape');
+goog.require('ol.style.Stroke');
+goog.require('ol.style.Style');
 
 
 /** @const **/
@@ -39,6 +44,21 @@ app.MainController = function(gmfThemes) {
     projection: 'EPSG:21781',
     url: 'https://geomapfish-demo.camptocamp.net/2.0/wsgi/fulltextsearch'
   }];
+
+  var fill = new ol.style.Fill({color: [255, 255, 255, 0.6]});
+  var stroke = new ol.style.Stroke({color: [255, 0, 0, 1], width: 2});
+  /**
+   * @type {Object.<string, ol.style.Style>} Map of styles for search overlay.
+   * @export
+   */
+  this.searchStyles = {
+    'osm': new ol.style.Style({
+      fill: fill,
+      image: new ol.style.Circle({fill: fill, radius: 5, stroke: stroke}),
+      stroke: stroke
+    })
+  };
+
 
   /**
    * @type {ol.Map}

--- a/contribs/gmf/src/controllers/abstractmobile.js
+++ b/contribs/gmf/src/controllers/abstractmobile.js
@@ -67,6 +67,18 @@ gmf.AbstractMobileController = function(config, $scope, $injector) {
    */
   this.searchOverlayVisible = false;
 
+  /**
+   * @type {ngeox.SearchDirectiveListeners}
+   * @export
+   */
+  this.searchListeners = /** @type {ngeox.SearchDirectiveListeners} */ ({
+    open: function() {
+      this.searchOverlayVisible = true;
+    }.bind(this),
+    close: function() {
+      this.searchOverlayVisible = false;
+    }.bind(this)
+  });
 
   var positionFeatureStyle = config.positionFeatureStyle || new ol.style.Style({
     image: new ol.style.Circle({
@@ -134,19 +146,6 @@ gmf.AbstractMobileController = function(config, $scope, $injector) {
     event.stopPropagation();
     alert('Geo-location failed');
   }.bind(this));
-
-  /**
-   * @type {ngeox.SearchDirectiveListeners}
-   * @export
-   */
-  this.searchListeners = /** @type {ngeox.SearchDirectiveListeners} */ ({
-    open: function() {
-      this.searchOverlayVisible = true;
-    }.bind(this),
-    close: function() {
-      this.searchOverlayVisible = false;
-    }.bind(this)
-  });
 
   goog.base(
       this, config, $scope, $injector);

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -199,6 +199,12 @@ gmf.SearchController = function($scope, $compile, $timeout, gettextCatalog,
   this.ngeoCreateGeoJSONBloodhound_ = ngeoCreateGeoJSONBloodhound;
 
   /**
+   * @type {ngeo.FeatureOverlayMgr}
+   * @private
+   */
+  this.ngeoFeatureOverlayMgr = ngeoFeatureOverlayMgr;
+
+  /**
    * @type {ngeo.AutoProjection}
    * @private
    */
@@ -579,6 +585,15 @@ gmf.SearchController.prototype.getSearchStyle_ = function(feature, resolution) {
       this.styles_[feature.get('layer_name')] || this.styles_['default'];
 };
 
+/**
+ * Set a new color for the search feature style.
+ * @param {string} color The color to set.
+ * @export
+ */
+gmf.SearchController.prototype.setStyleColor = function(color) {
+  this.styles_['default'].getStroke().setColor(color);
+  this.ngeoFeatureOverlayMgr.getLayer().changed();
+};
 
 /**
  * @private

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -110,7 +110,7 @@ gmf.searchDirective = function(gmfSearchTemplateUrl) {
     scope: {
       'getMapFn': '&gmfSearchMap',
       'getDatasourcesFn': '&gmfSearchDatasources',
-      'featuresStyles': '=?gmfSearchStyles',
+      'featuresStyles': '<?gmfSearchStyles',
       'clearbutton': '=gmfSearchClearbutton',
       'coordinatesProjections': '=?gmfSearchCoordinatesprojections',
       'additionalListeners': '=gmfSearchListeners'
@@ -214,6 +214,12 @@ gmf.SearchController = function($scope, $compile, $timeout, gettextCatalog,
   this.map_ = map;
 
   /**
+   * @type {Object}
+   * @private
+   */
+  this.styles_ = {};
+
+  /**
    * Whether or not to show a button to clear the search text.
    * Default to false.
    * @type {boolean}
@@ -235,6 +241,7 @@ gmf.SearchController = function($scope, $compile, $timeout, gettextCatalog,
   this.coordinatesProjections_ = coordProj;
 
   ngeoFeatureOverlayMgr.init(this.map_);
+  this.initStyles_();
 
   /**
    * @type {ngeo.FeatureOverlay}
@@ -533,15 +540,14 @@ gmf.SearchController.prototype.createSearchCoordinates_ = function(view) {
 
 
 /**
- * Style for search results.
- * @param {null|ol.Feature|ol.render.Feature} feature The searched feature.
- * @param {number} resolution The current resolution of the map.
- * @return {ol.style.Style} A style for this kind of features.
+ * Init the style object for the search results. It set defaults for the
+ * coordinates and the polygon styles, and both can be overloaded from directive
+ * attributes. The styles from directive attributes can specify custom styles
+ * for each search group.
  * @private
  */
-gmf.SearchController.prototype.getSearchStyle_ = function(feature, resolution) {
-  var styles = {};
-  styles[gmf.COORDINATES_LAYER_NAME] = new ol.style.Style({
+gmf.SearchController.prototype.initStyles_ = function() {
+  this.styles_[gmf.COORDINATES_LAYER_NAME] = new ol.style.Style({
     image: new ol.style.RegularShape({
       stroke: new ol.style.Stroke({color: [0, 0, 0, 0.7], width: 2}),
       points: 4,
@@ -552,19 +558,25 @@ gmf.SearchController.prototype.getSearchStyle_ = function(feature, resolution) {
   });
   var fill = new ol.style.Fill({color: [255, 255, 255, 0.6]});
   var stroke = new ol.style.Stroke({color: [60, 150, 200, 1], width: 2});
-  styles['default'] = new ol.style.Style({
+  this.styles_['default'] = new ol.style.Style({
     fill: fill,
     stroke: stroke,
     image: new ol.style.Circle({radius: 5, fill: fill, stroke: stroke})
   });
   var customStyles = this.scope_['featuresStyles'] || {};
-  goog.object.extend(styles, customStyles);
-  var defaultStyle = styles['default'];
-  if (feature === null) {
-    return defaultStyle;
-  }
-  var kind = feature.get('layer_name');
-  return styles[kind] || defaultStyle;
+  goog.object.extend(this.styles_, customStyles);
+};
+
+/**
+ * Style for search results.
+ * @param {null|ol.Feature|ol.render.Feature} feature The searched feature.
+ * @param {number} resolution The current resolution of the map.
+ * @return {ol.style.Style} A style for this kind of features.
+ * @private
+ */
+gmf.SearchController.prototype.getSearchStyle_ = function(feature, resolution) {
+  return feature && feature.get('layer_name') &&
+      this.styles_[feature.get('layer_name')] || this.styles_['default'];
 };
 
 

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -17,6 +17,11 @@ goog.require('ol.Feature');
 goog.require('ol.Map');
 goog.require('ol.geom.Point');
 goog.require('ol.proj');
+goog.require('ol.style.Circle');
+goog.require('ol.style.Fill');
+goog.require('ol.style.RegularShape');
+goog.require('ol.style.Stroke');
+goog.require('ol.style.Style');
 
 
 gmf.module.value('gmfSearchTemplateUrl',
@@ -46,6 +51,7 @@ gmf.module.value('gmfSearchTemplateUrl',
  * Example flat results:
  *
  *      <gmf-search gmf-search-map="ctrl.map"
+ *        gmf-search-styles="ctrl.searchStyles"
  *        gmf-search-datasources="ctrl.searchDatasources"
  *        gmf-search-coordinatesprojections="ctrl.searchCoordinatesProjections"
  *        gmf-search-clearbutton="true">
@@ -62,6 +68,7 @@ gmf.module.value('gmfSearchTemplateUrl',
  * Example with categories:
  *
  *      <gmf-search gmf-search-map="ctrl.map"
+ *        gmf-search-styles="ctrl.searchStyles"
  *        gmf-search-datasources="ctrl.searchDatasources"
  *        gmf-search-coordinatesprojections="ctrl.searchCoordinatesProjections"
  *        gmf-search-clearbutton="true">
@@ -79,6 +86,12 @@ gmf.module.value('gmfSearchTemplateUrl',
  * @htmlAttribute {ol.Map} gmf-search-map The map.
  * @htmlAttribute {gmfx.SearchDirectiveDatasource} gmf-search-datasource
  *      The datasources.
+ * @htmlAttribute {Object.<string, ol.style.Style>}
+ *      gmf-search-styles A map of styles to apply on searched features. Keys
+ *      must be the 'layer_name' propertie of features except for coordinates
+ *      where the key ifor its style is the value of the constant
+ *      'gmf.COORDINATES_LAYER_NAME'. The 'default' key is used to apply the
+ *      default style.
  * @htmlAttribute {Array.<string>} gmf-search-coordinatesprojections codes
  *      of supported projections for coordinates search (projections must be
  *      defined in ol3). If not provided, only the map's view projection
@@ -97,6 +110,7 @@ gmf.searchDirective = function(gmfSearchTemplateUrl) {
     scope: {
       'getMapFn': '&gmfSearchMap',
       'getDatasourcesFn': '&gmfSearchDatasources',
+      'featuresStyles': '=?gmfSearchStyles',
       'clearbutton': '=gmfSearchClearbutton',
       'coordinatesProjections': '=?gmfSearchCoordinatesprojections',
       'additionalListeners': '=gmfSearchListeners'
@@ -227,6 +241,7 @@ gmf.SearchController = function($scope, $compile, $timeout, gettextCatalog,
    * @private
    */
   this.featureOverlay_ = ngeoFeatureOverlayMgr.getFeatureOverlay();
+  this.featureOverlay_.setStyle(this.getSearchStyle_.bind(this));
 
   var datasources = this.scope_['getDatasourcesFn']();
   goog.asserts.assertArray(datasources);
@@ -302,9 +317,8 @@ gmf.SearchController = function($scope, $compile, $timeout, gettextCatalog,
     }, this);
   }
 
+  // For searching coordinates
   this.datasets.push({
-    name: 'coordinates',
-    display: 'label',
     source: this.createSearchCoordinates_(this.map_.getView())
   });
 
@@ -319,7 +333,6 @@ gmf.SearchController = function($scope, $compile, $timeout, gettextCatalog,
       close: gmf.SearchController.close_.bind(this)
     }));
 };
-
 
 /**
  * Merges the custom listeners received via the directive attributes and the
@@ -509,10 +522,49 @@ gmf.SearchController.prototype.createSearchCoordinates_ = function(view) {
     }
     var geom = new ol.geom.Point(position);
     this.featureOverlay_.clear();
-    this.featureOverlay_.addFeature(new ol.Feature(geom));
+    this.featureOverlay_.addFeature(new ol.Feature({
+      geometry: geom,
+      'layer_name': gmf.COORDINATES_LAYER_NAME
+    }));
     view.setCenter(position);
     this.leaveSearch_();
   }.bind(this);
+};
+
+
+/**
+ * Style for search results.
+ * @param {null|ol.Feature|ol.render.Feature} feature The searched feature.
+ * @param {number} resolution The current resolution of the map.
+ * @return {ol.style.Style} A style for this kind of features.
+ * @private
+ */
+gmf.SearchController.prototype.getSearchStyle_ = function(feature, resolution) {
+  var styles = {};
+  styles[gmf.COORDINATES_LAYER_NAME] = new ol.style.Style({
+    image: new ol.style.RegularShape({
+      stroke: new ol.style.Stroke({color: [0, 0, 0, 0.7], width: 2}),
+      points: 4,
+      radius: 8,
+      radius2: 0,
+      angle: 0
+    })
+  });
+  var fill = new ol.style.Fill({color: [255, 255, 255, 0.6]});
+  var stroke = new ol.style.Stroke({color: [60, 150, 200, 1], width: 2});
+  styles['default'] = new ol.style.Style({
+    fill: fill,
+    stroke: stroke,
+    image: new ol.style.Circle({radius: 5, fill: fill, stroke: stroke})
+  });
+  var customStyles = this.scope_['featuresStyles'] || {};
+  goog.object.extend(styles, customStyles);
+  var defaultStyle = styles['default'];
+  if (feature === null) {
+    return defaultStyle;
+  }
+  var kind = feature.get('layer_name');
+  return styles[kind] || defaultStyle;
 };
 
 

--- a/contribs/gmf/src/gmf.js
+++ b/contribs/gmf/src/gmf.js
@@ -20,5 +20,12 @@ gmf.baseTemplateUrl = 'gmf';
 
 /**
  * @const
+ * @export
  */
 gmf.DATALAYERGROUP_NAME = 'data';
+
+/**
+ * @const
+ * @export
+ */
+gmf.COORDINATES_LAYER_NAME = 'gmfCoordinatesLayerName';


### PR DESCRIPTION
Rework on #922.
Fix #869 

This PR handle the style customisation of search result feature.
We can define a custom style for polygon and point (coordinates) search.
Also, user can dynamically change the feature color.

-  [x] Can pass object of styles to the directive (each key is the name of the search group or define coordinate style
- [ ] See if we remove the ability to have different styles for different group
- [x] Make style dynamic from user perspective
- [ ] Add a color picker for feature color

Work style in progress