### PR TITLE
Add ngeo draw feature directive

### DIFF
--- a/contribs/gmf/src/directives/partials/featurestyle.html
+++ b/contribs/gmf/src/directives/partials/featurestyle.html
@@ -11,7 +11,7 @@
   </div>
 
   <div class="form-group"
-       ng-if="fsCtrl.type !== 'text'">
+       ng-if="fsCtrl.type !== 'Text'">
     <div class="col-xs-12">
       <span
           class="gmf-featurestyle-measure">
@@ -29,7 +29,7 @@
   </div>
 
   <div
-      ng-if="fsCtrl.type === 'point'"
+      ng-if="fsCtrl.type === 'Point'"
       class="form-group">
     <label class="control-label col-xs-4">{{'Size' | translate}}</label>
     <div class="col-xs-8">
@@ -45,7 +45,7 @@
   </div>
 
   <div
-      ng-if="fsCtrl.type === 'text'"
+      ng-if="fsCtrl.type === 'Text'"
       class="form-group">
     <label class="control-label col-xs-4">{{'Size' | translate}}</label>
     <div class="col-xs-8">
@@ -61,7 +61,7 @@
   </div>
 
   <div
-      ng-if="fsCtrl.type === 'circle' || fsCtrl.type === 'linestring' || fsCtrl.type === 'polygon' || fsCtrl.type === 'rectangle'"
+      ng-if="fsCtrl.type === 'Circle' || fsCtrl.type === 'LineString' || fsCtrl.type === 'Polygon' || fsCtrl.type === 'Rectangle'"
       class="form-group">
     <label class="control-label col-xs-4">{{'Stroke' | translate}}</label>
     <div class="col-xs-8">
@@ -77,7 +77,7 @@
   </div>
 
   <div
-      ng-if="fsCtrl.type === 'circle' || fsCtrl.type === 'polygon' || fsCtrl.type === 'rectangle'"
+      ng-if="fsCtrl.type === 'Circle' || fsCtrl.type === 'Polygon' || fsCtrl.type === 'Rectangle'"
       class="form-group">
     <label class="control-label col-xs-4">{{'Opacity' | translate}}</label>
     <div class="col-xs-8">
@@ -93,7 +93,7 @@
   </div>
 
   <div
-      ng-if="fsCtrl.type === 'text'"
+      ng-if="fsCtrl.type === 'Text'"
       class="form-group">
     <label class="control-label col-xs-4">{{'Angle' | translate}}</label>
     <div class="col-xs-8">
@@ -109,7 +109,7 @@
   </div>
 
   <div
-      ng-if="fsCtrl.type !== 'text'"
+      ng-if="fsCtrl.type !== 'Text'"
       class="form-group">
     <div class="col-xs-12">
       <input
@@ -121,19 +121,19 @@
           ng-switch="fsCtrl.type"
           for="gmf-featurestyle-showmeasure"
           class="control-label">
-        <span ng-switch-when="circle">
+        <span ng-switch-when="Circle">
           {{'Display surface' | translate}}
         </span>
-        <span ng-switch-when="polygon">
+        <span ng-switch-when="Polygon">
           {{'Display surface' | translate}}
         </span>
-        <span ng-switch-when="rectangle">
+        <span ng-switch-when="Rectangle">
           {{'Display surface' | translate}}
         </span>
-        <span ng-switch-when="linestring">
+        <span ng-switch-when="LineString">
           {{'Display length' | translate}}
         </span>
-        <span ng-switch-when="point">
+        <span ng-switch-when="Point">
           {{'Display coordinates' | translate}}
         </span>
       </label>

--- a/contribs/gmf/src/directives/partials/search.html
+++ b/contribs/gmf/src/directives/partials/search.html
@@ -8,4 +8,5 @@
 <span class="clear-button ng-hide"
         ng-hide="!ctrl.clearButton || ctrl.input_value == ''"
         ng-click="ctrl.onClearButton()"></span>
+  <input data-ng-model="color" data-ng-change="ctrl.setStyleColor(color)"></input>
 </div>

--- a/examples/animation.html
+++ b/examples/animation.html
@@ -57,6 +57,7 @@
     <p>Use the <em>Open sidebar!</em> to open the sidebar and change the width of the map.</p>
     <p id="desc">This example shows how to animate the resizing of a map without distortions of the map during the animation. This uses the <code><a href="../apidoc/ngeo.resizemapDirective.html" title="Read our documentation">ngeoResizemap</a></code> directive.</p>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=animation.js"></script>
     <script src="default.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/examples/backgroundlayer.html
+++ b/examples/backgroundlayer.html
@@ -41,6 +41,7 @@
     </div> <!-- container -->
 
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=backgroundlayer.js"></script>
     <script src="default.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/examples/backgroundlayerdropdown.html
+++ b/examples/backgroundlayerdropdown.html
@@ -25,6 +25,7 @@
     </div>
     <script src="../node_modules/jquery/dist/jquery.js"></script>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>
     <script src="/@?main=backgroundlayerdropdown.js"></script>
     <script src="default.js"></script>

--- a/examples/colorpicker.html
+++ b/examples/colorpicker.html
@@ -77,6 +77,7 @@
       <p id="desc">This example shows how to write an application-specific directive (<code>app-colorpicker</code>) based on <code>ngeo-colorpicker</code>to create a color picker.</p>
     </div>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=colorpicker.js"></script>
     <script src="default.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/examples/control.html
+++ b/examples/control.html
@@ -21,6 +21,7 @@
     Mouse position: <div id="mouse-position" ngeo-control="ctrl.control" ngeo-control-map="ctrl.map"></div>
     <p id="desc">This example shows how to use the <code><a href="../apidoc/ngeo.controlDirective.html" title="Read our documentation">ngeo-control</a></code> directive to insert an OpenLayers control in the page.</p>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=control.js"></script>
     <script src="default.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/examples/drawfeature.html
+++ b/examples/drawfeature.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>Draw Feature Example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+
+    <style>
+      #map {
+        width: 600px;
+        height: 400px;
+      }
+      ngeo-drawfeature {
+        margin: 10px 0;
+      }
+      .ngeo-drawfeature-circle:before {
+        content: 'Circle'
+      }
+      .ngeo-drawfeature-linestring:before {
+        content: 'LineString'
+      }
+      .ngeo-drawfeature-point:before {
+        content: 'Point'
+      }
+      .ngeo-drawfeature-polygon:before {
+        content: 'Polygon'
+      }
+      .ngeo-drawfeature-rectangle:before {
+        content: 'Rectangle'
+      }
+      .ngeo-drawfeature-text:before {
+        content: 'Text'
+      }
+      .tooltip {
+        position: relative;
+        background: rgba(0, 0, 0, 0.5);
+        border-radius: 4px;
+        color: white;
+        padding: 4px 8px;
+        opacity: 0.7;
+        white-space: nowrap;
+      }
+      .tooltip-measure {
+        opacity: 1;
+        font-weight: bold;
+      }
+      .tooltip-static {
+        display: none;
+      }
+      .tooltip-measure:before,
+      .tooltip-static:before {
+        border-top: 6px solid rgba(0, 0, 0, 0.5);
+        border-right: 6px solid transparent;
+        border-left: 6px solid transparent;
+        content: "";
+        position: absolute;
+        bottom: -6px;
+        margin-left: -7px;
+        left: 50%;
+      }
+      .tooltip-static:before {
+        border-top-color: #ffcc33;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <div id="map" ngeo-map="ctrl.map"></div>
+
+    <ngeo-drawfeature
+        ngeo-btn-group
+        class="btn-group"
+        ngeo-drawfeature-active="ctrl.drawActive"
+        ngeo-drawfeature-map="ctrl.map">
+      <a
+        href
+        translate
+        ngeo-btn
+        ngeo-drawpoint
+        class="btn btn-default ngeo-drawfeature-point"
+        ng-class="{active: dfCtrl.drawPoint.active}"
+        ng-model="dfCtrl.drawPoint.active"></a>
+      <a
+        href
+        translate
+        ngeo-btn
+        ngeo-measurelength
+        class="btn btn-default ngeo-drawfeature-linestring"
+        ng-class="{active: dfCtrl.measureLength.active}"
+        ng-model="dfCtrl.measureLength.active"></a>
+      <a
+        href
+        translate
+        ngeo-btn
+        ngeo-measurearea
+        class="btn btn-default ngeo-drawfeature-polygon"
+        ng-class="{active: dfCtrl.measureArea.active}"
+        ng-model="dfCtrl.measureArea.active"></a>
+      <a
+        href
+        translate
+        ngeo-btn
+        ngeo-measureazimut
+        class="btn btn-default ngeo-drawfeature-circle"
+        ng-class="{active: dfCtrl.measureAzimut.active}"
+        ng-model="dfCtrl.measureAzimut.active"></a>
+      <a
+        href
+        translate
+        ngeo-btn
+        ngeo-drawrectangle
+        class="btn btn-default ngeo-drawfeature-rectangle"
+        ng-class="{active: dfCtrl.drawRectangle.active}"
+        ng-model="dfCtrl.drawRectangle.active"></a>
+      <a
+        href
+        translate
+        ngeo-btn
+        ngeo-drawtext
+        class="btn btn-default ngeo-drawfeature-text"
+        ng-class="{active: dfCtrl.drawText.active}"
+        ng-model="dfCtrl.drawText.active"></a>
+    </ngeo-drawfeature>
+
+    <input type="checkbox"
+       ng-model="ctrl.dummyActive" /> Dummy
+
+    <p id="desc">
+      This example shows how to use the <code>ngeo-drawfeature</code>
+      directive to draw vector features on the map.
+    </p>
+
+    <script src="../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../node_modules/angular-touch/angular-touch.js"></script>
+    <script src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="/@?main=drawfeature.js"></script>
+    <script src="default.js"></script>
+    <script src="../utils/watchwatchers.js"></script>
+  </body>
+</html>

--- a/examples/drawfeature.js
+++ b/examples/drawfeature.js
@@ -1,0 +1,81 @@
+goog.provide('drawfeature');
+
+goog.require('ngeo.Features');
+goog.require('ngeo.ToolActivate');
+goog.require('ngeo.ToolActivateMgr');
+goog.require('ngeo.drawfeatureDirective');
+goog.require('ngeo.mapDirective');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['ngeo']);
+
+
+/**
+ * @param {!angular.Scope} $scope Angular scope.
+ * @param {ol.Collection.<ol.Feature>} ngeoFeatures Collection of features.
+ * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
+ *     service.
+ * @constructor
+ */
+app.MainController = function($scope, ngeoFeatures, ngeoToolActivateMgr) {
+
+  /**
+   * @type {!angular.Scope}
+   * @private
+   */
+  this.scope_ = $scope;
+
+  var vector = new ol.layer.Vector({
+    source: new ol.source.Vector({
+      wrapX: false,
+      features: ngeoFeatures
+    })
+  });
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      }),
+      vector
+    ],
+    view: new ol.View({
+      center: [0, 0],
+      zoom: 3
+    })
+  });
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.drawActive = false;
+
+  var drawToolActivate = new ngeo.ToolActivate(this, 'drawActive');
+  ngeoToolActivateMgr.registerTool('mapTools', drawToolActivate, false);
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.dummyActive = true;
+
+  var dummyToolActivate = new ngeo.ToolActivate(this, 'dummyActive');
+  ngeoToolActivateMgr.registerTool('mapTools', dummyToolActivate, true);
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/examples/geolocation.html
+++ b/examples/geolocation.html
@@ -22,6 +22,7 @@
     </p>
     <p id="desc">This example shows how to use the <code><a href="../apidoc/ngeo.DecorateGeolocation.html" title="Read our documentation">ngeoDecorateGeolocation</a></code> service to bind the <code>Geolocation</code>'s <code>tracking</code> value to an input checkbox.</p>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=geolocation.js"></script>
     <script src="default.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/examples/importfeatures.html
+++ b/examples/importfeatures.html
@@ -21,6 +21,7 @@
     <p id="desc">This example shows how to use the <code><a href="../apidoc/ngeo.filereaderDirective.html" title="Read our documentation">ngeo-filereader</a></code> directive to import features from a KML file read from the user's file system.</p>
     <p>You can download and use the <a href="http://openlayers.org/en/master/examples/data/kml/2012-02-10.kml">2012-02-10.kml file</a> from the OpenLayers examples for testing.</p>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=importfeatures.js"></script>
     <script src="default.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/examples/interactionbtngroup.html
+++ b/examples/interactionbtngroup.html
@@ -33,6 +33,7 @@
     <div ng-show="ctrl.showInfo" ng-cloak class="alert alert-success" role="alert"><b>ngeo-btn</b> directive works also outside <b>ngeo-btn-group</b> one</div>
     <p id="desc">This example shows how to use the <code><a href="../apidoc/ngeo.btngroupDirective.html" title="Read our documentation">ngeo-btn-group</a></code> and <code><a href="../apidoc/ngeo.btnDirective.html" title="Read our documentation">ngeo-btn</a></code> directives to activate/deactivate OpenLayers interactions in a toggle group.</p>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=interactionbtngroup.js"></script>
     <script src="default.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/examples/interactiontoggle.html
+++ b/examples/interactiontoggle.html
@@ -22,6 +22,7 @@
     </p>
     <p id="desc">This examples shows how to use <code><a href="../apidoc/ngeo.DecorateInteraction.html" title="Read our documentation">ngeoDecorateInteraction</a></code> to activate/deactivate an interaction through <code>ng-model</code>.</p>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=interactiontoggle.js"></script>
     <script src="default.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/examples/layeropacity.html
+++ b/examples/layeropacity.html
@@ -22,6 +22,7 @@
     </p>
     <p id="desc">This examples shows how to use <code><a href="../apidoc/ngeo.DecorateLayer.html" title="Read our documentation">ngeoDecorateLayer</a></code> to control the visibility of a layer through <code>ng-model</code>.</p>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=layeropacity.js"></script>
     <script src="default.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/examples/layerorder.html
+++ b/examples/layerorder.html
@@ -60,6 +60,7 @@
     <label>
       <p id="desc">This example shows how to use the <code><a href="../apidoc/ngeo.sortableDirective.html" title="Read our documentation">ngeo-sortable</a></code> directive and the <code><a href="../apidoc/ngeo.SyncArrays.html" title="Read our documentation">ngeoSyncArrays</a></code> service to create a list of layers where the order of layers can be changed using drag-and-drop.</p>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=layerorder.js"></script>
     <script src="default.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/examples/layertree.html
+++ b/examples/layertree.html
@@ -72,6 +72,7 @@
     <app-layertree app-layertree-map="::mainCtrl.map"></app-layertree>
     <p id="desc">This example shows how to use ngeo's layer tree directive (<code><a href="../apidoc/ngeo.layertreeDirective.html" title="Read our documentation">ngeo-layertree</a></code>). It also shows how to define an application-specific HTML partial for the tree nodes.</p>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=layertree.js"></script>
     <script src="default.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/examples/layervisibility.html
+++ b/examples/layervisibility.html
@@ -24,6 +24,7 @@
     </p>
     <p id="desc">This examples shows how to use <code><a href="../apidoc/ngeo.DecorateLayer.html" title="Read our documentation">ngeoDecorateLayer</a></code> to control the visibility of a layer through <code>ng-model</code>.</p>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=layervisibility.js"></script>
     <script src="default.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/examples/mapfishprint.html
+++ b/examples/mapfishprint.html
@@ -22,6 +22,7 @@
     <p>In this example the best print scale is chosen based on the current map resolution.</p>
     <script src="../node_modules/proj4/dist/proj4.js"></script>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=mapfishprint.js"></script>
     <script src="default.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/examples/measure.html
+++ b/examples/measure.html
@@ -59,6 +59,7 @@
     <select ng-options="lang for lang in ['en', 'fr']" ng-model="ctrl.lang"></select>
     <p id="desc">This example shows how to use the <code><a href="../apidoc/ngeo.interaction.MeasureLength.html" title="Read our documentation">ngeo.interaction.MeasureLength</a></code>, <code><a href="../apidoc/ngeo.interaction.MeasureArea.html" title="Read our documentation">ngeo.interaction.MeasureArea</a></code>, and <code><a href="../apidoc/ngeo.interaction.MeasureAzimut.html" title="Read our documentation">ngeo.interaction.MeasureAzimut</a></code> interactions to create measure tools for an OpenLayers map.</p>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=measure.js"></script>
     <script src="default.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/examples/mobilequery.html
+++ b/examples/mobilequery.html
@@ -44,6 +44,7 @@
     <app-queryresult></app-queryresult>
 
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="../node_modules/proj4/dist/proj4.js"></script>
     <script src="../node_modules/jquery/dist/jquery.js"></script>
     <script src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>

--- a/examples/modal.html
+++ b/examples/modal.html
@@ -33,6 +33,7 @@
     </ngeo-modal>
     <script src="../node_modules/jquery/dist/jquery.js"></script>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>
     <script src="/@?main=modal.js"></script>
     <script src="default.js"></script>

--- a/examples/permalink.html
+++ b/examples/permalink.html
@@ -19,6 +19,7 @@
     <app-draw app-draw-map="::ctrl.map" app-draw-layer="::ctrl.vectorLayer"></app-draw>
     <p id="desc">This example shows how to create an application-specific map directive based on the <code><a href="../apidoc/ngeo.mapDirective.html" title="Read our documentation">ngeoMap</a></code> directive that uses the <code><a href="../apidoc/ngeo.Location.html" title="Read our documentation">ngeoLocation</a></code> and <code><a href="../apidoc/ngeo.Debounce.html" title="Read our documentation">ngeoDebounce</a></code> services to update the browser address bar URL when the map view changes.</p>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=permalink.js"></script>
     <script src="default.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/examples/profile.html
+++ b/examples/profile.html
@@ -38,6 +38,7 @@
 
     <p id="desc">This example shows how to use <code><a href="../apidoc/ngeo.profileDirective.html" title="Read our documentation">ngeo-profile</a></code> to create a D3-based elevation profile graphic.</p>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="../node_modules/d3/d3.js"></script>
     <script src="/@?main=profile.js"></script>
     <script src="default.js"></script>

--- a/examples/scaleselector.html
+++ b/examples/scaleselector.html
@@ -31,6 +31,7 @@
     </div>
     <script src="../node_modules/jquery/dist/jquery.js"></script>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>
     <script src="/@?main=scaleselector.js"></script>
     <script src="default.js"></script>

--- a/examples/search.html
+++ b/examples/search.html
@@ -85,6 +85,7 @@
     </div>
     <script src="../node_modules/jquery/dist/jquery.js"></script>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="../node_modules/typeahead.js/dist/typeahead.bundle.js"></script>
     <script src="../node_modules/proj4/dist/proj4.js"></script>
     <script src="/@?main=search.js"></script>

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -18,6 +18,7 @@
     <div id="map" ngeo-map="ctrl.map"></div>
     <p id="desc">This example shows how to use the <code><a href="../apidoc/ngeo.mapDirective.html" title="Read our documentation">ngeo-map</a></code> directive to insert an OpenLayers map in a page.</p>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=simple.js"></script>
     <script src="default.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/examples/toolActivate.html
+++ b/examples/toolActivate.html
@@ -25,6 +25,7 @@
     <div id="popup-content"></div>
     <p id="desc">This example shows how to use <code><a href="../apidoc/ngeo.ToolActivate.html" title="Read our documentation">ngeo.ToolActivate</a></code> objects with the <code><a href="../apidoc/ngeo.ToolActivateMgr.html" title="Read our documentation">ngeo.ToolActivateMgr</a></code>to active only one map control at once. If none draw control is choose, the click on the map is enabled.</p>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=toolActivate.js"></script>
     <script src="default.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/src/directives/drawfeature.js
+++ b/src/directives/drawfeature.js
@@ -1,0 +1,299 @@
+goog.provide('ngeo.DrawfeatureController');
+goog.provide('ngeo.drawfeatureDirective');
+
+goog.require('ngeo');
+goog.require('ngeo.DecorateInteraction');
+goog.require('ngeo.FeatureHelper');
+/** @suppress {extraRequire} */
+goog.require('ngeo.btngroupDirective');
+/** @suppress {extraRequire} */
+goog.require('ngeo.drawpointDirective');
+/** @suppress {extraRequire} */
+goog.require('ngeo.drawrectangleDirective');
+/** @suppress {extraRequire} */
+goog.require('ngeo.drawtextDirective');
+/** @suppress {extraRequire} */
+goog.require('ngeo.measureareaDirective');
+/** @suppress {extraRequire} */
+goog.require('ngeo.measureazimutDirective');
+/** @suppress {extraRequire} */
+goog.require('ngeo.measurelengthDirective');
+goog.require('ol.Feature');
+
+/**
+ * Directive used to draw vector features on a map.
+ * Example:
+ *
+ *     <ngeo-drawfeature
+ *         ngeo-btn-group
+ *         class="btn-group"
+ *         ngeo-drawfeature-active="ctrl.drawActive"
+ *         ngeo-drawfeature-map="::ctrl.map">
+ *       <a
+ *         href
+ *         translate
+ *         ngeo-btn
+ *         ngeo-drawpoint
+ *         class="btn btn-default ngeo-drawfeature-point"
+ *         ng-class="{active: dfCtrl.drawPoint.active}"
+ *         ng-model="dfCtrl.drawPoint.active"></a>
+ *       <a
+ *         href
+ *         translate
+ *         ngeo-btn
+ *         ngeo-measurelength
+ *         class="btn btn-default ngeo-drawfeature-linestring"
+ *         ng-class="{active: dfCtrl.measureLength.active}"
+ *         ng-model="dfCtrl.measureLength.active"></a>
+ *       <a
+ *         href
+ *         translate
+ *         ngeo-btn
+ *         ngeo-measurearea
+ *         class="btn btn-default ngeo-drawfeature-polygon"
+ *         ng-class="{active: dfCtrl.measureArea.active}"
+ *         ng-model="dfCtrl.measureArea.active"></a>
+ *       <a
+ *         href
+ *         translate
+ *         ngeo-btn
+ *         ngeo-measureazimut
+ *         class="btn btn-default ngeo-drawfeature-circle"
+ *         ng-class="{active: dfCtrl.measureAzimut.active}"
+ *         ng-model="dfCtrl.measureAzimut.active"></a>
+ *       <a
+ *         href
+ *         translate
+ *         ngeo-btn
+ *         ngeo-drawrectangle
+ *         class="btn btn-default ngeo-drawfeature-rectangle"
+ *         ng-class="{active: dfCtrl.drawRectangle.active}"
+ *         ng-model="dfCtrl.drawRectangle.active"></a>
+ *       <a
+ *         href
+ *         translate
+ *         ngeo-btn
+ *         ngeo-drawtext
+ *         class="btn btn-default ngeo-drawfeature-text"
+ *         ng-class="{active: dfCtrl.drawText.active}"
+ *         ng-model="dfCtrl.drawText.active"></a>
+ *     </ngeo-drawfeature>
+ *
+ * @htmlAttribute {boolean} ngeo-drawfeature-active Whether the directive is
+ *     active or not.
+ * @htmlAttribute {ol.Map} ngeo-drawfeature-map The map.
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname ngeoDrawfeature
+ */
+ngeo.drawfeatureDirective = function() {
+  return {
+    controller: 'ngeoDrawfeatureController',
+    scope: true,
+    bindToController: {
+      'active': '=ngeoDrawfeatureActive',
+      'map': '=ngeoDrawfeatureMap'
+    },
+    controllerAs: 'dfCtrl'
+  };
+};
+
+ngeo.module.directive('ngeoDrawfeature', ngeo.drawfeatureDirective);
+
+
+/**
+ * @param {!angular.Scope} $scope Scope.
+ * @param {angular.$compile} $compile Angular compile service.
+ * @param {angular.$sce} $sce Angular sce service.
+ * @param {gettext} gettext Gettext service.
+ * @param {angularGettext.Catalog} gettextCatalog Gettext service.
+ * @param {ngeo.DecorateInteraction} ngeoDecorateInteraction Decorate
+ *     interaction service.
+ * @param {ngeo.FeatureHelper} ngeoFeatureHelper Ngeo feature helper service.
+ * @param {ol.Collection.<ol.Feature>} ngeoFeatures Collection of features.
+ * @constructor
+ * @ngInject
+ * @ngdoc controller
+ * @ngname ngeoDrawfeatureController
+ */
+ngeo.DrawfeatureController = function($scope, $compile, $sce, gettext,
+    gettextCatalog, ngeoDecorateInteraction, ngeoFeatureHelper, ngeoFeatures) {
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.active;
+
+  if (this.active === undefined) {
+    this.active = false;
+  }
+
+  /**
+   * @type {angularGettext.Catalog}
+   * @private
+   */
+  this.gettextCatalog_ = gettextCatalog;
+
+  /**
+   * @type {ngeo.DecorateInteraction}
+   * @private
+   */
+  this.ngeoDecorateInteraction_ = ngeoDecorateInteraction;
+
+  /**
+   * @type {ngeo.FeatureHelper}
+   * @private
+   */
+  this.featureHelper_ = ngeoFeatureHelper;
+
+  /**
+   * @type {ol.Collection.<ol.Feature>}
+   * @private
+   */
+  this.features_ = ngeoFeatures;
+
+  /**
+   * @type {Array.<ol.interaction.Interaction>}
+   * @private
+   */
+  this.interactions_ = [];
+
+  /**
+   * @type {ol.interaction.Draw}
+   * @export
+   */
+  this.drawPoint;
+
+  /**
+   * @type {ngeo.interaction.MeasureLength}
+   * @export
+   */
+  this.measureLength;
+
+  /**
+   * @type {ngeo.interaction.MeasureArea}
+   * @export
+   */
+  this.measureArea;
+
+  /**
+   * @type {ngeo.interaction.MeasureAzimut}
+   * @export
+   */
+  this.measureAzimut;
+
+  /**
+   * @type {ol.interaction.Draw}
+   * @export
+   */
+  this.drawRectangle;
+
+  /**
+   * @type {ol.interaction.Draw}
+   * @export
+   */
+  this.drawText;
+
+
+  // Watch the "active" property, and disable the draw interactions
+  // when "active" gets set to false.
+  $scope.$watch(
+    function() {
+      return this.active;
+    }.bind(this),
+    function(newVal) {
+      if (newVal === false) {
+        this.interactions_.forEach(function(interaction) {
+          interaction.setActive(false);
+        }, this);
+      }
+    }.bind(this)
+  );
+
+};
+
+
+/**
+ * Register a draw|measure interaction by setting it inactive, decorating it
+ * and adding it to the map
+ * @param {ol.interaction.Interaction} interaction Interaction to register.
+ * @export
+ */
+ngeo.DrawfeatureController.prototype.registerInteraction = function(
+    interaction) {
+  this.interactions_.push(interaction);
+  interaction.setActive(false);
+  this.ngeoDecorateInteraction_(interaction);
+  this.map.addInteraction(interaction);
+};
+
+
+/**
+ * Called when any of the draw or measure interaction active property changes.
+ * Set the active property of this directive accordingly, i.e. if at least
+ * one of the draw or measure is active then the active property is set to true.
+ * @param {ol.ObjectEvent} event Event.
+ * @export
+ */
+ngeo.DrawfeatureController.prototype.handleActiveChange = function(event) {
+  this.active = this.interactions_.some(function(interaction) {
+    return interaction.getActive();
+  }, this);
+};
+
+
+/**
+ * Called when a feature is finished being drawn. Set the default properties
+ * for its style, then set its style and add it to the features collection.
+ * @param {string} type Type of geometry being drawn.
+ * @param {ol.interaction.DrawEvent|ngeo.MeasureEvent} event Event.
+ * @export
+ */
+ngeo.DrawfeatureController.prototype.handleDrawEnd = function(type, event) {
+  var feature = new ol.Feature(event.feature.getGeometry());
+
+  var prop = ngeo.FeatureProperties;
+
+  switch (type) {
+    case ngeo.GeometryType.CIRCLE:
+      feature.set(prop.IS_CIRCLE, true);
+      break;
+    case ngeo.GeometryType.TEXT:
+      feature.set(prop.IS_TEXT, true);
+      break;
+    case ngeo.GeometryType.RECTANGLE:
+      feature.set(prop.IS_RECTANGLE, true);
+      break;
+    default:
+      break;
+  }
+
+  /**
+   * @type {string}
+   */
+  var name = this.gettextCatalog_.getString(type);
+  feature.set(prop.NAME, name + ' ' + (this.features_.getLength() + 1));
+
+  feature.set(prop.ANGLE, 0);
+  feature.set(prop.COLOR, '#ed1c24');
+  feature.set(prop.OPACITY, 0.2);
+  feature.set(prop.SHOW_MEASURE, false);
+  feature.set(prop.SIZE, 10);
+  feature.set(prop.STROKE, 1);
+
+  // set style
+  this.featureHelper_.setStyle(feature);
+
+  // push in collection
+  this.features_.push(feature);
+};
+
+ngeo.module.controller('ngeoDrawfeatureController', ngeo.DrawfeatureController);

--- a/src/directives/drawpoint.js
+++ b/src/directives/drawpoint.js
@@ -1,0 +1,52 @@
+goog.provide('ngeo.drawpointDirective');
+
+goog.require('ngeo');
+goog.require('ol.geom.GeometryType');
+goog.require('ol.interaction.Draw');
+
+
+/**
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname ngeoDrawpoint
+ */
+ngeo.drawpointDirective = function() {
+  return {
+    restrict: 'A',
+    require: '^^ngeoDrawfeature',
+    /**
+     * @param {!angular.Scope} $scope Scope.
+     * @param {angular.JQLite} element Element.
+     * @param {angular.Attributes} attrs Attributes.
+     * @param {ngeo.DrawfeatureController} drawFeatureCtrl Controller.
+     */
+    link: function($scope, element, attrs, drawFeatureCtrl) {
+
+      var drawPoint = new ol.interaction.Draw({
+        type: ol.geom.GeometryType.POINT
+      });
+
+      drawFeatureCtrl.registerInteraction(drawPoint);
+      drawFeatureCtrl.drawPoint = drawPoint;
+
+      ol.events.listen(
+          drawPoint,
+          ol.interaction.DrawEventType.DRAWEND,
+          drawFeatureCtrl.handleDrawEnd.bind(
+              drawFeatureCtrl, ngeo.GeometryType.POINT),
+          drawFeatureCtrl
+      );
+      ol.events.listen(
+          drawPoint,
+          ol.Object.getChangeEventType(
+              ol.interaction.InteractionProperty.ACTIVE),
+          drawFeatureCtrl.handleActiveChange,
+          drawFeatureCtrl
+      );
+    }
+  };
+};
+
+
+ngeo.module.directive('ngeoDrawpoint', ngeo.drawpointDirective);

--- a/src/directives/drawrectangle.js
+++ b/src/directives/drawrectangle.js
@@ -1,0 +1,65 @@
+goog.provide('ngeo.drawrectangleDirective');
+
+goog.require('ngeo');
+goog.require('ol.geom.GeometryType');
+goog.require('ol.interaction.Draw');
+goog.require('ol.geom.Polygon');
+
+
+/**
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname ngeoDrawrectangle
+ */
+ngeo.drawrectangleDirective = function() {
+  return {
+    restrict: 'A',
+    require: '^^ngeoDrawfeature',
+    /**
+     * @param {!angular.Scope} $scope Scope.
+     * @param {angular.JQLite} element Element.
+     * @param {angular.Attributes} attrs Attributes.
+     * @param {ngeo.DrawfeatureController} drawFeatureCtrl Controller.
+     */
+    link: function($scope, element, attrs, drawFeatureCtrl) {
+
+      var drawRectangle = new ol.interaction.Draw({
+        type: ol.geom.GeometryType.LINE_STRING,
+        geometryFunction: function(coordinates, geometry) {
+          if (!geometry) {
+            geometry = new ol.geom.Polygon(null);
+          }
+          var start = coordinates[0];
+          var end = coordinates[1];
+          geometry.setCoordinates([
+            [start, [start[0], end[1]], end, [end[0], start[1]], start]
+          ]);
+          return geometry;
+        },
+        maxPoints: 2
+      });
+
+      drawFeatureCtrl.registerInteraction(drawRectangle);
+      drawFeatureCtrl.drawRectangle = drawRectangle;
+
+      ol.events.listen(
+          drawRectangle,
+          ol.interaction.DrawEventType.DRAWEND,
+          drawFeatureCtrl.handleDrawEnd.bind(
+              drawFeatureCtrl, ngeo.GeometryType.RECTANGLE),
+          drawFeatureCtrl
+      );
+      ol.events.listen(
+          drawRectangle,
+          ol.Object.getChangeEventType(
+              ol.interaction.InteractionProperty.ACTIVE),
+          drawFeatureCtrl.handleActiveChange,
+          drawFeatureCtrl
+      );
+    }
+  };
+};
+
+
+ngeo.module.directive('ngeoDrawrectangle', ngeo.drawrectangleDirective);

--- a/src/directives/drawtext.js
+++ b/src/directives/drawtext.js
@@ -1,0 +1,52 @@
+goog.provide('ngeo.drawtextDirective');
+
+goog.require('ngeo');
+goog.require('ol.geom.GeometryType');
+goog.require('ol.interaction.Draw');
+
+
+/**
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname ngeoDrawtext
+ */
+ngeo.drawtextDirective = function() {
+  return {
+    restrict: 'A',
+    require: '^^ngeoDrawfeature',
+    /**
+     * @param {!angular.Scope} $scope Scope.
+     * @param {angular.JQLite} element Element.
+     * @param {angular.Attributes} attrs Attributes.
+     * @param {ngeo.DrawfeatureController} drawFeatureCtrl Controller.
+     */
+    link: function($scope, element, attrs, drawFeatureCtrl) {
+
+      var drawText = new ol.interaction.Draw({
+        type: ol.geom.GeometryType.POINT
+      });
+
+      drawFeatureCtrl.registerInteraction(drawText);
+      drawFeatureCtrl.drawText = drawText;
+
+      ol.events.listen(
+          drawText,
+          ol.interaction.DrawEventType.DRAWEND,
+          drawFeatureCtrl.handleDrawEnd.bind(
+              drawFeatureCtrl, ngeo.GeometryType.TEXT),
+          drawFeatureCtrl
+      );
+      ol.events.listen(
+          drawText,
+          ol.Object.getChangeEventType(
+              ol.interaction.InteractionProperty.ACTIVE),
+          drawFeatureCtrl.handleActiveChange,
+          drawFeatureCtrl
+      );
+    }
+  };
+};
+
+
+ngeo.module.directive('ngeoDrawtext', ngeo.drawtextDirective);

--- a/src/directives/measurearea.js
+++ b/src/directives/measurearea.js
@@ -1,0 +1,60 @@
+goog.provide('ngeo.measureareaDirective');
+
+goog.require('ngeo');
+goog.require('ngeo.interaction.MeasureArea');
+goog.require('ol.style.Style');
+
+
+/**
+ * @param {angular.$compile} $compile Angular compile service.
+ * @param {gettext} gettext Gettext service.
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname ngeoDrawpoint
+ */
+ngeo.measureareaDirective = function($compile, gettext) {
+  return {
+    restrict: 'A',
+    require: '^^ngeoDrawfeature',
+    /**
+     * @param {!angular.Scope} $scope Scope.
+     * @param {angular.JQLite} element Element.
+     * @param {angular.Attributes} attrs Attributes.
+     * @param {ngeo.DrawfeatureController} drawFeatureCtrl Controller.
+     */
+    link: function($scope, element, attrs, drawFeatureCtrl) {
+
+      var helpMsg = gettext('Click to start drawing area');
+      var contMsg = gettext('Click to continue drawing<br/>' +
+          'Double-click or click last starting point to finish');
+
+      var measureArea = new ngeo.interaction.MeasureArea({
+        style: new ol.style.Style(),
+        startMsg: $compile('<div translate>' + helpMsg + '</div>')($scope)[0],
+        continueMsg: $compile('<div translate>' + contMsg + '</div>')($scope)[0]
+      });
+
+      drawFeatureCtrl.registerInteraction(measureArea);
+      drawFeatureCtrl.measureArea = measureArea;
+
+      ol.events.listen(
+          measureArea,
+          ngeo.MeasureEventType.MEASUREEND,
+          drawFeatureCtrl.handleDrawEnd.bind(
+              drawFeatureCtrl, ngeo.GeometryType.POLYGON),
+          drawFeatureCtrl
+      );
+      ol.events.listen(
+          measureArea,
+          ol.Object.getChangeEventType(
+              ol.interaction.InteractionProperty.ACTIVE),
+          drawFeatureCtrl.handleActiveChange,
+          drawFeatureCtrl
+      );
+    }
+  };
+};
+
+
+ngeo.module.directive('ngeoMeasurearea', ngeo.measureareaDirective);

--- a/src/directives/measurelength.js
+++ b/src/directives/measurelength.js
@@ -1,0 +1,60 @@
+goog.provide('ngeo.measurelengthDirective');
+
+goog.require('ngeo');
+goog.require('ngeo.interaction.MeasureLength');
+goog.require('ol.style.Style');
+
+
+/**
+ * @param {angular.$compile} $compile Angular compile service.
+ * @param {gettext} gettext Gettext service.
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname ngeoDrawpoint
+ */
+ngeo.measurelengthDirective = function($compile, gettext) {
+  return {
+    restrict: 'A',
+    require: '^^ngeoDrawfeature',
+    /**
+     * @param {!angular.Scope} $scope Scope.
+     * @param {angular.JQLite} element Element.
+     * @param {angular.Attributes} attrs Attributes.
+     * @param {ngeo.DrawfeatureController} drawFeatureCtrl Controller.
+     */
+    link: function($scope, element, attrs, drawFeatureCtrl) {
+
+      var helpMsg = gettext('Click to start drawing length');
+      var contMsg = gettext('Click to continue drawing<br/>' +
+                            'Double-click or click last point to finish');
+
+      var measureLength = new ngeo.interaction.MeasureLength({
+        style: new ol.style.Style(),
+        startMsg: $compile('<div translate>' + helpMsg + '</div>')($scope)[0],
+        continueMsg: $compile('<div translate>' + contMsg + '</div>')($scope)[0]
+      });
+
+      drawFeatureCtrl.registerInteraction(measureLength);
+      drawFeatureCtrl.measureLength = measureLength
+
+      ol.events.listen(
+          measureLength,
+          ngeo.MeasureEventType.MEASUREEND,
+          drawFeatureCtrl.handleDrawEnd.bind(
+              drawFeatureCtrl, ngeo.GeometryType.LINE_STRING),
+          drawFeatureCtrl
+      );
+      ol.events.listen(
+          measureLength,
+          ol.Object.getChangeEventType(
+              ol.interaction.InteractionProperty.ACTIVE),
+          drawFeatureCtrl.handleActiveChange,
+          drawFeatureCtrl
+      );
+    }
+  };
+};
+
+
+ngeo.module.directive('ngeoMeasurelength', ngeo.measurelengthDirective);

--- a/src/ngeo.js
+++ b/src/ngeo.js
@@ -5,7 +5,7 @@ goog.provide('ngeo');
 
 
 /** @type {!angular.Module} */
-ngeo.module = angular.module('ngeo', []);
+ngeo.module = angular.module('ngeo', ['gettext']);
 
 
 /**
@@ -36,10 +36,10 @@ ngeo.FeatureProperties = {
  * @enum {string}
  */
 ngeo.GeometryType = {
-  CIRCLE: 'circle',
-  LINESTRING: 'linestring',
-  POINT: 'point',
-  POLYGON: 'polygon',
-  RECTANGLE: 'rectangle',
-  TEXT: 'text'
+  CIRCLE: 'Circle',
+  LINE_STRING: 'LineString',
+  POINT: 'Point',
+  POLYGON: 'Polygon',
+  RECTANGLE: 'Rectangle',
+  TEXT: 'Text'
 };

--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -77,7 +77,7 @@ ngeo.FeatureHelper.prototype.getStyle = function(feature) {
   var style;
 
   switch (type) {
-    case ngeo.GeometryType.LINESTRING:
+    case ngeo.GeometryType.LINE_STRING:
       style = this.getLineStringStyle_(feature);
       break;
     case ngeo.GeometryType.POINT:
@@ -395,7 +395,7 @@ ngeo.FeatureHelper.prototype.getType = function(feature) {
       type = ngeo.GeometryType.POLYGON;
     }
   } else if (geometry instanceof ol.geom.LineString) {
-    type = ngeo.GeometryType.LINESTRING;
+    type = ngeo.GeometryType.LINE_STRING;
   }
 
   goog.asserts.assert(type, 'Type should be thruthy');

--- a/src/services/features.js
+++ b/src/services/features.js
@@ -1,0 +1,7 @@
+goog.provide('ngeo.Features')
+goog.require('ngeo');
+
+goog.require('ol.Collection');
+
+
+ngeo.module.value('ngeoFeatures', new ol.Collection());


### PR DESCRIPTION
This PR introduces a `ngeo-drawfeature` directive and an example featuring it.

## Todo

 * [x] deal with i18n values
 * [x] use contants for feature properties and geometry types once #955 is merged
 * [x] set the default style of the features when drawn once #955 is merged
 * [x] prevent the features and overlay that are added in the measure interactions to be shown, as those conflict with the actual drawn features.
 * [x] code review
 * [x] merge into one commit
 * [x] travis build passes

## Live example

 * http://adube.github.io/ngeo/edit-feature-draw/examples/drawfeature.html