### PR TITLE
Support drawn features (gmf-drawfeature) in gmf-permalink

### DIFF
--- a/src/ol-ext/interaction/modify.js
+++ b/src/ol-ext/interaction/modify.js
@@ -214,9 +214,11 @@ ngeo.interaction.Modify.prototype.removeFeature_ = function(feature) {
  */
 ngeo.interaction.Modify.prototype.getFeatureCollection_ = function(feature) {
   var features;
-  if (feature.get(ngeo.FeatureProperties.IS_CIRCLE) === true) {
+  var isCircle = feature.get(ngeo.FeatureProperties.IS_CIRCLE);
+  var isRectangle = feature.get(ngeo.FeatureProperties.IS_RECTANGLE);
+  if (isCircle === true || isCircle === 'true') {
     features = this.circleFeatures_;
-  } else if (feature.get(ngeo.FeatureProperties.IS_RECTANGLE) === true) {
+  } else if (isRectangle === true || isRectangle === 'true') {
     features = this.rectangleFeatures_;
   } else {
     features = this.otherFeatures_;

--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -126,7 +126,7 @@ ngeo.FeatureHelper.prototype.getLineStringStyle_ = function(feature) {
 
   var strokeWidth = this.getStrokeProperty(feature);
   var showMeasure = this.getShowMeasureProperty(feature);
-  var color = this.getColorProperty(feature);
+  var color = this.getRGBAColorProperty(feature);
 
   var options = {
     stroke: new ol.style.Stroke({
@@ -152,7 +152,7 @@ ngeo.FeatureHelper.prototype.getLineStringStyle_ = function(feature) {
 ngeo.FeatureHelper.prototype.getPointStyle_ = function(feature) {
 
   var size = this.getSizeProperty(feature);
-  var color = this.getColorProperty(feature);
+  var color = this.getRGBAColorProperty(feature);
 
   var options = {
     image: new ol.style.Circle({
@@ -183,13 +183,11 @@ ngeo.FeatureHelper.prototype.getPolygonStyle_ = function(feature) {
 
   var strokeWidth = this.getStrokeProperty(feature);
   var opacity = this.getOpacityProperty(feature);
-  var color = this.getColorProperty(feature);
+  var color = this.getRGBAColorProperty(feature);
 
   // fill color with opacity
-  var rgbColor = ol.color.fromString(color);
-  var rgbaColor = rgbColor.slice();
-  rgbaColor[3] = opacity;
-  var fillColor = ol.color.toString(rgbaColor);
+  var fillColor = color.slice();
+  fillColor[3] = opacity;
 
   var options = {
     fill: new ol.style.Fill({
@@ -222,7 +220,7 @@ ngeo.FeatureHelper.prototype.getTextStyle_ = function(feature) {
   var label = this.getNameProperty(feature);
   var size = this.getSizeProperty(feature);
   var angle = this.getAngleProperty(feature);
-  var color = this.getColorProperty(feature);
+  var color = this.getRGBAColorProperty(feature);
 
   return new ol.style.Style({
     text: this.createTextStyle_(label, size, angle, color)
@@ -317,7 +315,7 @@ ngeo.FeatureHelper.prototype.getHaloStyle_ = function(feature) {
         image: new ol.style.Circle({
           radius: size + haloSize,
           fill: new ol.style.Fill({
-            color: 'white'
+            color: [255, 255, 255, 1]
           })
         })
       });
@@ -329,7 +327,7 @@ ngeo.FeatureHelper.prototype.getHaloStyle_ = function(feature) {
       var strokeWidth = this.getStrokeProperty(feature);
       style = new ol.style.Style({
         stroke: new ol.style.Stroke({
-          color: 'white',
+          color: [255, 255, 255, 1],
           width: strokeWidth + haloSize * 2
         })
       });
@@ -338,7 +336,7 @@ ngeo.FeatureHelper.prototype.getHaloStyle_ = function(feature) {
       var label = this.getNameProperty(feature);
       size = this.getSizeProperty(feature);
       var angle = this.getAngleProperty(feature);
-      var color = 'white';
+      var color = [255, 255, 255, 1];
       style = new ol.style.Style({
         text: this.createTextStyle_(label, size, angle, color, haloSize * 2)
       })
@@ -386,6 +384,16 @@ ngeo.FeatureHelper.prototype.getColorProperty = function(feature) {
 
 /**
  * @param {ol.Feature} feature Feature.
+ * @return {ol.Color} Color.
+ * @export
+ */
+ngeo.FeatureHelper.prototype.getRGBAColorProperty = function(feature) {
+  return ol.color.fromString(this.getColorProperty(feature));
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature.
  * @return {string} Name.
  * @export
  */
@@ -415,13 +423,14 @@ ngeo.FeatureHelper.prototype.getOpacityProperty = function(feature) {
  * @export
  */
 ngeo.FeatureHelper.prototype.getShowMeasureProperty = function(feature) {
-  var showMeasure = (/** @type {boolean} */ (
-        feature.get(ngeo.FeatureProperties.SHOW_MEASURE)));
+  var showMeasure = feature.get(ngeo.FeatureProperties.SHOW_MEASURE);
   if (showMeasure === undefined) {
     showMeasure = false;
+  } else if (typeof showMeasure === 'string') {
+    showMeasure = (showMeasure === 'true') ? true : false;
   }
   goog.asserts.assertBoolean(showMeasure);
-  return showMeasure;
+  return /** @type {boolean} */ (showMeasure);
 };
 
 
@@ -553,7 +562,7 @@ ngeo.FeatureHelper.prototype.export_ = function(features, format, fileName,
  * @param {string} text The text to display.
  * @param {number} size The size in `pt` of the text font.
  * @param {number=} opt_angle The angle in degrees of the text.
- * @param {string=} opt_color The color of the text.
+ * @param {ol.Color=} opt_color The color of the text.
  * @param {number=} opt_width The width of the outline color.
  * @return {ol.style.Text} Style.
  * @private
@@ -564,14 +573,14 @@ ngeo.FeatureHelper.prototype.createTextStyle_ = function(text, size,
   var angle = opt_angle !== undefined ? opt_angle : 0;
   var rotation = angle * Math.PI / 180;
   var font = ['normal', size + 'pt', 'Arial'].join(' ');
-  var color = opt_color !== undefined ? opt_color : '#000000';
+  var color = opt_color !== undefined ? opt_color : [0, 0, 0, 1];
   var width = opt_width !== undefined ? opt_width : 3;
 
   return new ol.style.Text({
     font: font,
     text: text,
     fill: new ol.style.Fill({color: color}),
-    stroke: new ol.style.Stroke({color: '#ffffff', width: width}),
+    stroke: new ol.style.Stroke({color: [255, 255, 255, 1], width: width}),
     rotation: rotation
   });
 };


### PR DESCRIPTION
This PR introduces the support of drawn vector features by the `gmf-drawfeature` directive inside the `gmf-permalink` service.

## Todo

 * [x] review
 * [ ] rename properties - the inner property values, such as `isCircle`, `name`, `angle`, etc. could be rename to a single character, which would make the url lighter.  Those are already defined in enums.

## Live example

 * http://adube.github.io/ngeo/gmf-drawfeature-permalink/examples/contribs/gmf/drawfeature.html