### PR TITLE
Fix bug in built version of the modify rectangle interaction

### DIFF
--- a/src/ol-ext/interaction/modifyrectangle.js
+++ b/src/ol-ext/interaction/modifyrectangle.js
@@ -136,13 +136,26 @@ ngeo.interaction.ModifyRectangle.prototype.addFeature_ = function(feature) {
     var boxSource = this.vectorBoxes_.getSource();
     var pointSource = this.vectorPoints_.getSource();
 
-    try {
-      boxSource.addFeature(feature);
-    } catch (e) {
-      // If the feature is in the source already, its corners were already
-      // created, no need to create them again.
+    // If the feature is in the source already, its corners were already
+    // created, no need to create them again.
+    var featureExists = false;
+    var featureId = feature.getId();
+    if (featureId) {
+      featureExists = !!boxSource.getFeatureById(featureId);
+    } else {
+      featureId = goog.getUid(feature).toString();
+      var features = boxSource.getFeatures();
+      for (var i = 0; i < features.length; i++) {
+        if (goog.getUid(features[i]).toString() == featureId) {
+          featureExists = true;
+          break;
+        }
+      }
+    }
+    if (featureExists) {
       return;
     }
+    boxSource.addFeature(feature);
 
     // from each corners, create a point feature and add it to the point layer.
     // each point is then associated with 2 siblings in order to update the


### PR DESCRIPTION
This commit fixes a bug in the modify rectangle that only occurs in the built version.

Vector sources usually raise an assert error when trying to add a feature to them that was already added, but it turns out that this error is not raised in the built version (I think that may be a bug in ol?).

So what this commit does is check manually if the feature has already been added.

This fixes the issue when if you select and unselect the rectangle repeatedly, the feature would sometimes be added in double and not removed.

Here is a link to the working interaction, integrated in the draw feature example:
http://jlap.github.io/ngeo/modify-rectangle-bug-build/examples/contribs/gmf/drawfeature.html

@fgravin this is ready to review.