### PR TITLE
Add standard design for layertree

### DIFF
--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -4,7 +4,7 @@
 @import 'font.less';
 @import 'base.less';
 @import 'map.less';
-@import 'layertree.less';
+@import 'desktoplayertree.less';
 @import 'icons.less';
 @import 'search.less';
 
@@ -132,10 +132,6 @@ main {
       width: 50%;
     }
   }
-}
-
-gmf-layertree ul .treenode {
-  padding-top: @app-margin;
 }
 
 

--- a/contribs/gmf/less/desktoplayertree.less
+++ b/contribs/gmf/less/desktoplayertree.less
@@ -1,0 +1,31 @@
+@import 'layertree.less';
+
+gmf-layertree {
+  ul {
+    padding-top: @micro-app-margin;
+  }
+  > :first-child{
+    margin-right: @half-app-margin;
+  }
+}
+
+.gmf-layertree-node {
+
+  &.depth-1 {
+    //styling first level node for desktop app
+    background-color: @nav-bg;
+    box-shadow: 0 0 4px 1px @input-border-focus;
+
+    > ul {
+      //adding space after the last li elem of the first level nodes
+      padding-bottom: @half-app-margin;
+    }
+  }
+
+  .group {
+    &.depth-1 {
+      background-color: @main-bg-color;
+      padding: @half-app-margin;
+    }
+  }
+}

--- a/contribs/gmf/less/desktoplayertree.less
+++ b/contribs/gmf/less/desktoplayertree.less
@@ -4,7 +4,7 @@ gmf-layertree {
   ul {
     padding-top: @micro-app-margin;
   }
-  > :first-child{
+  > :first-child {
     margin-right: @half-app-margin;
   }
 }
@@ -22,10 +22,8 @@ gmf-layertree {
     }
   }
 
-  .group {
-    &.depth-1 {
+  .group.depth-1 {
       background-color: @main-bg-color;
       padding: @half-app-margin;
-    }
   }
 }

--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -1,12 +1,25 @@
-gmf-layertree div {
-  margin-right: @app-margin;
-}
+.gmf-layertree-node {
+  /**
+   * Style rules for treenodes in the layertree
+   */
+  margin-top: @half-app-margin;
 
-gmf-layertree ul .treenode {
-  padding-top: @app-margin;
+  &.depth-1 {
+    margin: 0 @micro-app-margin @app-margin @micro-app-margin;
+  }
 
   ul {
-    padding-left: 20px;
+    padding: 0 @app-margin 0 2*@app-margin; //shifting child nodes
+
+    
+
+    ul {
+      //nested ul (i.e node groups into node groups should not add extra padding)
+      padding-right: 0;
+      li:last-child {
+        padding-bottom: 0;
+      }
+    }
   }
 
   a {
@@ -20,6 +33,7 @@ gmf-layertree ul .treenode {
     }
 
     &.expand-node.fa {
+      color : @color-light;
       display: inline-block;
       &::before {
         content: "\f054";
@@ -30,32 +44,60 @@ gmf-layertree ul .treenode {
     }
   }
 
-  .rightButtons *::after {
-    background: none;
-    color: @map-tools-color;
-    display: inline;
-    font-family: FontAwesome;
+  .rightButtons {
+    float: right;
+
+    *::before,
+    *::after {
+      background: none;
+      position: relative;
+      right: initial;
+    }
+
+    *::after {
+      color: @map-tools-color;
+      display: inline;
+      font-family: FontAwesome;
+    }
+
   }
+
   .state {
     font-family: gmf-icons;
     color: @color;
   }
+
   .on .state {
     color: @special-link;
   }
+
   .off, .off .legend img {
     opacity: 0.5;
   }
-  .leaf .state::after {
-    content: "\e603";
+
+  .leaf {
+    font-size: smaller;
+    .state::after {
+      content: "\e603";
+    }
   }
 
   .group {
+    font-size: smaller;
     .state::after {
       content: "\e600";
     }
     .layerIcon {
       display: none;
+    }
+
+    &.depth-1 {
+      //styling the header of first level groups
+      font-size: small;
+      .name {
+        font-weight: bold;
+        color: black;
+      }
     }
   }
 
@@ -64,17 +106,11 @@ gmf-layertree ul .treenode {
     height: @app-margin;
     width: 2 * @app-margin;
   }
+
   .name {
     white-space: normal;
   }
-  .rightButtons {
-    float: right;
-    *::after, *::before {
-      background: none;
-      position: relative;
-      right: initial;
-    }
-  }
+
   .metadata {
     a {
       padding: 0;
@@ -85,6 +121,7 @@ gmf-layertree ul .treenode {
       }
     }
   }
+
   .zoom {
     display: none;
     &:hover {
@@ -94,12 +131,14 @@ gmf-layertree ul .treenode {
       content: "\f18e";
     }
   }
+
   .noSource {
     opacity: 0.3;
     &::after {
       content: "(source not available)";
     }
   }
+
   .outOfResolution {
     .rightButtons {
       .zoom {
@@ -113,6 +152,7 @@ gmf-layertree ul .treenode {
       content: "\e604";
     }
   }
+
   .legendButton {
     a {
       padding: 0;
@@ -122,6 +162,7 @@ gmf-layertree ul .treenode {
       }
     }
   }
+
   .legend {
     a::before {
       display: none;
@@ -130,4 +171,5 @@ gmf-layertree ul .treenode {
       padding-left: @app-margin + @half-app-margin;
     }
   }
+
 }

--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -11,8 +11,6 @@
   ul {
     padding: 0 @app-margin 0 2*@app-margin; //shifting child nodes
 
-    
-
     ul {
       //nested ul (i.e node groups into node groups should not add extra padding)
       padding-right: 0;
@@ -72,14 +70,14 @@
   }
 
   .leaf {
-    font-size: smaller;
+    font-size: @font-size-small;
     .state::after {
       content: "\e603";
     }
   }
 
   .group {
-    font-size: smaller;
+    font-size: @font-size-small;
     .state::after {
       content: "\e600";
     }
@@ -89,7 +87,7 @@
 
     &.depth-1 {
       //styling the header of first level groups
-      font-size: small;
+      font-size: @font-size-base;
       .name {
         font-weight: bold;
         color: black;

--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -67,10 +67,6 @@
     color: @color;
   }
 
-  .on .state {
-    color: @special-link;
-  }
-
   .off, .off .legend img {
     opacity: 0.5;
   }

--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -5,7 +5,7 @@
 @import 'base.less';
 @import 'map.less';
 @import 'search.less';
-@import 'layertree.less';
+@import 'mobilelayertree.less';
 @import 'fullscreenpopup.less';
 @import 'mobile-nav.less';
 @import 'icons.less';

--- a/contribs/gmf/less/mobilelayertree.less
+++ b/contribs/gmf/less/mobilelayertree.less
@@ -1,0 +1,1 @@
+@import 'layertree.less';

--- a/contribs/gmf/less/mobilelayertree.less
+++ b/contribs/gmf/less/mobilelayertree.less
@@ -1,1 +1,6 @@
 @import 'layertree.less';
+
+nav.nav-left .gmf-layertree-node a[data-toggle] {
+  //override rule: nav.nav-left a[data-toggle] padding-right: 4rem
+  padding-right: 0;
+}

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -1,4 +1,4 @@
-<span ng-if="::!layertreeCtrl.isRoot" id="node-{{::layertreeCtrl.uid}}" ng-class="[layertreeCtrl.node.children ? 'group' : 'leaf', 'depth-' + layertreeCtrl.depth, gmfLayertreeCtrl.getResolutionStyle(layertreeCtrl.node), gmfLayertreeCtrl.getNoSourceStyle(layertreeCtrl), gmfLayertreeCtrl.getNodeState(layertreeCtrl)]">
+<div ng-if="::!layertreeCtrl.isRoot" id="node-{{::layertreeCtrl.uid}}" ng-class="[layertreeCtrl.node.children ? 'group' : 'leaf', 'depth-' + layertreeCtrl.depth, gmfLayertreeCtrl.getResolutionStyle(layertreeCtrl.node), gmfLayertreeCtrl.getNoSourceStyle(layertreeCtrl), gmfLayertreeCtrl.getNodeState(layertreeCtrl)]">
     <a  ng-if="::layertreeCtrl.node.children"
         data-toggle="collapse"
         href="#layer-group-{{::layertreeCtrl.uid}}"
@@ -33,11 +33,11 @@
       </a>
     </div>
   </span>
-</span>
+</div>
 <ul id="layer-group-{{::layertreeCtrl.uid}}"
     ng-if="::layertreeCtrl.node.children"
     ng-class="{collapse: !layertreeCtrl.isRoot, in : layertreeCtrl.node.isExpanded}">
-  <li class="treenode" ng-repeat="node in layertreeCtrl.node.children"
+  <li class="gmf-layertree-node" ng-repeat="node in layertreeCtrl.node.children" ng-class="'depth-' + layertreeCtrl.depth"
       ngeo-layertree="node"
       ngeo-layertree-notroot
       ngeo-layertree-map="layertreeCtrl.map"


### PR DESCRIPTION
Following the spec [#1708](https://github.com/camptocamp/c2cgeoportal/wiki/Spec-%231708-Layertree-desktop)

- Adding the desktop layertree design
- Splitting layertree.less in 3 files in order to have a different design for mobile/desktop with a common base style
- Refactoring selectors for the future needs (e.g for #819 )

