### PR TITLE
Add the alternate desktop application to the examples list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -473,6 +473,7 @@ node_modules/angular/angular.min.js: .build/node_modules.timestamp
 	.build/python-venv/bin/python buildtools/generate-examples-index.py \
 		--app 'Mobile application' apps/mobile/index.html 'The mobile example application for GeoMapFish.' \
 		--app 'Desktop application' apps/desktop/index.html 'The desktop example application for GeoMapFish.' \
+		--app 'Alternate desktop application' apps/desktop_alt/index.html 'An alternate desktop example application for GeoMapFish.' \
 		$< $(GMF_EXAMPLES_HTML_FILES) > $@
 
 .build/%.check.timestamp: .build/examples-hosted/%.html \


### PR DESCRIPTION
See: https://camptocamp.github.io/ngeo/add-desktop-alt/examples/contribs/gmf/