### PR TITLE
Add gmf mouse position directive

### DIFF
--- a/contribs/gmf/examples/mouseposition.html
+++ b/contribs/gmf/examples/mouseposition.html
@@ -1,0 +1,50 @@
+<!DOCTYPE>
+<html ng-app='app'>
+  <head>
+    <title>GeoMapFish Mouse Position Example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../../../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/font-awesome/css/font-awesome.css" type="text/css">
+    <style>
+      gmf-map > div {
+        width: 600px;
+        height: 400px;
+      }
+      #mouse-position {
+        text-align: right;
+        min-width: 210px;
+      }
+      .footer {
+        min-height: 30px;
+        background-color: rgba(224, 224, 224, 0.8);
+        width: 600px;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <div class="container">
+      <gmf-map gmf-map-map="ctrl.map"></gmf-map>
+      <div class="footer">
+        <gmf-mouseposition gmf-mouseposition-map="::ctrl.map"
+                           gmf-mouseposition-projections="::ctrl.projections">
+        </gmf-mouseposition>
+      </div>
+    </div>
+    <p id="desc">This example shows how to use the <code>gmf.mouseposition</code> directive.</p>
+
+    <script src="../../../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../../../node_modules/angular/angular.js"></script>
+    <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
+    <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
+    <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../../../node_modules/proj4/dist/proj4.js"></script>
+    <script src="/@?main=mouseposition.js"></script>
+    <script src="default.js"></script>
+    <script src="../../../utils/watchwatchers.js"></script>
+  </body>
+</html>

--- a/contribs/gmf/examples/mouseposition.js
+++ b/contribs/gmf/examples/mouseposition.js
@@ -1,0 +1,66 @@
+goog.provide('gmf-mouseposition');
+
+/** @suppress {extraRequire} */
+goog.require('gmf.mapDirective');
+/** @suppress {extraRequire} */
+goog.require('ngeo.CoordinateFormat');
+goog.require('ngeo.CoordinateFormatConfig');
+goog.require('gmf.mousepositionDirective');
+goog.require('ngeo.proj.EPSG21781');
+goog.require('ngeo.proj.EPSG2056');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['gmf']);
+
+
+/**
+ *
+ * @param {ngeo.CoordinateFormat} ngeoCoordinateFormat Coordinates format
+ *     projection config.
+ * @constructor
+ * @ngInject
+ */
+app.MainController = function(ngeoCoordinateFormat) {
+
+  /**
+   * @type {Array.<string>}
+   * @export
+   */
+  this.projections = ['EPSG:4326', 'EPSG:4326:DMS', 'EPSG:4326:UTM3132'];
+
+  /**
+   *
+   * @type {ngeo.CoordinateFormatConfig|undefined}
+   */
+  var projWgs84Dms = ngeoCoordinateFormat.getProjection('EPSG:4326:DMS');
+  if (projWgs84Dms) {
+    projWgs84Dms.label = 'Custom DMS label';
+  }
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      })
+    ],
+    view: new ol.View({
+      center: [0, 0],
+      zoom: 4
+    })
+  });
+};
+
+app.module.controller('MainController', app.MainController);

--- a/contribs/gmf/src/directives/mouseposition.js
+++ b/contribs/gmf/src/directives/mouseposition.js
@@ -1,0 +1,102 @@
+goog.provide('gmf.MousepositionController');
+goog.provide('gmf.mousepositionDirective');
+
+goog.require('gmf');
+goog.require('ngeo.CoordinateFormat');
+goog.require('ngeo.CoordinateFormatConfig');
+goog.require('ol.control.MousePosition');
+
+/**
+ * Provide a directive to display the mouse position coordinates depending
+ * on the chosen projection. The directive also provides a projection picker
+ * to choose how the coordinates are displayed.
+ * The projection picker is initialized from the `ngeoCoordinateFormat`
+ * service.
+ *
+ * Example:
+ *  <gmf-mouseposition gmf-mouseposition-map="ctrl.map"
+ *     gmf-mouseposition-projections="ctrl.projections">
+ *  </gmf-mouseposition>
+ *
+ * @htmlAttribute {ol.Map} gmf-mouseposition-map The map.
+ * @htmlAttribute {Array.<string>} gmf-mouseposition-projection The list of
+ *    the projections. If undefined, then all projections will be set.
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname gmfMouseposition
+ */
+gmf.mousepositionDirective = function() {
+  return {
+    restrict: 'E',
+    controller: 'gmfMousepositionController',
+    scope: {
+      'map': '<gmfMousepositionMap',
+      'projectionCodes': '<?gmfMousepositionProjections'
+    },
+    bindToController: true,
+    controllerAs: 'ctrl',
+    templateUrl: gmf.baseTemplateUrl + '/mouseposition.html'
+  };
+};
+
+gmf.module.directive('gmfMouseposition', gmf.mousepositionDirective);
+
+
+/**
+ *
+ * @param {!angular.Scope} $scope Angular scope.
+ * @param {ngeo.CoordinateFormat} ngeoCoordinateFormat Coordinates format projection config.
+ * @constructor
+ * @export
+ * @ngInject
+ * @ngdoc controller
+ * @ngname gmfMousepositionController
+ */
+gmf.MousepositionController = function($scope, ngeoCoordinateFormat) {
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
+
+  /**
+   * @type {Array.<string>|undefined}
+   * @export
+   */
+  this.projectionCodes;
+
+  /**
+   * @type {ngeo.CoordinateFormatConfig}
+   * @export
+   */
+  this.projection;
+
+  /**
+   * @type {Array.<ngeo.CoordinateFormatConfig>}
+   * @export
+   */
+  this.projections = ngeoCoordinateFormat.getProjections.apply(
+          ngeoCoordinateFormat, this.projectionCodes);
+
+  var control = new ol.control.MousePosition({
+    className: 'custom-mouse-position',
+    target: document.getElementById('mouse-position'),
+    undefinedHTML: '&nbsp;'
+  });
+
+  $scope.$watch(function() {
+    return this.projection;
+  }.bind(this), function(projection) {
+    control.setProjection(ol.proj.get(projection.id));
+    control.setCoordinateFormat(projection.format);
+  });
+
+  this.projection = this.projections[0];
+
+  this.map.addControl(control);
+};
+
+gmf.module.controller('gmfMousepositionController',
+    gmf.MousepositionController);

--- a/contribs/gmf/src/directives/partials/mouseposition.html
+++ b/contribs/gmf/src/directives/partials/mouseposition.html
@@ -1,0 +1,17 @@
+<div class="btn-group dropup pull-right">
+  <div class="btn btn-sm">
+    <span class="fa fa-fw fa-location-arrow"></span>
+  </div>
+  <div id="mouse-position" class="btn btn-sm" style=""></div>
+  <div class="btn btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+    <span class="fa fa-fw fa-ellipsis-v"></span>
+  </div>
+  <ul class="dropdown-menu" role="menu">
+    <li ng-repeat="projitem in ::ctrl.projections">
+      <a href ng-click="ctrl.projection = projitem">
+        <span class="fa fa-fw" ng-class="{'fa-check': ctrl.projection == projitem}"></span>
+        {{::projitem.label}}
+      </a>
+    </li>
+  </ul>
+</div>

--- a/src/services/coordinateformat.js
+++ b/src/services/coordinateformat.js
@@ -1,0 +1,178 @@
+goog.provide('ngeo.CoordinateFormat');
+goog.provide('ngeo.CoordinateFormatConfig');
+
+goog.require('goog.math');
+goog.require('goog.string');
+goog.require('ol.coordinate');
+goog.require('ol.proj');
+goog.require('ngeo');
+
+
+/**
+ * @typedef {{
+ *   code: (string|undefined),
+ *   id: (string),
+ *   label: (string),
+ *   format: (function(ol.Coordinate))
+ * }}
+ */
+ngeo.CoordinateFormatConfig;
+
+/**
+ * The `ngeoCoordinateFormat` provides a list of projection config & formaters
+ * that are used to display coordinates.
+ * The service provides a default config list in `projectionFormat`. This
+ * list is public and can be extended. You can pick an item from the list
+ * with `getProjection` function and overrides it.
+ * To get a subset of this array, you can use `getProjections` function.
+ *
+ * @constructor
+ * @export
+ * @ngInject
+ * @ngdoc service
+ * @ngname gmfMousepositionController
+ */
+ngeo.CoordinateFormat = function() {
+
+  if (typeof proj4 == 'function') {
+
+    proj4.defs('EPSG:32631', '+proj=utm +zone=31 +ellps=WGS84 ' +
+        '+datum=WGS84 +units=m +no_defs ');
+
+    proj4.defs('EPSG:32632', '+proj=utm +zone=32 +ellps=WGS84 ' +
+        '+datum=WGS84 +units=m +no_defs ');
+  }
+
+  /**
+   * @type {Array.<ngeo.CoordinateFormatConfig>}
+   * @export
+   */
+  this.projectionFormat = [{
+    id: 'EPSG:2056',
+    code: 'EPSG:2056',
+    label: 'CH1903+ / LV95',
+    format: coordinatesFormat_
+  },{
+    id: 'EPSG:21781',
+    label: 'CH1903 / LV03',
+    format: coordinatesFormat_
+  },{
+    id: 'EPSG:4326',
+    label: 'Lon/Lat WGS84',
+    format: function(coordinates) {
+      return ol.coordinate.format(coordinates, ' {x} E | {y} N', 5);
+    }
+  },{
+    id: 'EPSG:4326:DMS',
+    code: 'EPSG:4326',
+    label: 'Lon/Lat WGS84 DMS',
+    format: function(coordinates) {
+      var hdms = toStringHDMS_(coordinates);
+      var yhdms = hdms.split(' ').slice(0, 4).join(' ');
+      var xhdms = hdms.split(' ').slice(4, 8).join(' ');
+      return xhdms + ' | ' + yhdms;
+    }
+  },{
+    id: 'EPSG:4326:UTM3132',
+    code: 'EPSG:4326',
+    label: 'WGS84 UTM 32|31',
+    format: function(coordinates) {
+      if (coordinates[0] < 6 && coordinates[0] >= 0) {
+        var utm_31t = ol.proj.transform(coordinates,
+            'EPSG:4326', 'EPSG:32631');
+        return ol.coordinate.format(utm_31t, '{x} | {y} (UTM32N)', 0);
+      } else if (coordinates[0] < 12 && coordinates[0] >= 6) {
+        var utm_32t = ol.proj.transform(coordinates,
+            'EPSG:4326', 'EPSG:32632');
+        return ol.coordinate.format(utm_32t, '{x} | {y} (UTM32N)', 0);
+      } else {
+        return '-';
+      }
+    }
+  }];
+
+  /**
+   * @private
+   * @param {ol.Coordinate|undefined} coordinates Coordinate.
+   * @return {string} Formated coordinates.
+   */
+  function coordinatesFormat_(coordinates) {
+    return ol.coordinate.format(coordinates, ' {x} E | {y} N', 0).
+    replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+  }
+
+  /**
+   * @private
+   * @param {ol.Coordinate|undefined} coordinates Coordinate.
+   * @return {string} Hemisphere, degrees, minutes and seconds.
+   */
+  function toStringHDMS_(coordinates) {
+    if (goog.isDef(coordinates)) {
+      return degreesToStringHDMS_(coordinates[1], 'NS') + ' ' +
+          degreesToStringHDMS_(coordinates[0], 'EW');
+    } else {
+      return '';
+    }
+  }
+
+  /**
+   * @private
+   * @param {number} degrees Degrees.
+   * @param {string} hemispheres Hemispheres.
+   * @return {string} String.
+   */
+  function degreesToStringHDMS_(degrees, hemispheres) {
+    var normalizedDegrees = goog.math.modulo(degrees + 180, 360) - 180;
+    var x = Math.abs(3600 * normalizedDegrees);
+    return Math.floor(x / 3600) + '\u00b0 ' +
+        goog.string.padNumber(Math.floor((x / 60) % 60), 2) + '\u2032 ' +
+        goog.string.padNumber(Math.floor(x % 60), 2) + ',' +
+        Math.floor((x - (x < 0 ? Math.ceil(x) : Math.floor(x))) * 10) +
+        '\u2033 ' + hemispheres.charAt(normalizedDegrees < 0 ? 1 : 0);
+  }
+};
+
+/**
+ *
+ * @returns {Array.<ngeo.CoordinateFormatConfig>} A list of all projection
+ *    formats definitions.
+ * @export
+ */
+ngeo.CoordinateFormat.prototype.getProjections = function() {
+  /**
+   * @type {Array.<string>}
+   */
+  var codes = Array.prototype.splice.call(arguments, 0);
+
+  if (codes.length === 0) {
+    return this.projectionFormat;
+  }
+
+  var projectionFormats = [];
+  this.projectionFormat.forEach(function(format) {
+    if (codes.indexOf(format.id) >= 0) {
+      projectionFormats.push(format);
+    }
+  });
+  return projectionFormats;
+};
+
+/**
+ * @param {string} code The code of the projection.
+ * @returns {ngeo.CoordinateFormatConfig|undefined} The projection config object
+ *    if found.
+ * @export
+ */
+ngeo.CoordinateFormat.prototype.getProjection = function(code) {
+
+  var projection;
+  this.projectionFormat.some(function(format) {
+    if (code === format.id) {
+      projection = format;
+      return true;
+    }
+  });
+  return projection;
+};
+
+ngeo.module.service('ngeoCoordinateFormat', ngeo.CoordinateFormat);


### PR DESCRIPTION
Add a gmf directive for the mouse position.

The mouse position issue is the coordinates projection picker with associated formaters.
I added a `coordinateformat` service in ngeo that has default projection config set, and that can be extended.

See Specs: https://github.com/camptocamp/c2cgeoportal/wiki/Spec-%231668-Map-(Info-bar)

Example : http://fgravin.github.io/ngeo/mouseposition/examples/contribs/gmf/mouseposition.html