### PR TITLE
Require EPSG2056 in controllers

### DIFF
--- a/contribs/gmf/apps/desktop/js/controller.js
+++ b/contribs/gmf/apps/desktop/js/controller.js
@@ -16,6 +16,8 @@ goog.require('gmf.AbstractDesktopController');
 /** @suppress {extraRequire} */
 goog.require('gmf.authenticationDirective');
 /** @suppress {extraRequire} */
+goog.require('ngeo.proj.EPSG2056');
+/** @suppress {extraRequire} */
 goog.require('ngeo.proj.EPSG21781');
 
 

--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -16,6 +16,8 @@ goog.require('gmf.AbstractDesktopController');
 /** @suppress {extraRequire} */
 goog.require('gmf.authenticationDirective');
 /** @suppress {extraRequire} */
+goog.require('ngeo.proj.EPSG2056');
+/** @suppress {extraRequire} */
 goog.require('ngeo.proj.EPSG21781');
 
 

--- a/contribs/gmf/apps/mobile/js/controller.js
+++ b/contribs/gmf/apps/mobile/js/controller.js
@@ -15,6 +15,8 @@ goog.require('gmf.AbstractMobileController');
 /** @suppress {extraRequire} */
 goog.require('gmf.authenticationDirective');
 /** @suppress {extraRequire} */
+goog.require('ngeo.proj.EPSG2056');
+/** @suppress {extraRequire} */
 goog.require('ngeo.proj.EPSG21781');
 /** @suppress {extraRequire} */
 goog.require('ngeo.mobileGeolocationDirective');


### PR DESCRIPTION
Fix: https://github.com/camptocamp/ngeo/issues/973

Examples:
- https://ger-benjamin.github.io/ngeo/add_epsg2056/examples/contribs/gmf/apps/mobile
- https://ger-benjamin.github.io/ngeo/add_epsg2056/examples/contribs/gmf/apps/desktop (search "2600000 1200000" here)
- https://ger-benjamin.github.io/ngeo/add_epsg2056/examples/contribs/gmf/apps/desktop_alt