### PR TITLE
Fix mobile-query example

### DIFF
--- a/src/services/query.js
+++ b/src/services/query.js
@@ -1,6 +1,7 @@
 goog.provide('ngeo.Query');
 
 goog.require('ngeo');
+goog.require('ngeo.LayerHelper');
 goog.require('ol.format.WMSGetFeatureInfo');
 goog.require('ol.source.ImageWMS');
 goog.require('ol.source.TileWMS');


### PR DESCRIPTION
When running locally with `make serve`, the mobile-query example failed with:

> Error: [$injector:unpr] Unknown provider: ngeoLayerHelperProvider <- ngeoLayerHelper <- ngeoQuery <- ngeoMobileQueryDirective

[query.js](https://github.com/camptocamp/ngeo/blob/master/src/services/query.js) was missing a require to `ngeo.LayerHelper`. Unfortunately this is not detected by the tests because the examples are run in built-mode. 