### PR TITLE
Fix the templates path when the URL changed

### DIFF
--- a/contribs/gmf/src/directives/themeselector.js
+++ b/contribs/gmf/src/directives/themeselector.js
@@ -141,6 +141,12 @@ gmf.ThemeselectorController.prototype.setLocationPath_ = function(themeId) {
     pathElements.push('theme', themeId);
   }
   this.ngeoLocation_.setPath(pathElements.join('/'));
+  if (ngeo.baseTemplateUrl != 'ngeo') {
+    ngeo.baseTemplateUrl = '../../' + ngeo.baseTemplateUrl;
+  }
+  if (gmf.baseTemplateUrl != 'gmf') {
+    gmf.baseTemplateUrl = '../../' + gmf.baseTemplateUrl;
+  }
 };
 
 


### PR DESCRIPTION
demo: http://camptocamp.github.io/ngeo/template/examples/contribs/gmf/apps/desktop/index.html