### PR TITLE
Enhance ngeo.Popup, add example

### DIFF
--- a/examples/popup-service.html
+++ b/examples/popup-service.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>ngeoCreatePopup service factory example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link href="../node_modules/bootstrap/dist/css/bootstrap.css"
+          rel="stylesheet" type="text/css">
+    <style>
+      .buttons .btn {
+        margin: 0 0 5px 0;
+      }
+      .popup-with-iframe .popover-content {
+        height: calc(100% - 40px);
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <p id="desc">
+      This example shows how to use the <code>ngeoCreatePopup</code>
+      service factory to display all sorts of modals. One can display plain
+      text or display an external web page within an iframe.
+    </p>
+    <div class="buttons">
+      <button
+          ng-click="ctrl.simplePopup();"
+          title="Opens a popup with user-defined content (not using open)"
+          type="button"
+          class="btn btn-default">Simple</button>
+      <button
+          ng-click="ctrl.iframePopup();"
+          title="Opens a popup with an iframe (not using open)"
+          type="button"
+          class="btn btn-default">Iframe</button>
+      <button
+          ng-click="ctrl.heavyPopup();"
+          title="Opens a popup with lots of content (not using open)"
+          type="button"
+          class="btn btn-default">Heavy</button>
+      <button
+          ng-click="ctrl.openPopupWithContent();"
+          title="Opens a popup with user-defined content using the open method"
+          type="button"
+          class="btn btn-primary">Open</button>
+      <button
+          ng-click="ctrl.openPopupWithUrl();"
+          title="Opens a popup with an iframe using the open method"
+          type="button"
+          class="btn btn-primary">Open (iframe)</button>
+    </div>
+    <script src="../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js">
+    </script>
+    <script src="/@?main=popup-service.js"></script>
+    <script src="default.js"></script>
+    <script src="../utils/watchwatchers.js"></script>
+  </body>
+</html>

--- a/examples/popup-service.js
+++ b/examples/popup-service.js
@@ -1,0 +1,135 @@
+goog.provide('popup-service');
+
+goog.require('ngeo');
+goog.require('ngeo.CreatePopup');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['ngeo']);
+
+
+/**
+ * @param {angular.$sce} $sce Angular sce service.
+ * @param {ngeo.CreatePopup} ngeoCreatePopup Popup service.
+ * @constructor
+ */
+app.MainController = function($sce, ngeoCreatePopup) {
+
+  /**
+   * @private
+   * @type {angular.$sce}
+   */
+  this.sce_ = $sce;
+
+  /**
+   * @private
+   * @type {ngeo.CreatePopup}
+   */
+  this.createPopup_ = ngeoCreatePopup;
+
+  // initialize tooltips
+  $('[data-toggle="tooltip"]').tooltip({
+    container: 'body',
+    trigger: 'hover'
+  });
+
+};
+
+
+/**
+ * @export
+ */
+app.MainController.prototype.simplePopup = function() {
+  var popup = this.createPopup_();
+  popup.setAutoDestroy(true);
+  popup.setTitle('Simple popup');
+  var content = this.sce_.trustAsHtml('This is a simple 400x300 px popup.');
+  popup.setContent(content);
+  popup.setWidth('400px');
+  popup.setHeight('300px');
+  popup.setOpen(true);
+};
+
+
+/**
+ * @export
+ */
+app.MainController.prototype.iframePopup = function() {
+  var popup = this.createPopup_();
+  popup.setAutoDestroy(true);
+  popup.addClass('popup-with-iframe');
+  popup.setTitle('Iframe popup');
+  popup.setUrl('http://geomapfish.org/');
+  popup.setSize('400px', '300px');
+  popup.setOpen(true);
+};
+
+
+/**
+ * @export
+ */
+app.MainController.prototype.heavyPopup = function() {
+  var popup = this.createPopup_();
+  popup.setAutoDestroy(true);
+  popup.setTitle(
+    'This is a popup with lots and lots of content and a very long title');
+  var content = this.sce_.trustAsHtml(
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla eget' +
+    'quam at ex euismod bibendum et eget enim. Nulla sodales tortor ac' +
+    'sagittis aliquet. Ut malesuada quam vitae pulvinar porta. Nunc id' +
+    'magna id risus malesuada elementum eget id purus. Curabitur vel augue' +
+    'blandit, faucibus nulla quis, consequat tellus. Phasellus commodo,' +
+    'tellus et vulputate ultricies, nulla libero ornare arcu, quis' +
+    'fermentum sem diam quis tellus. Aliquam ut sapien tristique, lacinia' +
+    'ante et, lacinia arcu. Quisque sagittis eros at quam blandit' +
+    'gravida. Nulla sit amet enim semper, efficitur eros sit amet,' +
+    'porttitor libero. Fusce quis tellus est. Quisque ornare, ex eget' +
+    'luctus pharetra, nisl leo lobortis purus, sed tristique neque leo eget' +
+    'odio. Maecenas lobortis nisl ac magna mollis, ac pulvinar risus' +
+    'convallis. Donec ullamcorper sollicitudin maximus. Quisque bibendum' +
+    'elit sit amet ultrices ornare. Donec aliquam felis id urna ultrices' +
+    'scelerisque.'
+  );
+  popup.setContent(content);
+  popup.setOpen(true);
+};
+
+
+/**
+ * @export
+ */
+app.MainController.prototype.openPopupWithContent = function() {
+  var popup = this.createPopup_();
+  var content = this.sce_.trustAsHtml(
+    'This popup was opened using the <code>open</code> method.');
+  popup.open({
+    autoDestroy: true,
+    content: content,
+    height: '200px',
+    title: 'Opened with "open"',
+    width: '300px'
+  });
+};
+
+
+/**
+ * @export
+ */
+app.MainController.prototype.openPopupWithUrl = function() {
+  var popup = this.createPopup_();
+  popup.open({
+    autoDestroy: true,
+    cls: 'popup-with-iframe',
+    height: '300px',
+    title: 'Opened with "open" and "iframe"',
+    url: 'http://geomapfish.org/',
+    width: '400px'
+  });
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -137,7 +137,7 @@ ngeox.Message.prototype.type;
  *     height: (string|undefined),
  *     title: (string|undefined),
  *     url: (string|undefined),
- *     width: (string|undefined),
+ *     width: (string|undefined)
  * }}
  */
 ngeox.PopupOptions;

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -129,6 +129,71 @@ ngeox.Message.prototype.type;
 
 
 /**
+ * The options for a popup created by the popup factory.
+ * @typedef {{
+ *     autoDestroy: (boolean|undefined),
+ *     cls: (string|undefined),
+ *     content: (*|undefined),
+ *     height: (string|undefined),
+ *     title: (string|undefined),
+ *     url: (string|undefined),
+ *     width: (string|undefined),
+ * }}
+ */
+ngeox.PopupOptions;
+
+
+/**
+ * Whether the popup should be automatically destroyed when hidden or not.
+ * Defaults to `false`.
+ * @type {boolean|undefined}
+ */
+ngeox.PopupOptions.prototype.autoDestroy;
+
+
+/**
+ * Extra class name to add to the popup.
+ * @type {string|undefined}
+ */
+ngeox.PopupOptions.prototype.cls;
+
+
+/**
+ * The content of the popup. Either the content or url must be set.
+ * @type {*|undefined}
+ */
+ngeox.PopupOptions.prototype.content;
+
+
+/**
+ * The height of the popup.
+ * @type {string|undefined}
+ */
+ngeox.PopupOptions.prototype.height;
+
+
+/**
+ * The title of the popup.
+ * @type {string|undefined}
+ */
+ngeox.PopupOptions.prototype.title;
+
+
+/**
+ * The url to use for the iframe to include as content for the popup.
+ * @type {string|undefined}
+ */
+ngeox.PopupOptions.prototype.url;
+
+
+/**
+ * The width of the popup.
+ * @type {string|undefined}
+ */
+ngeox.PopupOptions.prototype.width;
+
+
+/**
  * The options for the query service.
  * @typedef {{
  *     limit: (number|undefined),

--- a/src/services/popup.js
+++ b/src/services/popup.js
@@ -31,10 +31,12 @@ ngeo.CreatePopup;
  * @constructor
  * @param {angular.$compile} $compile The compile provider.
  * @param {angular.Scope} $rootScope The rootScope provider.
+ * @param {angular.$sce} $sce Angular sce service.
+ * @param {angular.$timeout} $timeout Angular timeout service.
  * @ngdoc service
  * @ngname ngeoCreatePopup
  */
-ngeo.Popup = function($compile, $rootScope) {
+ngeo.Popup = function($compile, $rootScope, $sce, $timeout) {
 
   /**
    * The scope the compiled element is link to.
@@ -43,12 +45,44 @@ ngeo.Popup = function($compile, $rootScope) {
    */
   this.scope_ = $rootScope.$new(true);
 
+  // manage the auto destruction of the popup
+  this.scope_.$watch(
+    function() {
+      return this.scope_['open'];
+    }.bind(this),
+    function(open) {
+      if (!open && this.autoDestroy_) {
+        this.timeout_(function() {
+          this.destroy();
+        }.bind(this));
+      }
+    }.bind(this)
+  );
+
+  /**
+   * @private
+   * @type {angular.$sce}
+   */
+  this.sce_ = $sce;
+
+  /**
+   * @type {angular.$timeout}
+   * @private
+   */
+  this.timeout_ = $timeout;
+
   /**
    * The element.
    * @type {angular.JQLite}
    * @private
    */
   this.element_ = angular.element('<div ngeo-popup></div>');
+
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.autoDestroy_ = false;
 
 
   // Compile the element, link it to the scope and add it to the document.
@@ -110,18 +144,128 @@ ngeo.Popup.prototype.setContent = function(content) {
 
 
 /**
+ * Set the popup's content with an iframe using the given url.
+ * @param {string} url The url of the page.
+ * @export
+ */
+ngeo.Popup.prototype.setUrl = function(url) {
+  var content = this.sce_.trustAsHtml(
+    '<iframe src="' + url + '" width="100%" height="100%"></iframe>'
+  );
+  this.setContent(content);
+};
+
+
+/**
+ * Set the popup's width. The `max-width` is also set to override the one set
+ * by the bootstrap popover class.
+ * @param {string} width Width the popup should have.
+ * @export
+ */
+ngeo.Popup.prototype.setWidth = function(width) {
+  this.element_.width(width);
+  this.element_.css('max-width', width);
+};
+
+
+/**
+ * Set the popup's height.
+ * @param {string} height Height the popup should have.
+ * @export
+ */
+ngeo.Popup.prototype.setHeight = function(height) {
+  this.element_.height(height);
+};
+
+
+/**
+ * Set the popup's width and height.
+ * @param {string} width Width the popup should have.
+ * @param {string} height Height the popup should have.
+ * @export
+ */
+ngeo.Popup.prototype.setSize = function(width, height) {
+  this.setWidth(width);
+  this.setHeight(height);
+};
+
+
+/**
+ * Set the popup's autoDestroy property.
+ * @param {boolean} autoDestroy Whether to automatically destroy the popup when
+ *     being closed or not.
+ * @export
+ */
+ngeo.Popup.prototype.setAutoDestroy = function(autoDestroy) {
+  this.autoDestroy_ = autoDestroy;
+};
+
+
+/**
+ * Add an extra CSS class name to the popup.
+ * @param {string} cls Class name to add to the popup element.
+ * @export
+ */
+ngeo.Popup.prototype.addClass = function(cls) {
+  this.element_.addClass(cls);
+};
+
+
+/**
+ * Open a popup with the given properties.
+ * @param {ngeox.PopupOptions} options Options.
+ * @export
+ */
+ngeo.Popup.prototype.open = function(options) {
+
+  if (options.url) {
+    this.setUrl(options.url);
+  } else if (options.content) {
+    this.setContent(options.content);
+  } else {
+    goog.asserts.fail('ngeo.Popup options requirest "url" or "content".');
+  }
+
+  if (options.autoDestroy !== undefined) {
+    this.setAutoDestroy(options.autoDestroy);
+  }
+
+  if (options.cls !== undefined) {
+    this.addClass(options.cls);
+  }
+
+  if (options.height !== undefined) {
+    this.setHeight(options.height);
+  }
+
+  if (options.title !== undefined) {
+    this.setTitle(options.title);
+  }
+
+  if (options.width !== undefined) {
+    this.setWidth(options.width);
+  }
+
+  this.setOpen(true);
+};
+
+
+/**
  * @param {angular.$compile} $compile Angular compile service.
  * @param {angular.Scope} $rootScope Angular rootScope service.
+ * @param {angular.$sce} $sce Angular sce service.
+ * @param {angular.$timeout} $timeout Angular timeout service.
  * @return {ngeo.CreatePopup} The function to create a popup.
  * @ngInject
  */
-ngeo.createPopupServiceFactory = function($compile, $rootScope) {
+ngeo.createPopupServiceFactory = function($compile, $rootScope, $sce,
+    $timeout) {
   return (
       /**
        * @return {!ngeo.Popup} The popup instance.
        */
       function() {
-        return new ngeo.Popup($compile, $rootScope);
+        return new ngeo.Popup($compile, $rootScope, $sce, $timeout);
       });
 };
 ngeo.module.factory('ngeoCreatePopup', ngeo.createPopupServiceFactory);


### PR DESCRIPTION
This PR introduces new methods in the `ngeo.Popup`:

 * `setUrl`: set the content as iframe using an url
 * `setWidth`, `setHeight` and `setSize`: forces the popup to use the defined size
 * `addClass`: add an extra CSS class name to allow more customization of popups
 * `setAutoDestroy`: when set, the popup gets automatically destroyed when closed, which is useful to do some automatic cleanup.
 * `open`: a single method from which one can quickly and easily open a new popup with properties set in an object of options.  It is an alternative to calling each other methods separately.

It also introduces an example to show what's possible to do with the popup factory.

## Todo

 * [ ] review

## Live example

 * http://adube.github.io/ngeo/window-with-iframe/examples/popup-service.html