### PR TITLE
GMF draw feature directive

### DIFF
--- a/contribs/gmf/examples/drawfeature.html
+++ b/contribs/gmf/examples/drawfeature.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>Draw Feature Example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../../../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+
+    <style>
+      gmf-map > div {
+        width: 600px;
+        height: 400px;
+      }
+
+      /* drawfeature */
+
+      gmf-drawfeature {
+        display: block;
+        margin: 20px;
+        width: 425px;
+      }
+
+      .ngeo-drawfeature-actionbuttons {
+        float: right;
+      }
+
+      .gmf-drawfeature-featurelist li:hover {
+        background-color: #ADD8E6;
+        cursor: pointer;
+      }
+
+      .gmf-eol {
+        clear: both;
+      }
+
+      /* drawfeature */
+
+      ngeo-drawfeature {
+        margin: 10px 0;
+      }
+      .ngeo-drawfeature-circle:before {
+        content: 'Circle'
+      }
+      .ngeo-drawfeature-linestring:before {
+        content: 'LineString'
+      }
+      .ngeo-drawfeature-point:before {
+        content: 'Point'
+      }
+      .ngeo-drawfeature-polygon:before {
+        content: 'Polygon'
+      }
+      .ngeo-drawfeature-rectangle:before {
+        content: 'Rectangle'
+      }
+      .ngeo-drawfeature-text:before {
+        content: 'Text'
+      }
+      .tooltip {
+        position: relative;
+        background: rgba(0, 0, 0, 0.5);
+        border-radius: 4px;
+        color: white;
+        padding: 4px 8px;
+        opacity: 0.7;
+        white-space: nowrap;
+      }
+      .tooltip-measure {
+        opacity: 1;
+        font-weight: bold;
+      }
+      .tooltip-static {
+        display: none;
+      }
+      .tooltip-measure:before,
+      .tooltip-static:before {
+        border-top: 6px solid rgba(0, 0, 0, 0.5);
+        border-right: 6px solid transparent;
+        border-left: 6px solid transparent;
+        content: "";
+        position: absolute;
+        bottom: -6px;
+        margin-left: -7px;
+        left: 50%;
+      }
+      .tooltip-static:before {
+        border-top-color: #ffcc33;
+      }
+
+      /* featurestyle */
+
+      gmf-featurestyle .form-horizontal .control-label {
+        text-align: left;
+      }
+      .gmf-featurestyle-name {
+        font-weight: bold;
+        font-size: 16pt;
+      }
+      .gmf-featurestyle-name:not(:focus) {
+        border: none;
+        box-shadow: none;
+        -webkit-box-shadow: none;
+        padding: 0;
+      }
+      gmf-featurestyle input[type=range] {
+        padding: 6px 12px;
+      }
+      .palette {
+        border-collapse: separate;
+        border-spacing: 0px;
+      }
+      .palette tr {
+        cursor: default;
+      }
+      .palette td {
+        position: relative;
+        padding: 0px;
+        text-align: center;
+        vertical-align: middle;
+        font-size: 1px;
+        cursor: pointer;
+      }
+      .palette td > div {
+        position: relative;
+        height: 12px;
+        width: 12px;
+        border: 1px solid #fff;
+        box-sizing: content-box;
+      }
+      .palette td:hover > div::after {
+        display: block;
+        content: '';
+        background: inherit;
+        position: absolute;
+        width: 28px;
+        height: 28px;
+        top: -10px;
+        left: -10px;
+        border: 2px solid #fff;
+        -webkit-box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
+        -webkit-box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
+        box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
+        z-index: 11;
+      }
+      .palette td.selected > div::after {
+        border: 2px solid #444;
+        margin: 0;
+        content: '';
+        display: block;
+        width: 14px;
+        height: 14px;
+        position: absolute;
+        left: -3px;
+        top: -3px;
+        box-sizing: content-box;
+        z-index: 10;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <gmf-map gmf-map-map="::ctrl.map"></gmf-map>
+
+    <input type="checkbox"
+       id="checkbox-drawfeature"
+       ng-model="ctrl.drawFeatureActive" />
+    <label for="checkbox-drawfeature"> DrawFeature</label>
+
+    <input type="checkbox"
+       id="checkbox-pointermove"
+       ng-model="ctrl.pointerMoveActive" />
+    <label for="checkbox-pointermove"> PointerMove</label>
+    <span id="pointermove-feature"></span>
+
+    <gmf-drawfeature
+      ng-show="ctrl.drawFeatureActive === true"
+      gmf-drawfeature-active="ctrl.drawFeatureActive"
+      gmf-drawfeature-map="::ctrl.map">
+    </gmf-drawfeature>
+
+    <p id="desc">
+      This example shows how to use the <code>gmf-drawfeature</code>
+      directive to create, modify and delete vector features on a map and
+      style them as we please.
+    </p>
+    <script src="../../../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../../../node_modules/angular/angular.js"></script>
+    <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
+    <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="/@?main=drawfeature.js"></script>
+    <script src="default.js"></script>
+    <script src="../../../utils/watchwatchers.js"></script>
+  </body>
+</html>

--- a/contribs/gmf/examples/drawfeature.js
+++ b/contribs/gmf/examples/drawfeature.js
@@ -1,0 +1,124 @@
+goog.provide('gmf-drawfeature');
+
+goog.require('gmf.drawfeatureDirective');
+goog.require('gmf.mapDirective');
+goog.require('ngeo.FeatureHelper');
+goog.require('ngeo.Features');
+goog.require('ngeo.ToolActivate');
+goog.require('ngeo.ToolActivateMgr');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['gmf']);
+
+
+/**
+ * @param {!angular.Scope} $scope Angular scope.
+ * @param {ngeo.FeatureHelper} ngeoFeatureHelper Gmf feature helper service.
+ * @param {ol.Collection.<ol.Feature>} ngeoFeatures Collection of features.
+ * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
+ *     service.
+ * @constructor
+ */
+app.MainController = function($scope, ngeoFeatureHelper, ngeoFeatures,
+    ngeoToolActivateMgr) {
+
+  /**
+   * @type {!angular.Scope}
+   * @private
+   */
+  this.scope_ = $scope;
+
+  var view = new ol.View({
+    center: [0, 0],
+    zoom: 3
+  });
+
+  ngeoFeatureHelper.setProjection(view.getProjection());
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      }),
+      new ol.layer.Vector({
+        source: new ol.source.Vector({
+          wrapX: false,
+          features: ngeoFeatures
+        })
+      })
+    ],
+    view: view
+  });
+
+ /**
+   * @type {boolean}
+   * @export
+   */
+  this.drawFeatureActive = true;
+
+  var drawFeatureToolActivate = new ngeo.ToolActivate(
+      this, 'drawFeatureActive');
+  ngeoToolActivateMgr.registerTool(
+      'mapTools', drawFeatureToolActivate, true);
+
+ /**
+   * @type {boolean}
+   * @export
+   */
+  this.pointerMoveActive = false;
+
+  var pointerMoveToolActivate = new ngeo.ToolActivate(
+      this, 'pointerMoveActive');
+  ngeoToolActivateMgr.registerTool(
+      'mapTools', pointerMoveToolActivate, false);
+
+  $scope.$watch(
+    function() {
+      return this.pointerMoveActive;
+    }.bind(this),
+    function(newVal) {
+      if (newVal) {
+        this.map.on('pointermove', this.handleMapPointerMove_, this);
+      } else {
+        this.map.un('pointermove', this.handleMapPointerMove_, this);
+        $('#pointermove-feature').html('');
+      }
+    }.bind(this)
+  );
+
+};
+
+
+/**
+ * @param {ol.MapBrowserEvent} evt MapBrowser event
+ * @private
+ */
+app.MainController.prototype.handleMapPointerMove_ = function(evt) {
+  var pixel = evt.pixel;
+
+  var feature = this.map.forEachFeatureAtPixel(pixel, function(feature) {
+    return feature;
+  });
+
+  $('#pointermove-feature').html(
+    (feature) ? feature.get(ngeo.FeatureProperties.NAME) : 'None'
+  );
+
+  this.scope_.$apply();
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/contribs/gmf/src/directives/drawfeature.js
+++ b/contribs/gmf/src/directives/drawfeature.js
@@ -1,0 +1,335 @@
+goog.provide('gmf.DrawfeatureController');
+goog.provide('gmf.drawfeatureDirective');
+
+goog.require('gmf');
+/** @suppress {extraRequire} */
+goog.require('gmf.featurestyleDirective');
+goog.require('ngeo.ToolActivate');
+goog.require('ngeo.ToolActivateMgr');
+/** @suppress {extraRequire} */
+goog.require('ngeo.btngroupDirective');
+/** @suppress {extraRequire} */
+goog.require('ngeo.drawfeatureDirective');
+goog.require('ngeo.interaction.Modify');
+goog.require('ol.Collection');
+
+
+/**
+ * Directive used to create, modify and delete vector features on a map with
+ * the addition of changing their style.
+ * Example:
+ *
+ *     <gmf-drawfeature
+ *         gmf-drawfeature-active="ctrl.drawFeatureActive">
+ *         gmf-drawfeature-map="::ctrl.map">
+ *     </gmf-drawfeature>
+ *
+ * @htmlAttribute {boolean} gmf-drawfeature-active Whether the directive is
+ *     active or not.
+ * @htmlAttribute {ol.Map} gmf-drawfeature-map The map.
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname gmfDrawfeature
+ */
+gmf.drawfeatureDirective = function() {
+  return {
+    controller: 'GmfDrawfeatureController',
+    scope: {
+      'active': '=gmfDrawfeatureActive',
+      'map': '<gmfDrawfeatureMap'
+    },
+    bindToController: true,
+    controllerAs: 'efCtrl',
+    templateUrl: gmf.baseTemplateUrl + '/drawfeature.html'
+  };
+};
+
+gmf.module.directive('gmfDrawfeature', gmf.drawfeatureDirective);
+
+
+/**
+ * @param {!angular.Scope} $scope Angular scope.
+ * @param {angular.$timeout} $timeout Angular timeout service.
+ * @param {ngeo.DecorateInteraction} ngeoDecorateInteraction Decorate
+ *     interaction service.
+ * @param {ol.Collection.<ol.Feature>} ngeoFeatures Collection of features.
+ * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
+ *     service.
+ * @constructor
+ * @ngInject
+ * @ngdoc controller
+ * @ngname GmfDrawfeatureController
+ */
+gmf.DrawfeatureController = function($scope, $timeout, ngeoDecorateInteraction,
+    ngeoFeatures, ngeoToolActivateMgr) {
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.active;
+
+  if (this.active === undefined) {
+    this.active = false;
+  }
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.drawActive = false;
+
+ /**
+   * @type {ngeo.ToolActivate}
+   * @export
+   */
+  this.drawToolActivate = new ngeo.ToolActivate(this, 'drawActive');
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.mapSelectActive = true;
+
+  /**
+   * @type {ngeo.ToolActivate}
+   * @export
+   */
+  this.mapSelectToolActivate = new ngeo.ToolActivate(this, 'mapSelectActive');
+
+  /**
+   * @type {!angular.Scope}
+   * @private
+   */
+  this.scope_ = $scope;
+
+  /**
+   * @type {angular.$timeout}
+   * @private
+   */
+  this.timeout_ = $timeout;
+
+  /**
+   * @type {ol.Collection.<ol.Feature>}
+   * @export
+   */
+  this.features = ngeoFeatures;
+
+  /**
+   * @type {ngeo.ToolActivateMgr}
+   * @private
+   */
+  this.ngeoToolActivateMgr_ = ngeoToolActivateMgr;
+
+  /**
+   * @type {?ol.Feature}
+   * @export
+   */
+  this.selectedFeature = null;
+
+  /**
+   * @type {ol.Collection.<ol.Feature>}
+   * @private
+   */
+  this.selectedFeatures_ = new ol.Collection();
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.otherActive = true;
+
+  /**
+   * @type {ngeo.ToolActivate}
+   * @export
+   */
+  this.otherToolActivate = new ngeo.ToolActivate(this, 'otherActive');
+
+  /**
+   * @type {ngeo.interaction.Modify}
+   * @private
+   */
+  this.modify_ = new ngeo.interaction.Modify({
+    features: this.selectedFeatures_
+  });
+  var modify = this.modify_;
+  modify.setActive(false);
+  ngeoDecorateInteraction(modify);
+  this.map.addInteraction(modify);
+
+  /**
+   * @type {Array.<ol.events.Key>}
+   * @private
+   */
+  this.listenerKeys_ = [];
+
+  $scope.$watch(
+    function() {
+      return this.active;
+    }.bind(this),
+    this.handleActiveChange_.bind(this)
+  );
+
+  $scope.$watch(
+    function() {
+      return this.drawActive;
+    }.bind(this),
+    function(active) {
+      if (active) {
+        this.selectedFeature = null;
+      }
+    }.bind(this)
+  );
+
+  $scope.$watch(
+    function() {
+      return this.selectedFeature;
+    }.bind(this),
+    function(newFeature, previousFeature) {
+      if (previousFeature) {
+        this.selectedFeatures_.clear();
+      }
+      if (newFeature) {
+        this.selectedFeatures_.push(newFeature);
+      }
+    }.bind(this)
+  );
+
+  $scope.$watch(
+    function() {
+      return this.mapSelectActive;
+    }.bind(this),
+    this.handleMapSelectActiveChange_.bind(this)
+  );
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.nameProperty = ngeo.FeatureProperties.NAME;
+
+};
+
+
+/**
+ * Called when the active property of the this directive changes. Manage
+ * the activation/deactivation accordingly (event management, etc.)
+ * @param {boolean} active Whether the directive is active or not.
+ * @private
+ */
+gmf.DrawfeatureController.prototype.handleActiveChange_ = function(active) {
+
+  var keys = this.listenerKeys_;
+  var drawUid = ['draw-', goog.getUid(this)].join('-');
+  var otherUid = ['other-', goog.getUid(this)].join('-');
+  var toolMgr = this.ngeoToolActivateMgr_;
+
+  if (active) {
+    // when activated
+
+    keys.push(ol.events.listen(this.features, ol.CollectionEventType.ADD,
+        this.handleFeaturesAdd_, this));
+    keys.push(ol.events.listen(this.features, ol.CollectionEventType.REMOVE,
+        this.handleFeaturesRemove_, this));
+
+    toolMgr.registerTool(drawUid, this.drawToolActivate, false);
+    toolMgr.registerTool(drawUid, this.mapSelectToolActivate, true);
+
+    toolMgr.registerTool(otherUid, this.drawToolActivate, false);
+    toolMgr.registerTool(otherUid, this.otherToolActivate, true);
+
+    this.mapSelectActive = true;
+    this.modify_.setActive(true);
+  } else {
+    // when deactivated
+
+    keys.forEach(function(key) {
+      ol.events.unlistenByKey(key);
+    }, this);
+
+    toolMgr.unregisterTool(drawUid, this.drawToolActivate);
+    toolMgr.unregisterTool(drawUid, this.mapSelectToolActivate);
+
+    toolMgr.unregisterTool(otherUid, this.drawToolActivate);
+    toolMgr.unregisterTool(otherUid, this.otherToolActivate);
+
+    this.drawActive = false;
+    this.modify_.setActive(false);
+    this.mapSelectActive = false;
+    this.selectedFeature = null;
+  }
+
+};
+
+
+/**
+ * @param {ol.CollectionEvent} evt Event.
+ * @private
+ */
+gmf.DrawfeatureController.prototype.handleFeaturesAdd_ = function(evt) {
+  // timeout to prevent double-click to zoom the map
+  this.timeout_(function() {
+    this.selectedFeature = /** @type {ol.Feature} */ (evt.element);
+    this.drawActive = false;
+    this.scope_.$apply();
+  }.bind(this));
+};
+
+
+/**
+ * @param {ol.CollectionEvent} evt Event.
+ * @private
+ */
+gmf.DrawfeatureController.prototype.handleFeaturesRemove_ = function(evt) {
+  this.selectedFeature = null;
+};
+
+
+/**
+ * Called when the mapSelectActive property changes.
+ * @param {boolean} active Whether the map select is active or not.
+ * @private
+ */
+gmf.DrawfeatureController.prototype.handleMapSelectActiveChange_ = function(
+    active) {
+
+  if (active) {
+    ol.events.listen(this.map, ol.MapBrowserEvent.EventType.CLICK,
+        this.handleMapClick_, this);
+  } else {
+    ol.events.unlisten(this.map, ol.MapBrowserEvent.EventType.CLICK,
+        this.handleMapClick_, this);
+  }
+
+};
+
+
+/**
+ * @param {ol.MapBrowserEvent} evt Event.
+ * @private
+ */
+gmf.DrawfeatureController.prototype.handleMapClick_ = function(evt) {
+
+  var pixel = evt.pixel;
+
+  var feature = this.map.forEachFeatureAtPixel(pixel, function(feature) {
+    var ret = false;
+    if (ol.array.includes(this.features.getArray(), feature)) {
+      ret = feature;
+    }
+    return ret;
+  }.bind(this));
+
+  this.selectedFeature = feature ? feature : null;
+  this.scope_.$apply();
+};
+
+
+gmf.module.controller('GmfDrawfeatureController', gmf.DrawfeatureController);

--- a/contribs/gmf/src/directives/featurestyle.js
+++ b/contribs/gmf/src/directives/featurestyle.js
@@ -54,6 +54,12 @@ gmf.FeaturestyleController = function($scope, ngeoFeatureHelper) {
   this.feature;
 
   /**
+   * @type {!angular.Scope}
+   * @private
+   */
+  this.scope_ = $scope;
+
+  /**
    * @type {ngeo.FeatureHelper}
    * @private
    */
@@ -281,6 +287,8 @@ gmf.FeaturestyleController.prototype.handleGeometryChange_ = function() {
   if (showMeasure) {
     this.handleFeatureChange_();
   }
+
+  this.scope_.$apply();
 };
 
 

--- a/contribs/gmf/src/directives/partials/drawfeature.html
+++ b/contribs/gmf/src/directives/partials/drawfeature.html
@@ -1,0 +1,117 @@
+<div>
+
+  <h2>{{'Draw & Measure' | translate}}</h2>
+
+  <hr />
+
+  <ngeo-drawfeature
+      ngeo-btn-group
+      class="btn-group"
+      ngeo-drawfeature-active="efCtrl.drawActive"
+      ngeo-drawfeature-map="efCtrl.map">
+    <a
+      href
+      translate
+      ngeo-btn
+      ngeo-drawpoint
+      class="btn btn-default ngeo-drawfeature-point"
+      ng-class="{active: dfCtrl.drawPoint.active}"
+      ng-model="dfCtrl.drawPoint.active"></a>
+    <a
+      href
+      translate
+      ngeo-btn
+      ngeo-measurelength
+      class="btn btn-default ngeo-drawfeature-linestring"
+      ng-class="{active: dfCtrl.measureLength.active}"
+      ng-model="dfCtrl.measureLength.active"></a>
+    <a
+      href
+      translate
+      ngeo-btn
+      ngeo-measurearea
+      class="btn btn-default ngeo-drawfeature-polygon"
+      ng-class="{active: dfCtrl.measureArea.active}"
+      ng-model="dfCtrl.measureArea.active"></a>
+    <a
+      href
+      translate
+      ngeo-btn
+      ngeo-measureazimut
+      class="btn btn-default ngeo-drawfeature-circle"
+      ng-class="{active: dfCtrl.measureAzimut.active}"
+      ng-model="dfCtrl.measureAzimut.active"></a>
+    <a
+      href
+      translate
+      ngeo-btn
+      ngeo-drawrectangle
+      class="btn btn-default ngeo-drawfeature-rectangle"
+      ng-class="{active: dfCtrl.drawRectangle.active}"
+      ng-model="dfCtrl.drawRectangle.active"></a>
+    <a
+      href
+      translate
+      ngeo-btn
+      ngeo-drawtext
+      class="btn btn-default ngeo-drawfeature-text"
+      ng-class="{active: dfCtrl.drawText.active}"
+      ng-model="dfCtrl.drawText.active"></a>
+  </ngeo-drawfeature>
+
+  <hr />
+
+  <div ng-switch="efCtrl.selectedFeature">
+
+    <div ng-switch-when="null">
+      <div class="ngeo-drawfeature-actionbuttons">
+        <button
+            class="btn btn-default">
+          {{'Export' | translate}}
+        </button>
+        <button
+            ng-click="efCtrl.features.clear();"
+            class="btn btn-default">
+          {{'Delete All' | translate}}
+        </button>
+      </div>
+
+      <div class="gmf-eol"></div>
+
+      <ul class="gmf-drawfeature-featurelist">
+        <li
+            ng-repeat="feature in efCtrl.features.getArray()"
+            ng-click="efCtrl.selectedFeature = feature;">
+          {{ feature.get(efCtrl.nameProperty) }}
+        </li>
+      </ul>
+
+    </div>
+
+    <div ng-switch-default>
+
+      <div class="ngeo-drawfeature-actionbuttons">
+        <button
+            ng-click="efCtrl.selectedFeature = null;"
+            class="btn btn-default">
+          {{'<- List' | translate}}
+        </button>
+        <button
+            class="btn btn-default">
+          {{'Export' | translate}}
+        </button>
+        <button
+            ng-click="efCtrl.features.remove(efCtrl.selectedFeature);"
+            class="btn btn-default">
+          {{'Delete' | translate}}
+        </button>
+      </div>
+
+      <gmf-featurestyle
+        gmf-featurestyle-feature="efCtrl.selectedFeature">
+      </gmf-featurestyle>
+    </div>
+
+  </div>
+
+</div>

--- a/src/directives/drawfeature.js
+++ b/src/directives/drawfeature.js
@@ -20,6 +20,7 @@ goog.require('ngeo.measureazimutDirective');
 goog.require('ngeo.measurelengthDirective');
 goog.require('ol.Feature');
 
+
 /**
  * Directive used to draw vector features on a map.
  * Example:
@@ -282,8 +283,13 @@ ngeo.DrawfeatureController.prototype.handleDrawEnd = function(type, event) {
   var name = this.gettextCatalog_.getString(type);
   feature.set(prop.NAME, name + ' ' + (this.features_.getLength() + 1));
 
+  /**
+   * @type {string}
+   */
+  var color = type !== ngeo.GeometryType.TEXT ? '#DB4436' : '#000000';
+  feature.set(prop.COLOR, color);
+
   feature.set(prop.ANGLE, 0);
-  feature.set(prop.COLOR, '#ed1c24');
   feature.set(prop.OPACITY, 0.2);
   feature.set(prop.SHOW_MEASURE, false);
   feature.set(prop.SIZE, 10);

--- a/src/ngeo.js
+++ b/src/ngeo.js
@@ -17,29 +17,95 @@ ngeo.baseTemplateUrl = 'ngeo';
 
 /**
  * @enum {string}
+ * @export
  */
 ngeo.FeatureProperties = {
+  /**
+   * @type {string}
+   * @export
+   */
   ANGLE: 'angle',
+  /**
+   * @type {string}
+   * @export
+   */
   COLOR: 'color',
+  /**
+   * @type {string}
+   * @export
+   */
   IS_CIRCLE: 'isCircle',
+  /**
+   * @type {string}
+   * @export
+   */
   IS_RECTANGLE: 'isRectangle',
+  /**
+   * @type {string}
+   * @export
+   */
   IS_TEXT: 'isText',
+  /**
+   * @type {string}
+   * @export
+   */
   NAME: 'name',
+  /**
+   * @type {string}
+   * @export
+   */
   OPACITY: 'opacity',
+  /**
+   * @type {string}
+   * @export
+   */
   SHOW_MEASURE: 'showMeasure',
+  /**
+   * @type {string}
+   * @export
+   */
   SIZE: 'size',
+  /**
+   * @type {string}
+   * @export
+   */
   STROKE: 'stroke'
 };
 
 
 /**
  * @enum {string}
+ * @export
  */
 ngeo.GeometryType = {
+  /**
+   * @type {string}
+   * @export
+   */
   CIRCLE: 'Circle',
+  /**
+   * @type {string}
+   * @export
+   */
   LINE_STRING: 'LineString',
+  /**
+   * @type {string}
+   * @export
+   */
   POINT: 'Point',
+  /**
+   * @type {string}
+   * @export
+   */
   POLYGON: 'Polygon',
+  /**
+   * @type {string}
+   * @export
+   */
   RECTANGLE: 'Rectangle',
+  /**
+   * @type {string}
+   * @export
+   */
   TEXT: 'Text'
 };

--- a/src/ol-ext/interaction/modify.js
+++ b/src/ol-ext/interaction/modify.js
@@ -1,0 +1,186 @@
+goog.provide('ngeo.interaction.Modify');
+
+goog.require('ol.interaction.Interaction');
+goog.require('ol.Collection');
+goog.require('ol.interaction.Modify');
+
+
+/**
+ * This interaction combines multiple kind of feature modification interactions
+ * in order to be able to modify vector features depending on their geometry
+ * type. The different kind of interactions supported are:
+ *
+ * - `ol.interaction.Modify`
+ * - `ngeo.interaction.ModifyCircle`
+ * - `ngeo.interaction.ModifyCircle`
+ *
+ * This interaction receives a collection of features. Its job is to listen
+ * to added/removed features to and from it and add them in the proper
+ * collection that is uniquely used for each inner interaction. Those inner
+ * interactions follow the `active` property of this interaction, i.e. when
+ * this interaction is activated, so do the inner interactions. Since they will
+ * never share the same feature, they don't collide with one an other.
+ *
+ * @constructor
+ * @extends {ol.interaction.Interaction}
+ * @param {ngeo.interaction.MeasureBaseOptions} options Options.
+ * @export
+ */
+ngeo.interaction.Modify = function(options) {
+
+  /**
+   * @type {ol.Collection.<ol.Feature>}
+   * @private
+   */
+  this.features_ = options.features;
+
+  /**
+   * @type {!Array.<ol.events.Key>}
+   * @private
+   */
+  this.listenerKeys_ = [];
+
+  /**
+   * @type {Array.<ol.interaction.Interaction>}
+   * @private
+   */
+  this.interactions_ = [];
+
+  /**
+   * @type {ol.Collection.<ol.Feature>}
+   * @private
+   */
+  this.otherFeatures_ = new ol.Collection();
+
+  this.interactions_.push(new ol.interaction.Modify({
+    features: this.otherFeatures_
+  }));
+
+  goog.base(this, {
+    handleEvent: goog.functions.TRUE
+  });
+
+};
+goog.inherits(ngeo.interaction.Modify, ol.interaction.Interaction);
+
+
+/**
+ * Activate or deactivate the interaction.
+ * @param {boolean} active Active.
+ * @export
+ */
+ngeo.interaction.Modify.prototype.setActive = function(active) {
+  goog.base(this, 'setActive', active);
+  this.setState_();
+};
+
+
+/**
+ * Remove the interaction from its current map and attach it to the new map.
+ * Subclasses may set up event handlers to get notified about changes to
+ * the map here.
+ * @param {ol.Map} map Map.
+ */
+ngeo.interaction.Modify.prototype.setMap = function(map) {
+
+  var interactions = this.interactions_;
+
+  var currentMap = this.getMap();
+  if (currentMap) {
+    interactions.forEach(function(interaction) {
+      currentMap.removeInteraction(interaction);
+    }, this);
+  }
+
+  goog.base(this, 'setMap', map);
+
+  if (map) {
+    interactions.forEach(function(interaction) {
+      map.addInteraction(interaction);
+    }, this);
+  }
+
+  this.setState_();
+};
+
+
+/**
+ * Toggle interactions.
+ * @private
+ */
+ngeo.interaction.Modify.prototype.setState_ = function() {
+  var map = this.getMap();
+  var active = this.getActive();
+  var interactions = this.interactions_;
+  var keys = this.listenerKeys_;
+
+  interactions.forEach(function(interaction) {
+    interaction.setActive(active && !!map);
+  }, this);
+
+  if (active && map) {
+    this.features_.forEach(this.addFeature_, this);
+    keys.push(ol.events.listen(this.features_, ol.CollectionEventType.ADD,
+        this.handleFeaturesAdd_, this));
+    keys.push(ol.events.listen(this.features_, ol.CollectionEventType.REMOVE,
+        this.handleFeaturesRemove_, this));
+  } else {
+    keys.forEach(function(key) {
+      ol.events.unlistenByKey(key);
+    }, this);
+    this.features_.forEach(this.removeFeature_, this);
+  }
+};
+
+
+/**
+ * @param {ol.CollectionEvent} evt Event.
+ * @private
+ */
+ngeo.interaction.Modify.prototype.handleFeaturesAdd_ = function(evt) {
+  var feature = evt.element;
+  goog.asserts.assertInstanceof(feature, ol.Feature,
+      'feature should be an ol.Feature');
+  this.addFeature_(feature);
+};
+
+
+/**
+ * @param {ol.CollectionEvent} evt Event.
+ * @private
+ */
+ngeo.interaction.Modify.prototype.handleFeaturesRemove_ = function(evt) {
+  var feature = /** @type {ol.Feature} */ (evt.element);
+  this.removeFeature_(feature);
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature.
+ * @private
+ */
+ngeo.interaction.Modify.prototype.addFeature_ = function(feature) {
+  var collection = this.getFeatureCollection_(feature);
+  collection.push(feature);
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature.
+ * @private
+ */
+ngeo.interaction.Modify.prototype.removeFeature_ = function(feature) {
+  var collection = this.getFeatureCollection_(feature);
+  collection.remove(feature);
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature.
+ * @return {ol.Collection.<ol.Feature>} Collection of features for this feature.
+ * @private
+ */
+ngeo.interaction.Modify.prototype.getFeatureCollection_ = function(feature) {
+  // FIXME - update when more than one interaction is supported here
+  return this.otherFeatures_;
+};

--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -26,7 +26,7 @@ ngeo.FeatureHelper = function($injector) {
    * @type {?number}
    * @private
    */
-  this.decimals = null;
+  this.decimals_ = null;
 
   if ($injector.has('ngeoMeasureDecimals')) {
     this.decimals_ = $injector.get('ngeoMeasureDecimals');


### PR DESCRIPTION
This PR introduces the `gmf-drawfeature` directive, which allows the user to draw vector features on the map and change their style, geometry, etc.  There are still things to do to consider the tool completed.

## Features

### This PR introduces

 * a new `gmf-drawfeature` directive that combines the `ngeo-drawfeature` and `gmf-featurestyle` directives
 * an example
 * you can select a feature from the list or from the map
 * you can change the style
 * you can modify the geometry
 * delete one or more features

It also contains some bug fixes across the other components used by the directive.

### This PR will not introduce

 * proper modification of circles
 * proper modification of rectangles
 * move feature
 * export
 * drop-down menu on feature "click"
 * official CSS styling
 * show vertexes on selection / feature modification
 * export

## Todo

 * [x] Fix the example (not working properly in builded version)
 * [x] Code review
 * [x] Travis build passes
 * [x] Merge into 1 commit

## Live example

 * http://adube.github.io/ngeo/edit-feature/examples/contribs/gmf/drawfeature.html