### PR TITLE
Fix event unlistening in gmf-featurestyle

### DIFF
--- a/contribs/gmf/src/directives/featurestyle.js
+++ b/contribs/gmf/src/directives/featurestyle.js
@@ -112,6 +112,9 @@ gmf.FeaturestyleController.prototype.handleFeatureSet_ = function(
   var keys = this.featureListenerKeys_;
 
   if (previousFeature) {
+    keys.forEach(function(key) {
+      ol.events.unlistenByKey(key);
+    }, this);
     this.type = null;
     this.color = null;
     this.measure = null;


### PR DESCRIPTION
This PR fixes the un-listening of events in the `gmf-featurestyle` directive that are bound to the feature.