### PR TITLE
Use node.metadata.legendImage by default

### DIFF
--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -675,6 +675,10 @@ gmf.LayertreeController.prototype.getLegendURL = function(treeCtrl) {
     return null;
   }
 
+  if (node.metadata['legendImage']) {
+    return node.metadata['legendImage'];
+  }
+
   var layer = treeCtrl.layer;
   if (node.type === 'WMTS' && goog.isDefAndNotNull(layer)) {
     goog.asserts.assertInstanceof(layer, ol.layer.Tile);


### PR DESCRIPTION
Close #1086
@ger-benjamin @sbrunner  those little changes do the work?
For now there is no node in the layertree with the metadata attribut legendImage for testing.
