### PR TITLE
Truncate long layer names

### DIFF
--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -106,7 +106,14 @@
   }
 
   .name {
-    white-space: normal;
+    // take the full width minus the width for a layer icon, visibility checkbox,
+    // and legend icon
+    width: calc(~'100%' - 6 * @app-margin);
+    overflow: hidden;
+    display: inline-block;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin-bottom: -4px;
   }
 
   .metadata {

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -10,7 +10,7 @@
       <img ng-src="{{::gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl)}}"></img>
     </span>
     <span class="state"></span>
-    <span class="name">{{layertreeCtrl.node.name | translate}}</span>
+    <span class="name" title="{{layertreeCtrl.node.name | translate}}">{{layertreeCtrl.node.name | translate}}</span>
   </a>
   <span class="rightButtons">
     <span class="metadata" ng-if="::layertreeCtrl.node.metadata.metadataUrl">


### PR DESCRIPTION
Long layer names are truncated using `text-overflow: ellipsis`, the title attribute contains the full name.

![gmf-layer-names](https://cloud.githubusercontent.com/assets/266474/14463054/e35d0db4-00c9-11e6-9453-5840d633f2c1.png)

Closes https://github.com/camptocamp/ngeo/issues/968

Note that this PR is made against master and not 2.0 as confirmed with @ybolognini.

