### PR TITLE
UI layertree legend

### DIFF
--- a/contribs/gmf/less/desktoplayertree.less
+++ b/contribs/gmf/less/desktoplayertree.less
@@ -66,8 +66,8 @@ gmf-layertree {
   }
 
   .leaf .legend:hover {
-    cursor: pointer;
     a {
+      cursor: pointer;
       display: inline-block;
     }
   }

--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -186,17 +186,20 @@
   .legend {
     margin-left: @app-margin + @half-app-margin;
     position: relative;
+    border: 1px solid @main-bg-color;
     background-color: lighten(@main-bg-color, 8%);
     a {
       display: none;
       position: absolute;
-      color: @brand-info;
       right: @half-app-margin;
-      text-decoration: underline;
-      font-size: 10;
+      font-size: 1.1rem;
 
       &::before {
         display: none;
+      }
+
+      &:hover {
+        text-decoration: underline;
       }
     }
   }


### PR DESCRIPTION
Following @pgiraud advices on issue: #1115
- "hide legend" link a is bit smaller,
- Use "@link-color" for the "hide legend" link
- pointer cursor only on the "hide legend" link

demo: https://oliviersemet.github.io/ngeo/pr-layertree-ui-improvement/examples/contribs/gmf/apps/desktop/index.html

@pgiraud @ybolognini @sbrunner 