### PR TITLE
changing the rule .treenode ul ul {} to .treenode ul {}

### DIFF
--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -4,7 +4,7 @@ gmf-layertree div {
 gmf-layertree ul .treenode {
   padding-top: @app-margin;
 
-  ul ul {
+  ul {
     padding-left: 20px;
   }
 


### PR DESCRIPTION
fixes #967


Cherry-pick #953 into the 2.0 branch