### PR TITLE
Add a notification on adding a group that is already in the tree

### DIFF
--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -602,8 +602,6 @@ gmf.SearchController.select_ = function(event, feature, dataset) {
       if (actionName == 'add_theme') {
         this.gmfTreeManager_.addThemeByName(actionData);
       } else if (actionName == 'add_group') {
-        // FIXME: Display "this group is already loaded" (Issue also in the
-        // treemanager service).
         this.gmfTreeManager_.addGroupByName(actionData, true);
       } else if (actionName == 'add_layer' &&
             groupActions.indexOf('add_layer') >= 0) {


### PR DESCRIPTION
Fix: https://github.com/camptocamp/c2cgeoportal/issues/1710
(Fix the last point `missing: Showing a message when a group is already loaded`)

Example: https://ger-benjamin.github.io/ngeo/groupAlreadyLoaded/examples/contribs/gmf/apps/desktop_alt
