### PR TITLE
Use notification service in desktop geolocation

### DIFF
--- a/examples/desktopgeolocation.html
+++ b/examples/desktopgeolocation.html
@@ -16,6 +16,13 @@
       button[ngeo-desktop-geolocation]:after {
         content: 'Toggle'
       }
+      .ngeo-notification {
+        left: 50%;
+        margin: 0 0 0 -100px;
+        position: absolute;
+        top: 0;
+        width: 200px;
+      }
     </style>
   </head>
   <body ng-controller="MainController as ctrl">
@@ -32,6 +39,7 @@
     </div>
     <script src="../node_modules/jquery/dist/jquery.js"></script>
     <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>
     <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=desktopgeolocation.js"></script>
     <script src="../utils/watchwatchers.js"></script>

--- a/examples/desktopgeolocation.js
+++ b/examples/desktopgeolocation.js
@@ -66,11 +66,6 @@ app.MainController = function($scope, ngeoFeatureOverlayMgr) {
   });
 
   ngeoFeatureOverlayMgr.init(this.map);
-
-  $scope.$on(ngeo.DesktopGeolocationEventType.ERROR, function(event, error) {
-    event.stopPropagation();
-    alert('Geo-location failed');
-  }.bind(this));
 };
 
 

--- a/src/directives/desktopgeolocation.js
+++ b/src/directives/desktopgeolocation.js
@@ -5,6 +5,7 @@ goog.require('ngeo');
 goog.require('ngeo.DecorateGeolocation');
 goog.require('ngeo.FeatureOverlay');
 goog.require('ngeo.FeatureOverlayMgr');
+goog.require('ngeo.Notification');
 goog.require('ol.Feature');
 goog.require('ol.Geolocation');
 goog.require('ol.Map');
@@ -63,18 +64,18 @@ ngeo.module.directive('ngeoDesktopGeolocation',
  * @constructor
  * @param {angular.Scope} $scope The directive's scope.
  * @param {angular.JQLite} $element Element.
-
  * @param {ngeo.DecorateGeolocation} ngeoDecorateGeolocation Decorate
  *     Geolocation service.
  * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *     overlay manager service.
+ * @param {ngeo.Notification} ngeoNotification Ngeo notification service.
  * @export
  * @ngInject
  * @ngdoc controller
  * @ngname NgeoDesktopGeolocationController
  */
 ngeo.DesktopGeolocationController = function($scope, $element,
-    ngeoDecorateGeolocation, ngeoFeatureOverlayMgr) {
+    ngeoDecorateGeolocation, ngeoFeatureOverlayMgr, ngeoNotification) {
 
   $element.on('click', this.toggle.bind(this));
 
@@ -97,6 +98,12 @@ ngeo.DesktopGeolocationController = function($scope, $element,
   this.$scope_ = $scope;
 
   /**
+   * @type {ngeo.Notification}
+   * @private
+   */
+  this.notification_ = ngeoNotification;
+
+  /**
    * @type {ngeo.FeatureOverlay}
    * @private
    */
@@ -113,6 +120,7 @@ ngeo.DesktopGeolocationController = function($scope, $element,
   // handle geolocation error.
   this.geolocation_.on('error', function(error) {
     this.deactivate_();
+    this.notification_.error(error.message);
     $scope.$emit(ngeo.DesktopGeolocationEventType.ERROR, error);
   }, this);
 
@@ -198,6 +206,7 @@ ngeo.DesktopGeolocationController.prototype.activate_ = function() {
 ngeo.DesktopGeolocationController.prototype.deactivate_ = function() {
   this.featureOverlay_.clear();
   this.active_ = false;
+  this.notification_.clear();
 };
 
 

--- a/src/directives/desktopgeolocation.js
+++ b/src/directives/desktopgeolocation.js
@@ -64,7 +64,6 @@ ngeo.module.directive('ngeoDesktopGeolocation',
  * @constructor
  * @param {angular.Scope} $scope The directive's scope.
  * @param {angular.JQLite} $element Element.
- * @param {angularGettext.Catalog} gettextCatalog Gettext service.
  * @param {ngeo.DecorateGeolocation} ngeoDecorateGeolocation Decorate
  *     Geolocation service.
  * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
@@ -75,7 +74,7 @@ ngeo.module.directive('ngeoDesktopGeolocation',
  * @ngdoc controller
  * @ngname NgeoDesktopGeolocationController
  */
-ngeo.DesktopGeolocationController = function($scope, $element, gettextCatalog,
+ngeo.DesktopGeolocationController = function($scope, $element,
     ngeoDecorateGeolocation, ngeoFeatureOverlayMgr, ngeoNotification) {
 
   $element.on('click', this.toggle.bind(this));
@@ -97,12 +96,6 @@ ngeo.DesktopGeolocationController = function($scope, $element, gettextCatalog,
    * @private
    */
   this.$scope_ = $scope;
-
-  /**
-   * @type {angularGettext.Catalog}
-   * @private
-   */
-  this.gettextCatalog_ = gettextCatalog;
 
   /**
    * @type {ngeo.Notification}
@@ -223,20 +216,6 @@ ngeo.DesktopGeolocationController.prototype.deactivate_ = function() {
  */
 ngeo.DesktopGeolocationController.prototype.setPosition_ = function(event) {
   var position = /** @type {ol.Coordinate} */ (this.geolocation_.getPosition());
-
-  // if user is using Firefox and selects the "not now" option, OL geolocation
-  // doesn't return an error
-  if (position === undefined) {
-    this.deactivate_();
-    this.notification_.error(
-      this.gettextCatalog_.getString(
-          'User chose not to share his or her location for now.')
-    );
-    this.$scope_.$emit(ngeo.DesktopGeolocationEventType.ERROR, null);
-    return;
-  }
-
-  goog.asserts.assert(position !== undefined);
   var point = new ol.geom.Point(position);
 
   this.positionFeature_.setGeometry(point);

--- a/src/directives/desktopgeolocation.js
+++ b/src/directives/desktopgeolocation.js
@@ -64,6 +64,7 @@ ngeo.module.directive('ngeoDesktopGeolocation',
  * @constructor
  * @param {angular.Scope} $scope The directive's scope.
  * @param {angular.JQLite} $element Element.
+ * @param {angularGettext.Catalog} gettextCatalog Gettext service.
  * @param {ngeo.DecorateGeolocation} ngeoDecorateGeolocation Decorate
  *     Geolocation service.
  * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
@@ -74,7 +75,7 @@ ngeo.module.directive('ngeoDesktopGeolocation',
  * @ngdoc controller
  * @ngname NgeoDesktopGeolocationController
  */
-ngeo.DesktopGeolocationController = function($scope, $element,
+ngeo.DesktopGeolocationController = function($scope, $element, gettextCatalog,
     ngeoDecorateGeolocation, ngeoFeatureOverlayMgr, ngeoNotification) {
 
   $element.on('click', this.toggle.bind(this));
@@ -96,6 +97,12 @@ ngeo.DesktopGeolocationController = function($scope, $element,
    * @private
    */
   this.$scope_ = $scope;
+
+  /**
+   * @type {angularGettext.Catalog}
+   * @private
+   */
+  this.gettextCatalog_ = gettextCatalog;
 
   /**
    * @type {ngeo.Notification}
@@ -221,6 +228,10 @@ ngeo.DesktopGeolocationController.prototype.setPosition_ = function(event) {
   // doesn't return an error
   if (position === undefined) {
     this.deactivate_();
+    this.notification_.error(
+      this.gettextCatalog_.getString(
+          'User chose not to share his or her location for now.')
+    );
     this.$scope_.$emit(ngeo.DesktopGeolocationEventType.ERROR, null);
     return;
   }


### PR DESCRIPTION
This PR introduces the usability of the `ngeo.Notification` service within the `ngeo.DesktopGeolocation` directive. Instead of listening to the event and manage the errors at the application level, those are now managed directly in the geolocation service.

## Todo

 * [ ] review

## Live example

After clicking the "Toggle" button, when the browser asks to share your location, choose "Block".  You'll see the error message being displayed.

 * https://adube.github.io/ngeo/notification-on-geolocation-failure-desktop/examples/desktopgeolocation.html