### PR TITLE
Rotation interaction

### DIFF
--- a/contribs/gmf/src/directives/drawfeature.js
+++ b/contribs/gmf/src/directives/drawfeature.js
@@ -370,6 +370,10 @@ gmf.DrawfeatureController.prototype.handleActiveChange_ = function(active) {
         ol.interaction.TranslateEventType.TRANSLATEEND,
         this.handleTranslateEnd_, this));
 
+    keys.push(ol.events.listen(this.rotate_,
+        ngeo.RotateEventType.ROTATEEND,
+        this.handleRotateEnd_, this));
+
     toolMgr.registerTool(drawUid, this.drawToolActivate, false);
     toolMgr.registerTool(drawUid, this.mapSelectToolActivate, true);
 
@@ -537,6 +541,16 @@ gmf.DrawfeatureController.prototype.handleMenuActionClick_ = function(evt) {
  */
 gmf.DrawfeatureController.prototype.handleTranslateEnd_ = function(evt) {
   this.translate_.setActive(false);
+  this.scope_.$apply();
+};
+
+
+/**
+ * @param {ngeo.RotateEvent} evt Event.
+ * @private
+ */
+gmf.DrawfeatureController.prototype.handleRotateEnd_ = function(evt) {
+  this.rotate_.setActive(false);
   this.scope_.$apply();
 };
 

--- a/contribs/gmf/src/directives/drawfeature.js
+++ b/contribs/gmf/src/directives/drawfeature.js
@@ -14,6 +14,7 @@ goog.require('ngeo.drawfeatureDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.exportfeaturesDirective');
 goog.require('ngeo.interaction.Modify');
+goog.require('ngeo.interaction.Rotate');
 goog.require('ngeo.interaction.Translate');
 goog.require('ol.Collection');
 goog.require('ol.style.Fill');
@@ -229,6 +230,31 @@ gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
   this.registerInteraction_(this.translate_);
 
   /**
+   * @type {ngeo.interaction.Rotate}
+   * @private
+   */
+  this.rotate_ = new ngeo.interaction.Rotate({
+    features: this.selectedFeatures,
+    layers: [this.layer],
+    style: new ol.style.Style({
+      text: new ol.style.Text({
+        text: '\uf01e',
+        font: 'normal 18px FontAwesome',
+        fill: new ol.style.Fill({
+          color: '#7a7a7a'
+        })
+      })
+    })
+  });
+  this.registerInteraction_(this.rotate_);
+
+  /**
+   * @type {ngeo.ToolActivate}
+   * @export
+   */
+  this.rotateToolActivate = new ngeo.ToolActivate(this.rotate_, 'active');
+
+  /**
    * @type {ngeo.ToolActivate}
    * @export
    */
@@ -350,6 +376,7 @@ gmf.DrawfeatureController.prototype.handleActiveChange_ = function(active) {
     toolMgr.registerTool(otherUid, this.drawToolActivate, false);
     toolMgr.registerTool(otherUid, this.modifyToolActivate, true);
     toolMgr.registerTool(otherUid, this.translateToolActivate, false);
+    toolMgr.registerTool(otherUid, this.rotateToolActivate, false);
 
     this.mapSelectActive = true;
     this.modify_.setActive(true);
@@ -366,6 +393,7 @@ gmf.DrawfeatureController.prototype.handleActiveChange_ = function(active) {
     toolMgr.unregisterTool(otherUid, this.drawToolActivate);
     toolMgr.unregisterTool(otherUid, this.modifyToolActivate);
     toolMgr.unregisterTool(otherUid, this.translateToolActivate);
+    toolMgr.unregisterTool(otherUid, this.rotateToolActivate);
 
     this.drawActive = false;
     this.modify_.setActive(false);
@@ -489,6 +517,10 @@ gmf.DrawfeatureController.prototype.handleMenuActionClick_ = function(evt) {
       break;
     case gmf.DrawfeatureController.MenuActionType.MOVE:
       this.translate_.setActive(true);
+      this.scope_.$apply();
+      break;
+    case gmf.DrawfeatureController.MenuActionType.ROTATE:
+      this.rotate_.setActive(true);
       this.scope_.$apply();
       break;
     default:

--- a/examples/rotate.html
+++ b/examples/rotate.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>Rotate interaction example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/font-awesome/css/font-awesome.css" type="text/css">
+    <style>
+        #map {
+          width: 800px;
+          height: 400px;
+        }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <div id="map" ngeo-map="ctrl.map"></div>
+    <p id="desc">
+      This examples shows how to use the
+      <code>ngeo.interaction.Rotate</code>. This interaction allows to
+      rotate a feature. Click on the feature to activate the interaction,
+      then click and drag to rotate it.
+    </p>
+    <script src="../node_modules/angular/angular.js"></script>
+    <script src="/@?main=rotate.js"></script>
+    <script src="default.js"></script>
+    <script src="../utils/watchwatchers.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+  </body>
+</html>

--- a/examples/rotate.js
+++ b/examples/rotate.js
@@ -110,7 +110,7 @@ app.MainController = function() {
   })();
 
   /**
-   * @type {ngeo.interaction.ModifyRectangle}
+   * @type {ngeo.interaction.Rotate}
    * @export
    */
   this.interaction = new ngeo.interaction.Rotate(

--- a/examples/rotate.js
+++ b/examples/rotate.js
@@ -1,6 +1,6 @@
-goog.provide('modifyrectangle');
+goog.provide('rotate');
 
-goog.require('ngeo.interaction.ModifyRectangle');
+goog.require('ngeo.interaction.Rotate');
 goog.require('ngeo.mapDirective');
 goog.require('ol.Map');
 goog.require('ol.View');
@@ -8,6 +8,7 @@ goog.require('ol.layer.Tile');
 goog.require('ol.layer.Vector');
 goog.require('ol.source.MapQuest');
 goog.require('ol.source.Vector');
+goog.require('ol.style.Text');
 goog.require('ol.geom.Polygon');
 
 
@@ -43,7 +44,7 @@ app.MainController = function() {
 
   var map = this.map;
 
-  var rectangle = new ol.geom.Polygon([[
+  var polygon = new ol.geom.Polygon([[
               [-9e6, 4e6], [-11e6, 4e6], [-11e6, 6e6], [-9e6, 6e6]
   ]]);
 
@@ -54,9 +55,20 @@ app.MainController = function() {
   this.features = new ol.Collection();
 
   this.features.push(new ol.Feature({
-    geometry: rectangle,
-    'isRectangle': true
+    geometry: polygon
   }));
+
+  var vectorSource = new ol.source.Vector({
+    features: this.features
+  });
+  var vectorLayer = new ol.layer.Vector({
+    source: vectorSource
+  });
+
+  // Use vectorLayer.setMap(map) rather than map.addLayer(vectorLayer). This
+  // makes the vector layer "unmanaged", meaning that it is always on top.
+  vectorLayer.setMap(map);
+
 
   var style = (function() {
     var styles = {};
@@ -79,22 +91,17 @@ app.MainController = function() {
         })
       })
     ];
-
-    styles['Point'] = [
-      new ol.style.Style({
-        image: new ol.style.Circle({
-          radius: 7,
-          fill: new ol.style.Fill({
-            color: [0, 153, 255, 1]
-          }),
-          stroke: new ol.style.Stroke({
-            color: [255, 255, 255, 0.75],
-            width: 1.5
-          })
-        }),
-        zIndex: 100000
+    styles['Point'] = new ol.style.Style({
+      image: new ol.style.Circle(),
+      text: new ol.style.Text({
+        text: '\uf01e',
+        font: 'normal 18px FontAwesome',
+        fill: new ol.style.Fill({
+          color: '#ffffff'
+        })
       })
-    ];
+    });
+
     styles['GeometryCollection'] = styles['Polygon'].concat(styles['Point']);
 
     return function(feature, resolution) {
@@ -102,31 +109,30 @@ app.MainController = function() {
     };
   })();
 
-  var vectorSource = new ol.source.Vector({
-    features: this.features
-  });
-  var vectorLayer = new ol.layer.Vector({
-    source: vectorSource
-  });
-
-  // Use vectorLayer.setMap(map) rather than map.addLayer(vectorLayer). This
-  // makes the vector layer "unmanaged", meaning that it is always on top.
-  vectorLayer.setMap(map);
-
   /**
    * @type {ngeo.interaction.ModifyRectangle}
    * @export
    */
-  this.interaction = new ngeo.interaction.ModifyRectangle(
+  this.interaction = new ngeo.interaction.Rotate(
     /** @type {olx.interaction.ModifyOptions} */({
       features: this.features,
+      layers: [this.vectorLayer],
       style: style
     }));
 
   var interaction = this.interaction;
+  interaction.setActive(false);
   map.addInteraction(interaction);
-  interaction.setActive(true);
 
+  map.on('singleclick', function(evt) {
+    var feature = this.map.forEachFeatureAtPixel(evt.pixel,
+      function(feature) {
+        return feature;
+      });
+    if (feature) {
+      this.interaction.setActive(true);
+    }
+  }, this);
 };
 
 

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -753,6 +753,18 @@ ngeox.MeasureEvent.prototype.feature;
 
 
 /**
+ * @interface
+ */
+ngeox.RotateEvent = function() {};
+
+
+/**
+ * @type {ol.Feature}
+ */
+ngeox.RotateEvent.prototype.feature;
+
+
+/**
  * Options for the mobile geolocations directive.
  * @typedef {{
  *    accuracyFeatureStyle: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined),

--- a/src/ol-ext/interaction/modifyrectangle.js
+++ b/src/ol-ext/interaction/modifyrectangle.js
@@ -364,7 +364,7 @@ ngeo.interaction.ModifyRectangle.prototype.handleDrag_ = function(evt) {
     var boxFeature = feature.get('boxFeature');
     var geom = boxFeature.getGeometry();
     goog.asserts.assertInstanceof(geom, ol.geom.Polygon);
-    geom.setCoordinates([[evt.coordinate, b2Coordinate, origin, c2Coordinate]]);
+    geom.setCoordinates([[evt.coordinate, b2Coordinate, origin, c2Coordinate, evt.coordinate]]);
 
     this.coordinate_[0] = evt.coordinate[0];
     this.coordinate_[1] = evt.coordinate[1];

--- a/src/ol-ext/interaction/modifyrectangle.js
+++ b/src/ol-ext/interaction/modifyrectangle.js
@@ -7,7 +7,6 @@ goog.require('ol.CollectionEventType');
 goog.require('ol.Feature');
 goog.require('ol.MapBrowserPointerEvent');
 goog.require('ol.events');
-goog.require('ol.extent');
 goog.require('ol.geom.Point');
 goog.require('ol.geom.Polygon');
 goog.require('ol.interaction.ModifyEvent');
@@ -147,10 +146,9 @@ ngeo.interaction.ModifyRectangle.prototype.addFeature_ = function(feature) {
         'corner': true,
         'geometry': cornerPoint,
         'siblingX': null,
-        'siblingY': null
+        'siblingY': null,
+        'boxFeature': feature
       });
-      ol.events.listen(cornerPoint, ol.events.EventType.CHANGE,
-          goog.bind(this.handleCornerGeometryChange_, this, cornerFeature), this);
 
       pointFeatures.push(cornerFeature);
     }, this);
@@ -188,73 +186,6 @@ ngeo.interaction.ModifyRectangle.prototype.addFeature_ = function(feature) {
 
 
 /**
- * Callback method fired when the geometry of one of the corner features is
- * changed.  Change the siblings geometry accordingly.  Prevent handling
- * corner geometry change if an other action is already in progress,
- * i.e. an other feature (corner or center) is already being dragged.
- *
- * @param {ol.Feature} feature the corner feature
- * @param {goog.events.Event} event event
- * @private
- */
-ngeo.interaction.ModifyRectangle.prototype.handleCornerGeometryChange_ = function(
-    feature, event) {
-
-  if (this.changingFeature_) {
-    return;
-  }
-
-  this.changingFeature_ = true;
-
-  // update the siblings coordinates
-  var point = feature.getGeometry();
-  goog.asserts.assertInstanceof(point, ol.geom.Point);
-  var coordinates = /** @type {ol.geom.Point} */ (point).getCoordinates();
-
-  var siblingX = feature.get('siblingX');
-  goog.asserts.assertInstanceof(siblingX, ol.Feature);
-  var siblingXPoint = siblingX.getGeometry();
-  goog.asserts.assertInstanceof(siblingXPoint, ol.geom.Point);
-  siblingXPoint.setCoordinates([
-    siblingXPoint.getCoordinates()[0],
-    coordinates[1]
-  ]);
-
-  var siblingY = feature.get('siblingY');
-  goog.asserts.assertInstanceof(siblingY, ol.Feature);
-  var siblingYPoint = siblingY.getGeometry();
-  goog.asserts.assertInstanceof(siblingYPoint, ol.geom.Point);
-  siblingYPoint.setCoordinates([
-    coordinates[0],
-    siblingYPoint.getCoordinates()[1]
-  ]);
-
-  // update box
-  var boxExtent = ol.extent.createEmpty();
-  var pointFeatures = this.vectorPoints_.getSource().getFeatures();
-  pointFeatures.forEach(function(pointFeature) {
-    point = pointFeature.getGeometry();
-    ol.extent.extendCoordinate(boxExtent, /** @type {ol.geom.Point} */ (point).getCoordinates());
-  });
-
-  var corners = [];
-  ol.extent.forEachCorner(boxExtent, function(corner) {
-    corners.push(corner);
-  }, this);
-  var boxCoordinates = goog.array.concat(corners, [corners[0]]);
-
-  this.features_.forEach(function(boxFeature) {
-    var geom = boxFeature.getGeometry();
-    goog.asserts.assertInstanceof(geom, ol.geom.Polygon);
-    geom.setCoordinates([boxCoordinates]);
-  }, this);
-
-
-  this.changingFeature_ = false;
-};
-
-
-/**
  * @param {ol.MapBrowserPointerEvent} evt Map browser event
  * @private
  */
@@ -276,9 +207,6 @@ ngeo.interaction.ModifyRectangle.prototype.removeFeature_ = function(feature) {
   var item = this.cache_[uid];
   var corners = item.corners;
   for (var i = 0; i < corners.length; i++) {
-    ol.events.unlisten(corners[i], ol.events.EventType.CHANGE,
-        this.handleCornerGeometryChange_);
-
     this.vectorPoints_.getSource().removeFeature(corners[i]);
   }
   this.feature_ = null;
@@ -377,20 +305,96 @@ ngeo.interaction.ModifyRectangle.prototype.handleDown_ = function(evt) {
  */
 ngeo.interaction.ModifyRectangle.prototype.handleDrag_ = function(evt) {
   this.willModifyFeatures_(evt);
+  var feature = this.feature_;
 
   var geometry = /** @type {ol.geom.SimpleGeometry} */
-      (this.feature_.getGeometry());
+      (feature.getGeometry());
 
   if (geometry instanceof ol.geom.Point) {
     this.vectorPoints_.setVisible(true);
-    var deltaX = evt.coordinate[0] - this.coordinate_[0];
-    var deltaY = evt.coordinate[1] - this.coordinate_[1];
 
-    geometry.translate(deltaX, deltaY);
+    geometry.setCoordinates(evt.coordinate);
+
+    // Get all four corners' coordinates
+
+    // 1 - The pixel of the handle we dragged
+    var destinationPixel = evt.pixel;
+
+    // 2 - One of our siblings
+    var siblingX = feature.get('siblingX');
+    goog.asserts.assertInstanceof(siblingX, ol.Feature);
+    var siblingXPoint = siblingX.getGeometry();
+    goog.asserts.assertInstanceof(siblingXPoint, ol.geom.Point);
+    var siblingXCoordinate = siblingXPoint.getCoordinates();
+    var siblingXPixel = this.getMap().getPixelFromCoordinate(siblingXCoordinate);
+
+    // 3 - The second sibling
+    var siblingY = feature.get('siblingY');
+    goog.asserts.assertInstanceof(siblingY, ol.Feature);
+    var siblingYPoint = siblingY.getGeometry();
+    goog.asserts.assertInstanceof(siblingYPoint, ol.geom.Point);
+    var siblingYCoordinate = siblingYPoint.getCoordinates();
+    var siblingYPixel = this.getMap().getPixelFromCoordinate(siblingYCoordinate);
+
+    // 4 - The point opposite of the handle we dragged
+    var opposite = siblingY.get('siblingY');
+    goog.asserts.assertInstanceof(opposite, ol.Feature);
+    if (goog.getUid(feature) == goog.getUid(opposite)) {
+      opposite = siblingY.get('siblingX');
+    }
+
+    goog.asserts.assertInstanceof(opposite, ol.Feature);
+    var oppositePoint = opposite.getGeometry();
+    goog.asserts.assertInstanceof(oppositePoint, ol.geom.Point);
+    var origin = oppositePoint.getCoordinates();
+    var originPixel = this.getMap().getPixelFromCoordinate(origin);
+
+    // Calculate new positions of siblings
+    var b2Pixel = this.calculateNewPixel_(originPixel, destinationPixel, siblingXPixel);
+    var b2Coordinate = this.getMap().getCoordinateFromPixel(b2Pixel);
+    siblingXPoint.setCoordinates(b2Coordinate);
+
+    var c2Pixel = this.calculateNewPixel_(originPixel, destinationPixel, siblingYPixel);
+    var c2Coordinate = this.getMap().getCoordinateFromPixel(c2Pixel);
+
+    siblingYPoint.setCoordinates(c2Coordinate);
+
+
+    // Resize the box
+    var boxFeature = feature.get('boxFeature');
+    var geom = boxFeature.getGeometry();
+    goog.asserts.assertInstanceof(geom, ol.geom.Polygon);
+    geom.setCoordinates([[evt.coordinate, b2Coordinate, origin, c2Coordinate]]);
 
     this.coordinate_[0] = evt.coordinate[0];
     this.coordinate_[1] = evt.coordinate[1];
   }
+};
+
+
+/**
+ * Calculate the new position of a point as projected on a vector from origin to
+ * destination.
+ * @param {ol.Pixel} origin Pixel of origin (opposite of the drag handle)
+ * @param {ol.Pixel} destination Pixel of destination (the handle we dragged)
+ * @param {ol.Pixel} point The point to transform.
+ * @return {ol.Pixel} The new pixel of the point
+ * @private
+ */
+ngeo.interaction.ModifyRectangle.prototype.calculateNewPixel_ = function(
+  origin, destination, point) {
+
+  var aVector = [destination[0] - origin[0], destination[1] - origin[1]];
+  var bVector = [point[0] - origin[0],
+                 point[1] - origin[1]];
+
+  var abScalarProduct = aVector[0] * bVector[0] + aVector[1] * bVector[1];
+  var bDivisor = Math.pow(bVector[0], 2) + Math.pow(bVector[1], 2);
+
+  var b2Vector = [(bVector[0] * abScalarProduct) / bDivisor,
+                  (bVector[1] * abScalarProduct) / bDivisor];
+
+  return [b2Vector[0] + origin[0], b2Vector[1] + origin[1]];
 };
 
 

--- a/src/ol-ext/interaction/rotate.js
+++ b/src/ol-ext/interaction/rotate.js
@@ -1,0 +1,362 @@
+goog.provide('ngeo.interaction.Rotate');
+
+goog.require('goog.asserts');
+goog.require('goog.events');
+goog.require('goog.events.EventType');
+goog.require('ol');
+goog.require('ol.Collection');
+goog.require('ol.CollectionEventType');
+goog.require('ol.Feature');
+goog.require('ol.MapBrowserPointerEvent');
+goog.require('ol.events');
+goog.require('ol.interaction.ModifyEvent');
+goog.require('ol.interaction.Pointer');
+goog.require('ol.geom.Point');
+goog.require('ol.layer.Vector');
+goog.require('ol.source.Vector');
+
+
+/**
+ * @classdesc
+ * Interaction to rotate features.
+ *
+ * @constructor
+ * @extends {ol.interaction.Pointer}
+ * @param {olx.interaction.ModifyOptions} options Options.
+ * @fires ngeo.interaction.ModifyCircleEvent
+ * @export
+ * @api
+ */
+ngeo.interaction.Rotate = function(options) {
+
+  /**
+   * @type {Array.<ol.events.Key>}
+   * @private
+   */
+  this.listenerKeys_ = [];
+
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.modified_ = false;
+
+  /**
+   * @type {?goog.events.Key}
+   * @private
+   */
+  this.keyPressListenerKey_ = null;
+
+  /**
+   * Indicate whether the interaction is currently changing a feature's
+   * coordinates.
+   * @type {boolean}
+   * @private
+   */
+  this.changingFeature_ = false;
+
+  /**
+   * @type {number}
+   * @private
+   */
+  this.pixelTolerance_ = options.pixelTolerance !== undefined ?
+      options.pixelTolerance : 10;
+
+  /**
+   * @type {ol.Collection.<ol.Feature>}
+   * @private
+   */
+  this.features_ = options.features;
+
+  /**
+   * The feature currently modified.
+   * @type {ol.Feature}
+   * @private
+   */
+  this.feature_ = null;
+
+  /**
+   * @type {ol.Pixel}
+   * @private
+   */
+  this.coordinate_ = null;
+
+  /**
+   * @type {ol.Coordinate}
+   * @private
+   */
+  this.centerCoordinate_ = null;
+
+  var style = options.style ? options.style : ol.interaction.Modify.getDefaultStyleFunction();
+
+  /**
+   * Draw overlay where sketch features are drawn.
+   * @type {ol.layer.Vector}
+   * @private
+   */
+  this.overlay_ = new ol.layer.Vector({
+    source: new ol.source.Vector({
+      useSpatialIndex: false,
+      wrapX: !!options.wrapX
+    }),
+    style: style,
+    updateWhileAnimating: true,
+    updateWhileInteracting: true
+  });
+
+  /**
+   * @type {!Object.<number, ol.Feature>}
+   * @private
+   */
+  this.centerFeatures_ = {};
+
+  goog.base(this, {
+    handleDownEvent: this.handleDown_,
+    handleDragEvent: this.handleDrag_,
+    handleUpEvent: this.handleUp_
+  });
+
+};
+goog.inherits(ngeo.interaction.Rotate, ol.interaction.Pointer);
+
+
+/**
+ * Activate or deactivate the interaction.
+ * @param {boolean} active Active.
+ * @export
+ */
+ngeo.interaction.Rotate.prototype.setActive = function(active) {
+
+  if (this.keyPressListenerKey_) {
+    goog.events.unlistenByKey(this.keyPressListenerKey_);
+    this.keyPressListenerKey_ = null;
+  }
+
+  goog.base(this, 'setActive', active);
+
+  if (active) {
+    this.keyPressListenerKey_ = goog.events.listen(
+      document,
+      goog.events.EventType.KEYUP,
+      this.handleKeyUp_,
+      false,
+      this
+    );
+    this.features_.forEach(this.addFeature_, this);
+    this.listenerKeys_.push(ol.events.listen(this.features_,
+        ol.CollectionEventType.ADD, this.handleFeatureAdd_, this));
+    this.listenerKeys_.push(ol.events.listen(this.features_,
+        ol.CollectionEventType.REMOVE, this.handleFeatureRemove_, this));
+
+  } else {
+    this.listenerKeys_.forEach(function(key) {
+      ol.events.unlistenByKey(key);
+    }, this);
+    this.features_.forEach(this.removeFeature_, this);
+  }
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature.
+ * @private
+ */
+ngeo.interaction.Rotate.prototype.addFeature_ = function(feature) {
+  var geometry = feature.getGeometry();
+  goog.asserts.assertInstanceof(geometry, ol.geom.Geometry);
+
+  feature.set('angle', 0);
+
+  // Add the center icon to the overlay
+  var uid = goog.getUid(feature);
+  var point = new ol.geom.Point(this.getCenterCoordinate_(geometry));
+  var centerFeature = new ol.Feature(point);
+  this.centerFeatures_[uid] = centerFeature;
+  this.overlay_.getSource().addFeature(centerFeature);
+
+};
+
+
+/**
+ * @param {ol.MapBrowserPointerEvent} evt Map browser event
+ * @private
+ */
+ngeo.interaction.Rotate.prototype.willModifyFeatures_ = function(evt) {
+  if (!this.modified_) {
+    this.modified_ = true;
+    this.dispatchEvent(new ol.interaction.ModifyEvent(
+        ol.ModifyEventType.MODIFYSTART, this.features_, evt));
+  }
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature.
+ * @private
+ */
+ngeo.interaction.Rotate.prototype.removeFeature_ = function(feature) {
+  this.feature_ = null;
+  //this.overlay_.getSource().removeFeature(feature);
+
+  if (feature) {
+    var uid = goog.getUid(feature);
+
+    if (this.centerFeatures_[uid]) {
+      this.overlay_.getSource().removeFeature(this.centerFeatures_[uid]);
+      delete this.centerFeatures_[uid];
+    }
+  }
+};
+
+
+/**
+ * @inheritDoc
+ */
+ngeo.interaction.Rotate.prototype.setMap = function(map) {
+  this.overlay_.setMap(map);
+  goog.base(this, 'setMap', map);
+};
+
+
+/**
+ * @param {ol.CollectionEvent} evt Event.
+ * @private
+ */
+ngeo.interaction.Rotate.prototype.handleFeatureAdd_ = function(evt) {
+  var feature = evt.element;
+  goog.asserts.assertInstanceof(feature, ol.Feature,
+      'feature should be an ol.Feature');
+  this.addFeature_(feature);
+};
+
+
+/**
+ * @param {ol.CollectionEvent} evt Event.
+ * @private
+ */
+ngeo.interaction.Rotate.prototype.handleFeatureRemove_ = function(evt) {
+  var feature = /** @type {ol.Feature} */ (evt.element);
+  this.removeFeature_(feature);
+};
+
+
+/**
+ * @param {ol.MapBrowserPointerEvent} evt Event.
+ * @return {boolean} Start drag sequence?
+ * @private
+ */
+ngeo.interaction.Rotate.prototype.handleDown_ = function(evt) {
+  var map = evt.map;
+
+  var feature = map.forEachFeatureAtPixel(evt.pixel,
+      function(feature, layer) {
+        return feature;
+      }, undefined);
+
+  if (feature) {
+    var found = false;
+    this.features_.forEach(function(f) {
+      if (goog.getUid(f) == goog.getUid(feature)) {
+        found = true;
+      }
+    });
+    if (!found) {
+      feature = null;
+    }
+  }
+
+  if (feature) {
+    this.coordinate_ = evt.coordinate;
+    this.feature_ = feature;
+    var geometry = (this.feature_.getGeometry());
+    if (geometry !== undefined) {
+      this.centerCoordinate_ = this.getCenterCoordinate_(geometry);
+    }
+
+    return true;
+  }
+
+  return false;
+};
+
+
+/**
+ * @param {ol.geom.Geometry} geometry Geometry.
+ * @return {ol.Coordinate} The center coordinate of the geometry.
+ * @private
+ */
+ngeo.interaction.Rotate.prototype.getCenterCoordinate_ = function(
+    geometry) {
+
+  var center;
+
+  if (geometry instanceof ol.geom.LineString) {
+    center = geometry.getFlatMidpoint();
+  } else if (geometry instanceof ol.geom.Polygon) {
+    center = geometry.getFlatInteriorPoint();
+  } else {
+    var extent = geometry.getExtent();
+    center = ol.extent.getCenter(extent);
+  }
+
+  return center;
+};
+
+
+/**
+ * @param {ol.MapBrowserPointerEvent} evt Event.
+ * @private
+ */
+ngeo.interaction.Rotate.prototype.handleDrag_ = function(evt) {
+  this.willModifyFeatures_(evt);
+
+  var geometry = /** @type {ol.geom.SimpleGeometry} */
+      (this.feature_.getGeometry());
+
+  var oldX = this.coordinate_[0], oldY = this.coordinate_[1];
+
+  var centerX = this.centerCoordinate_[0];
+  var centerY = this.centerCoordinate_[1];
+
+  var dx1 = oldX - centerX;
+  var dy1 = oldY - centerY;
+  var dx0 = evt.coordinate[0] - centerX;
+  var dy0 = evt.coordinate[1] - centerY;
+
+  this.coordinate_[0] = evt.coordinate[0];
+  this.coordinate_[1] = evt.coordinate[1];
+
+  var a0 = Math.atan2(dy0, dx0);
+  var a1 = Math.atan2(dy1, dx1);
+  var angle = a1 - a0;
+
+  geometry.rotate(-angle, [centerX, centerY]);
+};
+
+
+/**
+ * @param {ol.MapBrowserPointerEvent} evt Event.
+ * @return {boolean} Stop drag sequence?
+ * @private
+ */
+ngeo.interaction.Rotate.prototype.handleUp_ = function(evt) {
+  if (this.modified_) {
+    this.dispatchEvent(new ol.interaction.ModifyEvent(
+        ol.ModifyEventType.MODIFYEND, this.features_, evt));
+    this.modified_ = false;
+    this.setActive(false);
+  }
+  return false;
+};
+
+
+/**
+ * Deactivate this interaction if the ESC key is pressed.
+ * @param {goog.events.Event} evt Event.
+ * @private
+ */
+ngeo.interaction.Rotate.prototype.handleKeyUp_ = function(evt) {
+  if (evt.keyCode === goog.events.KeyCodes.ESC) {
+    this.setActive(false);
+  }
+};

--- a/src/ol-ext/interaction/rotate.js
+++ b/src/ol-ext/interaction/rotate.js
@@ -1,3 +1,5 @@
+goog.provide('ngeo.RotateEvent');
+goog.provide('ngeo.RotateEventType');
 goog.provide('ngeo.interaction.Rotate');
 
 goog.require('goog.asserts');
@@ -14,6 +16,45 @@ goog.require('ol.interaction.Pointer');
 goog.require('ol.geom.Point');
 goog.require('ol.layer.Vector');
 goog.require('ol.source.Vector');
+
+
+/**
+ * @enum {string}
+ */
+ngeo.RotateEventType = {
+  /**
+   * Triggered upon rotate draw end
+   * @event ngeo.RotateEvent#rotateend
+   */
+  ROTATEEND: 'rotateend'
+
+};
+
+
+/**
+ * @classdesc
+ * Events emitted by {@link ngeo.interaction.Rotate} instances are
+ * instances of this type.
+ *
+ * @constructor
+ * @extends {ol.events.Event}
+ * @implements {ngeox.RotateEvent}
+ * @param {ngeo.RotateEventType} type Type.
+ * @param {ol.Feature} feature The feature rotated.
+ */
+ngeo.RotateEvent = function(type, feature) {
+
+  goog.base(this, type);
+
+  /**
+   * The feature being rotated.
+   * @type {ol.Feature}
+   * @api stable
+   */
+  this.feature = feature;
+
+};
+goog.inherits(ngeo.RotateEvent, ol.events.Event);
 
 
 /**
@@ -341,8 +382,8 @@ ngeo.interaction.Rotate.prototype.handleDrag_ = function(evt) {
  */
 ngeo.interaction.Rotate.prototype.handleUp_ = function(evt) {
   if (this.modified_) {
-    this.dispatchEvent(new ol.interaction.ModifyEvent(
-        ol.ModifyEventType.MODIFYEND, this.features_, evt));
+    this.dispatchEvent(new ngeo.RotateEvent(ngeo.RotateEventType.ROTATEEND,
+      this.feature_));
     this.modified_ = false;
     this.setActive(false);
   }


### PR DESCRIPTION
This commit adds a new Rotation interaction that allows the user to rotate features.

The integration with the draw feature example is included in this commit.

The modify rectangle had to be modified a bit as the calculation I used didn't work when the rectangle was on an angle.

The rotate interaction works similarly to the translate interaction:
- Activating the interaction adds an icon at the center of the polygon or line.
- Pressing the escape key deactivates the interaction.
- When you're done with your rotation (on mouse up), the interaction gets deactivated.

You can try it out in two places:
- Stand alone example: http://jlap.github.io/ngeo/rotation/examples/rotate.html
- Integrated with the draw feature: http://jlap.github.io/ngeo/rotation/examples/contribs/gmf/drawfeature.html

**Things to do before merging**:

 - [X] Decide between the two rotation behavior
 - [ ] Review 