### PR TITLE
Add ngeo-exportfeatures directive, used in gmf-drawfeature

### DIFF
--- a/contribs/gmf/examples/drawfeature.html
+++ b/contribs/gmf/examples/drawfeature.html
@@ -26,6 +26,7 @@
 
       .ngeo-drawfeature-actionbuttons {
         float: right;
+        position: relative;
       }
 
       .gmf-drawfeature-featurelist li:hover {

--- a/contribs/gmf/examples/drawfeature.js
+++ b/contribs/gmf/examples/drawfeature.js
@@ -20,6 +20,12 @@ var app = {};
 app.module = angular.module('app', ['gmf']);
 
 
+app.module.constant('ngeoExportFeatureFormats', [
+  ngeo.FeatureHelper.FormatType.KML,
+  ngeo.FeatureHelper.FormatType.GPX
+]);
+
+
 /**
  * @param {!angular.Scope} $scope Angular scope.
  * @param {ngeo.FeatureHelper} ngeoFeatureHelper Gmf feature helper service.

--- a/contribs/gmf/src/directives/drawfeature.js
+++ b/contribs/gmf/src/directives/drawfeature.js
@@ -11,6 +11,8 @@ goog.require('ngeo.ToolActivateMgr');
 goog.require('ngeo.btngroupDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.drawfeatureDirective');
+/** @suppress {extraRequire} */
+goog.require('ngeo.exportfeaturesDirective');
 goog.require('ngeo.interaction.Modify');
 goog.require('ngeo.interaction.Translate');
 goog.require('ol.Collection');
@@ -165,16 +167,16 @@ gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
 
   /**
    * @type {ol.Collection.<ol.Feature>}
-   * @private
+   * @export
    */
-  this.selectedFeatures_ = new ol.Collection();
+  this.selectedFeatures = new ol.Collection();
 
   /**
    * @type {ngeo.interaction.Modify}
    * @private
    */
   this.modify_ = new ngeo.interaction.Modify({
-    features: this.selectedFeatures_,
+    features: this.selectedFeatures,
     style: ngeoFeatureHelper.getVertexStyle(false)
   });
   this.registerInteraction_(this.modify_);
@@ -212,7 +214,7 @@ gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
    * @private
    */
   this.translate_ = new ngeo.interaction.Translate({
-    features: this.selectedFeatures_,
+    features: this.selectedFeatures,
     layers: [this.layer],
     style: new ol.style.Style({
       text: new ol.style.Text({
@@ -263,11 +265,11 @@ gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
     function(newFeature, previousFeature) {
       if (previousFeature) {
         this.featureHelper_.setStyle(previousFeature);
-        this.selectedFeatures_.clear();
+        this.selectedFeatures.clear();
       }
       if (newFeature) {
         this.featureHelper_.setStyle(newFeature, true);
-        this.selectedFeatures_.push(newFeature);
+        this.selectedFeatures.push(newFeature);
       } else {
         this.menu_.close();
       }

--- a/contribs/gmf/src/directives/partials/drawfeature.html
+++ b/contribs/gmf/src/directives/partials/drawfeature.html
@@ -91,6 +91,12 @@
       <div ng-show="efCtrl.features.getLength()">
         <div class="ngeo-drawfeature-actionbuttons">
           <button
+              type="button"
+              data-toggle="dropdown"
+              aria-haspopup="true"
+              aria-expanded="false"
+              ngeo-exportfeatures
+              ngeo-exportfeatures-features="efCtrl.features"
               class="btn btn-link">
             <span class="fa fa-mail-forward"></span>
             {{'Export' | translate}}
@@ -127,6 +133,12 @@
       </button>
       <div class="ngeo-drawfeature-actionbuttons">
         <button
+            type="button"
+            data-toggle="dropdown"
+            aria-haspopup="true"
+            aria-expanded="false"
+            ngeo-exportfeatures
+            ngeo-exportfeatures-features="efCtrl.selectedFeatures"
             class="btn btn-link">
           <span class="fa fa-mail-forward"></span>
           {{'Export' | translate}}

--- a/src/directives/exportfeatures.js
+++ b/src/directives/exportfeatures.js
@@ -1,0 +1,214 @@
+goog.provide('ngeo.ExportfeaturesController');
+goog.provide('ngeo.exportfeaturesDirective');
+
+goog.require('ngeo');
+
+
+/**
+ * Directive used to export vector features in different types of format.
+ * To configure which formats to use, define the `ngeoExportFeatureFormats`
+ * constant, as such:
+ *
+ *     app.module.constant('ngeoExportFeatureFormats', [
+ *         ngeo.FeatureHelper.FormatType.KML,
+ *         ngeo.FeatureHelper.FormatType.GPX
+ *     ]);
+ *
+ * Example:
+ *
+ *     <button
+ *       ngeo-exportfeatures
+ *       ngeo-exportfeatures-features="ctrl.features"
+ *       class="btn btn-link">Export</button>
+ *
+ * @htmlAttribute {ol.Collection.<ol.Feature>} ngeo-exportfeatures-features The
+ *     features to export
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname ngeoExportfeatures
+ */
+ngeo.exportfeaturesDirective = function() {
+  return {
+    controller: 'ngeoExportfeaturesController',
+    scope: true,
+    bindToController: {
+      'features': '=ngeoExportfeaturesFeatures'
+    },
+    controllerAs: 'efCtrl'
+  };
+};
+
+
+ngeo.module.directive('ngeoExportfeatures', ngeo.exportfeaturesDirective);
+
+
+/**
+ * @param {angular.JQLite} $element Element.
+ * @param {angular.$injector} $injector Main injector.
+ * @param {!angular.Scope} $scope Angular scope.
+ * @param {ngeo.FeatureHelper} ngeoFeatureHelper Ngeo feature helper service.
+ * @constructor
+ * @ngInject
+ * @ngdoc controller
+ * @ngname ngeoExportfeaturesController
+ */
+ngeo.ExportfeaturesController = function($element, $injector, $scope,
+    ngeoFeatureHelper) {
+
+  /**
+   * @type {ol.Collection.<ol.Feature>}
+   * @private
+   */
+  this.features;
+
+  /**
+   * @type {angular.JQLite}
+   * @private
+   */
+  this.element_ = $element;
+
+  var uid = goog.getUid(this);
+  var id = ['ngeo-exportfeature', uid].join('-');
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.id_ = id;
+
+  /**
+   * @type {ngeo.FeatureHelper}
+   * @private
+   */
+  this.featureHelper_ = ngeoFeatureHelper;
+
+  var formats;
+  if ($injector.has('ngeoExportFeatureFormats')) {
+    formats = $injector.get('ngeoExportFeatureFormats');
+  } else {
+    formats = [ngeo.FeatureHelper.FormatType.KML];
+  }
+
+  /**
+   * @type {?jQuery}
+   * @private
+   */
+  this.menu_ = null;
+
+  /**
+   * @type {Array.<jQuery>}
+   * @private
+   */
+  this.items_ = [];
+
+  // build the drop-down menu and items of there's more than one format
+  if (formats.length > 1) {
+    $element.attr('id', id);
+    var $menu = $('<ul />', {
+      'class': 'dropdown-menu',
+      'aria-labelledby': id
+    }).appendTo($element.parent()[0]);
+
+    this.menu_ = $menu;
+    var $item;
+
+    formats.forEach(function(format) {
+      $item = $('<li />')
+        .appendTo($menu)
+        .append($('<a />', {
+          'href': '#',
+          'text': format
+        })
+        .on(
+          ['click', id].join('.'),
+          this.handleMenuItemClick_.bind(this, format)
+        )
+      );
+      this.items_.push($item);
+    }, this);
+  }
+
+  /**
+   * @type {Array.<string>}
+   * @private
+   */
+  this.formats_ = formats;
+
+  $element.on(['click', id].join('.'), this.handleElementClick_.bind(this));
+
+  $scope.$on('$destroy', this.handleDestroy_.bind(this));
+};
+
+
+/**
+ * Called when the element bound to this directive is clicked. Use the feature
+ * helper to export the feature(s) depending on the format(s) available(s).
+ * If there's only one, the call to the export method is direct, otherwise
+ * a drop-down menu is show to let the user choose the format of the export.
+ * Finally, if there's only one feature in the collection to export and there's
+ * more than one format set, some formats may not support the type of geometry.
+ * If that's the case, then disable each format item in the drop-down menu
+ * that doesn't support the type of geometry.
+ * @private
+ */
+ngeo.ExportfeaturesController.prototype.handleElementClick_ = function() {
+
+  var features = this.features.getArray();
+
+  if (this.formats_.length === 1) {
+    this.featureHelper_.export(features, this.formats_[0]);
+  } else if (features.length === 1) {
+    var feature = features[0];
+    var geom = feature.getGeometry();
+    var $item;
+    this.formats_.forEach(function(format, i) {
+      $item = this.items_[i];
+      if (format === ngeo.FeatureHelper.FormatType.GPX) {
+        if (geom instanceof ol.geom.Point ||
+            geom instanceof ol.geom.LineString) {
+          $item.removeClass('disabled');
+        } else {
+          $item.addClass('disabled');
+        }
+      }
+    }, this);
+  }
+};
+
+
+/**
+ * Called when a menu item is clicked. Export the features to the selected
+ * format.
+ * @param {string} format Format.
+ * @private
+ */
+ngeo.ExportfeaturesController.prototype.handleMenuItemClick_ = function(
+    format) {
+  var features = this.features.getArray();
+  this.featureHelper_.export(features, format);
+};
+
+
+/**
+ * Cleanup event listeners and remove the menu from DOM, if any.
+ * @private
+ */
+ngeo.ExportfeaturesController.prototype.handleDestroy_ = function() {
+  var id = this.id_;
+
+  this.element_.off(['click', id].join('.'));
+
+  if (this.menu_) {
+    this.menu_.remove();
+    this.items_.forEach(function($item) {
+      $item.off(['click', id].join('.'));
+    }, this);
+    this.items_.length = 0;
+    this.menu_ = null;
+  }
+};
+
+
+ngeo.module.controller(
+    'ngeoExportfeaturesController', ngeo.ExportfeaturesController);

--- a/src/directives/exportfeatures.js
+++ b/src/directives/exportfeatures.js
@@ -102,7 +102,7 @@ ngeo.ExportfeaturesController = function($element, $injector, $scope,
    */
   this.items_ = [];
 
-  // build the drop-down menu and items of there's more than one format
+  // build the drop-down menu and items if there's more than one format
   if (formats.length > 1) {
     $element.attr('id', id);
     var $menu = $('<ul />', {

--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -516,24 +516,22 @@ ngeo.FeatureHelper.prototype.export_ = function(features, format, fileName,
     opt_mimeType) {
   var mimeType = opt_mimeType !== undefined ? opt_mimeType : 'text/plain';
 
-  // clone the features to:
-  //  - transform the exported features to EPSG:4326
-  //  - apply the original style to the clone (the original may have select
-  //    style active)
+  // clone the features to apply the original style to the clone
+  // (the original may have select style active)
   var clones = [];
   var clone;
   features.forEach(function(feature) {
-    clone = new ol.Feature();
-    clone.setProperties(feature.getProperties());
-    clone.setGeometry(clone.getGeometry().clone());
-    if (this.projection_) {
-      clone.getGeometry().transform(this.projection_, ol.proj.get('EPSG:4326'));
-    }
+    clone = new ol.Feature(feature.getProperties());
     this.setStyle(clone, false);
     clones.push(clone);
   }, this);
 
-  var data = format.writeFeatures(clones);
+  var writeOptions = this.projection_ ? {
+    dataProjection: 'EPSG:4326',
+    featureProjection: this.projection_
+  } : {};
+
+  var data = format.writeFeatures(clones, writeOptions);
 
   $('<a />', {
     'download': fileName,

--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -2,9 +2,12 @@ goog.provide('ngeo.FeatureHelper')
 
 goog.require('ngeo');
 goog.require('ngeo.interaction.Measure');
+goog.require('ol.Feature');
 goog.require('ol.geom.LineString');
 goog.require('ol.geom.MultiPoint');
 goog.require('ol.geom.Polygon');
+goog.require('ol.format.GPX');
+goog.require('ol.format.KML');
 goog.require('ol.style.Circle');
 goog.require('ol.style.Fill');
 goog.require('ol.style.RegularShape');
@@ -17,6 +20,7 @@ goog.require('ol.style.Text');
  * Provides methods for features, such as:
  *  - style setting / getting
  *  - measurement
+ *  - export
  *
  * @constructor
  * @param {angular.$injector} $injector Main injector.
@@ -446,6 +450,104 @@ ngeo.FeatureHelper.prototype.getStrokeProperty = function(feature) {
 };
 
 
+// === EXPORT ===
+
+
+/**
+ * Export features in the given format. The projection of the exported features
+ * is: `EPSG:4326`.
+ * @param {Array.<ol.Feature>} features Array of vector features.
+ * @param {string} formatType Format type to export the features.
+ * @export
+ */
+ngeo.FeatureHelper.prototype.export = function(features, formatType) {
+  switch (formatType) {
+    case ngeo.FeatureHelper.FormatType.GPX:
+      this.exportGPX(features)
+      break;
+    case ngeo.FeatureHelper.FormatType.KML:
+      this.exportKML(features)
+      break;
+    default:
+      break;
+  }
+};
+
+
+/**
+ * Export features in GPX and download the result to the browser. The
+ * projection of the exported features is: `EPSG:4326`.
+ * @param {Array.<ol.Feature>} features Array of vector features.
+ * @export
+ */
+ngeo.FeatureHelper.prototype.exportGPX = function(features) {
+  var format = new ol.format.GPX();
+  var mimeType = 'application/gpx+xml';
+  var fileName = 'export.gpx';
+  this.export_(features, format, fileName, mimeType);
+};
+
+
+/**
+ * Export features in KML and download the result to the browser. The
+ * projection of the exported features is: `EPSG:4326`.
+ * @param {Array.<ol.Feature>} features Array of vector features.
+ * @export
+ */
+ngeo.FeatureHelper.prototype.exportKML = function(features) {
+  var format = new ol.format.KML();
+  var mimeType = 'application/vnd.google-earth.kml+xml';
+  var fileName = 'export.kml';
+  this.export_(features, format, fileName, mimeType);
+};
+
+
+/**
+ * Export features using a given format to a specific filename and download
+ * the result to the browser. The projection of the exported features is:
+ * `EPSG:4326`.
+ * @param {Array.<ol.Feature>} features Array of vector features.
+ * @param {ol.format.Feature} format Format
+ * @param {string} fileName Name of the file.
+ * @param {string=} opt_mimeType Mime type. Defaults to 'text/plain'.
+ * @private
+ */
+ngeo.FeatureHelper.prototype.export_ = function(features, format, fileName,
+    opt_mimeType) {
+  var mimeType = opt_mimeType !== undefined ? opt_mimeType : 'text/plain';
+
+  // clone the features to:
+  //  - transform the exported features to EPSG:4326
+  //  - apply the original style to the clone (the original may have select
+  //    style active)
+  var clones = [];
+  var clone;
+  features.forEach(function(feature) {
+    clone = new ol.Feature();
+    clone.setProperties(feature.getProperties());
+    clone.setGeometry(clone.getGeometry().clone());
+    if (this.projection_) {
+      clone.getGeometry().transform(this.projection_, ol.proj.get('EPSG:4326'));
+    }
+    this.setStyle(clone, false);
+    clones.push(clone);
+  }, this);
+
+  var data = format.writeFeatures(clones);
+
+  $('<a />', {
+    'download': fileName,
+    'href': [
+      'data:',
+      mimeType,
+      ';charset=utf-8,',
+      encodeURIComponent(data)
+    ].join(''),
+    'mimeType': mimeType
+  })[0].click();
+};
+
+
 // === OTHER UTILITY METHODS ===
 
 
@@ -542,3 +644,24 @@ ngeo.FeatureHelper.prototype.getType = function(feature) {
 
 
 ngeo.module.service('ngeoFeatureHelper', ngeo.FeatureHelper);
+
+
+// === FORMAT TYPES ===
+
+
+/**
+ * @enum {string}
+ * @export
+ */
+ngeo.FeatureHelper.FormatType = {
+  /**
+   * @type {string}
+   * @export
+   */
+  GPX: 'GPX',
+  /**
+   * @type {string}
+   * @export
+   */
+  KML: 'KML'
+};


### PR DESCRIPTION
This PR introduces the ability to `export` features that are drawn using the `gmf-drawfeature` directive.  

 * The `ngeo.FeatureHelper` is responsible of executing the writing of features and download as well.
 * A `ngeo-exportfeatures` directive is responsible of the UI aspect.  It will also be responsible to show a drop-down list if more than one format is defined.
 * The `ngeoExportFeatureFormats` constant will be responsible of defining in what formats we want the exportation to be supported.  Defaults to `KML` only, if not defined.

## Todo

 * [x] support KML export
 * [x] support GPX
 * [x] show drop-down menu if more than one format defined
 * [x] review
 * [x] apply reviewer's corrections
 * [x] reproject when writing features

We won't use template instead of jQuery to build menu items, because the menu has to be a sibling of the button. That can't work with pure Angular.

## Live demo

 * http://adube.github.io/ngeo/gmf-drawfeature-export/examples/contribs/gmf/drawfeature.html