### PR TITLE
Fix styling issue with the modify rectangle.

### DIFF
--- a/examples/modifyrectangle.js
+++ b/examples/modifyrectangle.js
@@ -102,6 +102,17 @@ app.MainController = function() {
     };
   })();
 
+  var vectorSource = new ol.source.Vector({
+    features: this.features
+  });
+  var vectorLayer = new ol.layer.Vector({
+    source: vectorSource
+  });
+
+  // Use vectorLayer.setMap(map) rather than map.addLayer(vectorLayer). This
+  // makes the vector layer "unmanaged", meaning that it is always on top.
+  vectorLayer.setMap(map);
+
   /**
    * @type {ngeo.interaction.ModifyRectangle}
    * @export


### PR DESCRIPTION
This commit fixes a glitch with the modify rectangle that only occurs on the built version, and it also fixes a the styling issue in the gmf draw feature example where selecting the rectangle causes the style to be added twice.

This was occurring by a combination of the modify rectangle wanting to manage its own layer of polygons, which really wasn't necessary, and a bad management of added / removed features when creating / removing their corner handles.

The example now working well in the integrated draw feature example is available here: http://jlap.github.io/ngeo/modify-rectangle-style-bug/examples/contribs/gmf/drawfeature.html

The modify rectangle works exactly the same as it used to: http://jlap.github.io/ngeo/modify-rectangle-style-bug/examples/modifyrectangle.html