### PR TITLE
Fix gmf-permalink features on feature delete

### DIFF
--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -965,6 +965,7 @@ gmf.Permalink.prototype.addNgeoFeature_ = function(feature) {
 gmf.Permalink.prototype.removeNgeoFeature_ = function(feature) {
   var uid = goog.getUid(feature);
   this.initListenerKey_(uid); // clear event listeners
+  this.handleNgeoFeaturesChange_();
 };
 
 


### PR DESCRIPTION
This PR fixes the `gmf-permalink` when one or more features gets deleted the url is updated.