### PR TITLE
Use notification service in gmf authentication directive

### DIFF
--- a/contribs/gmf/src/directives/authenticationdirective.js
+++ b/contribs/gmf/src/directives/authenticationdirective.js
@@ -3,6 +3,7 @@ goog.provide('gmf.authenticationDirective');
 
 goog.require('gmf');
 goog.require('gmf.Authentication');
+goog.require('ngeo.Notification');
 /** @suppress {extraRequire} */
 goog.require('ngeo.modalDirective');
 
@@ -61,13 +62,14 @@ gmf.module.directive('gmfAuthentication', gmf.authenticationDirective);
  * @param {angular.Scope} $scope The directive's scope.
  * @param {gmf.Authentication} gmfAuthentication GMF Authentication service
  * @param {gmf.User} gmfUser User.
+ * @param {ngeo.Notification} ngeoNotification Ngeo notification service.
  * @constructor
  * @ngInject
  * @ngdoc controller
  * @ngname GmfAuthenticationController
  */
 gmf.AuthenticationController = function(gettextCatalog, $scope,
-    gmfAuthentication, gmfUser) {
+    gmfAuthentication, gmfUser, ngeoNotification) {
 
   /**
    * @type {gmf.User}
@@ -94,6 +96,12 @@ gmf.AuthenticationController = function(gettextCatalog, $scope,
   this.gmfAuthentication_ = gmfAuthentication;
 
   /**
+   * @type {ngeo.Notification}
+   * @private
+   */
+  this.notification_ = ngeoNotification;
+
+  /**
    * @type {boolean}
    * @export
    */
@@ -112,10 +120,10 @@ gmf.AuthenticationController = function(gettextCatalog, $scope,
   this.resetPasswordModalShown = false;
 
   /**
-   * @type {string}
+   * @type {boolean}
    * @export
    */
-  this.error = '';
+  this.error = false;
 
   // LOGIN form values
 
@@ -260,7 +268,19 @@ gmf.AuthenticationController.prototype.changePasswordReset = function() {
  * @private
  */
 gmf.AuthenticationController.prototype.setError_ = function(error) {
-  this.error = error;
+  if (this.error) {
+    this.resetError_();
+  }
+
+  this.error = true;
+
+  var container = angular.element('.gmf-authentication-error');
+
+  this.notification_.notify({
+    msg: error,
+    target: container,
+    type: ngeo.NotificationType.ERROR
+  });
 };
 
 
@@ -268,7 +288,8 @@ gmf.AuthenticationController.prototype.setError_ = function(error) {
  * @private
  */
 gmf.AuthenticationController.prototype.resetError_ = function() {
-  this.setError_('');
+  this.notification_.clear();
+  this.error = false;
 };
 
 

--- a/contribs/gmf/src/directives/partials/authentication.html
+++ b/contribs/gmf/src/directives/partials/authentication.html
@@ -19,7 +19,7 @@
     </div>
     <span
         ng-show="authCtrl.error"
-        class="help-block">{{ authCtrl.error }}</span>
+        class="gmf-authentication-error help-block"></span>
     <div class="form-group">
     <input
         type="button"
@@ -71,7 +71,7 @@
     </div>
     <div class="form-group">
       <span ng-show="authCtrl.error"
-            class="help-block">{{ authCtrl.error }}</span>
+            class="gmf-authentication-error help-block"></span>
     <input
         type="button"
         class="form-control btn btn-default"
@@ -137,7 +137,7 @@
     </div>
     <span
         ng-show="authCtrl.error"
-        class="help-block">{{ authCtrl.error }}</span>
+        class="gmf-authentication-error help-block"></span>
     <div class="form-group">
       <a ng-click="authCtrl.resetPassword()"
          href="">{{'Password forgotten?' | translate}}</a>


### PR DESCRIPTION
This PR introduces the usability of the `ngeo.Notification` service within the `gmf.Authentication` directive.  The message are displayed where they used to be.

## Todo

 * [ ] review

## Live example

Try:

 * login with bad credentials
 * change password with bad credentials

in this example:

 * https://adube.github.io/ngeo/notification-on-authentication-failure/examples/contribs/gmf/authentication.html