### PR TITLE
#1178 improvements (todo items only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "less-plugin-autoprefix": "1.5.1",
     "less-plugin-clean-css": "1.5.1",
     "nomnom": "1.8.1",
-    "openlayers": "fredj/ol3#afb2084",
+    "openlayers": "fredj/ol3#b49546d2af8e665c35cda5e3563aaa13295b8cb7",
     "phantomjs-prebuilt": "2.1.7",
     "proj4": "2.3.14",
     "temp": "0.8.3",

--- a/src/ol-ext/interaction/measure.js
+++ b/src/ol-ext/interaction/measure.js
@@ -5,6 +5,7 @@ goog.provide('ngeo.interaction.Measure');
 goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.dom.classlist');
+goog.require('goog.i18n.NumberFormat');
 goog.require('ol.Feature');
 goog.require('ol.MapBrowserEvent');
 goog.require('ol.Overlay');
@@ -231,6 +232,8 @@ goog.inherits(ngeo.interaction.Measure, ol.interaction.Interaction);
  */
 ngeo.interaction.Measure.getFormattedArea = function(
     polygon, projection, decimals) {
+  var numberFormat = new goog.i18n.NumberFormat(
+      goog.i18n.NumberFormat.Format.DECIMAL);
   var geom = /** @type {ol.geom.Polygon} */ (
       polygon.clone().transform(projection, 'EPSG:4326'));
   var coordinates = geom.getLinearRing(0).getCoordinates();
@@ -238,17 +241,19 @@ ngeo.interaction.Measure.getFormattedArea = function(
   var output;
   if (area > 1000000) {
     if (decimals !== null) {
-      output = goog.string.padNumber(area / 1000000, 0, decimals);
+      output = parseFloat(goog.string.padNumber(area / 1000000, 0, decimals));
     } else {
       output = parseFloat((area / 1000000).toPrecision(3));
     }
+    output = numberFormat.format(output);
     output += ' ' + 'km²';
   } else {
     if (decimals !== null) {
-      output = goog.string.padNumber(area, 0, decimals);
+      output = parseFloat(goog.string.padNumber(area, 0, decimals));
     } else {
       output = parseFloat(area.toPrecision(3));
     }
+    output = numberFormat.format(output);
     output += ' ' + 'm²';
   }
   return output;
@@ -265,21 +270,25 @@ ngeo.interaction.Measure.getFormattedArea = function(
  */
 ngeo.interaction.Measure.getFormattedCircleArea = function(
     circle, decimals) {
+  var numberFormat = new goog.i18n.NumberFormat(
+      goog.i18n.NumberFormat.Format.DECIMAL);
   var area = Math.PI * Math.pow(circle.getRadius(), 2);
   var output;
   if (area > 1000000) {
     if (decimals !== null) {
-      output = goog.string.padNumber(area / 1000000, 0, decimals);
+      output = parseFloat(goog.string.padNumber(area / 1000000, 0, decimals));
     } else {
       output = parseFloat((area / 1000000).toPrecision(3));
     }
+    output = numberFormat.format(output);
     output += ' ' + 'km²';
   } else {
     if (decimals !== null) {
-      output = goog.string.padNumber(area, 0, decimals);
+      output = parseFloat(goog.string.padNumber(area, 0, decimals));
     } else {
       output = parseFloat(area.toPrecision(3));
     }
+    output = numberFormat.format(output);
     output += ' ' + 'm²';
   }
   return output;
@@ -297,6 +306,8 @@ ngeo.interaction.Measure.getFormattedCircleArea = function(
  */
 ngeo.interaction.Measure.getFormattedLength = function(lineString, projection,
     decimals) {
+  var numberFormat = new goog.i18n.NumberFormat(
+      goog.i18n.NumberFormat.Format.DECIMAL);
   var length = 0;
   var coordinates = lineString.getCoordinates();
   for (var i = 0, ii = coordinates.length - 1; i < ii; ++i) {
@@ -307,17 +318,19 @@ ngeo.interaction.Measure.getFormattedLength = function(lineString, projection,
   var output;
   if (length > 1000) {
     if (decimals !== null) {
-      output = goog.string.padNumber(length / 1000, 0, decimals);
+      output = parseFloat(goog.string.padNumber(length / 1000, 0, decimals));
     } else {
       output = parseFloat((length / 1000).toPrecision(3));
     }
+    output = numberFormat.format(output);
     output += ' ' + 'km';
   } else {
     if (decimals !== null) {
-      output = goog.string.padNumber(length, 0, decimals);
+      output = parseFloat(goog.string.padNumber(length, 0, decimals));
     } else {
       output = parseFloat(length.toPrecision(3));
     }
+    output = numberFormat.format(output);
     output += ' ' + 'm';
   }
   return output;

--- a/src/ol-ext/interaction/translate.js
+++ b/src/ol-ext/interaction/translate.js
@@ -117,13 +117,13 @@ ngeo.interaction.Translate.prototype.setMap = function(map) {
 
   var currentMap = this.getMap();
   if (currentMap) {
-    currentMap.removeLayer(this.vectorLayer_);
+    this.vectorLayer_.setMap(null);
   }
 
   goog.base(this, 'setMap', map);
 
   if (map) {
-    map.addLayer(this.vectorLayer_);
+    this.vectorLayer_.setMap(map);
   }
 
   this.setState_();

--- a/src/services/featureoverlay.js
+++ b/src/services/featureoverlay.js
@@ -10,7 +10,6 @@ goog.require('ol.Feature');
 goog.require('ol.layer.Vector');
 goog.require('ol.source.Vector');
 goog.require('ol.style.Style');
-goog.require('ol.style.StyleFunction');
 
 
 /**


### PR DESCRIPTION
The purpose of this PR is to fix the issues raised in #1178.

This currently has some cherry-picked fixes while #1188 isn't merged.

## What's fixed so far:

 * the length and area should be formatted (34'000 instead of 34000)
  * it's formatted `34,000`, see: https://closure-library.googlecode.com/git-history/docs/class_goog_i18n_NumberFormat.html
 * ￼ the move icon should be on top (above the feature and the label)

## Live demo

 * http://adube.github.io/ngeo/1178-improvements/examples/contribs/gmf/drawfeature.html?rl_features