### PR TITLE
Fix going back after theme selection

### DIFF
--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -89,7 +89,7 @@
         gmf-themeselector-defaulttheme="OSM"
         gmf-themeselector-currenttheme="mainCtrl.theme"
         gmf-themeselector-filter="::mainCtrl.filter"
-        gmf-mobile-nav-back="mainCtrl.theme">
+        gmf-mobile-nav-back="mainCtrl.theme.name">
       </gmf-themeselector>
     </nav>
     <nav class="nav-right" gmf-mobile-nav>


### PR DESCRIPTION
Listen on `theme.name` instead of `theme`. Because theme is an object that never changes, only its values change.
See https://github.com/camptocamp/ngeo/issues/594#issuecomment-197804863

Closes https://github.com/camptocamp/ngeo/issues/594 again