### PR TITLE
Properly register group layers in permalink service

### DIFF
--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -737,6 +737,13 @@ gmf.Permalink.prototype.registerLayer_ = function(layer, opt_init) {
   var layerUid = goog.getUid(layer);
 
   if (layer instanceof ol.layer.Group) {
+    // set up a listener on group layers because layers can also later be added
+    // to a group
+    this.addListenerKey_(layerUid, ol.events.listen(layer.getLayers(),
+        ol.CollectionEventType.ADD, this.handleLayersAdd_, this));
+    this.addListenerKey_(layerUid, ol.events.listen(layer.getLayers(),
+        ol.CollectionEventType.REMOVE, this.handleLayersRemove_, this));
+
     layer.getLayers().forEach(function(layer) {
       this.registerLayer_(layer, opt_init);
     }, this);
@@ -790,10 +797,10 @@ gmf.Permalink.prototype.unregisterLayer_ = function(layer) {
 
   var layerUid = goog.getUid(layer);
 
+  this.initListenerKey_(layerUid); // clear event listeners
   if (layer instanceof ol.layer.Group) {
     layer.getLayers().forEach(this.unregisterLayer_, this);
   } else {
-    this.initListenerKey_(layerUid); // clear event listeners
     var isMerged = layer.get('isMerged');
     if (isMerged) {
       goog.asserts.assert(

--- a/contribs/gmf/test/spec/services/permalinkservice.spec.js
+++ b/contribs/gmf/test/spec/services/permalinkservice.spec.js
@@ -49,13 +49,17 @@ describe('Permalink service', function() {
 
   }));
 
-  it('Should registerLayer/unregisterLayer recursively but not ol.layer.Group', function() {
+  it('Should registerLayer/unregisterLayer recursively', function() {
     expect(PermalinkService).toBeDefined();
     expect(Object.keys(PermalinkService.listenerKeys_).length).toBe(0);
 
     PermalinkService.registerDataLayerGroup_(map);
     firstLevelGroup.getLayers().forEach(shouldHaveBeenRegistered);
     secondLevelGroup.getLayers().forEach(shouldHaveBeenRegistered);
+
+    // try to add a new layer to a group and check that the new one is registered
+    firstLevelGroup.getLayers().push(LayerHelper.createBasicWMSLayer('', 'l_g1_3'));
+    firstLevelGroup.getLayers().forEach(shouldHaveBeenRegistered);
 
     PermalinkService.unregisterLayer_(dataGroup);
     firstLevelGroup.getLayers().forEach(shouldHaveBeenUnRegistered);
@@ -64,22 +68,14 @@ describe('Permalink service', function() {
     function shouldHaveBeenRegistered(layer) {
       var uid = goog.getUid(layer),
           listeners = PermalinkService.listenerKeys_[uid];
-      if (layer instanceof ol.layer.Group) {
-        expect(listeners).toBeUndefined();
-      } else {
-        expect(listeners).toBeDefined();
-      }
+      expect(listeners).toBeDefined();
     }
 
     function shouldHaveBeenUnRegistered(layer) {
       var uid = goog.getUid(layer),
           listeners = PermalinkService.listenerKeys_[uid];
-      if (layer instanceof ol.layer.Group) {
-        expect(listeners).toBeUndefined();
-      } else {
-        expect(PermalinkService.listenerKeys_[uid].ol.length).toBe(0);
-        expect(PermalinkService.listenerKeys_[uid].goog.length).toBe(0);
-      }
+      expect(PermalinkService.listenerKeys_[uid].ol.length).toBe(0);
+      expect(PermalinkService.listenerKeys_[uid].goog.length).toBe(0);
     }
 
   });


### PR DESCRIPTION
The moment the group layer for mixed layers is registered with the permalink service, the group does not have any layers yet. They are only added later when the directive in the layer tree is compiled (?).

By setting up a listener on the layer collection of each group layer, all layers can be registered.

Closes https://github.com/camptocamp/ngeo/issues/1163