### PR TITLE
Support HTML in feature attributes (query popup)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ GMF_APPS_LIBS_JS_FILES += \
 	node_modules/angular/angular.min.js \
 	node_modules/angular-animate/angular-animate.min.js \
 	node_modules/angular-gettext/dist/angular-gettext.min.js \
+	node_modules/angular-sanitize/angular-sanitize.min.js \
 	node_modules/angular-touch/angular-touch.min.js \
 	node_modules/bootstrap/dist/js/bootstrap.min.js \
 	node_modules/proj4/dist/proj4.js \
@@ -42,6 +43,7 @@ EXAMPLE_HOSTED_REQUIREMENTS = .build/examples-hosted/lib/ngeo.js \
 	.build/examples-hosted/lib/angular.min.js \
 	.build/examples-hosted/lib/angular-animate.min.js \
 	.build/examples-hosted/lib/angular-gettext.min.js \
+	.build/examples-hosted/lib/angular-sanitize.min.js \
 	.build/examples-hosted/lib/angular-touch.min.js \
 	.build/examples-hosted/lib/bootstrap.min.js \
 	.build/examples-hosted/lib/bootstrap.min.css \
@@ -309,6 +311,10 @@ dist/gmf.js.map: dist/gmf.js
 	mkdir -p $(dir $@)
 	cp $< $@
 
+.build/examples-hosted/lib/angular-sanitize.min.js: node_modules/angular-sanitize/angular-sanitize.min.js
+	mkdir -p $(dir $@)
+	cp $< $@
+
 .build/examples-hosted/lib/angular-touch.min.js: node_modules/angular-touch/angular-touch.min.js
 	mkdir -p $(dir $@)
 	cp $< $@
@@ -412,6 +418,7 @@ node_modules/angular/angular.min.js: .build/node_modules.timestamp
 		-e 's|\.\./node_modules/angular/angular\.js|lib/angular.min.js|' \
 		-e 's|\.\./node_modules/angular-animate/angular-animate\.js|lib/angular-animate.min.js|' \
 		-e 's|\.\./node_modules/angular-gettext/dist/angular-gettext\.js|lib/angular-gettext.min.js|' \
+		-e 's|\.\./node_modules/angular-sanitize/angular-sanitize\.js|lib/angular-sanitize.min.js|' \
 		-e 's|\.\./node_modules/angular-touch/angular-touch\.js|lib/angular-touch.min.js|' \
 		-e 's|\.\./node_modules/d3/d3\.js|lib/d3.min.js|' \
 		-e 's|\.\./node_modules/typeahead.js/dist/typeahead.bundle\.js|lib/typeahead.bundle.min.js|' \

--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -96,6 +96,7 @@
     <script src="../../../../node_modules/jquery/dist/jquery.js"></script>
     <script src="../../../../node_modules/angular/angular.js"></script>
     <script src="../../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
     <script src="../../../../node_modules/angular-touch/angular-touch.js"></script>
     <script src="../../../../node_modules/typeahead.js/dist/typeahead.bundle.js"></script>
     <script src="../../../../node_modules/proj4/dist/proj4-src.js" type="text/javascript"></script>

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -127,6 +127,7 @@
     <script src="../../../../node_modules/jquery/dist/jquery.js"></script>
     <script src="../../../../node_modules/angular/angular.js"></script>
     <script src="../../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
     <script src="../../../../node_modules/angular-touch/angular-touch.js"></script>
     <script src="../../../../node_modules/typeahead.js/dist/typeahead.bundle.js"></script>
     <script src="../../../../node_modules/proj4/dist/proj4-src.js" type="text/javascript"></script>

--- a/contribs/gmf/examples/asitvd.html
+++ b/contribs/gmf/examples/asitvd.html
@@ -22,6 +22,7 @@
     </p>
     <script src="../../../node_modules/angular/angular.js"></script>
     <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
     <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
     <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=asitvd.js"></script>

--- a/contribs/gmf/examples/authentication.html
+++ b/contribs/gmf/examples/authentication.html
@@ -25,6 +25,7 @@
     <script src="../../../node_modules/jquery/dist/jquery.js"></script>
     <script src="../../../node_modules/angular/angular.js"></script>
     <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
     <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
     <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
     <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>

--- a/contribs/gmf/examples/layertree.html
+++ b/contribs/gmf/examples/layertree.html
@@ -136,6 +136,7 @@
     <script src="../../../node_modules/proj4/dist/proj4.js"></script>
     <script src="../../../node_modules/angular/angular.js"></script>
     <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
     <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
     <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
     <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>

--- a/contribs/gmf/examples/mobilebackgroundlayerselector.html
+++ b/contribs/gmf/examples/mobilebackgroundlayerselector.html
@@ -63,6 +63,7 @@
     <gmf-map gmf-map-map="ctrl.map"></gmf-map>
     <script src="../../../node_modules/angular/angular.js"></script>
     <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
     <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
     <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="../../../node_modules/proj4/dist/proj4.js"></script>

--- a/contribs/gmf/examples/mobilemeasure.html
+++ b/contribs/gmf/examples/mobilemeasure.html
@@ -87,6 +87,7 @@
     </p>
     <script src="../../../node_modules/angular/angular.js"></script>
     <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
     <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
     <script src="../../../node_modules/proj4/dist/proj4.js"></script>
     <script src="/@?main=mobilemeasure.js"></script>

--- a/contribs/gmf/examples/mobilequery.html
+++ b/contribs/gmf/examples/mobilequery.html
@@ -281,6 +281,7 @@
     <script src="../../../node_modules/jquery/dist/jquery.js"></script>
     <script src="../../../node_modules/angular/angular.js"></script>
     <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
     <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
     <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
     <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>

--- a/contribs/gmf/examples/permalink.html
+++ b/contribs/gmf/examples/permalink.html
@@ -54,6 +54,7 @@
     <script src="../../../node_modules/jquery/dist/jquery.js"></script>
     <script src="../../../node_modules/angular/angular.js"></script>
     <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
     <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
     <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
     <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>

--- a/contribs/gmf/examples/search.html
+++ b/contribs/gmf/examples/search.html
@@ -114,6 +114,7 @@
     <script src="../../../node_modules/jquery/dist/jquery.js"></script>
     <script src="../../../node_modules/angular/angular.js"></script>
     <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
     <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
     <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="../../../node_modules/typeahead.js/dist/typeahead.bundle.js"></script>

--- a/contribs/gmf/examples/simple.html
+++ b/contribs/gmf/examples/simple.html
@@ -19,6 +19,7 @@
     <p id="desc">This example shows how to use the <code>gmf-map</code> directive to insert an OpenLayers map in a GeoMapFish page.</p>
     <script src="../../../node_modules/angular/angular.js"></script>
     <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
     <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
     <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=simple.js"></script>

--- a/contribs/gmf/examples/themeselector.html
+++ b/contribs/gmf/examples/themeselector.html
@@ -61,6 +61,7 @@
 
     <script src="../../../node_modules/angular/angular.js"></script>
     <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
     <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
     <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=themeselector.js"></script>

--- a/contribs/gmf/src/directives/partials/mobiledisplayqueries.html
+++ b/contribs/gmf/src/directives/partials/mobiledisplayqueries.html
@@ -12,7 +12,7 @@
           <table>
             <tr ng-repeat="(key, value) in ctrl.getFeatureValues()" ng-if="value.length && key !== 'boundedBy'">
               <td class="key">{{key | translate}}</td>
-              <td class="value">{{value}}</td>
+              <td class="value" ng-bind-html="value"></td>
             </tr>
           </table>
         </div>

--- a/contribs/gmf/src/gmf.js
+++ b/contribs/gmf/src/gmf.js
@@ -8,7 +8,7 @@ goog.require('ngeo');
 
 /** @type {!angular.Module} */
 gmf.module = angular.module('gmf', [ngeo.module.name, 'gettext',
-    'ngAnimate', 'ngTouch']);
+    'ngAnimate', 'ngTouch', 'ngSanitize']);
 
 
 /**

--- a/karma-conf.js
+++ b/karma-conf.js
@@ -30,6 +30,7 @@ module.exports = function(config) {
       'node_modules/angular-gettext/dist/angular-gettext.js',
       'node_modules/angular-animate/angular-animate.js',
       'node_modules/angular-mocks/angular-mocks.js',
+      'node_modules/angular-sanitize/angular-sanitize.js',
       'node_modules/angular-touch/angular-touch.js',
       'test/spec/beforeeach.js',
       'test/spec/data/*.js',

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "angular-gettext-tools": "2.1.2",
     "angular-jsdoc": "1.2.1",
     "angular-mocks": "1.5.0",
+    "angular-sanitize": "1.5.0",
     "angular-touch": "1.5.0",
     "bootstrap": "3.3.6",
     "clean-css": "3.4.10",


### PR DESCRIPTION
This PR proposes to use [angular-sanitize](https://docs.angularjs.org/api/ng/directive/ngBindHtml) to sanitize feature attributes so that HTML code is rendered as HTML.

Closes https://github.com/camptocamp/ngeo/issues/965