### PR TITLE
Add gmf feature style directive

### DIFF
--- a/contribs/gmf/examples/featurestyle.html
+++ b/contribs/gmf/examples/featurestyle.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>Feature Style Example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../../../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+
+    <style>
+      gmf-map > div {
+        width: 600px;
+        height: 400px;
+      }
+      gmf-featurestyle {
+        display: block;
+        margin: 20px;
+        width: 260px;
+      }
+      gmf-featurestyle .form-horizontal .control-label {
+        text-align: left;
+      }
+      .gmf-featurestyle-name {
+        font-weight: bold;
+        font-size: 16pt;
+      }
+      .gmf-featurestyle-name:not(:focus) {
+        border: none;
+        box-shadow: none;
+        -webkit-box-shadow: none;
+        padding: 0;
+      }
+      gmf-featurestyle input[type=range] {
+        padding: 6px 12px;
+      }
+      .palette {
+        border-collapse: separate;
+        border-spacing: 0px;
+      }
+      .palette tr {
+        cursor: default;
+      }
+      .palette td {
+        position: relative;
+        padding: 0px;
+        text-align: center;
+        vertical-align: middle;
+        font-size: 1px;
+        cursor: pointer;
+      }
+      .palette td > div {
+        position: relative;
+        height: 12px;
+        width: 12px;
+        border: 1px solid #fff;
+        box-sizing: content-box;
+      }
+      .palette td:hover > div::after {
+        display: block;
+        content: '';
+        background: inherit;
+        position: absolute;
+        width: 28px;
+        height: 28px;
+        top: -10px;
+        left: -10px;
+        border: 2px solid #fff;
+        -webkit-box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
+        -webkit-box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
+        box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
+        z-index: 11;
+      }
+      .palette td.selected > div::after {
+        border: 2px solid #444;
+        margin: 0;
+        content: '';
+        display: block;
+        width: 14px;
+        height: 14px;
+        position: absolute;
+        left: -3px;
+        top: -3px;
+        box-sizing: content-box;
+        z-index: 10;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <gmf-map gmf-map-map="ctrl.map"></gmf-map>
+    <gmf-featurestyle
+      gmf-featurestyle-feature="ctrl.selectedFeature">
+    </gmf-featurestyle>
+
+    <p id="desc">
+      This example shows how to use the <code>gmf-featurestyle</code>
+      directive to style a vector feature. Click on a feature to show the
+      directive.
+    </p>
+    <script src="../../../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../../../node_modules/angular/angular.js"></script>
+    <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
+    <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="/@?main=featurestyle.js"></script>
+    <script src="default.js"></script>
+    <script src="../../../utils/watchwatchers.js"></script>
+  </body>
+</html>

--- a/contribs/gmf/examples/featurestyle.js
+++ b/contribs/gmf/examples/featurestyle.js
@@ -1,0 +1,221 @@
+goog.provide('gmf-featurestyle');
+
+goog.require('gmf.featurestyleDirective');
+goog.require('gmf.mapDirective');
+goog.require('ol.Feature');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.format.GeoJSON');
+goog.require('ol.geom.Circle');
+goog.require('ol.geom.Polygon');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['gmf']);
+
+app.module.constant('ngeoMeasureDecimals', 2);
+
+
+/**
+ * @constructor
+ * @param {!angular.Scope} $scope Angular scope.
+ * @param {ngeo.FeatureHelper} ngeoFeatureHelper Gmf feature helper service.
+ */
+app.MainController = function($scope, ngeoFeatureHelper) {
+
+  /**
+   * @type {!angular.Scope}
+   * @private
+   */
+  this.scope_ = $scope;
+
+  // create features
+  var features = new ol.format.GeoJSON().readFeatures({
+    'type': 'FeatureCollection',
+    'features': [{
+      'type': 'Feature',
+      'geometry': {
+        'type': 'Point',
+        'coordinates': [-8458215, 6672646]
+      },
+      'properties': {
+        'color': '#009D57',
+        'name': 'Point 1',
+        'size': '6'
+      }
+    }, {
+      'type': 'Feature',
+      'geometry': {
+        'type': 'Point',
+        'coordinates': [-8007848, 6209744]
+      },
+      'properties': {
+        'angle': '0',
+        'color': '#000000',
+        'isText': true,
+        'name': 'Text 1',
+        'size': '16'
+      }
+    }, {
+      'type': 'Feature',
+      'geometry': {
+        'type': 'LineString',
+        'coordinates': [
+          [-8321240, 6523441],
+          [-8103547, 6726458],
+          [-8091318, 6408480],
+          [-7973910, 6631065]
+        ]
+      },
+      'properties': {
+        'color': '#0BA9CC',
+        'name': 'LineString 1',
+        'stroke': '4'
+      }
+    }, {
+      'type': 'Feature',
+      'geometry': {
+        'type': 'Polygon',
+        'coordinates': [
+          [
+            [-8512027, 6359560],
+            [-8531595, 6080718],
+            [-8267428, 6031798],
+            [-8238077, 6247045],
+            [-8512027, 6359560]
+          ]
+        ]
+      },
+      'properties': {
+        'color': '#4186F0',
+        'name': 'Polygon 1',
+        'opacity': '0.5',
+        'showMeasure': true,
+        'stroke': '1'
+      }
+    }, {
+      'type': 'Feature',
+      'geometry': {
+        'type': 'Polygon',
+        'coordinates': [
+          [
+            [-7952508, 6096617],
+            [-8051570, 5959642],
+            [-7848554, 5926621],
+            [-7754383, 6025683],
+            [-7952508, 6096617]
+          ]
+        ]
+      },
+      'properties': {
+        'color': '#CCCCCC',
+        'name': 'Polygon 2',
+        'opacity': '1',
+        'stroke': '3'
+      }
+    }, {
+      'type': 'Feature',
+      'geometry': {
+        'type': 'Polygon',
+        'coordinates': [
+          [
+            [-7874848, 6496535],
+            [-7874848, 6384020],
+            [-7730535, 6384020],
+            [-7730535, 6496535],
+            [-7874848, 6496535]
+          ]
+        ]
+      },
+      'properties': {
+        'color': '#000000',
+        'isRectangle': true,
+        'name': 'Rectangle 1',
+        'opacity': '0.5',
+        'stroke': '2'
+      }
+    }]
+  });
+
+  features.push(new ol.Feature({
+    geometry: ol.geom.Polygon.fromCircle(
+        new ol.geom.Circle([-7691093, 6166327], 35000), 64),
+    color: '#000000',
+    isCircle: true,
+    name: 'Circle 1',
+    opacity: '0.5',
+    stroke: '2'
+  }));
+
+  var view = new ol.View({
+    center: [-8174482, 6288627],
+    zoom: 6
+  });
+
+  ngeoFeatureHelper.setProjection(view.getProjection());
+
+  // set style
+  features.forEach(function(feature) {
+    ngeoFeatureHelper.setStyle(feature);
+  }, this);
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      }),
+      new ol.layer.Vector({
+        source: new ol.source.Vector({
+          wrapX: false,
+          features: features
+        })
+      })
+    ],
+    view: view
+  });
+
+  /**
+   * @type {?ol.Feature}
+   * @export
+   */
+  this.selectedFeature = null;
+
+  this.map.on('singleclick', this.handleMapSingleClick_, this);
+};
+
+
+/**
+ * @param {ol.MapBrowserEvent} evt MapBrowser event
+ * @private
+ */
+app.MainController.prototype.handleMapSingleClick_ = function(evt) {
+  var pixel = evt.pixel;
+
+  var feature = this.map.forEachFeatureAtPixel(pixel, function(feature) {
+    return feature;
+  });
+
+  if (feature) {
+    if (this.selectedFeature !== feature) {
+      this.selectedFeature = feature;
+    }
+  } else {
+    this.selectedFeature = null;
+  }
+
+  this.scope_.$apply();
+
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/contribs/gmf/src/directives/featurestyle.js
+++ b/contribs/gmf/src/directives/featurestyle.js
@@ -1,0 +1,284 @@
+goog.provide('gmf.FeaturestyleController');
+goog.provide('gmf.featurestyleDirective');
+
+goog.require('gmf');
+goog.require('ngeo.FeatureHelper');
+/** @suppress {extraRequire} */
+goog.require('ngeo.colorpickerDirective');
+
+
+/**
+ * Directive used to set the style of a vector feature. The options depend
+ * on the type of geometry.
+ * Example:
+ *
+ *     <gmf-featurestyle
+ *         gmf-featurestyle-feature="ctrl.selectedFeature">
+ *     </gmf-featurestyle>
+ *
+ * @htmlAttribute {ol.Feature} gmf-featurestyle-feature The feature.
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname gmfFeaturestyle
+ */
+gmf.featurestyleDirective = function() {
+  return {
+    controller: 'GmfFeaturestyleController',
+    scope: {
+      'feature': '=gmfFeaturestyleFeature'
+    },
+    bindToController: true,
+    controllerAs: 'fsCtrl',
+    templateUrl: gmf.baseTemplateUrl + '/featurestyle.html'
+  };
+};
+
+gmf.module.directive('gmfFeaturestyle', gmf.featurestyleDirective);
+
+
+/**
+ * @param {!angular.Scope} $scope Angular scope.
+ * @param {ngeo.FeatureHelper} ngeoFeatureHelper Gmf feature helper service.
+ * @constructor
+ * @ngInject
+ * @ngdoc controller
+ * @ngname GmfFeaturestyleController
+ */
+gmf.FeaturestyleController = function($scope, ngeoFeatureHelper) {
+
+  /**
+   * @type {?ol.Feature}
+   * @export
+   */
+  this.feature;
+
+  /**
+   * @type {ngeo.FeatureHelper}
+   * @private
+   */
+  this.featureHelper_ = ngeoFeatureHelper;
+
+  /**
+   * @type {?string}
+   * @export
+   */
+  this.color = null;
+
+  /**
+   * @type {?string}
+   * @export
+   */
+  this.measure = null;
+
+  $scope.$watch(
+    function() {
+      return this.color;
+    }.bind(this),
+    this.handleColorSet_.bind(this)
+  );
+
+  /**
+   * @type {Array.<ol.events.Key>}
+   * @private
+   */
+  this.featureListenerKeys_ = [];
+
+  /**
+   * @type {?string}
+   * @export
+   */
+  this.type;
+
+  $scope.$watch(
+    function() {
+      return this.feature;
+    }.bind(this),
+    this.handleFeatureSet_.bind(this)
+  );
+
+};
+
+
+/**
+ * Called when a new feature is set, which can also be null.
+ * @param {?ol.Feature} newFeature New feature or null value.
+ * @param {?ol.Feature} previousFeature Previous feature or null value.
+ * @private
+ */
+gmf.FeaturestyleController.prototype.handleFeatureSet_ = function(
+    newFeature, previousFeature) {
+
+  var keys = this.featureListenerKeys_;
+
+  if (previousFeature) {
+    this.type = null;
+    this.color = null;
+    this.measure = null;
+  }
+
+  if (newFeature) {
+    [
+      ngeo.FeatureProperties.ANGLE,
+      ngeo.FeatureProperties.COLOR,
+      ngeo.FeatureProperties.NAME,
+      ngeo.FeatureProperties.OPACITY,
+      ngeo.FeatureProperties.SHOW_MEASURE,
+      ngeo.FeatureProperties.SIZE,
+      ngeo.FeatureProperties.STROKE
+    ].forEach(function(propName) {
+      keys.push(
+          ol.events.listen(
+              newFeature,
+              ol.Object.getChangeEventType(propName),
+              this.handleFeatureChange_,
+              this
+          )
+      );
+    }, this);
+
+    var geometry = newFeature.getGeometry();
+    goog.asserts.assert(geometry, 'Geometry should be thruthy');
+
+    keys.push(
+        ol.events.listen(
+            geometry,
+            'change',
+            this.handleGeometryChange_,
+            this
+        )
+    );
+
+    this.type = this.featureHelper_.getType(newFeature);
+    this.color = this.featureHelper_.getColorProperty(newFeature);
+    this.measure = this.featureHelper_.getMeasure(newFeature);
+  }
+};
+
+
+/**
+ * @param {?string} newColor Color.
+ * @private
+ */
+gmf.FeaturestyleController.prototype.handleColorSet_ = function(
+    newColor) {
+  if (this.feature && newColor) {
+    var currentColor = this.feature.get(ngeo.FeatureProperties.COLOR);
+    if (currentColor !== newColor) {
+      this.feature.set(ngeo.FeatureProperties.COLOR, newColor);
+    }
+  }
+};
+
+
+/**
+ * @param {number|undefined} value A name value to set or undefined to get.
+ * @return {number} The angle of the feature.
+ * @export
+ */
+gmf.FeaturestyleController.prototype.getSetAngle = function(value) {
+  return /** @type {number} */ (
+      this.getSetProperty_(ngeo.FeatureProperties.ANGLE, value));
+};
+
+
+/**
+ * @param {string|undefined} value A name value to set or undefined to get.
+ * @return {string} The name of the feature.
+ * @export
+ */
+gmf.FeaturestyleController.prototype.getSetName = function(value) {
+  return /** @type {string} */ (
+      this.getSetProperty_(ngeo.FeatureProperties.NAME, value));
+};
+
+
+/**
+ * @param {string|undefined} value A stroke value to set or undefined to get.
+ * @return {string} The stroke of the feature.
+ * @export
+ */
+gmf.FeaturestyleController.prototype.getSetOpacity = function(value) {
+  return /** @type {string} */ (
+      this.getSetProperty_(ngeo.FeatureProperties.OPACITY, value));
+};
+
+
+/**
+ * @param {boolean|undefined} value A value to set or undefined to get for the
+ *     purpose of showing the geometry measurements or not.
+ * @return {boolean} Whether to show the measurements or not.
+ * @export
+ */
+gmf.FeaturestyleController.prototype.getSetShowMeasure = function(value) {
+  return /** @type {boolean} */ (
+      this.getSetProperty_(ngeo.FeatureProperties.SHOW_MEASURE, value));
+};
+
+
+/**
+ * @param {string|undefined} value A size value to set or undefined to get.
+ * @return {string} The size of the feature.
+ * @export
+ */
+gmf.FeaturestyleController.prototype.getSetSize = function(value) {
+  return /** @type {string} */ (
+      this.getSetProperty_(ngeo.FeatureProperties.SIZE, value));
+};
+
+
+/**
+ * @param {string|undefined} value A stroke value to set or undefined to get.
+ * @return {string} The stroke of the feature.
+ * @export
+ */
+gmf.FeaturestyleController.prototype.getSetStroke = function(value) {
+  return /** @type {string} */ (
+      this.getSetProperty_(ngeo.FeatureProperties.STROKE, value));
+};
+
+
+/**
+ * @param {string} key The property name.
+ * @param {boolean|number|string|undefined} value A value to set or undefined
+ *     to get.
+ * @return {boolean|number|string} The property value of the feature.
+ * @private
+ */
+gmf.FeaturestyleController.prototype.getSetProperty_ = function(key, value) {
+  if (value !== undefined) {
+    this.feature.set(key, value);
+  }
+  return /** @type {boolean|number|string} */ (this.feature.get(key));
+};
+
+
+/**
+ * @private
+ */
+gmf.FeaturestyleController.prototype.handleFeatureChange_ = function() {
+  var feature = this.feature;
+
+  if (!feature) {
+    return;
+  }
+
+  this.featureHelper_.setStyle(feature);
+};
+
+
+/**
+ * @private
+ */
+gmf.FeaturestyleController.prototype.handleGeometryChange_ = function() {
+  var feature = this.feature;
+  this.measure = this.featureHelper_.getMeasure(feature);
+
+  var showMeasure = this.featureHelper_.getShowMeasureProperty(feature);
+  if (showMeasure) {
+    this.handleFeatureChange_();
+  }
+};
+
+
+gmf.module.controller('GmfFeaturestyleController', gmf.FeaturestyleController);

--- a/contribs/gmf/src/directives/partials/featurestyle.html
+++ b/contribs/gmf/src/directives/partials/featurestyle.html
@@ -1,0 +1,144 @@
+<div
+    ng-if="fsCtrl.feature && fsCtrl.type"
+    class="form-horizontal">
+  <div class="form-group">
+    <div class="col-xs-12">
+      <input
+          ng-model="fsCtrl.getSetName"
+          ng-model-options="{getterSetter: true}"
+          class="form-control gmf-featurestyle-name"/>
+    </div>
+  </div>
+
+  <div class="form-group"
+       ng-if="fsCtrl.type !== 'text'">
+    <div class="col-xs-12">
+      <span
+          class="gmf-featurestyle-measure">
+        {{ fsCtrl.measure }}
+      </span>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <div
+        ngeo-colorpicker=""
+        ngeo-colorpicker-color="fsCtrl.color"
+        class="col-xs-12">
+    </div>
+  </div>
+
+  <div
+      ng-if="fsCtrl.type === 'point'"
+      class="form-group">
+    <label class="control-label col-xs-4">{{'Size' | translate}}</label>
+    <div class="col-xs-8">
+      <input
+          type="range"
+          min="3"
+          max="20"
+          step="1"
+          ng-model="fsCtrl.getSetSize"
+          ng-model-options="{getterSetter: true}"
+          />
+    </div>
+  </div>
+
+  <div
+      ng-if="fsCtrl.type === 'text'"
+      class="form-group">
+    <label class="control-label col-xs-4">{{'Size' | translate}}</label>
+    <div class="col-xs-8">
+      <input
+          type="range"
+          min="8"
+          max="30"
+          step="1"
+          ng-model="fsCtrl.getSetSize"
+          ng-model-options="{getterSetter: true}"
+          />
+    </div>
+  </div>
+
+  <div
+      ng-if="fsCtrl.type === 'circle' || fsCtrl.type === 'linestring' || fsCtrl.type === 'polygon' || fsCtrl.type === 'rectangle'"
+      class="form-group">
+    <label class="control-label col-xs-4">{{'Stroke' | translate}}</label>
+    <div class="col-xs-8">
+      <input
+          type="range"
+          min="0.5"
+          max="5"
+          step="0.5"
+          ng-model="fsCtrl.getSetStroke"
+          ng-model-options="{getterSetter: true}"
+          />
+    </div>
+  </div>
+
+  <div
+      ng-if="fsCtrl.type === 'circle' || fsCtrl.type === 'polygon' || fsCtrl.type === 'rectangle'"
+      class="form-group">
+    <label class="control-label col-xs-4">{{'Opacity' | translate}}</label>
+    <div class="col-xs-8">
+      <input
+          type="range"
+          min="0"
+          max="1"
+          step="0.05"
+          ng-model="fsCtrl.getSetOpacity"
+          ng-model-options="{getterSetter: true}"
+          />
+    </div>
+  </div>
+
+  <div
+      ng-if="fsCtrl.type === 'text'"
+      class="form-group">
+    <label class="control-label col-xs-4">{{'Angle' | translate}}</label>
+    <div class="col-xs-8">
+      <input
+          type="range"
+          min="-180"
+          max="180"
+          step="22.5"
+          ng-model="fsCtrl.getSetAngle"
+          ng-model-options="{getterSetter: true}"
+          />
+    </div>
+  </div>
+
+  <div
+      ng-if="fsCtrl.type !== 'text'"
+      class="form-group">
+    <div class="col-xs-12">
+      <input
+          id="gmf-featurestyle-showmeasure"
+          type="checkbox"
+          ng-model="fsCtrl.getSetShowMeasure"
+          ng-model-options="{getterSetter: true}"/>
+      <label
+          ng-switch="fsCtrl.type"
+          for="gmf-featurestyle-showmeasure"
+          class="control-label">
+        <span ng-switch-when="circle">
+          {{'Display surface' | translate}}
+        </span>
+        <span ng-switch-when="polygon">
+          {{'Display surface' | translate}}
+        </span>
+        <span ng-switch-when="rectangle">
+          {{'Display surface' | translate}}
+        </span>
+        <span ng-switch-when="linestring">
+          {{'Display length' | translate}}
+        </span>
+        <span ng-switch-when="point">
+          {{'Display coordinates' | translate}}
+        </span>
+      </label>
+    </div>
+
+  </div>
+
+</div>

--- a/src/ngeo.js
+++ b/src/ngeo.js
@@ -13,3 +13,33 @@ ngeo.module = angular.module('ngeo', []);
  * @type {string}
  */
 ngeo.baseTemplateUrl = 'ngeo';
+
+
+/**
+ * @enum {string}
+ */
+ngeo.FeatureProperties = {
+  ANGLE: 'angle',
+  COLOR: 'color',
+  IS_CIRCLE: 'isCircle',
+  IS_RECTANGLE: 'isRectangle',
+  IS_TEXT: 'isText',
+  NAME: 'name',
+  OPACITY: 'opacity',
+  SHOW_MEASURE: 'showMeasure',
+  SIZE: 'size',
+  STROKE: 'stroke'
+};
+
+
+/**
+ * @enum {string}
+ */
+ngeo.GeometryType = {
+  CIRCLE: 'circle',
+  LINESTRING: 'linestring',
+  POINT: 'point',
+  POLYGON: 'polygon',
+  RECTANGLE: 'rectangle',
+  TEXT: 'text'
+};

--- a/src/ol-ext/interaction/measure.js
+++ b/src/ol-ext/interaction/measure.js
@@ -242,14 +242,45 @@ ngeo.interaction.Measure.getFormattedArea = function(
     } else {
       output = parseFloat((area / 1000000).toPrecision(3));
     }
-    output += ' ' + 'km<sup>2</sup>';
+    output += ' ' + 'km²';
   } else {
     if (decimals !== null) {
       output = goog.string.padNumber(area, 0, decimals);
     } else {
       output = parseFloat(area.toPrecision(3));
     }
-    output += ' ' + 'm<sup>2</sup>';
+    output += ' ' + 'm²';
+  }
+  return output;
+};
+
+
+/**
+ * Calculate the area of the passed circle and return a formatted string
+ * of the area.
+ * @param {ol.geom.Circle} circle Circle
+ * @param {?number} decimals Decimals.
+ * @return {string} Formatted string of the area.
+ * @export
+ */
+ngeo.interaction.Measure.getFormattedCircleArea = function(
+    circle, decimals) {
+  var area = Math.PI * Math.pow(circle.getRadius(), 2);
+  var output;
+  if (area > 1000000) {
+    if (decimals !== null) {
+      output = goog.string.padNumber(area / 1000000, 0, decimals);
+    } else {
+      output = parseFloat((area / 1000000).toPrecision(3));
+    }
+    output += ' ' + 'km²';
+  } else {
+    if (decimals !== null) {
+      output = goog.string.padNumber(area, 0, decimals);
+    } else {
+      output = parseFloat(area.toPrecision(3));
+    }
+    output += ' ' + 'm²';
   }
   return output;
 };

--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -1,0 +1,407 @@
+goog.provide('ngeo.FeatureHelper')
+
+goog.require('ngeo');
+goog.require('ngeo.interaction.Measure');
+goog.require('ol.style.Circle');
+goog.require('ol.style.Fill');
+goog.require('ol.style.Stroke');
+goog.require('ol.style.Style');
+goog.require('ol.style.Text');
+
+
+/**
+ * Provides methods for features, such as:
+ *  - style setting / getting
+ *  - measurement
+ *
+ * @constructor
+ * @param {angular.$injector} $injector Main injector.
+ * @ngdoc service
+ * @ngname ngeoFeatureHelper
+ * @ngInject
+ */
+ngeo.FeatureHelper = function($injector) {
+
+  /**
+   * @type {?number}
+   * @private
+   */
+  this.decimals = null;
+
+  if ($injector.has('ngeoMeasureDecimals')) {
+    this.decimals_ = $injector.get('ngeoMeasureDecimals');
+  }
+
+  /**
+   * @type {ol.proj.Projection}
+   * @private
+   */
+  this.projection_;
+
+};
+
+
+/**
+ * @param {ol.proj.Projection} projection Projection.
+ * @export
+ */
+ngeo.FeatureHelper.prototype.setProjection = function(projection) {
+  this.projection_ = projection;
+};
+
+
+// === STYLE METHODS ===
+
+
+/**
+ * Set the style of a feature using its inner properties and depending on
+ * its geometry type.
+ * @param {ol.Feature} feature Feature.
+ * @export
+ */
+ngeo.FeatureHelper.prototype.setStyle = function(feature) {
+  var style = this.getStyle(feature);
+  feature.setStyle(style);
+};
+
+
+/**
+ * Create and return a style object from a given feature using its inner
+ * properties and depending on its geometry type.
+ * @param {ol.Feature} feature Feature.
+ * @return {ol.style.Style} The style object.
+ * @export
+ */
+ngeo.FeatureHelper.prototype.getStyle = function(feature) {
+  var type = this.getType(feature);
+  var style;
+
+  switch (type) {
+    case ngeo.GeometryType.LINESTRING:
+      style = this.getLineStringStyle_(feature);
+      break;
+    case ngeo.GeometryType.POINT:
+      style = this.getPointStyle_(feature);
+      break;
+    case ngeo.GeometryType.CIRCLE:
+    case ngeo.GeometryType.POLYGON:
+    case ngeo.GeometryType.RECTANGLE:
+      style = this.getPolygonStyle_(feature);
+      break;
+    case ngeo.GeometryType.TEXT:
+      style = this.getTextStyle_(feature);
+      break;
+    default:
+      break;
+  }
+
+  goog.asserts.assert(style, 'Style should be thruthy');
+
+  return style;
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature with linestring geometry.
+ * @return {ol.style.Style} Style.
+ * @private
+ */
+ngeo.FeatureHelper.prototype.getLineStringStyle_ = function(feature) {
+
+  var strokeWidth = this.getStrokeProperty(feature);
+  var showMeasure = this.getShowMeasureProperty(feature);
+  var color = this.getColorProperty(feature);
+
+  var options = {
+    stroke: new ol.style.Stroke({
+      color: color,
+      width: strokeWidth
+    })
+  };
+
+  if (showMeasure) {
+    var measure = this.getMeasure(feature);
+    options.text = this.createTextStyle_(measure, 10);
+  }
+
+  return new ol.style.Style(options);
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature with point geometry.
+ * @return {ol.style.Style} Style.
+ * @private
+ */
+ngeo.FeatureHelper.prototype.getPointStyle_ = function(feature) {
+
+  var size = this.getSizeProperty(feature);
+  var color = this.getColorProperty(feature);
+
+  var options = {
+    image: new ol.style.Circle({
+      radius: size,
+      fill: new ol.style.Fill({
+        color: color
+      })
+    })
+  };
+
+  var showMeasure = this.getShowMeasureProperty(feature);
+
+  if (showMeasure) {
+    var measure = this.getMeasure(feature);
+    options.text = this.createTextStyle_(measure, 10);
+  }
+
+  return new ol.style.Style(options);
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature with polygon geometry.
+ * @return {ol.style.Style} Style.
+ * @private
+ */
+ngeo.FeatureHelper.prototype.getPolygonStyle_ = function(feature) {
+
+  var strokeWidth = this.getStrokeProperty(feature);
+  var opacity = this.getOpacityProperty(feature);
+  var color = this.getColorProperty(feature);
+
+  // fill color with opacity
+  var rgbColor = ol.color.fromString(color);
+  var rgbaColor = rgbColor.slice();
+  rgbaColor[3] = opacity;
+  var fillColor = ol.color.toString(rgbaColor);
+
+  var options = {
+    fill: new ol.style.Fill({
+      color: fillColor
+    }),
+    stroke: new ol.style.Stroke({
+      color: color,
+      width: strokeWidth
+    })
+  };
+
+  var showMeasure = this.getShowMeasureProperty(feature);
+
+  if (showMeasure) {
+    var measure = this.getMeasure(feature);
+    options.text = this.createTextStyle_(measure, 10);
+  }
+
+  return new ol.style.Style(options);
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature with point geometry, rendered as text.
+ * @return {ol.style.Style} Style.
+ * @private
+ */
+ngeo.FeatureHelper.prototype.getTextStyle_ = function(feature) {
+
+  var label = this.getNameProperty(feature);
+  var size = this.getSizeProperty(feature);
+  var angle = this.getAngleProperty(feature);
+  var color = this.getColorProperty(feature);
+
+  return new ol.style.Style({
+    text: this.createTextStyle_(label, size, angle, color)
+  });
+};
+
+
+// === PROPERTY GETTERS ===
+
+
+/**
+ * @param {ol.Feature} feature Feature.
+ * @return {number} Angle.
+ * @export
+ */
+ngeo.FeatureHelper.prototype.getAngleProperty = function(feature) {
+  var angle = +(/** @type {string} */ (
+    feature.get(ngeo.FeatureProperties.ANGLE)));
+  goog.asserts.assertNumber(angle);
+  return angle;
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature.
+ * @return {string} Color.
+ * @export
+ */
+ngeo.FeatureHelper.prototype.getColorProperty = function(feature) {
+
+  var color = /** @type {string} */ (feature.get(ngeo.FeatureProperties.COLOR));
+
+  goog.asserts.assertString(color);
+
+  return color;
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature.
+ * @return {string} Name.
+ * @export
+ */
+ngeo.FeatureHelper.prototype.getNameProperty = function(feature) {
+  var name = /** @type {string} */ (feature.get(ngeo.FeatureProperties.NAME));
+  goog.asserts.assertString(name);
+  return name;
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature.
+ * @return {number} Opacity.
+ * @export
+ */
+ngeo.FeatureHelper.prototype.getOpacityProperty = function(feature) {
+  var opacity = +(/** @type {string} */ (
+      feature.get(ngeo.FeatureProperties.OPACITY)));
+  goog.asserts.assertNumber(opacity);
+  return opacity;
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature.
+ * @return {boolean} Show measure.
+ * @export
+ */
+ngeo.FeatureHelper.prototype.getShowMeasureProperty = function(feature) {
+  var showMeasure = (/** @type {boolean} */ (
+        feature.get(ngeo.FeatureProperties.SHOW_MEASURE)));
+  if (showMeasure === undefined) {
+    showMeasure = false;
+  }
+  goog.asserts.assertBoolean(showMeasure);
+  return showMeasure;
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature.
+ * @return {number} Size.
+ * @export
+ */
+ngeo.FeatureHelper.prototype.getSizeProperty = function(feature) {
+  var size = +(/** @type {string} */ (feature.get(ngeo.FeatureProperties.SIZE)));
+  goog.asserts.assertNumber(size);
+  return size;
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature.
+ * @return {number} Stroke.
+ * @export
+ */
+ngeo.FeatureHelper.prototype.getStrokeProperty = function(feature) {
+  var stroke = +(/** @type {string} */ (
+      feature.get(ngeo.FeatureProperties.STROKE)));
+  goog.asserts.assertNumber(stroke);
+  return stroke;
+};
+
+
+// === OTHER UTILITY METHODS ===
+
+
+/**
+ * @param {string} text The text to display.
+ * @param {number} size The size in `pt` of the text font.
+ * @param {number=} opt_angle The angle in degrees of the text.
+ * @param {string=} opt_color The color of the text
+ * @return {ol.style.Text} Style.
+ * @private
+ */
+ngeo.FeatureHelper.prototype.createTextStyle_ = function(text, size,
+                                                        opt_angle, opt_color) {
+
+  var angle = opt_angle !== undefined ? opt_angle : 0;
+  var rotation = angle * Math.PI / 180;
+  var font = ['normal', size + 'pt', 'Arial'].join(' ');
+  var color = opt_color !== undefined ? opt_color : '#000000';
+
+  return new ol.style.Text({
+    font: font,
+    text: text,
+    fill: new ol.style.Fill({color: color}),
+    stroke: new ol.style.Stroke({color: '#ffffff', width: 3}),
+    rotation: rotation
+  });
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature.
+ * @return {string} Measure.
+ * @export
+ */
+ngeo.FeatureHelper.prototype.getMeasure = function(feature) {
+
+  var geometry = feature.getGeometry();
+  goog.asserts.assert(geometry, 'Geometry should be truthy');
+
+  var measure = '';
+
+  if (geometry instanceof ol.geom.Polygon) {
+    measure = ngeo.interaction.Measure.getFormattedArea(
+      geometry, this.projection_, this.decimals_);
+  } else if (geometry instanceof ol.geom.LineString) {
+    measure = ngeo.interaction.Measure.getFormattedLength(
+      geometry, this.projection_, this.decimals_);
+  } else if (geometry instanceof ol.geom.Point) {
+    measure = ngeo.interaction.Measure.getFormattedPoint(
+      geometry, this.projection_, this.decimals_);
+  }
+
+  return measure;
+};
+
+
+/**
+ * Return the type of geometry of a feature using its geometry property and
+ * some inner properties.
+ * @param {ol.Feature} feature Feature.
+ * @return {string} The type of geometry.
+ * @export
+ */
+ngeo.FeatureHelper.prototype.getType = function(feature) {
+  var geometry = feature.getGeometry();
+  goog.asserts.assert(geometry, 'Geometry should be thruthy');
+
+  var type;
+
+  if (geometry instanceof ol.geom.Point) {
+    if (feature.get(ngeo.FeatureProperties.IS_TEXT)) {
+      type = ngeo.GeometryType.TEXT;
+    } else {
+      type = ngeo.GeometryType.POINT;
+    }
+  } else if (geometry instanceof ol.geom.Polygon) {
+    if (feature.get(ngeo.FeatureProperties.IS_CIRCLE)) {
+      type = ngeo.GeometryType.CIRCLE;
+    } else if (feature.get(ngeo.FeatureProperties.IS_RECTANGLE)) {
+      type = ngeo.GeometryType.RECTANGLE;
+    } else {
+      type = ngeo.GeometryType.POLYGON;
+    }
+  } else if (geometry instanceof ol.geom.LineString) {
+    type = ngeo.GeometryType.LINESTRING;
+  }
+
+  goog.asserts.assert(type, 'Type should be thruthy');
+
+  return type;
+};
+
+
+ngeo.module.service('ngeoFeatureHelper', ngeo.FeatureHelper);


### PR DESCRIPTION
This PR introduces a `gmf-featurestyle` directive and an example featuring it.  It also introduces a `gmf.FeatureHelper` service that is responsible of giving utility methods to create, get and set the style for a feature using its inner properties.  It also contains methods to calculate and return a measure string from a feature geometry.

Wiki: https://github.com/camptocamp/c2cgeoportal/wiki/Spec-%231658-Measures-and-redlining

## Tasks remaining to do

 * [x] Deal with circle measurements, i.e. how should we do it properly.  If we do not support `ol.geom.Circle` as type of geometry, then we need to adjust what has been made.  **Answer**: we'll keep circles as polygons, as before.
 * [x] Travis build pass
 * [x] Code review

## Live example

 * http://adube.github.io/ngeo/edit-feature-style/examples/contribs/gmf/featurestyle.html?map_x=-8003263&map_y=6362007&map_zoom=6