### PR TITLE
Dismiss popover if a drag and drop event occurs

### DIFF
--- a/src/directives/popover.js
+++ b/src/directives/popover.js
@@ -41,7 +41,7 @@ ngeo.popoverDirective = function() {
       ngeoPopoverCtrl.anchorElm.on('inserted.bs.popover', function() {
         ngeoPopoverCtrl.bodyElm.show();
         ngeoPopoverCtrl.shown = true;
-        ngeoPopoverCtrl.bodyElm.parent().on('click', function(e) {
+        ngeoPopoverCtrl.bodyElm.parent().on('mousedown', function(e) {
           e.stopPropagation();
         });
       });
@@ -129,16 +129,16 @@ ngeo.PopoverController = function($scope) {
    */
   this.bodyElm = undefined;
 
-  function onClick(clickEvent) {
+  function onMouseDown(clickEvent) {
     if (this.anchorElm[0] !== clickEvent.target && this.shown) {
       this.dismissPopover();
     }
   }
 
-  angular.element('body').on('click', onClick.bind(this));
+  angular.element('body').on('mousedown', onMouseDown.bind(this));
 
   $scope.$on('$destroy', function() {
-    angular.element('body').off('click', onClick);
+    angular.element('body').off('mousedown', onMouseDown);
   });
 };
 


### PR DESCRIPTION
Here is the issue. The dragListGroup component (from closure and used by the ngeo sortable directive) listen on a 'mousdown' event. When the event occurs, the component clone the node (in our case a gmf-Layertree node). So the DOM element dragged is a clone.

Definition of a click event:

> The click event is fired when a pointing device button (usually a mouse button) is pressed and released on a single element. 

Therefore when the device button is released, the element behind the pointer is not the same as when the mousdown event occurred. So neither the original element nor the cloned one won't trigger a click event.

That's why the click event do not occur and will never occur. 
We can't use a clic event.

@pgiraud @fredj Let me know if you think I missed something

Demo: https://oliviersemet.github.io/ngeo/pr-dismiss-popover-on-drag-and-drop-event/examples/contribs/gmf/apps/desktop/index.html

source: [click definition](https://developer.mozilla.org/fr/docs/Web/Events/click)