### PR TITLE
Add WFS permalink service

### DIFF
--- a/contribs/gmf/examples/wfs-permalink.html
+++ b/contribs/gmf/examples/wfs-permalink.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>GeoMapFish WFS Permalink example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../../../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/font-awesome/css/font-awesome.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+    <style>
+      gmf-map > div {
+        width: 600px;
+        height: 400px;
+      }
+
+      /* Display queries */
+      .mobiledisplayqueries {
+        max-height: 400px;
+        width: 350px;
+        max-width: 350px;
+        margin-left: -175px;
+        position: fixed;
+        top: 20px;
+        right: 0px;
+      }
+      .mobiledisplayqueries .collapse-button {
+        background-color: white;
+        border: solid 1px black;
+        border-bottom-width: 0;
+        border-radius: 4px 4px 0 0;
+        line-height: 0.5;
+        height: 28px;
+        width: 48px;
+        margin-left: calc(50% - 24px);
+      }
+      .mobiledisplayqueries .collapse-button.up:after {
+        content: "\f077";
+      }
+      .mobiledisplayqueries .collapse-button.down:after {
+        content: "\f078";
+      }
+      .mobiledisplayqueries .displayqueries-container {
+        background-color: white;
+        border: solid 1px black;
+      }
+      .mobiledisplayqueries .animation-container {
+        position: relative;
+        overflow: hidden;
+        height: 60px;
+        margin: 0 15px;
+        transition: 0.3s ease-in all;
+      }
+      .mobiledisplayqueries .animation-container.detailed {
+        height: 160px;
+      }
+      .mobiledisplayqueries .animation-container .slide-animation {
+        height: 100%;
+        padding: 5px 5px 0;
+        text-align: left;
+        white-space: nowrap;
+        overflow: hidden;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+      }
+      .mobiledisplayqueries .slide-animation.ng-enter, .slide-animation.ng-leave {
+        transition: 0.3s ease-in all;
+      }
+      /* Left to right animation */
+      .mobiledisplayqueries .next .slide-animation.ng-enter {
+        left: 100%;
+      }
+      .mobiledisplayqueries .next .slide-animation.ng-enter-active {
+        left: 0;
+      }
+      .mobiledisplayqueries .next .slide-animation.ng-leave {
+        left: 0;
+      }
+      .mobiledisplayqueries .next .slide-animation.ng-leave-active {
+        left: -100%;
+      }
+      /* Right to left animation */
+      .mobiledisplayqueries .previous .slide-animation.ng-enter {
+        left: -100%;
+      }
+      .mobiledisplayqueries .previous .slide-animation.ng-enter-active {
+        left: 0;
+      }
+      .mobiledisplayqueries .previous .slide-animation.ng-leave {
+        left: 0;
+      }
+      .mobiledisplayqueries .previous .slide-animation.ng-leave-active {
+        left: 100%;
+      }
+      .mobiledisplayqueries .header .title {
+        font-weight: bold;
+      }
+      .mobiledisplayqueries .header .subtitle {
+        margin-left: 10px;
+        height: 2ex;
+      }
+      .mobiledisplayqueries .details {
+        height: 65%;
+        overflow-x: hidden;
+        overflow-y: auto;
+        margin-left: 10px;
+        padding-bottom: 10px
+      }
+      .mobiledisplayqueries .details table {
+        font-size: 0.9em;
+      }
+      .mobiledisplayqueries .details .key {
+        padding-right: 25px;
+      }
+      .mobiledisplayqueries .slide-animation.ng-enter-active .details .value {
+        white-space: nowrap;
+      }
+      .mobiledisplayqueries .navigate {
+        border-top: solid 1px black;
+        text-align: center;
+        margin-top: 10px;
+        padding-top: 5px;
+        height: 32px;
+      }
+      .mobiledisplayqueries button {
+        background: none;
+        border: none;
+        font-family: FontAwesome;
+        width: 32px;
+      }
+      .mobiledisplayqueries button.close {
+        padding: 5px 5px 0 0;
+      }
+      .mobiledisplayqueries button.close:after {
+        content: "\f00d";
+      }
+      .mobiledisplayqueries .navigate .previous {
+        float: left;
+      }
+      .mobiledisplayqueries .navigate .previous:after {
+        content: "\f053";
+      }
+      .mobiledisplayqueries .navigate .next {
+        float: right;
+      }
+      .mobiledisplayqueries .navigate .next:after {
+        content: "\f054";
+      }
+      @media (max-width: 768px) {
+        .mobiledisplayqueries {
+          width: 100%;
+          max-width: 100%;
+          margin-left: -50%;
+          top: initial;
+          bottom: 0;
+        }
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+
+    <gmf-map gmf-map-map="ctrl.map"></gmf-map>
+
+    <p id="desc">
+      This example demonstrates the use of the <code>ngeoWfsPermalink</code>
+      service, which is injected inside the <code>gmf-map</code> directive.
+      The following links demonstrate the different features:
+      <ul>
+        <li>
+          <a href="?wfs_layer=fuel&wfs_osm_id=1420918679">
+            ?wfs_layer=fuel&wfs_osm_id=1420918679
+          </a>
+        </li>
+        <li>
+          <a href="?wfs_layer=fuel&wfs_osm_id=1420918679&wfs_showFeatures=0">
+            ?wfs_layer=fuel&wfs_osm_id=1420918679&wfs_showFeatures=0
+          </a>
+        </li>
+        <li>
+          <a href="?wfs_layer=fuel&wfs_osm_id=1420918679,441134960">
+            ?wfs_layer=fuel&wfs_osm_id=1420918679,441134960
+          </a>
+        </li>
+        <li>
+          <a href="?wfs_layer=osm_scale&wfs_highway=bus_stop&wfs_name=Grand-Pont&wfs_operator=TL">
+            ?wfs_layer=osm_scale&wfs_highway=bus_stop&wfs_name=Grand-Pont&wfs_operator=TL
+          </a>
+        </li>
+        <li>
+          <a href="?wfs_layer=osm_scale&wfs_ngroups=2&wfs_0_ele=380&wfs_0_highway=bus_stop&wfs_0_operator=TL&wfs_1_highway=bus_stop&wfs_1_name=Grand-Pont&wfs_1_operator=TL">
+            ?wfs_layer=osm_scale&wfs_ngroups=2&wfs_0_ele=380&wfs_0_highway=bus_stop&wfs_0_operator=TL&wfs_1_highway=bus_stop&wfs_1_name=Grand-Pont&wfs_1_operator=TL
+          </a>
+        </li>
+      </ul>
+    </p>
+
+    <gmf-mobiledisplayqueries
+      gmf-mobiledisplayqueries-featuresstyle="ctrl.featureStyle">
+    </gmf-mobiledisplayqueries>
+
+    <script src="../../../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../../../node_modules/angular/angular.js"></script>
+    <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
+    <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
+    <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="../../../node_modules/proj4/dist/proj4.js"></script>
+    <script src="/@?main=wfs-permalink.js"></script>
+    <script src="default.js"></script>
+    <script src="../../../utils/watchwatchers.js"></script>
+  </body>
+</html>

--- a/contribs/gmf/examples/wfs-permalink.js
+++ b/contribs/gmf/examples/wfs-permalink.js
@@ -1,0 +1,76 @@
+goog.provide('gmf-wfspermalink');
+
+goog.require('gmf.mapDirective');
+goog.require('gmf.mobiledisplayqueriesDirective');
+goog.require('ngeo.proj.EPSG21781');
+goog.require('ngeo');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.proj');
+goog.require('ol.source.OSM');
+goog.require('ol.style.RegularShape');
+goog.require('ol.style.Stroke');
+goog.require('ol.style.Style');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['gmf']);
+
+app.module.constant('ngeoWfsPermalinkOptions',
+    /** @type {ngeox.WfsPermalinkOptions} */ ({
+      url: 'https://geomapfish-demo.camptocamp.net/1.6/wsgi/mapserv_proxy',
+      wfsTypes: [
+        {featureType: 'fuel', label: 'display_name'},
+        {featureType: 'osm_scale', label: 'display_name'}
+      ],
+      defaultFeatureNS: 'http://mapserver.gis.umn.edu/mapserver',
+      defaultFeaturePrefix: 'feature'
+    }));
+
+/**
+ * @constructor
+ */
+app.MainController = function() {
+
+  var projection = ol.proj.get('EPSG:21781');
+  projection.setExtent([485869.5728, 76443.1884, 837076.5648, 299941.7864]);
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      })
+    ],
+    view: new ol.View({
+      projection: projection,
+      resolutions: [200, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5],
+      center: [537635, 152640],
+      zoom: 3
+    })
+  });
+
+  var fill = new ol.style.Fill({color: [255, 170, 0, 0.6]});
+  var stroke = new ol.style.Stroke({color: [255, 170, 0, 1], width: 2});
+
+  /**
+   * FeatureStyle used by the mobiledisplayqueries directive
+   * @type {ol.style.Style}
+   * @export
+   */
+  this.featureStyle = new ol.style.Style({
+    fill: fill,
+    image: new ol.style.Circle({fill: fill, radius: 5, stroke: stroke}),
+    stroke: stroke
+  });
+};
+
+app.module.controller('MainController', app.MainController);

--- a/contribs/gmf/examples/wfs-permalink.js
+++ b/contribs/gmf/examples/wfs-permalink.js
@@ -23,7 +23,7 @@ app.module = angular.module('app', ['gmf']);
 
 app.module.constant('ngeoWfsPermalinkOptions',
     /** @type {ngeox.WfsPermalinkOptions} */ ({
-      url: 'https://geomapfish-demo.camptocamp.net/1.6/wsgi/mapserv_proxy',
+      url: 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy',
       wfsTypes: [
         {featureType: 'fuel', label: 'display_name'},
         {featureType: 'osm_scale', label: 'display_name'}

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -245,6 +245,108 @@ ngeox.QuerySource.prototype.wmsSource;
 
 
 /**
+ * A WFS type. To be used with {@link ngeox.WfsPermalinkOptions}.
+ * @typedef {{
+ *     featureType: (string),
+ *     label: (string|undefined),
+ *     featureNS: (string|undefined),
+ *     featurePrefix: (string|undefined)
+ * }}
+ */
+ngeox.WfsType;
+
+
+/**
+ * The feature type name. Required.
+ * @type {string}
+ */
+ngeox.WfsType.prototype.featureType;
+
+
+/**
+ * The field of a feature used as label.
+ * @type {string|undefined}
+ */
+ngeox.WfsType.prototype.label;
+
+
+/**
+ * The namespace URI used for features. If not given, the default namespace set
+ * in {@link ngeox.WfsPermalinkOptions} will be used.
+ * @type {string|undefined}
+ */
+ngeox.WfsType.prototype.featureNS;
+
+
+/**
+ * The prefix for the feature namespace. If not given, the default prefix set
+ * in {@link ngeox.WfsPermalinkOptions} will be used.
+ * @type {string|undefined}
+ */
+ngeox.WfsType.prototype.featurePrefix;
+
+
+/**
+ * The options for the wfs query service (permalink).
+ * @typedef {{
+ *     url: (string),
+ *     wfsTypes: (!Array.<ngeox.WfsType>),
+ *     pointRecenterZoom: (number|undefined),
+ *     defaultFeatureNS: (string),
+ *     defaultFeaturePrefix: (string),
+ *     maxFeatures: (number|undefined)
+ * }}
+ */
+ngeox.WfsPermalinkOptions;
+
+
+/**
+ * URL to the WFS server.
+ * @type {string}
+ */
+ngeox.WfsPermalinkOptions.prototype.url;
+
+
+/**
+ * The queryable WFS types.
+ * @type {!Array.<ngeox.WfsType>}
+ */
+ngeox.WfsPermalinkOptions.prototype.wfsTypes;
+
+
+/**
+ * Zoom level to use when result is a single point feature. If not set the map
+ * is not zoomed to a specific zoom level.
+ * @type {number|undefined}
+ */
+ngeox.WfsPermalinkOptions.prototype.pointRecenterZoom;
+
+
+/**
+ * The default namespace URI used for features. This will be used if no custom
+ * namespace is given for a WFS type.
+ * @type {string}
+ */
+ngeox.WfsType.prototype.defaultFeatureNS;
+
+
+/**
+ * The default prefix for the feature namespace. This will be used if no custom
+ * prefix is given for a WFS type.
+ * @type {string}
+ */
+ngeox.WfsType.prototype.defaultFeaturePrefix;
+
+
+/**
+ * The maximum number of records per request the query service should ask.
+ * Defaults to `50`.
+ * @type {number|undefined}
+ */
+ngeox.WfsPermalinkOptions.prototype.maxFeatures;
+
+
+/**
  * MobileDraw Interaction
  * @typedef {{
  *     minPoints: (number|undefined),

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "less-plugin-autoprefix": "1.5.1",
     "less-plugin-clean-css": "1.5.1",
     "nomnom": "1.8.1",
-    "openlayers": "openlayers/ol3#8e3e47bed46cbb4833c592978fd61aa59cf60a4e",
+    "openlayers": "openlayers/ol3#b1648c9",
     "phantomjs-prebuilt": "2.1.7",
     "proj4": "2.3.14",
     "temp": "0.8.3",

--- a/src/services/location.js
+++ b/src/services/location.js
@@ -114,12 +114,43 @@ ngeo.Location.prototype.getParam = function(key) {
 
 
 /**
+ * Get a param in the location's URI as integer. If the entry does not exist,
+ * or if the value can not be parsed as integer, `undefined` is returned.
+ * @param {string} key Param key.
+ * @return {number|undefined} Param value.
+ * @export
+ */
+ngeo.Location.prototype.getParamAsInt = function(key) {
+  if (!this.hasParam(key)) {
+    return undefined;
+  }
+  var value = /** @type {string} */ (this.uri_.getQueryData().get(key));
+  var valueAsInt = parseInt(value, 10);
+  return (isNaN(valueAsInt)) ? undefined : valueAsInt;
+};
+
+
+/**
  * Get an array with all existing param's keys in the location's URI.
  * @return {Array.<string>} Param keys.
  * @export
  */
 ngeo.Location.prototype.getParamKeys = function() {
   return this.uri_.getQueryData().getKeys();
+};
+
+
+/**
+ * Get an array with all existing param's keys in the location's URI that start
+ * with the given prefix.
+ * @param {string} prefix Key prefix.
+ * @return {Array.<string>} Param keys.
+ * @export
+ */
+ngeo.Location.prototype.getParamKeysWithPrefix = function(prefix) {
+  return this.uri_.getQueryData().getKeys().filter(function(key) {
+    return key.indexOf(prefix) == 0;
+  });
 };
 
 

--- a/src/services/query.js
+++ b/src/services/query.js
@@ -148,7 +148,7 @@ ngeo.Query.DEFAULT_SOURCE_IDS_PROPERTY_ = 'querySourceIds';
  * Adds a new source to the query service.
  *
  * A source must at least have an `id` configured.  That id is then used to
- * associate the the corresponding layer object within a map.
+ * associate the corresponding layer object within a map.
  *
  * A source will require a `ol.source.ImageWMS` or `ol.source.TileWMS` object.
  * You can either set it directly in the config, or use the one from a given

--- a/src/services/wfspermalink.js
+++ b/src/services/wfspermalink.js
@@ -1,0 +1,304 @@
+goog.provide('ngeo.WfsPermalink');
+
+goog.require('ngeo');
+/** @suppress {extraRequire} - required for `ngeoQueryResult` */
+goog.require('ngeo.Query');
+goog.require('ol.format.WFS');
+
+
+/**
+ * @typedef {{
+ *     property: (string),
+ *     condition: (string|Array.<string>)
+ * }}
+ */
+ngeo.WfsPermalinkFilter;
+
+
+/**
+ * @typedef {{
+ *     filters: (Array.<ngeo.WfsPermalinkFilter>)
+ * }}
+ */
+ngeo.WfsPermalinkFilterGroup;
+
+
+/**
+ * @typedef {{
+ *     wfsType: (string),
+ *     filterGroups: (Array.<ngeo.WfsPermalinkFilterGroup>),
+ *     showFeatures: (boolean)
+ * }}
+ */
+ngeo.WfsPermalinkData;
+
+
+/**
+ * Constant that is supposed to be set in applications to enable the WFS
+ * permalink functionality.
+ */
+ngeo.module.constant('ngeoWfsPermalinkOptions',
+    /** @type {ngeox.WfsPermalinkOptions} */ ({
+      url: '', wfsTypes: [], defaultFeatureNS: '', defaultFeaturePrefix: ''
+    }));
+
+
+/**
+ * WFS permalink service that can be used to load features with a WFS
+ * GetFeature request given query parameters.
+ *
+ * @constructor
+ * @param {angular.$http} $http Angular $http service.
+ * @param {ngeo.QueryResult} ngeoQueryResult The ngeo query result service.
+ * @param {ngeox.WfsPermalinkOptions} ngeoWfsPermalinkOptions The options to
+ *     configure the ngeo wfs permalink service with.
+ * @ngdoc service
+ * @ngname ngeoWfsPermalink
+ * @ngInject
+ */
+ngeo.WfsPermalink = function($http, ngeoQueryResult, ngeoWfsPermalinkOptions) {
+
+  var options = ngeoWfsPermalinkOptions;
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.url_ = options.url;
+
+  /**
+   * @type {number}
+   * @private
+   */
+  this.maxFeatures_ = options.maxFeatures !== undefined ? options.maxFeatures : 50;
+
+  /**
+   * @type {Object<string, ngeox.WfsType>}
+   * @private
+   */
+  this.wfsTypes_ = {};
+  options.wfsTypes.forEach(function(wfsType) {
+    this.wfsTypes_[wfsType.featureType] = wfsType;
+  }.bind(this));
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.defaultFeatureNS_ = options.defaultFeatureNS;
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.defaultFeaturePrefix_ = options.defaultFeaturePrefix;
+
+  /**
+   * @type {number|undefined}
+   * @private
+   */
+  this.pointRecenterZoom_ = options.pointRecenterZoom;
+
+  /**
+   * @type {angular.$http}
+   * @private
+   */
+  this.$http_ = $http;
+
+  /**
+   * @type {ngeo.QueryResult}
+   * @private
+   */
+  this.result_ = ngeoQueryResult;
+};
+
+
+/**
+ * Clear the results.
+ * @export
+ */
+ngeo.WfsPermalink.prototype.clear = function() {
+  this.clearResult_();
+};
+
+
+/**
+ * Build a WFS GetFeature request for the given query parameter data, send the
+ * request and add the received features to {@link ngeo.QueryResult}.
+ *
+ * @param {ngeo.WfsPermalinkData} queryData Query data for the WFS request.
+ * @param {ol.Map} map The ol3 map object to get the current projection from.
+ * @export
+ */
+ngeo.WfsPermalink.prototype.issue = function(queryData, map) {
+  goog.asserts.assert(this.url_,
+      'url is not set. to use the wfs permalink service, ' +
+      'set the constant `ngeoWfsPermalinkOptions`');
+  this.clearResult_();
+
+  var typeName = queryData.wfsType;
+  if (!this.wfsTypes_.hasOwnProperty(typeName)) {
+    return;
+  }
+  var wfsType = this.wfsTypes_[typeName];
+
+  var filters = this.createFilters_(queryData.filterGroups);
+  if (filters === null) {
+    return;
+  }
+
+  this.issueRequest_(wfsType, filters, map, queryData.showFeatures);
+};
+
+
+/**
+ * @param {ngeox.WfsType} wfsType Type.
+ * @param {ol.format.ogc.filter.Filter} filter Filter.
+ * @param {ol.Map} map The ol3 map object to get the current projection from.
+ * @param {boolean} showFeatures Show features or only zoom to feature extent?
+ * @private
+ */
+ngeo.WfsPermalink.prototype.issueRequest_ = function(wfsType, filter, map, showFeatures) {
+  var featureRequestXml = new ol.format.WFS().writeGetFeature({
+    srsName: map.getView().getProjection().getCode(),
+    featureNS: (wfsType.featureNS !== undefined) ?
+        wfsType.featureNS : this.defaultFeatureNS_,
+    featurePrefix: (wfsType.featurePrefix !== undefined) ?
+        wfsType.featurePrefix : this.defaultFeaturePrefix_,
+    featureTypes: [wfsType.featureType],
+    outputFormat: 'GML3',
+    filter: filter,
+    maxFeatures: this.maxFeatures_
+  });
+
+  var featureRequest = new XMLSerializer().serializeToString(featureRequestXml);
+  this.$http_.post(this.url_, featureRequest).then(function(response) {
+    var features = new ol.format.WFS().readFeatures(response.data);
+    if (features.length == 0) {
+      return;
+    }
+
+    // zoom to features
+    var mapSize = map.getSize();
+    if (mapSize !== undefined) {
+      map.getView().fit(
+          this.getExtent_(features),
+          mapSize,
+          {maxZoom: this.pointRecenterZoom_, padding: [10, 10, 10, 10]});
+    }
+
+    // then show if requested
+    if (showFeatures) {
+      var resultSource = /** @type {ngeo.QueryResultSource} */ ({
+        'features': features,
+        'id': wfsType.featureType,
+        'identifierAttributeField': wfsType.label,
+        'label': wfsType.featureType,
+        'pending': false
+      });
+
+      this.result_.sources.push(resultSource);
+      this.result_.total = features.length;
+    }
+  }.bind(this));
+};
+
+
+/**
+ * @param {Array.<ol.Feature>} features Features.
+ * @return {ol.Extent} The extent of all features.
+ * @private
+ */
+ngeo.WfsPermalink.prototype.getExtent_ = function(features) {
+  return features.reduce(function(extent, feature) {
+    return ol.extent.extend(extent, feature.getGeometry().getExtent());
+  }, ol.extent.createEmpty());
+};
+
+/**
+ * Create OGC filters for the filter groups extracted from the query params.
+ *
+ * @param {Array.<ngeo.WfsPermalinkFilterGroup>} filterGroups Filter groups.
+ * @return {ol.format.ogc.filter.Filter} OGC filters.
+ * @private
+ */
+ngeo.WfsPermalink.prototype.createFilters_ = function(filterGroups) {
+  if (filterGroups.length == 0) {
+    return null;
+  }
+  var f = ol.format.ogc.filter;
+  var createFiltersForGroup = function(filterGroup) {
+    var filters = filterGroup.filters.map(function(filterDef) {
+      var condition = filterDef.condition;
+      if (Array.isArray(condition)) {
+        return ngeo.WfsPermalink.or_(condition.map(function(cond) {
+          return f.equalTo(filterDef.property, cond);
+        }));
+      } else {
+        return f.equalTo(filterDef.property, filterDef.condition);
+      }
+    });
+    return ngeo.WfsPermalink.and_(filters);
+  };
+  return ngeo.WfsPermalink.or_(filterGroups.map(createFiltersForGroup));
+};
+
+
+/**
+ * Join a list of filters with `and(...)`.
+ *
+ * @param {Array.<ol.format.ogc.filter.Filter>} filters The filters to join.
+ * @return {ol.format.ogc.filter.Filter} The joined filters.
+ * @private
+ */
+ngeo.WfsPermalink.and_ = function(filters) {
+  return ngeo.WfsPermalink.joinFilters_(filters, ol.format.ogc.filter.and);
+};
+
+
+/**
+ * Join a list of filters with `or(...)`.
+ *
+ * @param {Array.<ol.format.ogc.filter.Filter>} filters The filters to join.
+ * @return {ol.format.ogc.filter.Filter} The joined filters.
+ * @private
+ */
+ngeo.WfsPermalink.or_ = function(filters) {
+  return ngeo.WfsPermalink.joinFilters_(filters, ol.format.ogc.filter.or);
+};
+
+
+/**
+ * Join a list of filters with a given join function.
+ *
+ * @param {Array.<ol.format.ogc.filter.Filter>} filters The filters to join.
+ * @param {function(!ol.format.ogc.filter.Filter, !ol.format.ogc.filter.Filter):
+ *    ol.format.ogc.filter.Filter} joinFn The function to join two filters.
+ * @return {ol.format.ogc.filter.Filter} The joined filters.
+ * @private
+ */
+ngeo.WfsPermalink.joinFilters_ = function(filters, joinFn) {
+  return filters.reduce(function(combinedFilters, currentFilter) {
+    if (combinedFilters === null) {
+      return currentFilter;
+    } else {
+      goog.asserts.assert(currentFilter !== null);
+      return joinFn(combinedFilters, currentFilter);
+    }
+  }, null);
+};
+
+
+/**
+ * Clear every features for all result sources and reset the total counter
+ * as well.
+ * @private
+ */
+ngeo.WfsPermalink.prototype.clearResult_ = function() {
+  this.result_.total = 0;
+  this.result_.sources.forEach(function(source) {
+    source.features.length = 0;
+  }, this);
+};
+
+ngeo.module.service('ngeoWfsPermalink', ngeo.WfsPermalink);

--- a/test/spec/data/msGMLOutputFuel.js
+++ b/test/spec/data/msGMLOutputFuel.js
@@ -1,0 +1,65 @@
+goog.provide('ngeo.test.data.msGMLOutputFuel');
+
+var msGMLOutputFuel = '<?xml version=\'1.0\' encoding="UTF-8" ?>' +
+'<wfs:FeatureCollection' +
+'   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"' +
+'   xmlns:gml="http://www.opengis.net/gml"' +
+'   xmlns:wfs="http://www.opengis.net/wfs"' +
+'   xmlns:ogc="http://www.opengis.net/ogc"' +
+'   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' +
+'   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver https://geomapfish-demo.camptocamp.net/1.6/mapserv?SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=feature:fuel&amp;OUTPUTFORMAT=SFE_XMLSCHEMA  http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">' +
+'      <gml:boundedBy>' +
+'        <gml:Envelope srsName="EPSG:21781">' +
+'          <gml:lowerCorner>545277.898290 148729.093947</gml:lowerCorner>' +
+'          <gml:upperCorner>545277.898290 148729.093947</gml:upperCorner>' +
+'        </gml:Envelope>' +
+'      </gml:boundedBy>' +
+'    <gml:featureMember>' +
+'      <ms:fuel gml:id="fuel.1420918679">' +
+'        <gml:boundedBy>' +
+'          <gml:Envelope srsName="EPSG:21781">' +
+'            <gml:lowerCorner>545277.898290 148729.093947</gml:lowerCorner>' +
+'            <gml:upperCorner>545277.898290 148729.093947</gml:upperCorner>' +
+'          </gml:Envelope>' +
+'        </gml:boundedBy>' +
+'        <ms:THE_GEOM>' +
+'          <gml:Point srsName="EPSG:21781">' +
+'            <gml:pos>545277.898290 148729.093947</gml:pos>' +
+'          </gml:Point>' +
+'        </ms:THE_GEOM>' +
+'        <ms:display_name>1420918679</ms:display_name>' +
+'        <ms:name></ms:name>' +
+'        <ms:osm_id>1420918679</ms:osm_id>' +
+'        <ms:access></ms:access>' +
+'        <ms:aerialway></ms:aerialway>' +
+'        <ms:amenity>fuel</ms:amenity>' +
+'        <ms:barrier></ms:barrier>' +
+'        <ms:bicycle></ms:bicycle>' +
+'        <ms:brand></ms:brand>' +
+'        <ms:building></ms:building>' +
+'        <ms:covered></ms:covered>' +
+'        <ms:denomination></ms:denomination>' +
+'        <ms:ele></ms:ele>' +
+'        <ms:foot></ms:foot>' +
+'        <ms:highway></ms:highway>' +
+'        <ms:layer></ms:layer>' +
+'        <ms:leisure></ms:leisure>' +
+'        <ms:man_made></ms:man_made>' +
+'        <ms:motorcar></ms:motorcar>' +
+'        <ms:natural></ms:natural>' +
+'        <ms:operator>Frères Jubin</ms:operator>' +
+'        <ms:population></ms:population>' +
+'        <ms:power></ms:power>' +
+'        <ms:place></ms:place>' +
+'        <ms:railway></ms:railway>' +
+'        <ms:ref></ms:ref>' +
+'        <ms:religion></ms:religion>' +
+'        <ms:shop></ms:shop>' +
+'        <ms:sport></ms:sport>' +
+'        <ms:surface></ms:surface>' +
+'        <ms:tourism></ms:tourism>' +
+'        <ms:waterway></ms:waterway>' +
+'        <ms:wood></ms:wood>' +
+'      </ms:fuel>' +
+'    </gml:featureMember>' +
+'</wfs:FeatureCollection>';

--- a/test/spec/services/query.spec.js
+++ b/test/spec/services/query.spec.js
@@ -72,8 +72,8 @@ describe('ngeo.Query', function() {
 
       var url = 'https://geomapfish-demo.camptocamp.net/1.6/wsgi/mapserv_proxy';
 
-      var requestUrlBusStop = url + '?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetFeatureInfo&FORMAT=image%2Fpng&TRANSPARENT=true&INFO_FORMAT=application%2Fvnd.ogc.gml&FEATURE_COUNT=50&I=50&J=50&CRS=EPSG%3A21781&STYLES=&WIDTH=101&HEIGHT=101&BBOX=489100%2C119900.00000000003%2C509300%2C140100.00000000003&LAYERS=bus_stop&QUERY_LAYERS=bus_stop';
-      var requestUrlBusStopAndInformation = url + '?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetFeatureInfo&FORMAT=image%2Fpng&TRANSPARENT=true&INFO_FORMAT=application%2Fvnd.ogc.gml&FEATURE_COUNT=50&I=50&J=50&CRS=EPSG%3A21781&STYLES=&WIDTH=101&HEIGHT=101&BBOX=523700%2C142900.00000000003%2C543900%2C163100.00000000003&LAYERS=information%2Cbus_stop&QUERY_LAYERS=information%2Cbus_stop';
+      var requestUrlBusStop = url + '?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetFeatureInfo&FORMAT=image%2Fpng&TRANSPARENT=true&INFO_FORMAT=application%2Fvnd.ogc.gml&FEATURE_COUNT=50&I=50&J=50&CRS=EPSG%3A21781&STYLES&WIDTH=101&HEIGHT=101&BBOX=489100%2C119900.00000000003%2C509300%2C140100.00000000003&LAYERS=bus_stop&QUERY_LAYERS=bus_stop';
+      var requestUrlBusStopAndInformation = url + '?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetFeatureInfo&FORMAT=image%2Fpng&TRANSPARENT=true&INFO_FORMAT=application%2Fvnd.ogc.gml&FEATURE_COUNT=50&I=50&J=50&CRS=EPSG%3A21781&STYLES&WIDTH=101&HEIGHT=101&BBOX=523700%2C142900.00000000003%2C543900%2C163100.00000000003&LAYERS=information%2Cbus_stop&QUERY_LAYERS=information%2Cbus_stop';
 
       inject(function($injector) {
         $httpBackend = $injector.get('$httpBackend');

--- a/test/spec/services/wfspermalink.spec.js
+++ b/test/spec/services/wfspermalink.spec.js
@@ -10,7 +10,7 @@ describe('ngeo.WfsPermalink', function() {
   beforeEach(function() {
     module('ngeo', function($provide) {
       $provide.constant('ngeoWfsPermalinkOptions', {
-        url: 'https://geomapfish-demo.camptocamp.net/2.0/wsgi/mapserv_proxy',
+        url: 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy',
         wfsTypes: [{featureType: 'fuel'}, {featureType: 'highway'}],
         defaultFeatureNS: 'http://mapserver.gis.umn.edu/mapserver',
         defaultFeaturePrefix: 'ms'
@@ -33,7 +33,7 @@ describe('ngeo.WfsPermalink', function() {
     var map;
 
     beforeEach(function() {
-      var url = 'https://geomapfish-demo.camptocamp.net/2.0/wsgi/mapserv_proxy';
+      var url = 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy';
       inject(function($injector) {
         $httpBackend = $injector.get('$httpBackend');
         $httpBackend.when('POST', url).respond(msGMLOutputFuel);

--- a/test/spec/services/wfspermalink.spec.js
+++ b/test/spec/services/wfspermalink.spec.js
@@ -1,0 +1,146 @@
+goog.require('ngeo.WfsPermalink');
+goog.require('ol.format.ogc.filter');
+goog.require('ngeo.test.data.msGMLOutputFuel');
+
+describe('ngeo.WfsPermalink', function() {
+
+  var ngeoWfsPermalink;
+  var ngeoQueryResult;
+
+  beforeEach(function() {
+    module('ngeo', function($provide) {
+      $provide.constant('ngeoWfsPermalinkOptions', {
+        url: 'https://geomapfish-demo.camptocamp.net/2.0/wsgi/mapserv_proxy',
+        wfsTypes: [{featureType: 'fuel'}, {featureType: 'highway'}],
+        defaultFeatureNS: 'http://mapserver.gis.umn.edu/mapserver',
+        defaultFeaturePrefix: 'ms'
+      });
+    });
+
+    inject(function($injector) {
+      ngeoWfsPermalink = $injector.get('ngeoWfsPermalink');
+      ngeoQueryResult = $injector.get('ngeoQueryResult');
+    });
+  });
+
+  it('creates a service', function() {
+    expect(ngeoWfsPermalink instanceof ngeo.WfsPermalink).toBe(true);
+  });
+
+  describe('#issue', function() {
+
+    var $httpBackend;
+    var map;
+
+    beforeEach(function() {
+      var url = 'https://geomapfish-demo.camptocamp.net/2.0/wsgi/mapserv_proxy';
+      inject(function($injector) {
+        $httpBackend = $injector.get('$httpBackend');
+        $httpBackend.when('POST', url).respond(msGMLOutputFuel);
+        $httpBackend = $injector.get('$httpBackend');
+      });
+
+      var projection = ol.proj.get('EPSG:21781');
+      projection.setExtent([485869.5728, 76443.1884, 837076.5648, 299941.7864]);
+
+      map = new ol.Map({
+        layers: [],
+        view: new ol.View({
+          projection: projection,
+          resolutions: [200, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5],
+          center: [537635, 152640],
+          zoom: 0
+        })
+      });
+    });
+
+    afterEach(function() {
+      $httpBackend.verifyNoOutstandingExpectation();
+      $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    it('makes a query and adds the result', function() {
+      var queryData = {
+        'wfsType': 'fuel',
+        'showFeatures': true,
+        'filterGroups': [
+          {
+            'filters': [
+              {'property': 'osm_id', 'condition': '1420918679'}
+            ]
+          }
+        ]
+      };
+
+      ngeoWfsPermalink.issue(queryData, map);
+      $httpBackend.flush();
+      expect(ngeoQueryResult.sources[ngeoQueryResult.sources.length - 1].features.length).toBe(1);
+      ngeoWfsPermalink.clear();
+      expect(ngeoQueryResult.total).toBe(0);
+    });
+  });
+
+  describe('#createFilters_', function() {
+    var expectFiltersToEqual = function(filter1, filter2) {
+      expect(filter1.constructor).toBe(filter2.constructor, 'same filter type');
+      if (filter1 instanceof ol.format.ogc.filter.LogicalBinary) {
+        expectFiltersToEqual(filter1.conditionA, filter2.conditionA)
+        expectFiltersToEqual(filter1.conditionB, filter2.conditionB);
+      } else {
+        expect(filter1 instanceof ol.format.ogc.filter.EqualTo);
+        expect(filter1.propertyName).toBe(filter2.propertyName);
+        expect(filter1.expression).toBe(filter2.expression);
+      }
+    };
+
+    it('creates filters', function () {
+      var queryData = {
+        'wfsType': 'fuel',
+        'filterGroups': [
+          {
+            'filters': [
+              {'property': 'osm_id', 'condition': '12345'},
+              {'property': 'type', 'condition':['diesel', 'gas']}
+            ]
+          },
+          {
+            'filters': [
+              {'property': 'payment', 'condition': ['card', 'cash']}
+            ]
+          },
+          {
+            'filters': [
+              {'property': 'open_7_24', 'condition': '1'}
+            ]
+          }
+        ]
+      };
+      var f = ol.format.ogc.filter;
+      var expectedFilters = f.or(
+          f.or(
+            f.and(
+                f.equalTo('osm_id', '12345'),
+                f.or(
+                  f.equalTo('type', 'diesel'),
+                  f.equalTo('type', 'gas')
+                )
+            ),
+            f.or(
+              f.equalTo('payment', 'card'),
+              f.equalTo('payment', 'cash')
+            )
+          ),
+          f.equalTo('open_7_24', '1')
+      );
+      expectFiltersToEqual(
+          ngeoWfsPermalink.createFilters_(queryData['filterGroups']),
+          expectedFilters
+      );
+    });
+
+    it('handles 0 filter groups', function () {
+      expect(ngeoWfsPermalink.createFilters_([])).toBe(null);
+    });
+  });
+
+});


### PR DESCRIPTION
Adds a `ngeo.WfsPermalink` service which is used by `gmf.Permalink`. When calling the new example with e.g. `?wfs_layer=fuel&wfs_osm_id=1420918679`, a WFS GetFeature request is made and the features are shown with the `gmf-mobiledisplayqueries` directive.

For the yet to implement [WFS queries](https://github.com/camptocamp/c2cgeoportal/wiki/Spec-%231771-Querying-data-%28click-and-box%29), some functionality of `ngeo.WfsPermalink` might be refactored to avoid duplicated code.

Closes https://github.com/camptocamp/c2cgeoportal/issues/1670 