### PR TITLE
Fix #977 - Use notification in all gmf authentication err

### DIFF
--- a/contribs/gmf/src/directives/partials/authentication.html
+++ b/contribs/gmf/src/directives/partials/authentication.html
@@ -42,7 +42,6 @@
           class="form-control"
           name="oldpassword"
           ng-model="authCtrl.oldPwdVal"
-          required="required"
           placeholder="{{'Old password' | translate}}"/>
     </div>
     <div class="form-group">
@@ -51,7 +50,6 @@
           class="form-control"
           name="newpassword"
           ng-model="authCtrl.newPwdVal"
-          required="required"
           placeholder="{{'New password' | translate}}"/>
     </div>
     <div class="form-group">
@@ -60,7 +58,6 @@
           class="form-control"
           name="newpasswordconfirm"
           ng-model="authCtrl.newPwdConfVal"
-          required="required"
           placeholder="{{'Confirm new password' | translate}}"/>
     </div>
     <div class="form-group">
@@ -117,7 +114,6 @@
           class="form-control"
           name="login"
           ng-model="authCtrl.loginVal"
-          required="required"
           placeholder="{{'Username' | translate}}" />
     </div>
     <div class="form-group">
@@ -126,7 +122,6 @@
           class="form-control"
           name="password"
           ng-model="authCtrl.pwdVal"
-          required="required"
           placeholder="{{'Password' | translate}}"/>
     </div>
     <div class="form-group">


### PR DESCRIPTION
This PR makes sure that all errors messages within the gmf authentication service are shown using the notification service.

## Todo

 * [ ] review

## Live example

 * https://adube.github.io/ngeo/gmf-auth-fix-login-err/examples/contribs/gmf/authentication.html