### PR TITLE
Add missing require in gmf.Permalink

### DIFF
--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -2,6 +2,7 @@ goog.provide('gmf.Permalink');
 
 goog.require('gmf');
 goog.require('gmf.Themes');
+goog.require('gmf.TreeManager');
 goog.require('ngeo.BackgroundEventType');
 goog.require('ngeo.BackgroundLayerMgr');
 goog.require('ngeo.Debounce');


### PR DESCRIPTION
This PR fixes a missing `goog.require` in the dependencies of the `gmf.Permalink` service.