### PR TITLE
Reload themes on login/logout

### DIFF
--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -50,7 +50,20 @@ gmf.AbstractController = function(config, $scope, $injector) {
    * @type {gmf.Themes}
    */
   var gmfThemes = $injector.get('gmfThemes');
-  gmfThemes.loadThemes();
+
+  /**
+   * Authentication service
+   * @type {gmf.Authentication}
+   */
+  var gmfAuthentication = $injector.get('gmfAuthentication');
+  var loadThemes = function(evt) {
+    // reload themes when login status changes
+    var roleId = (evt.user.username !== null) ? evt.user.role_id : undefined;
+    gmfThemes.loadThemes(roleId);
+  };
+  ol.events.listen(gmfAuthentication, gmf.AuthenticationEventType.READY, loadThemes);
+  ol.events.listen(gmfAuthentication, gmf.AuthenticationEventType.LOGIN, loadThemes);
+  ol.events.listen(gmfAuthentication, gmf.AuthenticationEventType.LOGOUT, loadThemes);
 
   /**
    * @type {Array.<gmfx.SearchDirectiveDatasource>}

--- a/contribs/gmf/src/directives/mobilebackgroundlayerselector.js
+++ b/contribs/gmf/src/directives/mobilebackgroundlayerselector.js
@@ -130,7 +130,9 @@ gmf.MobileBackgroundlayerselectorController = function(
     this.setLayer(defaultBgLayer, true);
   }.bind(this);
 
-  gmfThemes.getBgLayers().then(getBgLayersSuccessFn);
+  ol.events.listen(gmfThemes, gmf.ThemesEventType.LOAD, function() {
+    gmfThemes.getBgLayers().then(getBgLayersSuccessFn);
+  });
 
   ol.events.listen(
       this.backgroundLayerMgr_,

--- a/contribs/gmf/src/directives/themeselector.js
+++ b/contribs/gmf/src/directives/themeselector.js
@@ -158,15 +158,20 @@ gmf.ThemeselectorController.prototype.setThemes_ = function() {
     if (gmf.ThemeselectorController.themeInUrl(pathElements)) {
       themeId = pathElements[pathElements.length - 1];
     }
-    currentTheme = goog.array.find(this.themes, function(object) {
-      return object['name'] === themeId;
-    });
+    currentTheme = gmf.Themes.findThemeByName(this.themes, themeId);
+    if (currentTheme === null) {
+      // if the current theme is not available (e.g. a restricted theme is no
+      // longer available after a logout), use the default
+      currentTheme = gmf.Themes.findThemeByName(this.themes, this.defaultTheme);
+    }
 
     this.switchTheme(currentTheme);
 
   }.bind(this);
 
-  this.gmfThemes_.getThemesObject().then(getThemesObjectSuccessFn);
+  ol.events.listen(this.gmfThemes_, gmf.ThemesEventType.LOAD, function() {
+    this.gmfThemes_.getThemesObject().then(getThemesObjectSuccessFn);
+  }.bind(this));
 };
 
 

--- a/contribs/gmf/src/services/authenticationservice.js
+++ b/contribs/gmf/src/services/authenticationservice.js
@@ -1,8 +1,10 @@
 goog.provide('gmf.Authentication');
 goog.provide('gmf.AuthenticationEventType');
+goog.provide('gmf.AuthenticationEvent');
 
 goog.require('gmf');
 goog.require('goog.uri.utils');
+goog.require('ol.events.Event');
 goog.require('ol.events.EventTarget');
 
 
@@ -69,6 +71,47 @@ gmf.module.value('gmfUser', {
 
 
 /**
+ * @enum {string}
+ */
+gmf.AuthenticationEventType = {
+  /**
+   * Triggered after a login.
+   */
+  LOGIN: 'login',
+  /**
+   * Triggered after a logout.
+   */
+  LOGOUT: 'logout',
+  /**
+   * Triggered after the authentication service has loaded the login status.
+   */
+  READY: 'ready'
+};
+
+/**
+ * @classdesc
+ * Event emitted by the authentication service.
+ *
+ * @constructor
+ * @extends {ol.events.Event}
+ * @param {gmf.AuthenticationEventType} type Event type.
+ * @param {gmf.User} user The current user.
+ */
+gmf.AuthenticationEvent = function(type, user) {
+
+  goog.base(this, type);
+
+  /**
+   * The logged-in user.
+   * @type {gmf.User}
+   */
+  this.user = user;
+
+};
+goog.inherits(gmf.AuthenticationEvent, ol.events.Event);
+
+
+/**
  * An "authentication" service for a GeoMapFish application. Upon loading, it
  * launches a request to determine whether a user is currently logged in or
  * not.
@@ -123,7 +166,7 @@ gmf.Authentication.prototype.load_ = function() {
   var url = goog.uri.utils.appendPath(
       this.baseUrl_, gmf.AuthenticationRouteSuffix.IS_LOGGED_IN);
   this.$http_.get(url, {withCredentials: true}).then(
-      this.handleLogin_.bind(this));
+      this.handleLogin_.bind(this, true));
 };
 
 
@@ -166,7 +209,7 @@ gmf.Authentication.prototype.login = function(login, pwd) {
     headers: {'Content-Type': 'application/x-www-form-urlencoded'},
     withCredentials: true
   }).then(
-      this.handleLogin_.bind(this));
+      this.handleLogin_.bind(this, false));
 };
 
 
@@ -209,25 +252,35 @@ gmf.Authentication.prototype.resetPassword = function(login) {
 
 
 /**
+ * @param {boolean} checkingLoginStatus Checking the login status?
  * @param {angular.$http.Response} resp Ajax response.
  * @return {angular.$http.Response} Response.
  * @private
  */
-gmf.Authentication.prototype.handleLogin_ = function(resp) {
+gmf.Authentication.prototype.handleLogin_ = function(checkingLoginStatus, resp) {
   var respData = /** @type {gmf.AuthenticationLoginResponse} */ (resp.data);
-  this.setUser_(respData);
+  this.setUser_(respData, !checkingLoginStatus);
+  if (checkingLoginStatus) {
+    this.dispatchEvent(new gmf.AuthenticationEvent(
+      gmf.AuthenticationEventType.READY, this.user_));
+  }
   return resp;
 };
 
 
 /**
  * @param {gmf.AuthenticationLoginResponse} respData Response.
+ * @param {boolean} emitEvent Emit a login event?
  * @private
  */
-gmf.Authentication.prototype.setUser_ = function(respData) {
+gmf.Authentication.prototype.setUser_ = function(respData, emitEvent) {
   if (respData.username !== undefined) {
     for (var key in respData) {
       this.user_[key] = respData[key];
+    }
+    if (emitEvent) {
+      this.dispatchEvent(new gmf.AuthenticationEvent(
+        gmf.AuthenticationEventType.LOGIN, this.user_));
     }
   }
 };
@@ -240,6 +293,8 @@ gmf.Authentication.prototype.resetUser_ = function() {
   for (var key in this.user_) {
     this.user_[key] = null;
   }
+  this.dispatchEvent(new gmf.AuthenticationEvent(
+    gmf.AuthenticationEventType.LOGOUT, this.user_));
 };
 
 

--- a/contribs/gmf/test/spec/beforeeach.js
+++ b/contribs/gmf/test/spec/beforeeach.js
@@ -1,5 +1,6 @@
 beforeEach(function() {
   module('gmf', function($provide) {
     $provide.value('gmfTreeUrl', 'http://fake/gmf/themes');
+    $provide.value('authenticationBaseUrl', 'https://fake/gmf/authentication');
   });
 });

--- a/contribs/gmf/test/spec/services/authenticationservice.spec.js
+++ b/contribs/gmf/test/spec/services/authenticationservice.spec.js
@@ -1,0 +1,102 @@
+goog.require('gmf.Authentication');
+goog.require('gmf.AuthenticationEventType');
+
+describe('gmf.Authentication', function() {
+  var gmfAuthentication;
+  var authenticationBaseUrl;
+  var isLoggedInUrl;
+  var loginUrl;
+  var logoutUrl;
+
+  beforeEach(function() {
+    inject(function($injector) {
+      gmfAuthentication = $injector.get('gmfAuthentication');
+      authenticationBaseUrl = $injector.get('authenticationBaseUrl');
+
+      isLoggedInUrl = goog.uri.utils.appendPath(
+          authenticationBaseUrl, gmf.AuthenticationRouteSuffix.IS_LOGGED_IN);
+      loginUrl = goog.uri.utils.appendPath(
+          authenticationBaseUrl, gmf.AuthenticationRouteSuffix.LOGIN);
+      logoutUrl = goog.uri.utils.appendPath(
+          authenticationBaseUrl, gmf.AuthenticationRouteSuffix.LOGOUT);
+
+      $httpBackend = $injector.get('$httpBackend');
+      $httpBackend.when('GET', isLoggedInUrl).respond({});
+
+      // need to flush after the initialization to process the request which
+      // queries the initial logged-in status
+      $httpBackend.flush();
+    });
+  });
+
+  afterEach(function() {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  it('emits READY after login status check', function() {
+    var spy = jasmine.createSpy();
+    var event;
+    ol.events.listenOnce(
+      gmfAuthentication, gmf.AuthenticationEventType.READY, function(evt) {
+        event = evt;
+        spy();
+      });
+
+    $httpBackend.when('GET', isLoggedInUrl).respond({});
+
+    gmfAuthentication.load_();
+    $httpBackend.flush();
+
+    expect(spy.calls.length).toBe(1);
+    expect(event).toBeDefined();
+    expect(event.type).toBe(gmf.AuthenticationEventType.READY);
+    expect(event.user.username).toBe(null);
+  });
+
+  it('logins successful', function() {
+    var spy = jasmine.createSpy();
+    var event;
+    ol.events.listenOnce(
+      gmfAuthentication, gmf.AuthenticationEventType.LOGIN, function(evt) {
+        event = evt;
+        spy();
+      });
+
+    $httpBackend.when('POST', loginUrl).respond({'username': 'user'});
+
+    gmfAuthentication.login('user', 'pwd');
+    $httpBackend.flush();
+
+    expect(spy.calls.length).toBe(1);
+    expect(event).toBeDefined();
+    expect(event.type).toBe(gmf.AuthenticationEventType.LOGIN);
+    expect(event.user.username).toBe('user');
+  });
+
+  it('trys to login with wrong credentials', function() {
+    var spy = jasmine.createSpy();
+    ol.events.listenOnce(
+      gmfAuthentication, gmf.AuthenticationEventType.LOGIN, spy);
+
+    $httpBackend.when('POST', loginUrl).respond({});
+
+    gmfAuthentication.login('user', 'wrong-pwd');
+    $httpBackend.flush();
+
+    expect(spy.calls.length).toBe(0);
+  });
+
+  it('logs out', function() {
+    var spy = jasmine.createSpy();
+    ol.events.listenOnce(
+      gmfAuthentication, gmf.AuthenticationEventType.LOGOUT, spy);
+
+    $httpBackend.when('GET', logoutUrl).respond('true');
+
+    gmfAuthentication.logout();
+    $httpBackend.flush();
+
+    expect(spy.calls.length).toBe(1);
+  });
+});

--- a/karma-conf.js
+++ b/karma-conf.js
@@ -25,6 +25,7 @@ module.exports = function(config) {
       '.build/ngeo-deps.js',
       '.build/gmf-deps.js',
       '.build/examples-hosted/lib/proj4.js',
+      'node_modules/jquery/dist/jquery.js',
       'node_modules/angular/angular.js',
       'node_modules/angular-gettext/dist/angular-gettext.js',
       'node_modules/angular-animate/angular-animate.js',


### PR DESCRIPTION
The authentication service now emits `login`, `logout` and  `ready` events, which later will also make it easier to disable/enable tools or other functionality depending on the user's permissions.

Closes https://github.com/camptocamp/ngeo/issues/966