### PR TITLE
changing the rule .treenode ul ul { padding-left:20px; } ==> .treenode ul { padding-left:20px; }

### DIFF
--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -5,7 +5,7 @@ gmf-layertree div {
 gmf-layertree ul .treenode {
   padding-top: @app-margin;
 
-  ul ul {
+  ul {
     padding-left: 20px;
   }
 


### PR DESCRIPTION

closes #845