### PR TITLE
Menu open/close behavior

### DIFF
--- a/contribs/gmf/examples/drawfeature.html
+++ b/contribs/gmf/examples/drawfeature.html
@@ -13,7 +13,7 @@
     <style>
       gmf-map > div {
         width: 600px;
-        height: 200px;
+        height: 400px;
       }
 
       /* gmf-drawfeature */

--- a/contribs/gmf/examples/drawfeature.html
+++ b/contribs/gmf/examples/drawfeature.html
@@ -13,7 +13,7 @@
     <style>
       gmf-map > div {
         width: 600px;
-        height: 400px;
+        height: 200px;
       }
 
       /* gmf-drawfeature */

--- a/contribs/gmf/src/directives/drawfeature.js
+++ b/contribs/gmf/src/directives/drawfeature.js
@@ -414,7 +414,7 @@ gmf.DrawfeatureController.prototype.handleFeaturesRemove_ = function(evt) {
 gmf.DrawfeatureController.prototype.handleMapSelectActiveChange_ = function(
     active) {
 
-  var mapDiv = this.map.getTarget();
+  var mapDiv = this.map.getTargetElement();
   goog.asserts.assertElement(mapDiv);
 
   if (active) {
@@ -515,8 +515,6 @@ gmf.DrawfeatureController.prototype.handleMapTouchEnd_ = function(evt) {
  * @private
  */
 gmf.DrawfeatureController.prototype.handleMapContextMenu_ = function(evt) {
-  evt.preventDefault();
-
   var pixel = this.map.getEventPixel(evt);
   var coordinate = this.map.getCoordinateFromPixel(pixel);
 
@@ -549,6 +547,8 @@ gmf.DrawfeatureController.prototype.handleMapContextMenu_ = function(evt) {
     if (ol.array.includes(supportedTypes, type)) {
       this.menu_.open(coordinate);
     }
+
+    evt.preventDefault();
   }
 
   // do not do any further action if feature is null or already selected


### PR DESCRIPTION
This commit is for the issue #1088 

The example is live at: http://jlap.github.io/ngeo/menu-behavior/examples/contribs/gmf/drawfeature.html?map_x=576979&map_y=1613530&map_zoom=3

The example displays the new behaviors as described in #1088: 

* Action menu opens on right-click and long-press on mobile (so it won't open on geometry selection)
* Action menu should disappear when user clicks anywhere else or when an action is selected
* Remove "Action" title and cross to close the menu

This PR is ready for review!