### PR TITLE
Fix the resizing of a circle in modify circle

### DIFF
--- a/examples/modifycircle.js
+++ b/examples/modifycircle.js
@@ -51,14 +51,16 @@ app.MainController = function() {
    */
   this.features = new ol.Collection();
 
-  this.features.push(new ol.Feature({
+  var circleFeature = new ol.Feature({
     geometry: ol.geom.Polygon.fromCircle(circle),
     color: '#000000',
     label: 'Circle 1',
     opacity: '0.5',
-    stroke: '2',
-    isCircle: true
-  }));
+    stroke: '2'
+  });
+
+  circleFeature.set(ngeo.FeatureProperties.IS_CIRCLE, true);
+  this.features.push(circleFeature);
 
   var vectorSource = new ol.source.Vector({
     features: this.features

--- a/src/ol-ext/interaction/modifycircle.js
+++ b/src/ol-ext/interaction/modifycircle.js
@@ -144,7 +144,7 @@ goog.inherits(ngeo.interaction.ModifyCircle, ol.interaction.Pointer);
  */
 ngeo.interaction.ModifyCircle.prototype.addFeature_ = function(feature) {
   if (feature.getGeometry().getType() === ol.geom.GeometryType.POLYGON &&
-      !!feature.get('isCircle')) {
+      !!feature.get(ngeo.FeatureProperties.IS_CIRCLE)) {
     var geometry = /** @type {ol.geom.Polygon}*/ (feature.getGeometry());
     this.writeCircleGeometry_(feature, geometry);
 


### PR DESCRIPTION
This fixes the bug where you couldn't resize a circle anymore.

This was caused by using the string 'isCircle' at some places, and a defined constant in other places, so when compiling some got minimized and some didn't. Now everything uses the constant, so the example here:
http://jlap.github.io/ngeo/fix-modify-circle/examples/contribs/gmf/drawfeature.html
and here:
http://jlap.github.io/ngeo/fix-modify-circle/examples/modifycircle.html

Are working again.