### PR TITLE
 Larger grab zone for reorder

### DIFF
--- a/contribs/gmf/less/desktoplayertree.less
+++ b/contribs/gmf/less/desktoplayertree.less
@@ -27,7 +27,7 @@ gmf-layertree {
     }
 
     &:hover {
-      .sortable-handle {
+      .sortable-handle-icon {
         visibility: visible;
       }
     }
@@ -77,9 +77,17 @@ gmf-layertree {
   }
 
   .sortable-handle {
-    color:#555;
     cursor: -webkit-grab;
     cursor: grab;
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    width : @app-margin;
+  }
+
+  .sortable-handle-icon {
+    color:#555;
     visibility: hidden;
   }
 }

--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -102,7 +102,7 @@
     }
 
     &.indeterminate .state::after {
-      content: "\e900"
+      content: "\e900";
     }
   }
 

--- a/contribs/gmf/less/mobilelayertree.less
+++ b/contribs/gmf/less/mobilelayertree.less
@@ -6,6 +6,7 @@ nav.nav-left .gmf-layertree-node a[data-toggle] {
 }
 
 .gmf-layertree-node  {
+  .sortable-handle-icon,
   .sortable-handle {
     display: none;
   }

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -1,5 +1,6 @@
 <div ng-if="::!layertreeCtrl.isRoot" id="node-{{::layertreeCtrl.uid}}" ng-class="[layertreeCtrl.node.children ? 'group' : 'leaf', 'depth-' + layertreeCtrl.depth, gmfLayertreeCtrl.getResolutionStyle(layertreeCtrl.node), gmfLayertreeCtrl.getNoSourceStyle(layertreeCtrl), gmfLayertreeCtrl.getNodeState(layertreeCtrl)]">
-  <i ng-if="layertreeCtrl.depth === 1 && gmfLayertreeCtrl.layers.length > 1" class="sortable-handle fa fa-ellipsis-v"></i>
+  <div class="sortable-handle" ng-if="layertreeCtrl.depth === 1 && gmfLayertreeCtrl.layers.length > 1"></div>
+  <i class="sortable-handle-icon fa fa-ellipsis-v" ng-if="layertreeCtrl.depth === 1 && gmfLayertreeCtrl.layers.length > 1"></i>
     <a  ng-if="::layertreeCtrl.node.children"
         data-toggle="collapse"
         href="#layer-group-{{::layertreeCtrl.uid}}"


### PR DESCRIPTION
Here is my proposal to get a larger grab zone for reorder (check todo tasks #1147) without changing the layertree design.
The idea is to display a zone (div) in absolute position with a larger width than the handler icon. Therefore the handler icon is only display for the design purpose. The real "handling zone"  is the div itself (so we can change easily its size).

- desktop demo: [here](https://oliviersemet.github.io/ngeo/increase-size-of-drag-and-drop-handle/examples/contribs/gmf/apps/desktop/)
-mobile demo: [here](https://oliviersemet.github.io/ngeo/increase-size-of-drag-and-drop-handle/examples/contribs/gmf/apps/mobile/)

ping @fredj @pgiraud @sbrunner  if the solution looks good for you.