### PR TITLE
Backward compatibility for rl_features

### DIFF
--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -213,7 +213,7 @@ gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
    * @private
    */
   this.featureHashFormat_ = new ngeo.format.FeatureHash({
-    setStyles: false,
+    setStyle: false,
     encodeStyles: false
   });
 

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -213,6 +213,7 @@ gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
    * @private
    */
   this.featureHashFormat_ = new ngeo.format.FeatureHash({
+    setStyles: false,
     encodeStyles: false
   });
 

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -333,10 +333,10 @@ ngeox.format.FeatureHashOptions.prototype.properties;
 /**
  * Determines whether the style defined for each feature is read and converted
  * into:
- *   A) an `ol.style.Style` object set in the feature, or 
- *   B) an object with key:values that defines the style propertiesset in
- *      the feature and for the `ngeo.FeatureHelper` to use to style the feature
- *      with.
+ *   A) an `ol.style.Style` object set in the feature, or
+ *   B) an object with key:values that defines the style properties set in
+ *      the feature and for the `ngeo.FeatureHelper` to use to style the
+ *      feature with.
  * Default is `true`, i.e. A).
  * @type {boolean|undefined}
  */

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -299,7 +299,8 @@ ngeox.format;
  * @typedef {{
  *    accuracy: (number|undefined),
  *    encodeStyles: (boolean|undefined),
- *    properties: (function(ol.Feature): Object.<string, (string|undefined)>|undefined)
+ *    properties: (function(ol.Feature): Object.<string, (string|undefined)>|undefined),
+ *    setStyle: (boolean|undefined)
  * }}
  */
 ngeox.format.FeatureHashOptions;
@@ -327,6 +328,19 @@ ngeox.format.FeatureHashOptions.prototype.encodeStyles;
  * @type {(function(ol.Feature): Object.<string, (string|undefined)>|undefined)}
  */
 ngeox.format.FeatureHashOptions.prototype.properties;
+
+
+/**
+ * Determines whether the style defined for each feature is read and converted
+ * into:
+ *   A) an `ol.style.Style` object set in the feature, or 
+ *   B) an object with key:values that defines the style propertiesset in
+ *      the feature and for the `ngeo.FeatureHelper` to use to style the feature
+ *      with.
+ * Default is `true`, i.e. A).
+ * @type {boolean|undefined}
+ */
+ngeox.format.FeatureHashOptions.prototype.setStyle;
 
 
 /**

--- a/src/ol-ext/format/featurehash.js
+++ b/src/ol-ext/format/featurehash.js
@@ -650,9 +650,28 @@ ngeo.format.FeatureHash.setStyleInFeature_ = function(text, feature) {
 ngeo.format.FeatureHash.setStyleProperties_ = function(text, feature) {
 
   var properties = ngeo.format.FeatureHash.getStyleProperties_(text, feature);
+  var geometry = feature.getGeometry();
   var clone = {};
 
-  // convert legacy properties
+  // Deal with legacy properties
+  if (geometry instanceof ol.geom.Point) {
+    if (properties['isLabel'] ||
+        properties[ngeo.FeatureProperties.IS_TEXT]) {
+      delete properties['strokeColor'];
+      delete properties['fillColor'];
+    } else {
+      delete properties['fontColor'];
+    }
+  } else {
+    delete properties['fontColor'];
+
+    if (geometry instanceof ol.geom.LineString) {
+      delete properties['fillColor'];
+      delete properties['fillOpacity'];
+    }
+  }
+
+  // Convert legacy properties
   for (var key in properties) {
     var value = properties[key];
     if (ngeo.format.FeatureHashLegacyProperties_[key]) {
@@ -663,7 +682,6 @@ ngeo.format.FeatureHash.setStyleProperties_ = function(text, feature) {
   }
 
   feature.setProperties(clone);
-
 };
 
 
@@ -681,7 +699,6 @@ ngeo.format.FeatureHash.setStyleProperties_ = function(text, feature) {
 ngeo.format.FeatureHash.getStyleProperties_ = function(text, feature) {
   var parts = text.split('\'');
   var properties = {};
-  var geometry = feature.getGeometry();
 
   var numProperties = [
     ngeo.FeatureProperties.ANGLE,
@@ -716,18 +733,6 @@ ngeo.format.FeatureHash.getStyleProperties_ = function(text, feature) {
     } else {
       properties[key] = val;
     }
-  }
-
-  if (geometry instanceof ol.geom.Point) {
-    if (properties['isLabel'] ||
-        properties[ngeo.FeatureProperties.IS_TEXT]) {
-      delete properties['strokeColor'];
-      delete properties['fillColor'];
-    } else {
-      delete properties['fontColor'];
-    }
-  } else {
-    delete properties['fontColor'];
   }
 
   return properties;

--- a/src/ol-ext/format/featurehash.js
+++ b/src/ol-ext/format/featurehash.js
@@ -651,7 +651,6 @@ ngeo.format.FeatureHash.setStyleProperties_ = function(text, feature) {
 
   var properties = ngeo.format.FeatureHash.getStyleProperties_(text, feature);
   var geometry = feature.getGeometry();
-  var clone = {};
 
   // Deal with legacy properties
   if (geometry instanceof ol.geom.Point) {
@@ -661,6 +660,7 @@ ngeo.format.FeatureHash.setStyleProperties_ = function(text, feature) {
       delete properties['fillColor'];
     } else {
       delete properties['fontColor'];
+      delete properties['fontSize'];
     }
   } else {
     delete properties['fontColor'];
@@ -671,7 +671,17 @@ ngeo.format.FeatureHash.setStyleProperties_ = function(text, feature) {
     }
   }
 
+  // Convert font size from px to pt
+  if (properties['fontSize']) {
+    var fontSize = parseFloat(properties['fontSize']);
+    if (properties['fontSize'].indexOf('px') !== -1) {
+      fontSize = Math.round(fontSize / 1.333333);
+    }
+    properties['fontSize'] = fontSize;
+  }
+
   // Convert legacy properties
+  var clone = {};
   for (var key in properties) {
     var value = properties[key];
     if (ngeo.format.FeatureHashLegacyProperties_[key]) {

--- a/src/ol-ext/format/featurehash.js
+++ b/src/ol-ext/format/featurehash.js
@@ -51,6 +51,26 @@ ngeo.format.FeatureHashStyleTypes_[ol.geom.GeometryType.MULTI_POLYGON] =
 
 
 /**
+ * @type {Object.<string, string>}
+ * @private
+ */
+ngeo.format.FeatureHashLegacyProperties_ = {
+  'fillColor': ngeo.FeatureProperties.COLOR,
+  'fillOpacity': ngeo.FeatureProperties.OPACITY,
+  'fontColor': ngeo.FeatureProperties.COLOR,
+  'fontSize': ngeo.FeatureProperties.SIZE,
+  'isBox': ngeo.FeatureProperties.IS_RECTANGLE,
+  'isCircle': ngeo.FeatureProperties.IS_CIRCLE,
+  'isLabel': ngeo.FeatureProperties.IS_TEXT,
+  'name': ngeo.FeatureProperties.NAME,
+  'pointRadius': ngeo.FeatureProperties.SIZE,
+  'showMeasure': ngeo.FeatureProperties.SHOW_MEASURE,
+  'strokeColor': ngeo.FeatureProperties.COLOR,
+  'strokeWidth': ngeo.FeatureProperties.STROKE
+};
+
+
+/**
  * @classdesc
  * Provide an OpenLayers format for encoding and decoding features for use
  * in permalinks.
@@ -99,6 +119,12 @@ ngeo.format.FeatureHash = function(opt_options) {
    */
   this.propertiesFunction_ = options.properties !== undefined ?
       options.properties : ngeo.format.FeatureHash.defaultPropertiesFunction_;
+
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.setStyle_ = options.setStyle !== undefined ? options.setStyle : true;
 
   /**
    * @type {number}
@@ -550,6 +576,9 @@ ngeo.format.FeatureHash.readMultiPolygonGeometry_ = function(text) {
 
 
 /**
+ * DEPRECATED - Use the `ngeo.FeatureHelper` instead in combination with the
+ * `setStyle: false` option.
+ *
  * Read a logical sequence of characters and apply the decoded style on the
  * given feature.
  * @param {string} text Text.
@@ -561,27 +590,14 @@ ngeo.format.FeatureHash.setStyleInFeature_ = function(text, feature) {
     return;
   }
   var fillColor, fontSize, fontColor, pointRadius, strokeColor, strokeWidth;
-  var parts = text.split('\'');
-  for (var i = 0; i < parts.length; ++i) {
-    var part = decodeURIComponent(parts[i]);
-    var keyVal = part.split('*');
-    goog.asserts.assert(keyVal.length === 2);
-    var key = keyVal[0];
-    var val = keyVal[1];
-    if (key === 'fillColor') {
-      fillColor = val;
-    } else if (key == 'fontSize') {
-      fontSize = val;
-    } else if (key == 'fontColor') {
-      fontColor = val;
-    } else if (key == 'pointRadius') {
-      pointRadius = +val;
-    } else if (key == 'strokeColor') {
-      strokeColor = val;
-    } else if (key == 'strokeWidth') {
-      strokeWidth = +val;
-    }
-  }
+  var properties = ngeo.format.FeatureHash.getStyleProperties_(text, feature);
+  fillColor = properties.fillColor;
+  fontSize = properties.fontSize;
+  fontColor = properties.fontColor;
+  pointRadius = properties.pointRadius;
+  strokeColor = properties.strokeColor;
+  strokeWidth = properties.strokeWidth;
+
   var fillStyle = null;
   if (fillColor !== undefined) {
     fillStyle = new ol.style.Fill({
@@ -620,6 +636,101 @@ ngeo.format.FeatureHash.setStyleInFeature_ = function(text, feature) {
     text: textStyle
   });
   feature.setStyle(style);
+};
+
+
+/**
+ * Read a logical sequence of characters and apply the decoded result as
+ * style properties for the feature. Legacy keys are converted to the new ones
+ * for compatibility.
+ * @param {string} text Text.
+ * @param {ol.Feature} feature Feature.
+ * @private
+ */
+ngeo.format.FeatureHash.setStyleProperties_ = function(text, feature) {
+
+  var properties = ngeo.format.FeatureHash.getStyleProperties_(text, feature);
+  var clone = {};
+
+  // convert legacy properties
+  for (var key in properties) {
+    var value = properties[key];
+    if (ngeo.format.FeatureHashLegacyProperties_[key]) {
+      clone[ngeo.format.FeatureHashLegacyProperties_[key]] = value;
+    } else {
+      clone[key] = value;
+    }
+  }
+
+  feature.setProperties(clone);
+
+};
+
+
+/**
+ * From a logical sequence of characters, create and return an object of
+ * style properties for a feature. The values are cast in the correct type
+ * depending on the property. Some properties are also deleted when they don't
+ * match the geometry of the feature.
+ * @param {string} text Text.
+ * @param {ol.Feature} feature Feature.
+ * @return {Object.<string, boolean|number|string>} The style properties for
+ *     the feature.
+ * @private
+ */
+ngeo.format.FeatureHash.getStyleProperties_ = function(text, feature) {
+  var parts = text.split('\'');
+  var properties = {};
+  var geometry = feature.getGeometry();
+
+  var numProperties = [
+    ngeo.FeatureProperties.ANGLE,
+    ngeo.FeatureProperties.OPACITY,
+    ngeo.FeatureProperties.SIZE,
+    ngeo.FeatureProperties.STROKE,
+    'pointRadius',
+    'strokeWidth'
+  ];
+  var boolProperties = [
+    ngeo.FeatureProperties.IS_CIRCLE,
+    ngeo.FeatureProperties.IS_RECTANGLE,
+    ngeo.FeatureProperties.IS_TEXT,
+    ngeo.FeatureProperties.SHOW_MEASURE,
+    'isCircle',
+    'isRectangle',
+    'isLabel',
+    'showMeasure'
+  ];
+
+  for (var i = 0; i < parts.length; ++i) {
+    var part = decodeURIComponent(parts[i]);
+    var keyVal = part.split('*');
+    goog.asserts.assert(keyVal.length === 2);
+    var key = keyVal[0];
+    var val = keyVal[1];
+
+    if (ol.array.includes(numProperties, key)) {
+      properties[key] = +val;
+    } else if (ol.array.includes(boolProperties, key)) {
+      properties[key] = (val === 'true') ? true : false;
+    } else {
+      properties[key] = val;
+    }
+  }
+
+  if (geometry instanceof ol.geom.Point) {
+    if (properties['isLabel'] ||
+        properties[ngeo.FeatureProperties.IS_TEXT]) {
+      delete properties['strokeColor'];
+      delete properties['fillColor'];
+    } else {
+      delete properties['fontColor'];
+    }
+  } else {
+    delete properties['fontColor'];
+  }
+
+  return properties;
 };
 
 
@@ -911,12 +1022,21 @@ ngeo.format.FeatureHash.prototype.readFeatureFromText = function(text, opt_optio
         var part = decodeURIComponent(parts[i]);
         var keyVal = part.split('*');
         goog.asserts.assert(keyVal.length === 2);
-        feature.set(keyVal[0], keyVal[1]);
+        var key = keyVal[0];
+        var value = keyVal[1];
+        if (!this.setStyle_ && ngeo.format.FeatureHashLegacyProperties_[key]) {
+          key = ngeo.format.FeatureHashLegacyProperties_[key];
+        }
+        feature.set(key, value);
       }
     }
     if (splitIndex >= 0) {
       var stylesText = attributesAndStylesText.substring(splitIndex + 1);
-      ngeo.format.FeatureHash.setStyleInFeature_(stylesText, feature);
+      if (this.setStyle_) {
+        ngeo.format.FeatureHash.setStyleInFeature_(stylesText, feature);
+      } else {
+        ngeo.format.FeatureHash.setStyleProperties_(stylesText, feature);
+      }
     }
   }
   return feature;

--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -410,8 +410,9 @@ ngeo.FeatureHelper.prototype.getNameProperty = function(feature) {
  * @export
  */
 ngeo.FeatureHelper.prototype.getOpacityProperty = function(feature) {
-  var opacity = +(/** @type {string} */ (
+  var opacityStr = (/** @type {string} */ (
       feature.get(ngeo.FeatureProperties.OPACITY)));
+  var opacity = opacityStr !== undefined ? +opacityStr : 1;
   goog.asserts.assertNumber(opacity);
   return opacity;
 };


### PR DESCRIPTION
This PR adds the backward compatibility for `rl_features` in the permalink, i.e. for the features of the redlining tool from 1.6.

## Was blocked by

This PR was blocked by: #1069 

## To do

 * [ ] Review


## Test cases

You can try them here: https://geomapfish-demo.camptocamp.net/2.0

Examples (removed prefix: https://geomapfish-demo.camptocamp.net/2.0/theme/Transport?map_x=542000&map_y=154000&map_zoom=2&):

 * [x] **point** 
  * http://adube.github.io/ngeo/ngeo-featurehash-write-new-properties/examples/contribs/gmf/drawfeature.html?rl_features=Fp%28w8saFhdf3!~name*Un%2520titre~fillColor*%2523ff0000%27strokeColor*%2523ff0000%27pointRadius*6%27fontColor*%2523000000%29
 *`rl_features=Fp%28w8saFhdf3!~name*Un%2520titre~fillColor*%2523ff0000%27strokeColor*%2523ff0000%27pointRadius*6%27fontColor*%2523000000%29`
  * works fine
  * `fontColor` is ignored
  * `fillColor` and `strokeColor` are the same, i.e. only one is used

 * [x] **line** 
  * http://adube.github.io/ngeo/ngeo-featurehash-write-new-properties/examples/contribs/gmf/drawfeature.html?rl_features=Fl%28drh7F9tx2!htv_z1k_~~strokeColor*%2523ff0000%27strokeWidth*1%29
  * `rl_features=Fl%28drh7F9tx2!htv_z1k_~~strokeColor*%2523ff0000%27strokeWidth*1%29`
  * this string doesn't currently work locally, but works in the minimized version... that's rare.  I don't know why yet.

 * [x] **polygon**
  * http://adube.github.io/ngeo/ngeo-featurehash-write-new-properties/examples/contribs/gmf/drawfeature.html?rl_features=Fa%285rx4F11p2!sp1!1rGh3h_gwr_rg9!grn-~showMeasure*true~fillColor*%2523ff0000%27strokeColor*%2523ff0000%27strokeWidth*1%29
  * `rl_features=Fa%285rx4F11p2!sp1!1rGh3h_gwr_rg9!grn-~showMeasure*true~fillColor*%2523ff0000%27strokeColor*%2523ff0000%27strokeWidth*1%29`
  * works fine
  * `fillColor` and `strokeColor` are the same, i.e. only one is used

 * [x] **rectangle** 
  * http://adube.github.io/ngeo/ngeo-featurehash-write-new-properties/examples/contribs/gmf/drawfeature.html?rl_features=Fa%285n25Fhzc1!.hec!9bt*..gec!~isBox*true~fillColor*%2523ff0000%27strokeColor*%2523ff0000%27strokeWidth*1%29
  * `rl_features=Fa%285n25Fhzc1!.hec!9bt*..gec!~isBox*true~fillColor*%2523ff0000%27strokeColor*%2523ff0000%27strokeWidth*1%29`
  * works, but produces junk in the url `object [Object]`
  * `fillColor` and `strokeColor` are the same, i.e. only one is used

 * [x] **circle**
  * http://adube.github.io/ngeo/ngeo-featurehash-write-new-properties/examples/contribs/gmf/drawfeature.html?rl_features=Fa%287ya3Ff274!fjGqr-36G7f!qhF33AqnEhkByjD7yCy9C55EuuAk4Fh9*uvF7m_bdGyWnnGxWknG6m_bdGg9*uvFtuAk4Fx9C55ExjD7yCpnEhkBphF33A26G7f!ejGqr-ppG.ejGpr-26G6f!mhF23ArnEgkBxjD6yCx9C45EtuAj4Fg9*tvF6m_adGvWjnGwWmnG7m_adGh9*tvFuuAj4Fy9C45EyjD6yCsnEgkBnhF23A36G6f!fjGpr-~isCircle*true~fillColor*%2523ff0000%27strokeColor*%2523ff0000%27strokeWidth*1%29
  * `rl_features=Fa%287ya3Ff274!fjGqr-36G7f!qhF33AqnEhkByjD7yCy9C55EuuAk4Fh9*uvF7m_bdGyWnnGxWknG6m_bdGg9*uvFtuAk4Fx9C55ExjD7yCpnEhkBphF33A26G7f!ejGqr-ppG.ejGpr-26G6f!mhF23ArnEgkBxjD6yCx9C45EtuAj4Fg9*tvF6m_adGvWjnGwWmnG7m_adGh9*tvFuuAj4Fy9C45EyjD6yCsnEgkBnhF23A36G6f!fjGpr-~isCircle*true~fillColor*%2523ff0000%27strokeColor*%2523ff0000%27strokeWidth*1%29`
  * works fine
  * `fillColor` and `strokeColor` are the same, i.e. only one is used

 * [x] **text** 
  * http://adube.github.io/ngeo/ngeo-featurehash-write-new-properties/examples/contribs/gmf/drawfeature.html?rl_features=Fp%285wx9F19ry_~name*Un%2520titre%27isLabel*true~fillColor*%2523ff0000%27strokeColor*%2523ff0000%27pointRadius*6%27fontColor*%2523000000%27fontSize*12px%27fontFamily*sans-serif%27graphic*false%29
  * `rl_features=Fp%285wx9F19ry_~name*Un%2520titre%27isLabel*true~fillColor*%2523ff0000%27strokeColor*%2523ff0000%27pointRadius*6%27fontColor*%2523000000%27fontSize*12px%27fontFamily*sans-serif%27graphic*false%29`
  * [x] `fontSize` was `12px`.  Now it's in `pt` (converted)
  * `fontFamily` is ignored (not supported)
  * `fillColor` and `strokeColor` are ignored.
  * `graphic`, old ol2 value.  Not used.
