### PR TITLE
Set select style (vertex, halo) in feature helper, used in gmf-drawfeature

### DIFF
--- a/contribs/gmf/examples/featurestyle.js
+++ b/contribs/gmf/examples/featurestyle.js
@@ -35,6 +35,12 @@ app.MainController = function($scope, ngeoFeatureHelper) {
    */
   this.scope_ = $scope;
 
+  /**
+   * @type {ngeo.FeatureHelper}
+   * @private
+   */
+  this.featureHelper_ = ngeoFeatureHelper;
+
   // create features
   var features = new ol.format.GeoJSON().readFeatures({
     'type': 'FeatureCollection',
@@ -205,9 +211,14 @@ app.MainController.prototype.handleMapSingleClick_ = function(evt) {
     return feature;
   });
 
+  if (this.selectedFeature) {
+    this.featureHelper_.setStyle(this.selectedFeature);
+  }
+
   if (feature) {
     if (this.selectedFeature !== feature) {
       this.selectedFeature = feature;
+      this.featureHelper_.setStyle(feature, true);
     }
   } else {
     this.selectedFeature = null;

--- a/contribs/gmf/src/directives/drawfeature.js
+++ b/contribs/gmf/src/directives/drawfeature.js
@@ -53,6 +53,7 @@ gmf.module.directive('gmfDrawfeature', gmf.drawfeatureDirective);
  * @param {angular.$timeout} $timeout Angular timeout service.
  * @param {ngeo.DecorateInteraction} ngeoDecorateInteraction Decorate
  *     interaction service.
+ * @param {ngeo.FeatureHelper} ngeoFeatureHelper Gmf feature helper service.
  * @param {ol.Collection.<ol.Feature>} ngeoFeatures Collection of features.
  * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
  *     service.
@@ -62,7 +63,7 @@ gmf.module.directive('gmfDrawfeature', gmf.drawfeatureDirective);
  * @ngname GmfDrawfeatureController
  */
 gmf.DrawfeatureController = function($scope, $timeout, ngeoDecorateInteraction,
-    ngeoFeatures, ngeoToolActivateMgr) {
+    ngeoFeatureHelper, ngeoFeatures, ngeoToolActivateMgr) {
 
   /**
    * @type {ol.Map}
@@ -117,6 +118,12 @@ gmf.DrawfeatureController = function($scope, $timeout, ngeoDecorateInteraction,
   this.timeout_ = $timeout;
 
   /**
+   * @type {ngeo.FeatureHelper}
+   * @private
+   */
+  this.featureHelper_ = ngeoFeatureHelper;
+
+  /**
    * @type {ol.Collection.<ol.Feature>}
    * @export
    */
@@ -157,7 +164,8 @@ gmf.DrawfeatureController = function($scope, $timeout, ngeoDecorateInteraction,
    * @private
    */
   this.modify_ = new ngeo.interaction.Modify({
-    features: this.selectedFeatures_
+    features: this.selectedFeatures_,
+    style: ngeoFeatureHelper.getVertexStyle(false)
   });
   var modify = this.modify_;
   modify.setActive(false);
@@ -194,9 +202,11 @@ gmf.DrawfeatureController = function($scope, $timeout, ngeoDecorateInteraction,
     }.bind(this),
     function(newFeature, previousFeature) {
       if (previousFeature) {
+        this.featureHelper_.setStyle(previousFeature);
         this.selectedFeatures_.clear();
       }
       if (newFeature) {
+        this.featureHelper_.setStyle(newFeature, true);
         this.selectedFeatures_.push(newFeature);
       }
     }.bind(this)

--- a/contribs/gmf/src/directives/featurestyle.js
+++ b/contribs/gmf/src/directives/featurestyle.js
@@ -272,7 +272,7 @@ gmf.FeaturestyleController.prototype.handleFeatureChange_ = function() {
     return;
   }
 
-  this.featureHelper_.setStyle(feature);
+  this.featureHelper_.setStyle(feature, true);
 };
 
 

--- a/src/ol-ext/interaction/modify.js
+++ b/src/ol-ext/interaction/modify.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.interaction.Modify');
 
+goog.require('ngeo.interaction.ModifyCircle');
 goog.require('ol.interaction.Interaction');
 goog.require('ol.Collection');
 goog.require('ol.interaction.Modify');
@@ -23,7 +24,7 @@ goog.require('ol.interaction.Modify');
  *
  * @constructor
  * @extends {ol.interaction.Interaction}
- * @param {ngeo.interaction.MeasureBaseOptions} options Options.
+ * @param {olx.interaction.ModifyOptions} options Options.
  * @export
  */
 ngeo.interaction.Modify = function(options) {
@@ -53,7 +54,23 @@ ngeo.interaction.Modify = function(options) {
   this.otherFeatures_ = new ol.Collection();
 
   this.interactions_.push(new ol.interaction.Modify({
-    features: this.otherFeatures_
+    features: this.otherFeatures_,
+    pixelTolerance: options.pixelTolerance,
+    style: options.style,
+    wrapX: options.wrapX
+  }));
+
+  /**
+   * @type {ol.Collection.<ol.Feature>}
+   * @private
+   */
+  this.circleFeatures_ = new ol.Collection();
+
+  this.interactions_.push(new ngeo.interaction.ModifyCircle({
+    features: this.circleFeatures_,
+    pixelTolerance: options.pixelTolerance,
+    style: options.style,
+    wrapX: options.wrapX
   }));
 
   goog.base(this, {
@@ -181,6 +198,11 @@ ngeo.interaction.Modify.prototype.removeFeature_ = function(feature) {
  * @private
  */
 ngeo.interaction.Modify.prototype.getFeatureCollection_ = function(feature) {
-  // FIXME - update when more than one interaction is supported here
-  return this.otherFeatures_;
+  var features;
+  if (feature.get(ngeo.FeatureProperties.IS_CIRCLE) === true) {
+    features = this.circleFeatures_;
+  } else {
+    features = this.otherFeatures_;
+  }
+  return features;
 };


### PR DESCRIPTION
This PR adds the support of drawing vertex in addition to the original style in the feature helper.  The `gmf-featurestyle` directive uses it, in addition to the `gmf-drawfeature` one.

Geometries that **have** the vertex drawn:

 * LineString
 * Polygon
 * Rectangle

Geometries that **don't have** vertex drawn:

 * Circle
 * Point
 * Text

An additional "halo" style is added to selected features.

As a bonus, this PR also includes the `ngeo.interaction.ModifyCircle` interaction.  Circles are now properly modified.

## Todo

 * [x] add white border around features
 * [x] use square for modify style
 * [x] add modify circle interaction
 * [x] rebase onto master once #1001 is merged
 * [x] code review
 * [x] apply reviewer's required corrections
 * [x] travis pass

## Live example

 * http://adube.github.io/ngeo/gmf-drawfeature-vertex/examples/contribs/gmf/drawfeature.html