### PR TITLE
Fix OL3 version (previous no longer exist due to push --force)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "less-plugin-autoprefix": "1.5.1",
     "less-plugin-clean-css": "1.5.1",
     "nomnom": "1.8.1",
-    "openlayers": "fredj/ol3#afb2084",
+    "openlayers": "fredj/ol3#b49546d2af8e665c35cda5e3563aaa13295b8cb7",
     "phantomjs-prebuilt": "2.1.7",
     "proj4": "2.3.14",
     "temp": "0.8.3",

--- a/src/services/featureoverlay.js
+++ b/src/services/featureoverlay.js
@@ -10,7 +10,6 @@ goog.require('ol.Feature');
 goog.require('ol.layer.Vector');
 goog.require('ol.source.Vector');
 goog.require('ol.style.Style');
-goog.require('ol.style.StyleFunction');
 
 
 /**


### PR DESCRIPTION
This PR fixes the current issue with OL3 version used.  The previous commit no longer exists probably due to a `git push --force`.