### PR TITLE
Add gmf-drawfeature directive in desktop app

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -50,8 +50,8 @@
             <span class="fa fa-print"></span>
           </button>
           <button ngeo-btn class="btn btn-default" ng-model="measureActive"
-            data-toggle="tooltip" data-placement="left" data-original-title="{{'Measure tools'|translate}}">
-            <span class="fa fa-circle"></span>
+            data-toggle="tooltip" data-placement="left" data-original-title="{{'Draw & Measure tools'|translate}}">
+            <span class="fa fa-pencil"></span>
           </button>
         </div>
         <div class="tools-content container-fluid" ng-class="{active: mainCtrl.toolsActive}">
@@ -81,8 +81,13 @@
               <div ng-show="measureActive" class="row">
                 <div class="col-sm-12">
                   <div class="tools-content-heading">
-                    Measure
+                    <span>{{'Draw & Measure'|translate}}</span>
                     <a class="btn close" ng-click="measureActive = false">&times;</a>
+                    <gmf-drawfeature
+                        gmf-drawfeature-active="measureActive"
+                        gmf-drawfeature-layer="::mainCtrl.drawFeatureLayer"
+                        gmf-drawfeature-map="::mainCtrl.map">
+                    </gmf-drawfeature>
                   </div>
                 </div>
               </div>

--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -83,12 +83,12 @@
                   <div class="tools-content-heading">
                     <span>{{'Draw & Measure'|translate}}</span>
                     <a class="btn close" ng-click="measureActive = false">&times;</a>
-                    <gmf-drawfeature
-                        gmf-drawfeature-active="measureActive"
-                        gmf-drawfeature-layer="::mainCtrl.drawFeatureLayer"
-                        gmf-drawfeature-map="::mainCtrl.map">
-                    </gmf-drawfeature>
                   </div>
+                  <gmf-drawfeature
+                      gmf-drawfeature-active="measureActive"
+                      gmf-drawfeature-layer="::mainCtrl.drawFeatureLayer"
+                      gmf-drawfeature-map="::mainCtrl.map">
+                  </gmf-drawfeature>
                 </div>
               </div>
             </div>

--- a/contribs/gmf/apps/desktop/js/controller.js
+++ b/contribs/gmf/apps/desktop/js/controller.js
@@ -21,6 +21,12 @@ goog.require('ngeo.proj.EPSG2056');
 goog.require('ngeo.proj.EPSG21781');
 
 
+app.module.constant('ngeoExportFeatureFormats', [
+  ngeo.FeatureHelper.FormatType.KML,
+  ngeo.FeatureHelper.FormatType.GPX
+]);
+
+
 app.module.constant('ngeoQueryOptions', {
   'limit': 20
 });

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -48,8 +48,8 @@
             <span class="fa fa-print"></span>
           </button>
           <button ngeo-btn class="btn btn-default" ng-model="measureActive"
-            data-toggle="tooltip" data-placement="left" data-original-title="{{'Measure tools'|translate}}">
-            <span class="fa fa-circle">
+            data-toggle="tooltip" data-placement="left" data-original-title="{{'Draw & Measure tools'|translate}}">
+            <span class="fa fa-pencil">
           </button>
         </div>
         <div class="tools-content container-fluid" ng-class="{active: mainCtrl.toolsActive}">
@@ -80,9 +80,14 @@
               <div ng-show="measureActive" class="row">
                 <div class="col-sm-12">
                   <div class="tools-content-heading">
-                    Measure
+                    <span>{{'Draw & Measure'|translate}}</span>
                     <a class="btn close" ng-click="measureActive = false">&times;</a>
                   </div>
+                  <gmf-drawfeature
+                      gmf-drawfeature-active="measureActive"
+                      gmf-drawfeature-layer="::mainCtrl.drawFeatureLayer"
+                      gmf-drawfeature-map="::mainCtrl.map">
+                  </gmf-drawfeature>
                 </div>
               </div>
             </div>

--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -21,6 +21,12 @@ goog.require('ngeo.proj.EPSG2056');
 goog.require('ngeo.proj.EPSG21781');
 
 
+app.module.constant('ngeoExportFeatureFormats', [
+  ngeo.FeatureHelper.FormatType.KML,
+  ngeo.FeatureHelper.FormatType.GPX
+]);
+
+
 app.module.constant('ngeoQueryOptions', {
   'limit': 20
 });

--- a/contribs/gmf/examples/drawfeature.html
+++ b/contribs/gmf/examples/drawfeature.html
@@ -192,7 +192,7 @@
     <span id="pointermove-feature"></span>
 
     <h2>Draw & Measure</h2>
-    
+
     <gmf-drawfeature
       ng-show="ctrl.drawFeatureActive === true"
       gmf-drawfeature-active="ctrl.drawFeatureActive"

--- a/contribs/gmf/examples/drawfeature.html
+++ b/contribs/gmf/examples/drawfeature.html
@@ -52,7 +52,9 @@
       /* drawfeature */
 
       ngeo-drawfeature {
-        margin: 10px 0;
+        border-bottom: 1px solid #333;
+        margin: 0 0 10px 0;
+        padding: 0 0 20px 0;
       }
 
       .gmf-icon-circle:before {
@@ -189,6 +191,8 @@
     <label for="checkbox-pointermove"> PointerMove</label>
     <span id="pointermove-feature"></span>
 
+    <h2>Draw & Measure</h2>
+    
     <gmf-drawfeature
       ng-show="ctrl.drawFeatureActive === true"
       gmf-drawfeature-active="ctrl.drawFeatureActive"

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -335,7 +335,6 @@ gmf-featurestyle {
       background-color: transparent;
       border: none;
       box-shadow: none;
-      -webkit-box-shadow: none;
       padding: 0;
    }
   }
@@ -380,8 +379,6 @@ gmf-featurestyle {
         top: -10px;
         left: -10px;
         border: 2px solid #fff;
-        -webkit-box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
-        -webkit-box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
         box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
         z-index: 11;
       }

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -384,7 +384,7 @@ gmf-featurestyle {
         -webkit-box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
         box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
         z-index: 11;
-      }     
+      }
     }
 
     &.selected > div::after {

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -233,3 +233,42 @@ main {
     border-radius: @app-margin;
     background: @brand-primary;
 }
+
+
+/**
+ * DrawFeature directive
+ */
+
+gmf-drawfeature h2 {
+  display: none;
+}
+
+
+.ngeo-drawfeature-actionbuttons {
+  float: right;
+  position: relative;
+}
+
+
+
+.gmf-eol {
+  clear: both;
+}
+
+gmf-featurestyle {
+  display: block;
+  margin: 10px 0 0 0;
+}
+
+.gmf-drawfeature-featurelist {
+  margin: 10px 0 0 0;
+  padding: 0;
+  list-style: none;
+
+  li {
+    &:hover {
+      background-color: #ADD8E6;
+      cursor: pointer;
+    }
+  }
+}

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -236,28 +236,20 @@ main {
 
 
 /**
- * DrawFeature directive
+ * GMF DrawFeature directive
  */
-
 gmf-drawfeature h2 {
   display: none;
 }
-
-
-.ngeo-drawfeature-actionbuttons {
-  float: right;
-  position: relative;
-}
-
-
 
 .gmf-eol {
   clear: both;
 }
 
-gmf-featurestyle {
-  display: block;
+.gmf-drawfeature-featurelistctn {
+  border-top: 1px solid #333;
   margin: 10px 0 0 0;
+  padding: 10px 0 0 0;
 }
 
 .gmf-drawfeature-featurelist {
@@ -269,6 +261,144 @@ gmf-featurestyle {
     &:hover {
       background-color: #ADD8E6;
       cursor: pointer;
+    }
+  }
+}
+
+
+/**
+ * NGEO DrawFeature directive & map tooltips
+ */
+.ngeo-drawfeature-actionbuttons {
+  float: right;
+  position: relative;
+}
+
+.ol-viewport {
+  .tooltip {
+    position: relative;
+    background: rgba(0, 0, 0, 0.5);
+    border-radius: 4px;
+    color: white;
+    padding: 4px 8px;
+    opacity: 0.7;
+    white-space: nowrap;
+  }
+  .tooltip-measure {
+    opacity: 1;
+    font-weight: bold;
+  }
+  .tooltip-static {
+    display: none;
+  }
+  .tooltip-measure:before,
+  .tooltip-static:before {
+    border-top: 6px solid rgba(0, 0, 0, 0.5);
+    border-right: 6px solid transparent;
+    border-left: 6px solid transparent;
+    content: "";
+    position: absolute;
+    bottom: -6px;
+    margin-left: -7px;
+    left: 50%;
+  }
+  .tooltip-static:before {
+    border-top-color: #ffcc33;
+  }
+}
+
+
+/**
+ * GMF FeatureStyle directive
+ */
+gmf-featurestyle {
+  display: block;
+  margin: 10px 0 0 0;
+
+  .form-horizontal {
+    .control-label {
+      padding-top: 0;
+      text-align: left;
+    }
+  }
+
+  input[type=range] {
+    background-color: transparent;
+    padding: 6px 12px;
+  }
+
+  .gmf-featurestyle-name {
+    font-weight: bold;
+    font-size: 16pt;
+
+    &:not(:focus) {
+      background-color: transparent;
+      border: none;
+      box-shadow: none;
+      -webkit-box-shadow: none;
+      padding: 0;
+   }
+  }
+}
+
+
+/**
+ * Color palette within GMF FeatureStyle directive
+ */
+.palette {
+  border-collapse: separate;
+  border-spacing: 0px;
+
+  tr {
+    cursor: default;
+  }
+
+  td {
+    position: relative;
+    padding: 0px;
+    text-align: center;
+    vertical-align: middle;
+    font-size: 1px;
+    cursor: pointer;
+
+    & > div {
+      position: relative;
+      height: 12px;
+      width: 12px;
+      border: 1px solid #fff;
+      box-sizing: content-box;
+    }
+
+    &:hover {
+      & > div::after {
+        display: block;
+        content: '';
+        background: inherit;
+        position: absolute;
+        width: 28px;
+        height: 28px;
+        top: -10px;
+        left: -10px;
+        border: 2px solid #fff;
+        -webkit-box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
+        -webkit-box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
+        box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
+        z-index: 11;
+      }     
+    }
+
+    &.selected > div::after {
+      border: 2px solid #444;
+      margin: 0;
+      content: '';
+      display: block;
+      width: 14px;
+      height: 14px;
+      position: absolute;
+      left: -3px;
+      top: -3px;
+      box-sizing: content-box;
+      z-index: 10;
     }
   }
 }

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -3,6 +3,8 @@ goog.provide('gmf.AbstractDesktopController');
 goog.require('gmf');
 goog.require('gmf.AbstractController');
 /** @suppress {extraRequire} */
+goog.require('gmf.drawfeatureDirective');
+/** @suppress {extraRequire} */
 goog.require('gmf.mobileBackgroundlayerselectorDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.printDirective');
@@ -10,6 +12,8 @@ goog.require('gmf.printDirective');
 goog.require('ngeo.btngroupDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.resizemapDirective');
+goog.require('ngeo.FeatureHelper');
+goog.require('ngeo.Features');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.control.ScaleLine');
@@ -78,6 +82,31 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
     trigger: 'hover',
     selector: '[data-toggle="tooltip"]'
   });
+
+  /**
+   * Ngeo FeatureHelper service
+   * @type {ngeo.FeatureHelper}
+   */
+  var ngeoFeatureHelper = $injector.get('ngeoFeatureHelper');
+  ngeoFeatureHelper.setProjection(this.map.getView().getProjection());
+
+  /**
+   * Collection of features for the draw interaction
+   * @type {ol.Collection.<ol.Feature>}
+   */
+  var ngeoFeatures = $injector.get('ngeoFeatures');
+
+  /**
+   * @type {ol.layer.Vector}
+   * @export
+   */
+  this.drawFeatureLayer = new ol.layer.Vector({
+    source: new ol.source.Vector({
+      wrapX: false,
+      features: ngeoFeatures
+    })
+  });
+  this.drawFeatureLayer.setMap(this.map);
 
   goog.base(
       this, config, $scope, $injector);

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -13,12 +13,15 @@ goog.require('ngeo.btngroupDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.resizemapDirective');
 goog.require('ngeo.FeatureHelper');
+/** @suppress {extraRequire} */
 goog.require('ngeo.Features');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.control.ScaleLine');
 goog.require('ol.control.Zoom');
 goog.require('ol.interaction');
+goog.require('ol.layer.Vector');
+goog.require('ol.source.Vector');
 
 gmf.module.constant('isDesktop', true);
 

--- a/contribs/gmf/src/directives/partials/drawfeature.html
+++ b/contribs/gmf/src/directives/partials/drawfeature.html
@@ -1,9 +1,5 @@
 <div>
 
-  <h2>{{'Draw & Measure' | translate}}</h2>
-
-  <hr />
-
   <ngeo-drawfeature
       ngeo-btn-group
       class="btn-group"
@@ -83,9 +79,9 @@
     </a>
   </ngeo-drawfeature>
 
-  <hr />
-
-  <div ng-switch="efCtrl.selectedFeature">
+  <div
+      ng-switch="efCtrl.selectedFeature"
+      class="gmf-drawfeature-featurelistctn">
 
     <div ng-switch-when="null">
       <div ng-show="efCtrl.features.getLength()">


### PR DESCRIPTION
This PR introduces the `gmf-drawfeature` directive within the **deskop** and **desktop_alt** apps.  The latter is the only one we can currently test, due to the issue described below.

## Todo

 * [x] Review

## Live demo

 * https://adube.github.io/ngeo/gmf-drawfeature-in-desktop-app/examples/contribs/gmf/apps/desktop_alt/?lang=fr&rl_features