### PR TITLE
Opacity slider must no be displayed for non-mixed nodes

### DIFF
--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -25,11 +25,11 @@
     <a href="" ng-if="::layertreeCtrl.depth == 1" ng-click="gmfLayertreeCtrl.removeNode(layertreeCtrl.node)">
       <span class="fa fa-trash"></span>
     </a>
-    <span ngeo-popover ng-if="!layertreeCtrl.node.mixed" ngeo-popover-dismiss=".content">
+    <span ngeo-popover ng-if="::(layertreeCtrl.depth === 1 && !layertreeCtrl.node.mixed) || (layertreeCtrl.depth > 1 && layertreeCtrl.parent.node.mixed) || (gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend)" ngeo-popover-dismiss=".content">
       <span ngeo-popover-anchor class="extra-actions fa fa-cog"></span>
       <div ngeo-popover-content>
         <ul>
-          <li>
+          <li ng-if="::(layertreeCtrl.depth === 1 && !layertreeCtrl.node.mixed) || (layertreeCtrl.depth > 1 && layertreeCtrl.parent.node.mixed)">
             <i class="fa fa-tint fa-fw"></i>
             <!-- TODO : use filter to translate Opacity -->
             <span for="layer-opactity">Opacity</span>


### PR DESCRIPTION
Fix #1217 

demo: https://oliviersemet.github.io/ngeo/fix-1217-opacity-slider-not-revelant-for-nodes-in-non-mixed-group/examples/contribs/gmf/apps/desktop/index.html

@pgiraud 