### PR TITLE
Add ngeo.Notification service (with example)

### DIFF
--- a/examples/notification.html
+++ b/examples/notification.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>Notification service example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link href="../node_modules/bootstrap/dist/css/bootstrap.css"
+          rel="stylesheet" type="text/css">
+    <style>
+      .buttons {
+        width: 300px;
+      }
+      .buttons .btn {
+        margin: 0 0 5px 0;
+      }
+      .ngeo-notification {
+        left: 50%;
+        margin: 0 0 0 -100px;
+        position: absolute;
+        top: 0;
+        width: 200px;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <p id="desc">
+      This example shows how to use the <code>ngeo-notification</code>
+      service to display all sorts of messages. By default, those are
+      displayed at a specific location, but you can define where to
+      display the messages. You can also define all sorts of options:
+      the type of message, the delay, etc.
+    </p>
+    <div class="buttons">
+      <button
+          ng-click="ctrl.notification.success('A success message')"
+          title="Displays a single success message using default options."
+          type="button"
+          class="btn btn-success">Success</button>
+      <button
+          ng-click="ctrl.notification.info('An information')"
+          title="Displays a single info message using default options."
+          type="button"
+          class="btn btn-info">Info</button>
+      <button
+          ng-click="ctrl.notification.warn('A warning')"
+          title="Displays a single warning message using default options."
+          type="button"
+          class="btn btn-warning">Warning</button>
+      <button
+          ng-click="ctrl.notification.error('An error')"
+          title="Displays a single error message using default options."
+          type="button"
+          class="btn btn-danger">Error</button>
+      <button
+          ng-click="ctrl.notifyMulti()"
+          title="Displays multiple messages in one call using default options."
+          type="button"
+          class="btn btn-primary">Multiple</button>
+      <button
+          ng-click="ctrl.notifyTarget()"
+          title="Displays a message in an other target."
+          type="button"
+          class="btn btn-default">Target</button>
+      <button
+          ng-click="ctrl.notifyQuick()"
+          title="Displays a message that lasts only 1 second."
+          type="button"
+          class="btn btn-default">1 sec.</button>
+      <button
+          ng-click="ctrl.notification.clear()"
+          title="Clears all messages."
+          type="button"
+          class="btn btn-danger">Clear</button>
+    </div>
+    <div id="my-messages"></div>
+    <script src="../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js">
+    </script>
+    <script src="/@?main=notification.js"></script>
+    <script src="default.js"></script>
+    <script src="../utils/watchwatchers.js"></script>
+  </body>
+</html>

--- a/examples/notification.js
+++ b/examples/notification.js
@@ -1,0 +1,90 @@
+goog.provide('notification');
+
+goog.require('ngeo');
+goog.require('ngeo.Notification');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['ngeo']);
+
+
+/**
+ * @param {ngeo.Notification} ngeoNotification Ngeo notification service.
+ * @constructor
+ */
+app.MainController = function(ngeoNotification) {
+
+  /**
+   * @type {ngeo.Notification}
+   * @export
+   */
+  this.notification = ngeoNotification;
+
+  /**
+   * @type {number}
+   * @private
+   */
+  this.i_ = 1;
+
+  // initialize tooltips
+  $('[data-toggle="tooltip"]').tooltip({
+    container: 'body',
+    trigger: 'hover'
+  });
+
+};
+
+
+/**
+ * Demonstrates how to display multiple messages at once with the notification
+ * service.
+ * @export
+ */
+app.MainController.prototype.notifyMulti = function() {
+  this.notification.notify([{
+    msg: ['Error #', this.i_++].join(''),
+    type: ngeo.NotificationType.ERROR
+  }, {
+    msg: ['Warning #', this.i_++].join(''),
+    type: ngeo.NotificationType.WARNING
+  }, {
+    msg: ['Information #', this.i_++].join(''),
+    type: ngeo.NotificationType.INFORMATION
+  }, {
+    msg: ['Success #', this.i_++].join(''),
+    type: ngeo.NotificationType.SUCCESS
+  }]);
+};
+
+
+/**
+ * Demonstrates how to display a message in an other target than the original
+ * one defined by the notification service.
+ * @export
+ */
+app.MainController.prototype.notifyTarget = function() {
+  this.notification.notify({
+    msg: 'Error in an other target',
+    target: angular.element('#my-messages'),
+    type: ngeo.NotificationType.ERROR
+  });
+};
+
+/**
+ * Demonstrates how to display a message for a specific number of seconds.
+ * @export
+ */
+app.MainController.prototype.notifyQuick = function() {
+  this.notification.notify({
+    delay: 1000,
+    msg: 'Lasts one second',
+    type: ngeo.NotificationType.SUCCESS
+  });
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -87,6 +87,48 @@ ngeox.MenuActionOptions.prototype.name;
 
 
 /**
+ * A message to display by the Ngeo notification service.
+ * @typedef {{
+ *     delay: (number|undefined),
+ *     msg: (string),
+ *     target: (angular.JQLite|Element|string|undefined),
+ *     type: (string|undefined)
+ * }}
+ */
+ngeox.Message;
+
+
+/**
+ * The delay in milliseconds the message is shown. Defaults to `7000`.
+ * @type {number|undefined}
+ */
+ngeox.Message.prototype.delay;
+
+
+/**
+ * The message text to display
+ * @type {string}
+ */
+ngeox.Message.prototype.msg;
+
+
+/**
+ * The target element (or selector to get the element) in which to display the
+ * message. If not defined, then the default target of the notification service
+ * is used.
+ * @type {angular.JQLite|Element|string|undefined}
+ */
+ngeox.Message.prototype.target;
+
+
+/**
+ * The type of message. Defaults to `info`.
+ * @type {string|undefined}
+ */
+ngeox.Message.prototype.type;
+
+
+/**
  * The options for the query service.
  * @typedef {{
  *     limit: (number|undefined),

--- a/src/services/notification.js
+++ b/src/services/notification.js
@@ -1,0 +1,300 @@
+goog.provide('ngeo.Notification');
+
+goog.require('goog.asserts');
+goog.require('ngeo');
+
+
+/**
+ * @enum {string}
+ * @export
+ */
+ngeo.NotificationType = {
+  /**
+   * @type {string}
+   * @export
+   */
+  ERROR: 'error',
+  /**
+   * @type {string}
+   * @export
+   */
+  INFORMATION: 'information',
+  /**
+   * @type {string}
+   * @export
+   */
+  SUCCESS: 'success',
+  /**
+   * @type {string}
+   * @export
+   */
+  WARNING: 'warning'
+};
+
+
+/**
+ * Provides methods to display any sort of messages, notifications, errors,
+ * etc.
+ *
+ * @constructor
+ * @param {angular.$q} $q The Angular $q service.
+ * @param {angular.$timeout} $timeout Angular timeout service.
+ * @ngdoc service
+ * @ngname ngeoNotification
+ * @ngInject
+ */
+ngeo.Notification = function($q, $timeout) {
+
+  /**
+   * @type {angular.$q}
+   * @private
+   */
+  this.q_ = $q;
+
+  /**
+   * @type {angular.$timeout}
+   * @private
+   */
+  this.timeout_ = $timeout;
+
+  var container = angular.element('<div class="ngeo-notification"></div>');
+  angular.element(document.body).append(container);
+
+  /**
+   * @type {angular.JQLite}
+   * @private
+   */
+  this.container_ = container;
+
+  /**
+   * @type {Object.<number, ngeo.Notification.CacheItem>}
+   * @private
+   */
+  this.cache_ = {};
+
+};
+
+
+/**
+ * Default delay (in milliseconds) a message should be displayed.
+ * @type {number}
+ * @private
+ */
+ngeo.Notification.DEFAULT_DELAY_ = 7000;
+
+
+// MAIN API METHODS
+
+
+/**
+ * Display the given message string or object or list of message strings or
+ * objects.
+ * @param {string|Array.<string>|ngeox.Message|Array.<ngeox.Message>}
+ *     object A message or list of messages as text or configuration objects.
+ * @export
+ */
+ngeo.Notification.prototype.notify = function(object) {
+  var msgObjects = this.getMessageObjects_(object);
+  msgObjects.forEach(this.notifyMessage_, this);
+};
+
+
+/**
+ * Clears all messages that are currently being shown.
+ * @export
+ */
+ngeo.Notification.prototype.clear = function() {
+  for (var uid in this.cache_) {
+    this.clearMessageByCacheItem_(this.cache_[parseInt(uid, 10)]);
+  }
+};
+
+
+// SHORTCUT METHODS
+
+
+/**
+ * Display the given error message or list of error messages.
+ * @param {string|Array.<string>} message Message or list of messages.
+ * @export
+ */
+ngeo.Notification.prototype.error = function(message) {
+  this.notify(this.getMessageObjects_(
+      message, ngeo.NotificationType.ERROR));
+};
+
+
+/**
+ * Display the given info message or list of info messages.
+ * @param {string|Array.<string>} message Message or list of messages.
+ * @export
+ */
+ngeo.Notification.prototype.info = function(message) {
+  this.notify(this.getMessageObjects_(
+      message, ngeo.NotificationType.INFORMATION));
+};
+
+
+/**
+ * Display the given success message or list of success messages.
+ * @param {string|Array.<string>} message Message or list of messages.
+ * @export
+ */
+ngeo.Notification.prototype.success = function(message) {
+  this.notify(this.getMessageObjects_(
+      message, ngeo.NotificationType.SUCCESS));
+};
+
+
+/**
+ * Display the given warning message or list of warning messages.
+ * @param {string|Array.<string>} message Message or list of messages.
+ * @export
+ */
+ngeo.Notification.prototype.warn = function(message) {
+  this.notify(this.getMessageObjects_(
+      message, ngeo.NotificationType.WARNING));
+};
+
+
+// UTILITY METHODS
+
+
+/**
+ * Display the message.
+ * @param {ngeox.Message} message Message.
+ * @private
+ */
+ngeo.Notification.prototype.notifyMessage_ = function(message) {
+  var type = message.type;
+  goog.asserts.assertString(type, 'Type should be set.');
+
+  var classNames = ['alert', 'fade'];
+  switch (type) {
+    case ngeo.NotificationType.ERROR:
+      classNames.push('alert-danger');
+      break;
+    case ngeo.NotificationType.INFORMATION:
+      classNames.push('alert-info');
+      break;
+    case ngeo.NotificationType.SUCCESS:
+      classNames.push('alert-success');
+      break;
+    case ngeo.NotificationType.WARNING:
+      classNames.push('alert-warning');
+      break;
+    default:
+      break;
+  }
+
+  var el = angular.element('<div class="' + classNames.join(' ') + '"></div>');
+  var container;
+
+  if (message.target) {
+    container = angular.element(message.target);
+  } else {
+    container = this.container_;
+  }
+
+  container.append(el);
+  el.html(message.msg).addClass('in');
+
+  var delay = message.delay !== undefined ? message.delay :
+      ngeo.Notification.DEFAULT_DELAY_;
+
+  var item = /** @type {ngeo.Notification.CacheItem} */ ({
+    el: el
+  });
+
+  // Keep a reference to the promise, in case we want to manually cancel it
+  // before the delay
+  var uid = goog.getUid(el);
+  item.promise = this.timeout_(function() {
+    el.alert('close');
+    delete this.cache_[uid];
+  }.bind(this), delay);
+
+  this.cache_[uid] = item;
+};
+
+
+/**
+ * Clear a message using its cache item.
+ * @param {ngeo.Notification.CacheItem} item Cache item.
+ * @private
+ */
+ngeo.Notification.prototype.clearMessageByCacheItem_ = function(item) {
+  var el = item.el;
+  var promise = item.promise;
+  var uid = goog.getUid(el);
+
+  // Close the message
+  el.alert('close');
+
+  // Cancel timeout in case we want to stop before delay. If called by the
+  // timeout itself, then this has no consequence.
+  this.timeout_.cancel(promise);
+
+  // Delete the cache item
+  delete this.cache_[uid];
+};
+
+
+/**
+ * Returns an array of message object from any given message string, list of
+ * message strings, message object or list message objects. The type can be
+ * overriden here as well OR defined (if the message(s) is/are string(s),
+ * defaults to 'information').
+ * @param {string|Array.<string>|ngeox.Message|Array.<ngeox.Message>}
+ *     object A message or list of messages as text or configuration objects.
+ * @param {string=} opt_type The type of message to override the messages with.
+ * @return {Array.<ngeox.Message>} List of message objects.
+ * @private
+ */
+ngeo.Notification.prototype.getMessageObjects_ = function(object, opt_type) {
+  var msgObjects = [];
+  var msgObject = null;
+  var defaultType = ngeo.NotificationType.INFORMATION;
+
+  if (typeof object === 'string') {
+    msgObjects.push({
+      msg: object,
+      type: opt_type !== undefined ? opt_type : defaultType
+    });
+  } else if (goog.isArray(object)) {
+    object.forEach(function(msg) {
+      if (typeof object === 'string') {
+        msgObject = {
+          msg: msg,
+          type: opt_type !== undefined ? opt_type : defaultType
+        };
+      } else {
+        msgObject = msg;
+        if (opt_type !== undefined) {
+          msgObject.type = opt_type;
+        }
+      }
+      msgObjects.push(msgObject);
+    }, this);
+  } else {
+    msgObject = object;
+    if (opt_type !== undefined) {
+      msgObject.type = opt_type;
+    }
+    msgObjects.push(msgObject);
+  }
+
+  return msgObjects;
+};
+
+
+/**
+ * @typedef {{
+ *     el: angular.JQLite,
+ *     promise: angular.$q.Promise
+ * }}
+ */
+ngeo.Notification.CacheItem;
+
+
+ngeo.module.service('ngeoNotification', ngeo.Notification);


### PR DESCRIPTION
This PR introduces the `ngeo.Notification` service. With it, one can display:

 * [x] any sort of boostrap messages (error, warning, information, success)
 * [x] define the delay of a message (defaults to 7000ms)
 * [x] define a specific target where to show the message, defaults is the container created by the service itself
 * [x] display any number of messages of any types and any configuration in a single call
 * [x] clear existing messages at any time

## Todo

 * [ ] Review
 * [ ] Apply reviewer's comments & required fixes

## Live demo

 * http://adube.github.io/ngeo/ngeo-notification/examples/notification.html