### PR TITLE
Use notification service in mobile geolocation

### DIFF
--- a/examples/mobilegeolocation.html
+++ b/examples/mobilegeolocation.html
@@ -16,6 +16,13 @@
       button[ngeo-mobile-geolocation]:after {
         content: 'Toggle tracking'
       }
+      .ngeo-notification {
+        left: 50%;
+        margin: 0 0 0 -100px;
+        position: absolute;
+        top: 0;
+        width: 200px;
+      }
     </style>
   </head>
   <body ng-controller="MainController as ctrl">
@@ -32,6 +39,7 @@
     </div>
     <script src="../node_modules/jquery/dist/jquery.js"></script>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>
     <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=mobilegeolocation.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/examples/mobilegeolocation.js
+++ b/examples/mobilegeolocation.js
@@ -66,11 +66,6 @@ app.MainController = function($scope, ngeoFeatureOverlayMgr) {
   });
 
   ngeoFeatureOverlayMgr.init(this.map);
-
-  $scope.$on(ngeo.MobileGeolocationEventType.ERROR, function(event, error) {
-    event.stopPropagation();
-    alert('Geo-location failed');
-  }.bind(this));
 };
 
 

--- a/src/directives/mobilegeolocation.js
+++ b/src/directives/mobilegeolocation.js
@@ -5,6 +5,7 @@ goog.require('ngeo');
 goog.require('ngeo.DecorateGeolocation');
 goog.require('ngeo.FeatureOverlay');
 goog.require('ngeo.FeatureOverlayMgr');
+goog.require('ngeo.Notification');
 goog.require('ol.Feature');
 goog.require('ol.Geolocation');
 goog.require('ol.Map');
@@ -65,13 +66,14 @@ ngeo.module.directive('ngeoMobileGeolocation', ngeo.mobileGeolocationDirective);
  *     Geolocation service.
  * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *     overlay manager service.
+ * @param {ngeo.Notification} ngeoNotification Ngeo notification service.
  * @export
  * @ngInject
  * @ngdoc controller
  * @ngname NgeoMobileGeolocationController
  */
 ngeo.MobileGeolocationController = function($scope, $element,
-    ngeoDecorateGeolocation, ngeoFeatureOverlayMgr) {
+    ngeoDecorateGeolocation, ngeoFeatureOverlayMgr, ngeoNotification) {
 
   $element.on('click', this.toggleTracking.bind(this));
 
@@ -94,6 +96,12 @@ ngeo.MobileGeolocationController = function($scope, $element,
   goog.asserts.assertObject(options);
 
   /**
+   * @type {ngeo.Notification}
+   * @private
+   */
+  this.notification_ = ngeoNotification;
+
+  /**
    * @type {ngeo.FeatureOverlay}
    * @private
    */
@@ -110,6 +118,7 @@ ngeo.MobileGeolocationController = function($scope, $element,
   // handle geolocation error.
   this.geolocation_.on('error', function(error) {
     this.untrack_();
+    this.notification_.error(error.message);
     $scope.$emit(ngeo.MobileGeolocationEventType.ERROR, error);
   }, this);
 
@@ -242,6 +251,7 @@ ngeo.MobileGeolocationController.prototype.untrack_ = function() {
   this.featureOverlay_.clear();
   this.follow_ = false;
   this.geolocation_.setTracking(false);
+  this.notification_.clear();
 };
 
 

--- a/src/services/notification.js
+++ b/src/services/notification.js
@@ -34,7 +34,8 @@ ngeo.NotificationType = {
 
 /**
  * Provides methods to display any sort of messages, notifications, errors,
- * etc.
+ * etc. Requires Bootstrap library (both CSS and JS) to display the alerts
+ * properly.
  *
  * @constructor
  * @param {angular.$timeout} $timeout Angular timeout service.


### PR DESCRIPTION
This PR introduces the usability of the `ngeo.Notification` service within the `ngeo.MobileGeolocation` directive. Instead of listening to the event and manage the errors at the application level, those are now managed directly in the geolocation service.

## Todo

 * [ ] review

## Live example

After clicking the "Toggle tracking" button, when the browser asks to share your location, choose "Block".  You'll see the error message being displayed.

 * https://adube.github.io/ngeo/notification-on-geolocation-failure/examples/mobilegeolocation.html