### PR TITLE
Make running the unit tests less painful

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,15 @@ test: .build/ol-deps.js .build/ngeo-deps.js .build/gmf-deps.js .build/templateca
 	@cat .build/coverage/coverage.txt
 	@echo "\nFull coverage report in: .build/coverage/lcov-report"
 
+.PHONY: test-debug
+test-debug: .build/ol-deps.js .build/ngeo-deps.js .build/gmf-deps.js .build/templatecache.js .build/gmftemplatecache.js .build/node_modules.timestamp .build/node_modules_karma-chrome-launcher.timestamp
+	./node_modules/karma/bin/karma start karma-conf.js --browsers=Chrome --single-run=false --autoWatch=true --debug
+
+.build/node_modules_karma-chrome-launcher.timestamp:
+	npm install karma-chrome-launcher
+	mkdir -p $(dir $@)
+	touch $@
+
 .PHONY: serve
 serve: .build/node_modules.timestamp $(FONTAWESOME_WEBFONT)
 	node buildtools/serve.js

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -201,6 +201,21 @@ how to write unit tests.
 To run the unit tests on the command line, just run `make test`. All the tests will be
 run inside [PhantomJS](http://phantomjs.org/).
 
+#### Running tests in debug mode
+
+For debugging purposes it is useful to run the unit tests in an actual browser with
+`make test-debug`. This task starts the Karma server and opens Chrome/Chromium. Click on
+`Debug` to open a new page that runs all unit tests. Now you can start the debugger.
+
+To run only a single test or test group, use `fdescribe` or `fit` to **f**ocus
+on a test:
+
+```javascript
+fdescribe('...', function() {
+
+  fit('...', function() {
+```
+
 ### Create a new stabilisation branch
 
 When we create a new stabilisation branch we should also duplicate the localisation.

--- a/karma-conf.js
+++ b/karma-conf.js
@@ -1,6 +1,11 @@
 // Karma configuration
 // Generated on Wed Jun 18 2014 14:25:40 GMT+0200 (CEST)
 
+
+var isDebug = process.argv.some(function(argument) {
+    return argument === '--debug';
+});
+
 module.exports = function(config) {
   var closureLibPath = 'node_modules/closure-util/.deps/library/**/';
   var olSrcPath = 'node_modules/openlayers/src/';
@@ -70,15 +75,15 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      'src/**/*.js': ['coverage'],
-      'contribs/gmf/src/**/*.js': ['coverage']
+      'src/**/*.js': isDebug ? [] : ['coverage'],
+      'contribs/gmf/src/**/*.js': isDebug ? [] : ['coverage']
     },
 
 
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress', 'coverage'],
+    reporters: isDebug ? ['progress'] : ['progress', 'coverage'],
 
 
     // web server port


### PR DESCRIPTION
This PR suggests to add a target `test-debug` to the Makefile which starts the unit tests in Chrome, so that the debugger can be used.

closes https://github.com/camptocamp/ngeo/issues/450