### PR TITLE
Display action icons on mouse hover #closes 1052

### DIFF
--- a/contribs/gmf/less/desktoplayertree.less
+++ b/contribs/gmf/less/desktoplayertree.less
@@ -11,6 +11,10 @@ gmf-layertree {
 
 .gmf-layertree-node {
 
+  .rightButtons {
+    visibility: hidden;
+  }
+
   &.depth-1 {
     //styling first level node for desktop app
     background-color: @nav-bg;
@@ -26,4 +30,12 @@ gmf-layertree {
       background-color: @main-bg-color;
       padding: @half-app-margin;
   }
+
+  .group:hover,
+  .leaf:hover {
+    .rightButtons {
+      visibility: visible;
+    }
+  }
+
 }


### PR DESCRIPTION
@pgiraud 
check live example [here](https://oliviersemet.github.io/ngeo/1052-tree-actions-buttons-only-displayed-on-hover/examples/contribs/gmf/apps/desktop/)
IMO we should add some extra UI to clarify which layer item is currently hovered 