### PR TITLE
ModifyRectangle - Set corner features in cache item

### DIFF
--- a/src/ol-ext/interaction/modifyrectangle.js
+++ b/src/ol-ext/interaction/modifyrectangle.js
@@ -169,9 +169,9 @@ ngeo.interaction.ModifyRectangle.prototype.addFeature_ = function(feature) {
       pointFeatures.push(cornerFeature);
     }, this);
     var uid = goog.getUid(feature);
-    var item = {
+    var item = /** @type {ngeo.interaction.ModifyRectangle.CacheItem} */ ({
       corners: pointFeatures
-    }
+    });
     this.cache_[uid] = item;
 
     var previousFeature;


### PR DESCRIPTION
This PR is a small fix for the `ngeo.interaction.ModifyRectangle` interaction.  The corner features were put in the feature's own properties, which was causing issues with the permalink.

Now, the corners are stocked in a cache item instead.

## Live example

 * http://adube.github.io/ngeo/fix-ngeo-modify-rectangle-corners/examples/contribs/gmf/drawfeature.html?rl_features=Fa(edkt_ccb5!nwknB..5x59*mwknB.~isRectangle*true%27name*Rectangle%25201%27color*%2523DB4436%27angle*0%27opacity*0.2%27showMeasure*false%27size*10%27stroke*1)&map_x=0&map_y=380882&map_zoom=3