### PR TITLE
Add options to control measure labels: X, Y

### DIFF
--- a/contribs/gmf/apps/desktop/js/controller.js
+++ b/contribs/gmf/apps/desktop/js/controller.js
@@ -26,6 +26,9 @@ app.module.constant('ngeoExportFeatureFormats', [
   ngeo.FeatureHelper.FormatType.GPX
 ]);
 
+app.module.constant('ngeoMeasureLabelX', 'E');
+
+app.module.constant('ngeoMeasureLabelY', 'N');
 
 app.module.constant('ngeoQueryOptions', {
   'limit': 20

--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -26,6 +26,9 @@ app.module.constant('ngeoExportFeatureFormats', [
   ngeo.FeatureHelper.FormatType.GPX
 ]);
 
+app.module.constant('ngeoMeasureLabelX', 'E');
+
+app.module.constant('ngeoMeasureLabelY', 'N');
 
 app.module.constant('ngeoQueryOptions', {
   'limit': 20

--- a/contribs/gmf/apps/mobile/js/controller.js
+++ b/contribs/gmf/apps/mobile/js/controller.js
@@ -23,6 +23,10 @@ goog.require('ngeo.mobileGeolocationDirective');
 
 /* global app */
 
+app.module.constant('ngeoMeasureLabelX', 'E');
+
+app.module.constant('ngeoMeasureLabelY', 'N');
+
 app.module.constant('ngeoQueryOptions', {
   'limit': 20
 });

--- a/src/ol-ext/interaction/measure.js
+++ b/src/ol-ext/interaction/measure.js
@@ -329,17 +329,19 @@ ngeo.interaction.Measure.getFormattedLength = function(lineString, projection,
  * @param {ol.geom.Point} point Point.
  * @param {ol.proj.Projection} projection Projection of the line string coords.
  * @param {?number} decimals Decimals.
+ * @param {Array.<string>=} opt_labels Labels for the X and Y coordinates
  * @return {string} Formatted string of coordinate.
  */
 ngeo.interaction.Measure.getFormattedPoint = function(
-    point, projection, decimals) {
+    point, projection, decimals, opt_labels) {
+  var labels = opt_labels !== undefined ? opt_labels : ['X', 'Y'];
   var coordinates = point.getCoordinates();
   var x = coordinates[0];
   var y = coordinates[1];
   decimals = decimals !== null ? decimals : 0;
   x = goog.string.padNumber(x, 0, decimals);
   y = goog.string.padNumber(y, 0, decimals);
-  return ['X: ', x, ', Y: ', y].join('');
+  return [labels[0], ': ', x, ', ', labels[1], ': ', y].join('');
 };
 
 

--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -41,6 +41,26 @@ ngeo.FeatureHelper = function($injector) {
   }
 
   /**
+   * @type {?string}
+   * @private
+   */
+  this.measureLabelX_ = null;
+
+  if ($injector.has('ngeoMeasureLabelX')) {
+    this.measureLabelX_ = $injector.get('ngeoMeasureLabelX');
+  }
+
+  /**
+   * @type {?string}
+   * @private
+   */
+  this.measureLabelY_ = null;
+
+  if ($injector.has('ngeoMeasureLabelY')) {
+    this.measureLabelY_ = $injector.get('ngeoMeasureLabelY');
+  }
+
+  /**
    * @type {ol.proj.Projection}
    * @private
    */
@@ -606,8 +626,12 @@ ngeo.FeatureHelper.prototype.getMeasure = function(feature) {
     measure = ngeo.interaction.Measure.getFormattedLength(
       geometry, this.projection_, this.decimals_);
   } else if (geometry instanceof ol.geom.Point) {
+    var xyLabels;
+    if (this.measureLabelX_ && this.measureLabelY_) {
+      xyLabels = [this.measureLabelX_, this.measureLabelY_];
+    }
     measure = ngeo.interaction.Measure.getFormattedPoint(
-      geometry, this.projection_, this.decimals_);
+      geometry, this.projection_, this.decimals_, xyLabels);
   }
 
   return measure;


### PR DESCRIPTION
This PR introduces options to choose the labels to show instead of the default `X` and `Y` when showing point measurements, i.e. when showing coordinates.

## Todo

 * [ ] review

## Live example

 * https://adube.github.io/ngeo/measure-labels-x-y/examples/contribs/gmf/apps/desktop_alt/?lang=fr&rl_features=Fp(yff7-55hI~n*Point%25201%27c*%2523DB4436%27a*0%27o*0.2%27m*true%27s*10%27k*1)&map_x=630880&map_y=202064&map_zoom=3