### PR TITLE
Add contextual menu on feature click in gmf-drawfeature

### DIFF
--- a/contribs/gmf/examples/drawfeature.html
+++ b/contribs/gmf/examples/drawfeature.html
@@ -16,7 +16,7 @@
         height: 400px;
       }
 
-      /* drawfeature */
+      /* gmf-drawfeature */
 
       gmf-drawfeature {
         display: block;
@@ -191,6 +191,7 @@
     <gmf-drawfeature
       ng-show="ctrl.drawFeatureActive === true"
       gmf-drawfeature-active="ctrl.drawFeatureActive"
+      gmf-drawfeature-layer="::ctrl.vectorLayer"
       gmf-drawfeature-map="::ctrl.map">
     </gmf-drawfeature>
 

--- a/contribs/gmf/examples/drawfeature.js
+++ b/contribs/gmf/examples/drawfeature.js
@@ -45,6 +45,17 @@ app.MainController = function($scope, ngeoFeatureHelper, ngeoFeatures,
   ngeoFeatureHelper.setProjection(view.getProjection());
 
   /**
+   * @type {ol.layer.Vector}
+   * @export
+   */
+  this.vectorLayer = new ol.layer.Vector({
+    source: new ol.source.Vector({
+      wrapX: false,
+      features: ngeoFeatures
+    })
+  });
+
+  /**
    * @type {ol.Map}
    * @export
    */
@@ -53,12 +64,7 @@ app.MainController = function($scope, ngeoFeatureHelper, ngeoFeatures,
       new ol.layer.Tile({
         source: new ol.source.OSM()
       }),
-      new ol.layer.Vector({
-        source: new ol.source.Vector({
-          wrapX: false,
-          features: ngeoFeatures
-        })
-      })
+      this.vectorLayer
     ],
     view: view
   });

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -10,6 +10,83 @@ var ngeox;
 
 
 /**
+ * @interface
+ */
+ngeox.MenuEvent = function() {};
+
+
+/**
+ * @type {string}
+ */
+ngeox.MenuEvent.prototype.action;
+
+
+/**
+ * The options for the contextual menu overlay.
+ * @typedef {{
+ *     actions: (Array.<ngeox.MenuActionOptions>),
+ *     autoClose: (boolean|undefined)
+ * }}
+ */
+ngeox.MenuOptions;
+
+
+/**
+ * A list of menu actions.
+ * @type {Array.<ngeox.MenuActionOptions>}
+ */
+ngeox.MenuOptions.prototype.actions;
+
+
+/**
+ * Whether to automatically close the contextual menu when an action is
+ * clicked or not. Defaults to `true`.
+ * @type {boolean|undefined}
+ */
+ngeox.MenuOptions.prototype.autoClose;
+
+
+/**
+ * A title to display as header of the contextual menu.
+ * @type {string|undefined}
+ */
+ngeox.MenuOptions.prototype.title;
+
+
+/**
+ * The options for an action item for the contextual menu overlay.
+ * @typedef {{
+ *     cls: (string|undefined),
+ *     label: (string|undefined),
+ *     name: (string)
+ * }}
+ */
+ngeox.MenuActionOptions;
+
+
+/**
+ * CSS class name(s) to use for the icon of the action item.
+ * @type {string|undefined}
+ */
+ngeox.MenuActionOptions.prototype.cls;
+
+
+/**
+ * The label to display for the action item. If not defined, the name is used.
+ * @type {string|undefined}
+ */
+ngeox.MenuActionOptions.prototype.label;
+
+
+/**
+ * A unique name for the menu action, which is used in the event fired when
+ * the action is clicked.
+ * @type {string}
+ */
+ngeox.MenuActionOptions.prototype.name;
+
+
+/**
  * The options for the query service.
  * @typedef {{
  *     limit: (number|undefined),
@@ -307,6 +384,31 @@ ngeox.interaction.MeasureOptions.prototype.style;
  * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined}
  */
 ngeox.interaction.MeasureOptions.prototype.sketchStyle;
+
+
+/**
+ * @typedef {{
+ *     features: (ol.Collection.<ol.Feature>|undefined),
+ *     style: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined)
+ * }}
+ */
+ngeox.interaction.TranslateOptions;
+
+
+/**
+ * Only features contained in this collection will be able to be translated. If
+ * not specified, all features on the map will be able to be translated.
+ * @type {ol.Collection.<ol.Feature>|undefined}
+ */
+ngeox.interaction.TranslateOptions.prototype.features;
+
+
+/**
+ * Style for the center features added by the translate interaction to
+ * to show that features can be moved.
+ * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined}
+ */
+ngeox.interaction.TranslateOptions.prototype.style;
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "less-plugin-autoprefix": "1.5.1",
     "less-plugin-clean-css": "1.5.1",
     "nomnom": "1.8.1",
-    "openlayers": "3.15.1",
+    "openlayers": "openlayers/ol3#8e3e47bed46cbb4833c592978fd61aa59cf60a4e",
     "phantomjs-prebuilt": "2.1.7",
     "proj4": "2.3.14",
     "temp": "0.8.3",

--- a/src/ol-ext/interaction/translate.js
+++ b/src/ol-ext/interaction/translate.js
@@ -1,0 +1,279 @@
+goog.provide('ngeo.interaction.Translate');
+
+goog.require('goog.events.KeyCodes');
+goog.require('ol.Feature');
+goog.require('ol.geom.LineString');
+goog.require('ol.geom.Point');
+goog.require('ol.geom.Polygon');
+goog.require('ol.interaction.Translate');
+goog.require('ol.layer.Vector');
+goog.require('ol.source.Vector');
+
+
+/**
+ * An extension of the OpenLayers Translate interaction that adds the following
+ * features to it:
+ *
+ * - show a small arrow icon in the middle of the features allowing a visual
+ *   aspect that tells the user "this feature can be moved"
+ * - pressing the ESC key automatically deactivate the interaction.
+ *
+ * @constructor
+ * @extends {ol.interaction.Translate}
+ * @param {ngeox.interaction.TranslateOptions} options Options.
+ * @export
+ */
+ngeo.interaction.Translate = function(options) {
+
+  /**
+   * @type {!Array.<ol.events.Key>}
+   * @private
+   */
+  this.listenerKeys_ = [];
+
+  /**
+   * @type {!Object.<number, ol.events.Key>}
+   * @private
+   */
+  this.featureListenerKeys_ = {};
+
+  /**
+   * @type {?goog.events.Key}
+   * @private
+   */
+  this.keyPressListenerKey_ = null;
+
+  /**
+   * @type {ol.Collection.<ol.Feature>}
+   * @private
+   */
+  this.myFeatures_ = options.features !== undefined ? options.features : null;
+
+  /**
+   * @type {ol.source.Vector}
+   * @private
+   */
+  this.vectorSource_ = new ol.source.Vector({
+    useSpatialIndex: false
+  });
+
+  /**
+   * @type {ol.layer.Vector}
+   * @private
+   */
+  this.vectorLayer_ = new ol.layer.Vector({
+    source: this.vectorSource_,
+    style: options.style,
+    updateWhileAnimating: true,
+    updateWhileInteracting: true
+  });
+
+  /**
+   * @type {!Object.<number, ol.Feature>}
+   * @private
+   */
+  this.centerFeatures_ = {};
+
+  goog.base(this, /** @type {olx.interaction.TranslateOptions} */ (options));
+};
+goog.inherits(ngeo.interaction.Translate, ol.interaction.Translate);
+
+
+/**
+ * Activate or deactivate the interaction.
+ * @param {boolean} active Active.
+ * @export
+ */
+ngeo.interaction.Translate.prototype.setActive = function(active) {
+
+  if (this.keyPressListenerKey_) {
+    goog.events.unlistenByKey(this.keyPressListenerKey_);
+    this.keyPressListenerKey_ = null;
+  }
+
+  goog.base(this, 'setActive', active);
+
+  if (active) {
+    this.keyPressListenerKey_ = goog.events.listen(
+      document,
+      goog.events.EventType.KEYUP,
+      this.handleKeyUp_,
+      false,
+      this
+    );
+  }
+
+  this.setState_();
+};
+
+
+/**
+ * Remove the interaction from its current map and attach it to the new map.
+ * Subclasses may set up event handlers to get notified about changes to
+ * the map here.
+ * @param {ol.Map} map Map.
+ */
+ngeo.interaction.Translate.prototype.setMap = function(map) {
+
+  var currentMap = this.getMap();
+  if (currentMap) {
+    currentMap.removeLayer(this.vectorLayer_);
+  }
+
+  goog.base(this, 'setMap', map);
+
+  if (map) {
+    map.addLayer(this.vectorLayer_);
+  }
+
+  this.setState_();
+};
+
+
+/**
+ * @private
+ */
+ngeo.interaction.Translate.prototype.setState_ = function() {
+  var map = this.getMap();
+  var active = this.getActive();
+  var features = this.myFeatures_;
+  var keys = this.listenerKeys_;
+
+  if (map && active && features) {
+    features.forEach(this.addFeature_, this);
+    keys.push(ol.events.listen(features, ol.CollectionEventType.ADD,
+        this.handleFeaturesAdd_, this));
+    keys.push(ol.events.listen(features, ol.CollectionEventType.REMOVE,
+        this.handleFeaturesRemove_, this));
+  } else {
+
+    if (map) {
+      var elem = map.getTargetElement();
+      elem.style.cursor = 'default';
+    }
+
+    keys.forEach(function(key) {
+      ol.events.unlistenByKey(key);
+    }, this);
+    features.forEach(this.removeFeature_, this);
+  }
+};
+
+
+/**
+ * @param {ol.CollectionEvent} evt Event.
+ * @private
+ */
+ngeo.interaction.Translate.prototype.handleFeaturesAdd_ = function(evt) {
+  var feature = evt.element;
+  goog.asserts.assertInstanceof(feature, ol.Feature,
+      'feature should be an ol.Feature');
+  this.addFeature_(feature);
+};
+
+
+/**
+ * @param {ol.CollectionEvent} evt Event.
+ * @private
+ */
+ngeo.interaction.Translate.prototype.handleFeaturesRemove_ = function(evt) {
+  var feature = /** @type {ol.Feature} */ (evt.element);
+  this.removeFeature_(feature);
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature.
+ * @private
+ */
+ngeo.interaction.Translate.prototype.addFeature_ = function(feature) {
+  var uid = goog.getUid(feature);
+  var geometry = feature.getGeometry();
+  goog.asserts.assertInstanceof(geometry, ol.geom.Geometry);
+
+  this.featureListenerKeys_[uid] = ol.events.listen(
+      geometry,
+      ol.events.EventType.CHANGE,
+      this.handleGeometryChange_.bind(this, feature),
+      this
+  );
+
+  var point = this.getGeometryCenterPoint_(geometry);
+  var centerFeature = new ol.Feature(point);
+  this.centerFeatures_[uid] = centerFeature;
+  this.vectorSource_.addFeature(centerFeature);
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature.
+ * @private
+ */
+ngeo.interaction.Translate.prototype.removeFeature_ = function(feature) {
+  var uid = goog.getUid(feature);
+  if (this.featureListenerKeys_[uid]) {
+    ol.events.unlistenByKey(this.featureListenerKeys_[uid]);
+    delete this.featureListenerKeys_[uid];
+
+    this.vectorSource_.removeFeature(this.centerFeatures_[uid]);
+    delete this.centerFeatures_[uid];
+  }
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature being moved.
+ * @param {ol.events.Event} evt Event.
+ * @private
+ */
+ngeo.interaction.Translate.prototype.handleGeometryChange_ = function(feature,
+    evt) {
+  var geometry = evt.target;
+  goog.asserts.assertInstanceof(geometry, ol.geom.Geometry);
+
+  var point = this.getGeometryCenterPoint_(geometry);
+  var uid = goog.getUid(feature);
+  this.centerFeatures_[uid].setGeometry(point);
+};
+
+
+/**
+ * @param {ol.geom.Geometry} geometry Geometry.
+ * @return {ol.geom.Point} The center point of the geometry.
+ * @private
+ */
+ngeo.interaction.Translate.prototype.getGeometryCenterPoint_ = function(
+    geometry) {
+
+  var center;
+  var point;
+
+  if (geometry instanceof ol.geom.Polygon) {
+    point = geometry.getInteriorPoint()
+  } else if (geometry instanceof ol.geom.LineString) {
+    center = geometry.getCoordinateAt(0.5);
+  } else {
+    var extent = geometry.getExtent();
+    center = ol.extent.getCenter(extent);
+  }
+
+  if (!point && center) {
+    point = new ol.geom.Point(center);
+  }
+
+  goog.asserts.assert(point, 'Point should be thruthy');
+
+  return point;
+};
+
+
+/**
+ * Deactivate this interaction if the ESC key is pressed.
+ * @param {goog.events.Event} evt Event.
+ * @private
+ */
+ngeo.interaction.Translate.prototype.handleKeyUp_ = function(evt) {
+  if (evt.keyCode === goog.events.KeyCodes.ESC) {
+    this.setActive(false);
+  }
+};

--- a/src/ol-ext/menu.js
+++ b/src/ol-ext/menu.js
@@ -1,0 +1,239 @@
+goog.provide('ngeo.Menu');
+goog.provide('ngeo.MenuEvent');
+goog.provide('ngeo.MenuEventType');
+
+goog.require('ol.Overlay');
+goog.require('ol.events.Event');
+
+
+/**
+ * @enum {string}
+ */
+ngeo.MenuEventType = {
+  /**
+   * Triggered upon clicking an action button
+   * @event ngeo.MenuEvent#actionclick
+   */
+  ACTION_CLICK: 'actionclick'
+};
+
+
+/**
+ * @classdesc
+ * Events emitted by {@link ngeo.Menu} instances are instances of this type.
+ *
+ * @constructor
+ * @extends {ol.events.Event}
+ * @implements {ngeox.MenuEvent}
+ * @param {ngeo.MenuEventType} type Type.
+ * @param {string} action Action name that was clicked.
+ */
+ngeo.MenuEvent = function(type, action) {
+
+  goog.base(this, type);
+
+  /**
+   * The action name that was clicked.
+   * @type {string}
+   * @api stable
+   */
+  this.action = action;
+
+};
+goog.inherits(ngeo.MenuEvent, ol.events.Event);
+
+
+/**
+ * @classdesc
+ * An OpenLayers overlay that shows a contextual menu with configurable actions
+ * anchored from its top left to a specific location. An event is fired when
+ * any of the action is clicked. It can be closed using the close button, or
+ * can be automatically closed when any action is clicked.
+ *
+ * @constructor
+ * @extends {ol.Overlay}
+ * @param {ngeox.MenuOptions=} menuOptions Menu options.
+ * @param {olx.OverlayOptions=} opt_overlayOptions Overlay options.
+ */
+ngeo.Menu = function(menuOptions, opt_overlayOptions) {
+
+  var options = opt_overlayOptions !== undefined ? opt_overlayOptions : {};
+
+  options.positioning = ol.OverlayPositioning.TOP_LEFT;
+
+  /**
+   * @type {Array.<goog.events.Key>}
+   * @private
+   */
+  this.listenerKeys_ = [];
+
+  /**
+   * @type {Array.<ol.events.Key>}
+   * @private
+   */
+  this.olListenerKeys_ = [];
+
+  var contentEl = $('<div/>', {
+    'class': 'panel panel-default'
+  });
+
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.autoClose_ = menuOptions.autoClose !== undefined ?
+      menuOptions.autoClose : true;
+
+  var headerEl = $('<div>', {
+    'class': 'panel-heading'
+  }).appendTo(contentEl);
+
+  // titleEl
+  if (menuOptions.title) {
+    $('<span>', {
+      text: menuOptions.title
+    }).appendTo(headerEl);
+  }
+
+  /**
+   * @type {jQuery}
+   * @private
+   */
+  this.closeEl_ = $('<button>', {
+    'type': 'button',
+    'class': 'close',
+    'aria-hidden': true,
+    'html': '&times;'
+  }).appendTo(headerEl);
+
+  // actionsEl
+  var actionsEl = $('<div>', {
+    'class': 'list-group'
+  }).appendTo(contentEl);
+
+  /**
+   * @type {Array.<jQuery>}
+   * @private
+   */
+  this.actions_ = [];
+
+  menuOptions.actions.forEach(function(action) {
+    this.actions_.push(
+      $('<button>', {
+        'class': 'list-group-item',
+        'data-name': action.name,
+        'text': [
+          ' ',
+          (action.label) !== undefined ? action.label : action.name
+        ].join('')
+      })
+        .appendTo(actionsEl)
+        .prepend($('<span>', {
+          'class': action.cls !== undefined ? action.cls : ''
+        }))
+    );
+  }, this);
+
+  options.element = contentEl[0];
+
+  goog.base(this, options);
+
+};
+goog.inherits(ngeo.Menu, ol.Overlay);
+
+
+/**
+ * @param {ol.Map|undefined} map Map.
+ * @export
+ */
+ngeo.Menu.prototype.setMap = function(map) {
+
+  var keys = this.listenerKeys_;
+  var olKeys = this.olListenerKeys_;
+
+  var currentMap = this.getMap();
+  if (currentMap) {
+    keys.forEach(function(key) {
+      goog.events.unlistenByKey(key);
+    }, this);
+    keys.length = 0;
+    olKeys.forEach(function(key) {
+      ol.events.unlistenByKey(key);
+    }, this);
+    olKeys.length = 0;
+  }
+
+  goog.base(this, 'setMap', map);
+
+  if (map) {
+    keys.push(goog.events.listen(this.closeEl_[0],
+        goog.events.EventType.CLICK, this.close, false, this));
+    this.actions_.forEach(function(action) {
+      var data = action.data();
+      keys.push(
+        goog.events.listen(
+          action[0],
+          goog.events.EventType.CLICK,
+          this.handleActionClick_.bind(this, data.name),
+          false,
+          this
+        )
+      );
+    }, this);
+    olKeys.push(
+      ol.events.listen(
+        map,
+        ol.MapBrowserEvent.EventType.POINTERMOVE,
+        this.handleMapPointerMove_,
+        this
+      )
+    );
+  }
+
+};
+
+
+/**
+ * @export
+ */
+ngeo.Menu.prototype.close = function() {
+  this.setPosition(undefined);
+};
+
+
+/**
+ * @param {string} action The action name that was clicked.
+ * @private
+ */
+ngeo.Menu.prototype.handleActionClick_ = function(action) {
+
+  this.dispatchEvent(
+      new ngeo.MenuEvent(ngeo.MenuEventType.ACTION_CLICK, action));
+
+  if (this.autoClose_) {
+    this.close();
+  }
+};
+
+
+/**
+ * When the mouse is hovering the menu, set the event coordinate and pixel
+ * values to Infinity to do as if the mouse had been move out of range of the
+ * map. This prevents behaviours such as vertex still appearing while mouse
+ * hovering edges of features bound to an active modify control while the
+ * cursor is on top of the menu.
+ * @param {ol.MapBrowserEvent} evt Event.
+ * @private
+ */
+ngeo.Menu.prototype.handleMapPointerMove_ = function(evt) {
+  var target = evt.originalEvent.target;
+  goog.asserts.assertInstanceof(target, Element);
+
+  var element = this.getElement();
+  goog.asserts.assertInstanceof(element, Element);
+
+  if (goog.dom.contains(element, target)) {
+    evt.coordinate = [Infinity, Infinity];
+    evt.pixel = [Infinity, Infinity];
+  }
+};


### PR DESCRIPTION
This PR introduces the `ngeo.Menu` overlay, which consists in a contextual menu configurable with any number of actions. When an action is clicked, it dispatches an event.  It can be closed with a close button, or automatically closed when an action is clicked (optional).

This PR also implements a `ngeo.Menu` in the `gmf-drawfeature` directive that is shown when a feature is clicked with the following actions:

 * Move (works, behaviour is the one from the spec)
 * Rotate (does nothing for now)
 * Delete (deletes the feature properly)

## Todo

 * [x] merge in one commit
 * [x] add a marker at the center of the feature when the translate is active
 * [x] confirm how we should manage the images required to style the center marker
 * [x] only allow moving the feature ONCE (as specified in the spec)
 * [x] rebase onto master once #1001 is merged
 * [x] use fontawesome instead of glyphicons
 * [x] use bootstrap panel and list
 * [x] wait for ol3 to review/merge the patch that allows filtering the translatable layers
 * [x] file renamed translate.js
 * [x] prevent Point and Text to show the contextual menu, at all.
 * [x] Make sure the menu disappears when the feature is deselected
 * [x] code review (by @fgravin)
 * [x] travis pass

## Live example

 * http://adube.github.io/ngeo/gmf-drawfeature-menu/examples/contribs/gmf/drawfeature.html