### PR TITLE
Manage search feature style

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -98,7 +98,7 @@
           class="search"
           gmf-search-datasources="mainCtrl.searchDatasources"
           gmf-search-coordinatesprojections="mainCtrl.searchCoordinatesProjections"
-          gmf-search-colorchooser="true"
+          gmf-search-colorchooser="false"
           gmf-search-clearbutton="true">
         </gmf-search>
         <div class="gmf-backgroundlayerbutton btn-group dropup">

--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -98,6 +98,7 @@
           class="search"
           gmf-search-datasources="mainCtrl.searchDatasources"
           gmf-search-coordinatesprojections="mainCtrl.searchCoordinatesProjections"
+          gmf-search-colorchooser="true"
           gmf-search-clearbutton="true">
         </gmf-search>
         <div class="gmf-backgroundlayerbutton btn-group dropup">

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -97,6 +97,7 @@
           class="search"
           gmf-search-datasources="mainCtrl.searchDatasources"
           gmf-search-coordinatesprojections="mainCtrl.searchCoordinatesProjections"
+          gmf-search-colorchooser="true"
           gmf-search-clearbutton="true">
         </gmf-search>
         <div class="gmf-backgroundlayerbutton btn-group dropup">

--- a/contribs/gmf/examples/search.html
+++ b/contribs/gmf/examples/search.html
@@ -7,9 +7,56 @@
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="mobile-web-app-capable" content="yes">
     <link rel="stylesheet" href="../../../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/font-awesome/css/font-awesome.css" type="text/css">
     <link rel="stylesheet" href="../../../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
     <link rel="stylesheet" href="../third-party/jquery-ui/jquery-ui.min.css">
     <style>
+      .palette {
+        border-collapse: separate;
+        border-spacing: 0;
+      }
+      .palette td {
+        position: relative;
+        padding: 0;
+        text-align: center;
+        vertical-align: middle;
+        font-size: 1px;
+      }
+      .palette td > div {
+        position: relative;
+        height: 12px;
+        width: 12px;
+        border: 1px solid #fff;
+        box-sizing: content-box;
+      }
+      .palette td:hover > div::after {
+        display: block;
+        content: '';
+        background: inherit;
+        position: absolute;
+        width: 28px;
+        height: 28px;
+        top: -10px;
+        left: -10px;
+        border: 2px solid #fff;
+        -webkit-box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
+        box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
+        z-index: 11;
+      }
+      .palette td.selected > div::after {
+        border: 2px solid #444;
+        margin: 0;
+        content: '';
+        display: block;
+        width: 14px;
+        height: 14px;
+        position: absolute;
+        left: -3px;
+        top: -3px;
+        box-sizing: content-box;
+        z-index: 10;
+      }
+
       gmf-map > div {
         width: 600px;
         height: 400px;
@@ -108,6 +155,7 @@
         gmf-search-map="ctrl.map"
         gmf-search-styles="ctrl.searchStyles"
         gmf-search-datasources="ctrl.searchDatasources"
+        gmf-search-colorchooser="true"
         gmf-search-clearbutton="true">
       </gmf-search>
       <p id="desc">This example shows how to use the <code>gmf-search</code> directive, which
@@ -125,6 +173,7 @@
     <script src="../../../node_modules/angular-dynamic-locale/dist/tmhDynamicLocale.js" type="text/javascript"></script>
     <script src="../../../node_modules/typeahead.js/dist/typeahead.bundle.js"></script>
     <script src="../../../node_modules/proj4/dist/proj4.js"></script>
+    <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
     <script src="/@?main=search.js"></script>
     <script src="default.js"></script>
     <script src="../../../utils/watchwatchers.js"></script>

--- a/contribs/gmf/examples/search.html
+++ b/contribs/gmf/examples/search.html
@@ -106,6 +106,7 @@
       <p>Search for « Laus » for example…<p>
       <gmf-search
         gmf-search-map="ctrl.map"
+        gmf-search-styles="ctrl.searchStyles"
         gmf-search-datasources="ctrl.searchDatasources"
         gmf-search-clearbutton="true">
       </gmf-search>

--- a/contribs/gmf/examples/search.js
+++ b/contribs/gmf/examples/search.js
@@ -7,6 +7,11 @@ goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Tile');
 goog.require('ol.source.OSM');
+goog.require('ol.style.Circle');
+goog.require('ol.style.Fill');
+goog.require('ol.style.RegularShape');
+goog.require('ol.style.Stroke');
+goog.require('ol.style.Style');
 
 
 /** @const **/
@@ -40,6 +45,21 @@ app.MainController = function(gmfThemes) {
     projection: 'EPSG:21781',
     url: 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/fulltextsearch'
   }];
+
+  var fill = new ol.style.Fill({color: [255, 255, 255, 0.6]});
+  var stroke = new ol.style.Stroke({color: [255, 0, 0, 1], width: 2});
+  /**
+   * @type {Object.<string, ol.style.Style>} Map of styles for search overlay.
+   * @export
+   */
+  this.searchStyles = {
+    'osm': new ol.style.Style({
+      fill: fill,
+      image: new ol.style.Circle({fill: fill, radius: 5, stroke: stroke}),
+      stroke: stroke
+    })
+  };
+
 
   /**
    * @type {ol.Map}

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -146,7 +146,6 @@ main {
 
 .search {
   position: absolute;
-  width: @search-width;
 
   .clear-button {
     top: 0;
@@ -164,7 +163,6 @@ main {
       left: -@app-margin!important;
       border: 1px solid @color;
       border-radius: @border-radius-base;
-      width: @search-width;
 
       .search-header {
         padding: @app-margin;

--- a/contribs/gmf/less/search.less
+++ b/contribs/gmf/less/search.less
@@ -38,6 +38,16 @@
       cursor: pointer;
     }
   }
+  .color-button {
+    width: @map-tools-size;
+    height: @map-tools-size;
+    background-color: @map-tools-bg-color;
+    border: solid 1px @border-color;
+    color: @map-tools-color;
+    &:hover {
+      background-color: @onhover-color;
+    }
+  }
   .twitter-typeahead {
     width: 100%;
   }

--- a/contribs/gmf/less/search.less
+++ b/contribs/gmf/less/search.less
@@ -6,6 +6,7 @@
 
   & > * {
     display: inline-block;
+    vertical-align: top;
   }
 
   .gmf-search {

--- a/contribs/gmf/less/search.less
+++ b/contribs/gmf/less/search.less
@@ -2,18 +2,23 @@
 
 .search {
   top: @app-margin;
-  height: @map-tools-size;
-  left: 0;
-  right: 0;
-  margin: 0 @app-margin + @map-tools-size;
-  padding: 0 @app-margin;
-  background-color: @map-tools-bg-color;
-  border: solid 0 @border-color;
-  border-width: 1px 0;
   z-index: @content-index;
-  input {
+
+  & > * {
+    display: inline-block;
+  }
+
+  .gmf-search {
+    background-color: @map-tools-bg-color;
+    border: 1px solid @border-color;
+    padding: 0 @app-margin;
     height: @map-tools-size;
-    font-size: 1.4rem!important;
+    position: relative;
+  }
+  // the container with border decides of search height, not the child elements
+  .twitter-typeahead,
+  input {
+    height: 100%;
   }
   // hide the native "clear x" in Edge
   input::-ms-clear {
@@ -107,16 +112,29 @@
   }
 }
 
+// Overrides for phone devices
+@media (max-width: @screen-sm-min) {
+  .search {
+    left: 0;
+    right: 0;
+    margin: 0 @app-margin + @map-tools-size;
+    .gmf-search {
+      border-width: 1px 0;
+      width: 100%;
+    }
+  }
+}
 
+@search-width: 6 * @map-tools-size;
 
 // Overrides for tablet devices
 @media (min-width: @screen-sm-min) {
-  @search-width: 6 * @map-tools-size;
   .search {
     margin: 0;
     left: 2 * @app-margin + @map-tools-size;
-    width: @search-width;
-    border-width: 1px;
+    .gmf-search {
+      width: @search-width;
+    }
     .clear-button {
       margin-right: @app-margin;
       right: 0;

--- a/contribs/gmf/src/controllers/abstractmobile.js
+++ b/contribs/gmf/src/controllers/abstractmobile.js
@@ -69,6 +69,18 @@ gmf.AbstractMobileController = function(config, $scope, $injector) {
    */
   this.searchOverlayVisible = false;
 
+  /**
+   * @type {ngeox.SearchDirectiveListeners}
+   * @export
+   */
+  this.searchListeners = /** @type {ngeox.SearchDirectiveListeners} */ ({
+    open: function() {
+      this.searchOverlayVisible = true;
+    }.bind(this),
+    close: function() {
+      this.searchOverlayVisible = false;
+    }.bind(this)
+  });
 
   var positionFeatureStyle = config.positionFeatureStyle || new ol.style.Style({
     image: new ol.style.Circle({
@@ -132,21 +144,7 @@ gmf.AbstractMobileController = function(config, $scope, $injector) {
         ol.interaction.defaults({pinchRotate: false})
   });
 
-  /**
-   * @type {ngeox.SearchDirectiveListeners}
-   * @export
-   */
-  this.searchListeners = /** @type {ngeox.SearchDirectiveListeners} */ ({
-    open: function() {
-      this.searchOverlayVisible = true;
-    }.bind(this),
-    close: function() {
-      this.searchOverlayVisible = false;
-    }.bind(this)
-  });
-
-  goog.base(
-      this, config, $scope, $injector);
+  goog.base(this, config, $scope, $injector);
 
 
   var dragEl = document.querySelector('main');

--- a/contribs/gmf/src/directives/partials/search.html
+++ b/contribs/gmf/src/directives/partials/search.html
@@ -9,10 +9,10 @@
     ng-hide="!ctrl.clearButton || ctrl.input_value == ''"
     ng-click="ctrl.onClearButton()">
   </span>
-  <span ng-show="ctrl.colorchooser && ctrl.displayColorPicker" ngeo-popover ngeo-popover-placement="bottom">
-    <button class="color-button fa fa-tint" ngeo-popover-anchor></button>
-    <div ngeo-popover-content>
-      <div ngeo-colorpicker ngeo-colorpicker-color="ctrl.color"></div>
-    </div>
-  </span>
 </div>
+<span ng-show="ctrl.colorchooser && ctrl.displayColorPicker" ngeo-popover ngeo-popover-placement="bottom">
+  <button class="color-button fa fa-tint" ngeo-popover-anchor></button>
+  <div ngeo-popover-content>
+    <div ngeo-colorpicker ngeo-colorpicker-color="ctrl.color"></div>
+  </div>
+</span>

--- a/contribs/gmf/src/directives/partials/search.html
+++ b/contribs/gmf/src/directives/partials/search.html
@@ -1,13 +1,18 @@
 <div class="gmf-search">
-<input type="text" placeholder="{{'Search…' | translate}}"
-        class="form-control"
-        ng-model="ctrl.input_value"
-        ngeo-search="ctrl.options"
-        ngeo-search-datasets="ctrl.datasets"
-        ngeo-search-listeners="ctrl.listeners">
-<span class="clear-button ng-hide"
-        ng-hide="!ctrl.clearButton || ctrl.input_value == ''"
-        ng-click="ctrl.onClearButton()">
-</span>
-<!-- <input data-ng-model="color" data-ng-change="ctrl.setStyleColor(color)"></input> Will be used later -->
+  <input type="text" placeholder="{{'Search…' | translate}}"
+    class="form-control"
+    ng-model="ctrl.input_value"
+    ngeo-search="ctrl.options"
+    ngeo-search-datasets="ctrl.datasets"
+    ngeo-search-listeners="ctrl.listeners">
+  <span class="clear-button ng-hide"
+    ng-hide="!ctrl.clearButton || ctrl.input_value == ''"
+    ng-click="ctrl.onClearButton()">
+  </span>
+  <span ng-show="ctrl.colorchooser && ctrl.displayColorPicker" ngeo-popover ngeo-popover-placement="bottom">
+    <button class="color-button fa fa-tint" ngeo-popover-anchor></button>
+    <div ngeo-popover-content>
+      <div ngeo-colorpicker ngeo-colorpicker-color="ctrl.color"></div>
+    </div>
+  </span>
 </div>

--- a/contribs/gmf/src/directives/partials/search.html
+++ b/contribs/gmf/src/directives/partials/search.html
@@ -11,7 +11,9 @@
   </span>
 </div>
 <span ng-show="ctrl.colorchooser && ctrl.displayColorPicker" ngeo-popover ngeo-popover-placement="bottom">
-  <button class="color-button fa fa-tint" ngeo-popover-anchor></button>
+  <button class="color-button fa fa-tint" ngeo-popover-anchor
+      data-toggle="tooltip"
+      data-title="{{'Change the color of the search result'|translate}}"></button>
   <div ngeo-popover-content>
     <div ngeo-colorpicker ngeo-colorpicker-color="ctrl.color"></div>
   </div>

--- a/contribs/gmf/src/directives/partials/search.html
+++ b/contribs/gmf/src/directives/partials/search.html
@@ -11,9 +11,7 @@
   </span>
 </div>
 <span ng-show="ctrl.colorchooser && ctrl.displayColorPicker" ngeo-popover ngeo-popover-placement="bottom">
-  <button class="color-button fa fa-tint" ngeo-popover-anchor
-      data-toggle="tooltip"
-      data-title="{{'Change the color of the search result'|translate}}"></button>
+  <button class="color-button fa fa-tint" ngeo-popover-anchor></button>
   <div ngeo-popover-content>
     <div ngeo-colorpicker ngeo-colorpicker-color="ctrl.color"></div>
   </div>

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -199,6 +199,12 @@ gmf.SearchController = function($scope, $compile, $timeout, gettextCatalog,
   this.ngeoCreateGeoJSONBloodhound_ = ngeoCreateGeoJSONBloodhound;
 
   /**
+   * @type {ngeo.FeatureOverlayMgr}
+   * @private
+   */
+  this.ngeoFeatureOverlayMgr = ngeoFeatureOverlayMgr;
+
+  /**
    * @type {ngeo.AutoProjection}
    * @private
    */
@@ -598,6 +604,15 @@ gmf.SearchController.prototype.getSearchStyle_ = function(feature, resolution) {
       this.styles_[feature.get('layer_name')] || this.styles_['default'];
 };
 
+/**
+ * Set a new color for the search feature style.
+ * @param {string} color The color to set.
+ * @export
+ */
+gmf.SearchController.prototype.setStyleColor = function(color) {
+  this.styles_['default'].getStroke().setColor(color);
+  this.ngeoFeatureOverlayMgr.getLayer().changed();
+};
 
 /**
  * @private

--- a/contribs/gmf/src/gmf.js
+++ b/contribs/gmf/src/gmf.js
@@ -29,5 +29,12 @@ gmf.baseTemplateUrl = 'gmf';
 
 /**
  * @const
+ * @export
  */
 gmf.DATALAYERGROUP_NAME = 'data';
+
+/**
+ * @const
+ * @export
+ */
+gmf.COORDINATES_LAYER_NAME = 'gmfCoordinatesLayerName';


### PR DESCRIPTION
replace #951 

https://github.com/camptocamp/c2cgeoportal/wiki/Specs-%23869---Color-of-search-result

without the color chooser:
 * https://fredj.github.io/ngeo/style_search_overlay/examples/contribs/gmf/apps/desktop_alt/

with the color chooser:
 * https://fredj.github.io/ngeo/style_search_overlay/examples/contribs/gmf/apps/desktop/

todo:
 - [x] change the stroke and fill color
 - [x] change all the styles, not only default
 - [x] only show the button when a feature is on the map
 - [x] deactivate in mobile
 - [x] fix button position
 - [x] hide the button on coordinate search
