### PR TITLE
Add ngeo-disclaimer service and example

### DIFF
--- a/contribs/gmf/src/directives/authenticationdirective.js
+++ b/contribs/gmf/src/directives/authenticationdirective.js
@@ -317,7 +317,7 @@ gmf.AuthenticationController.prototype.setError_ = function(errors) {
     this.notification_.notify({
       msg: error,
       target: container,
-      type: ngeo.NotificationType.ERROR
+      type: ngeo.MessageType.ERROR
     });
   }, this);
 };

--- a/examples/disclaimer.html
+++ b/examples/disclaimer.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>Disclaimer example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
+    <link href="../node_modules/bootstrap/dist/css/bootstrap.css"
+          rel="stylesheet" type="text/css">
+    <style>
+      #map {
+        width: 600px;
+        height: 400px;
+      }
+      .ngeo-disclaimer {
+        left: 50%;
+        margin: 0 0 0 -15rem;
+        position: absolute;
+        top: 0;
+        width: 30rem;
+      }
+      #disclaimers-in-map {
+        position: absolute;
+        bottom: 0.5rem;
+        left: 0.5rem;
+        width: 30rem;
+      }
+      #disclaimers-in-map .alert {
+        padding: 0.5rem 1rem;
+        margin: 0 0 0.5rem 0;
+      }
+      #disclaimers-in-map .alert-dismissable .close,
+      #disclaimers-in-map .alert-dismissible .close {
+        right: -5px;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <div style="position:relative;">
+      <div id="map" ngeo-map="ctrl.map"></div>
+      <div id="disclaimers-in-map"></div>
+    </div>
+    <p id="desc">
+      This example shows how to use the <code>ngeo-disclaimer</code>
+      service to show dismissable messages. Only one unique message
+      per type may be displayed at a time, i.e. 2 different "success"
+      messages may be displayed, but not twice the same one. The same
+      message can be displayed one in "success" the other "info", for
+      example.
+    </p>
+    <div class="buttons">
+      <button
+          ng-click="ctrl.disclaimer.success('Disclaimer with success style')"
+          title="Displays a disclaimer success message using default options."
+          type="button"
+          class="btn btn-success">Success</button>
+      <button
+          ng-click="ctrl.disclaimer.info('Disclaimer with information style')"
+          title="Displays a disclaimer info message using default options."
+          type="button"
+          class="btn btn-info">Info</button>
+      <button
+          ng-click="ctrl.disclaimer.warn('Disclaimer with warning style')"
+          title="Displays a disclaimer warning message using default options."
+          type="button"
+          class="btn btn-warning">Warning</button>
+      <button
+          ng-click="ctrl.disclaimer.error('Disclaimer with error style')"
+          title="Displays a disclaimer error message using default options."
+          type="button"
+          class="btn btn-danger">Error</button>
+      <button
+          ng-click="ctrl.inMap()"
+          title="Displays multiple disclaimer messages inside the map."
+          type="button"
+          class="btn btn-default">In Map</button>
+    </div>
+
+    <script src="../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="/@?main=disclaimer.js"></script>
+    <script src="default.js"></script>
+    <script src="../utils/watchwatchers.js"></script>
+  </body>
+</html>

--- a/examples/disclaimer.js
+++ b/examples/disclaimer.js
@@ -1,0 +1,78 @@
+goog.provide('disclaimer');
+
+goog.require('ngeo.Disclaimer');
+goog.require('ngeo.mapDirective');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['ngeo']);
+
+
+/**
+ * @param {ngeo.Disclaimer} ngeoDisclaimer Ngeo disclaimer service.
+ * @constructor
+ */
+app.MainController = function(ngeoDisclaimer) {
+
+  /**
+   * @type {ngeo.Disclaimer}
+   * @export
+   */
+  this.disclaimer = ngeoDisclaimer;
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      })
+    ],
+    view: new ol.View({
+      center: [0, 0],
+      zoom: 4
+    })
+  });
+
+  // initialize tooltips
+  $('[data-toggle="tooltip"]').tooltip({
+    container: 'body',
+    trigger: 'hover'
+  });
+};
+
+
+/**
+ * Demonstrates how to display a disclaimer message in an other target. In
+ * this case, it's shown in the map.
+ * @export
+ */
+app.MainController.prototype.inMap = function() {
+  var messages = [
+    'Disclaimer inside the map',
+    'An other message ',
+    'Map contributors',
+    'This is a long message inside a map'
+  ];
+
+  messages.forEach(function(message) {
+    this.disclaimer.alert({
+      msg: message,
+      target: angular.element('#disclaimers-in-map'),
+      type: ngeo.MessageType.WARNING
+    });
+  }, this);
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/examples/notification.js
+++ b/examples/notification.js
@@ -47,16 +47,16 @@ app.MainController = function(ngeoNotification) {
 app.MainController.prototype.notifyMulti = function() {
   this.notification.notify([{
     msg: ['Error #', this.i_++].join(''),
-    type: ngeo.NotificationType.ERROR
+    type: ngeo.MessageType.ERROR
   }, {
     msg: ['Warning #', this.i_++].join(''),
-    type: ngeo.NotificationType.WARNING
+    type: ngeo.MessageType.WARNING
   }, {
     msg: ['Information #', this.i_++].join(''),
-    type: ngeo.NotificationType.INFORMATION
+    type: ngeo.MessageType.INFORMATION
   }, {
     msg: ['Success #', this.i_++].join(''),
-    type: ngeo.NotificationType.SUCCESS
+    type: ngeo.MessageType.SUCCESS
   }]);
 };
 
@@ -70,7 +70,7 @@ app.MainController.prototype.notifyTarget = function() {
   this.notification.notify({
     msg: 'Error in an other target',
     target: angular.element('#my-messages'),
-    type: ngeo.NotificationType.ERROR
+    type: ngeo.MessageType.ERROR
   });
 };
 
@@ -82,7 +82,7 @@ app.MainController.prototype.notifyQuick = function() {
   this.notification.notify({
     delay: 1000,
     msg: 'Lasts one second',
-    type: ngeo.NotificationType.SUCCESS
+    type: ngeo.MessageType.SUCCESS
   });
 };
 

--- a/src/services/disclaimer.js
+++ b/src/services/disclaimer.js
@@ -1,0 +1,153 @@
+goog.provide('ngeo.Disclaimer');
+
+goog.require('goog.asserts');
+goog.require('ngeo');
+goog.require('ngeo.Message');
+
+
+/**
+ * Provides methods to display any sort of messages, disclaimers, errors,
+ * etc. Requires Bootstrap library (both CSS and JS) to display the alerts
+ * properly.
+ *
+ * @constructor
+ * @extends {ngeo.Message}
+ * @ngdoc service
+ * @ngname ngeoDisclaimer
+ * @ngInject
+ */
+ngeo.Disclaimer = function() {
+
+  goog.base(this);
+
+  var container = angular.element('<div class="ngeo-disclaimer"></div>');
+  angular.element(document.body).append(container);
+
+  /**
+   * @type {angular.JQLite}
+   * @private
+   */
+  this.container_ = container;
+
+  /**
+   * Cache of messages.
+   * @type {Object.<string, angular.JQLite>}
+   * @private
+   */
+  this.messages_ = {};
+
+};
+goog.inherits(ngeo.Disclaimer, ngeo.Message);
+
+
+/**
+ * Show disclaimer message string or object or list of disclamer message
+ * strings or objects.
+ * @param {string|Array.<string>|ngeox.Message|Array.<ngeox.Message>}
+ *     object A message or list of messages as text or configuration objects.
+ * @export
+ */
+ngeo.Disclaimer.prototype.alert = function(object) {
+  this.show(object);
+};
+
+
+/**
+ * Close disclaimer message string or object or list of disclamer message
+ * strings or objects.
+ * @param {string|Array.<string>|ngeox.Message|Array.<ngeox.Message>}
+ *     object A message or list of messages as text or configuration objects.
+ * @export
+ */
+ngeo.Disclaimer.prototype.close = function(object) {
+  var msgObjects = this.getMessageObjects(object);
+  msgObjects.forEach(this.closeMessage_, this);
+};
+
+
+/**
+ * Show the message.
+ * @param {ngeox.Message} message Message.
+ * @protected
+ */
+ngeo.Disclaimer.prototype.showMessage = function(message) {
+  var type = message.type;
+  goog.asserts.assertString(type, 'Type should be set.');
+
+  var uid = this.getMessageUid_(message);
+  if (this.messages_[uid] !== undefined) {
+    return;
+  }
+
+  var classNames = ['alert', 'fade', 'alert-dismissible'];
+  switch (type) {
+    case ngeo.MessageType.ERROR:
+      classNames.push('alert-danger');
+      break;
+    case ngeo.MessageType.INFORMATION:
+      classNames.push('alert-info');
+      break;
+    case ngeo.MessageType.SUCCESS:
+      classNames.push('alert-success');
+      break;
+    case ngeo.MessageType.WARNING:
+      classNames.push('alert-warning');
+      break;
+    default:
+      break;
+  }
+
+  var el = angular.element(
+    '<div role="alert" class="' + classNames.join(' ') + '"></div>');
+  var button = angular.element(
+    '<button type="button" class="close" data-dismiss="alert" aria-label="' +
+    'Close' +  // FIXME i18n
+    '"><span aria-hidden="true">&times;</span></button>');
+  var msg = angular.element('<span />').html(message.msg);
+  el.append(button).append(msg);
+
+  var container;
+
+  if (message.target) {
+    container = angular.element(message.target);
+  } else {
+    container = this.container_;
+  }
+
+  container.append(el);
+  el.addClass('in');
+
+  // Listen when the message gets closed to cleanup the cache of messages
+  el.on('closed.bs.alert', function() {
+    this.closeMessage_(message);
+  }.bind(this));
+
+  this.messages_[uid] =  el;
+};
+
+
+/**
+ * @param {ngeox.Message} message Message.
+ * @return {string} The uid.
+ * @private
+ */
+ngeo.Disclaimer.prototype.getMessageUid_ = function(message) {
+  return message.msg + '-' + message.type;
+};
+
+
+/**
+ * Close the message.
+ * @param {ngeox.Message} message Message.
+ * @protected
+ */
+ngeo.Disclaimer.prototype.closeMessage_ = function(message) {
+  var uid = this.getMessageUid_(message);
+  if (this.messages_[uid] === undefined) {
+    return;
+  }
+  delete this.messages_[uid];
+};
+
+
+ngeo.module.service('ngeoDisclaimer', ngeo.Disclaimer);

--- a/src/services/message.js
+++ b/src/services/message.js
@@ -1,0 +1,149 @@
+goog.provide('ngeo.Message');
+
+
+/**
+ * @enum {string}
+ * @export
+ */
+ngeo.MessageType = {
+  /**
+   * @type {string}
+   * @export
+   */
+  ERROR: 'error',
+  /**
+   * @type {string}
+   * @export
+   */
+  INFORMATION: 'information',
+  /**
+   * @type {string}
+   * @export
+   */
+  SUCCESS: 'success',
+  /**
+   * @type {string}
+   * @export
+   */
+  WARNING: 'warning'
+};
+
+
+/**
+ * Abstract class for services that display messages.
+ *
+ * @constructor
+ */
+ngeo.Message = function() {};
+
+
+/**
+ * Show the message.
+ * @param {ngeox.Message} message Message.
+ * @protected
+ */
+ngeo.Message.prototype.showMessage = goog.abstractMethod;
+
+
+/**
+ * Show disclaimer message string or object or list of disclame message
+ * strings or objects.
+ * @param {string|Array.<string>|ngeox.Message|Array.<ngeox.Message>}
+ *     object A message or list of messages as text or configuration objects.
+ * @export
+ */
+ngeo.Message.prototype.show = function(object) {
+  var msgObjects = this.getMessageObjects(object);
+  msgObjects.forEach(this.showMessage, this);
+};
+
+
+/**
+ * Display the given error message or list of error messages.
+ * @param {string|Array.<string>} message Message or list of messages.
+ * @export
+ */
+ngeo.Message.prototype.error = function(message) {
+  this.show(this.getMessageObjects(message, ngeo.MessageType.ERROR));
+};
+
+
+/**
+ * Display the given info message or list of info messages.
+ * @param {string|Array.<string>} message Message or list of messages.
+ * @export
+ */
+ngeo.Message.prototype.info = function(message) {
+  this.show(this.getMessageObjects(message, ngeo.MessageType.INFORMATION));
+};
+
+
+/**
+ * Display the given success message or list of success messages.
+ * @param {string|Array.<string>} message Message or list of messages.
+ * @export
+ */
+ngeo.Message.prototype.success = function(message) {
+  this.show(this.getMessageObjects(message, ngeo.MessageType.SUCCESS));
+};
+
+
+/**
+ * Display the given warning message or list of warning messages.
+ * @param {string|Array.<string>} message Message or list of messages.
+ * @export
+ */
+ngeo.Message.prototype.warn = function(message) {
+  this.show(this.getMessageObjects(message, ngeo.MessageType.WARNING));
+};
+
+
+/**
+ * Returns an array of message object from any given message string, list of
+ * message strings, message object or list message objects. The type can be
+ * overriden here as well OR defined (if the message(s) is/are string(s),
+ * defaults to 'information').
+ * @param {string|Array.<string>|ngeox.Message|Array.<ngeox.Message>}
+ *     object A message or list of messages as text or configuration objects.
+ * @param {string=} opt_type The type of message to override the messages with.
+ * @return {Array.<ngeox.Message>} List of message objects.
+ * @protected
+ */
+ngeo.Message.prototype.getMessageObjects = function(object, opt_type) {
+  var msgObjects = [];
+  var msgObject = null;
+  var defaultType = ngeo.MessageType.INFORMATION;
+
+  if (typeof object === 'string') {
+    msgObjects.push({
+      msg: object,
+      type: opt_type !== undefined ? opt_type : defaultType
+    });
+  } else if (goog.isArray(object)) {
+    object.forEach(function(msg) {
+      if (typeof object === 'string') {
+        msgObject = {
+          msg: msg,
+          type: opt_type !== undefined ? opt_type : defaultType
+        };
+      } else {
+        msgObject = msg;
+        if (opt_type !== undefined) {
+          msgObject.type = opt_type;
+        }
+      }
+      msgObjects.push(msgObject);
+    }, this);
+  } else {
+    msgObject = object;
+    if (opt_type !== undefined) {
+      msgObject.type = opt_type;
+    }
+    if (msgObject.type === undefined) {
+      msgObject.type = defaultType;
+    }
+    msgObjects.push(msgObject);
+  }
+
+  return msgObjects;
+};

--- a/src/services/notification.js
+++ b/src/services/notification.js
@@ -2,34 +2,7 @@ goog.provide('ngeo.Notification');
 
 goog.require('goog.asserts');
 goog.require('ngeo');
-
-
-/**
- * @enum {string}
- * @export
- */
-ngeo.NotificationType = {
-  /**
-   * @type {string}
-   * @export
-   */
-  ERROR: 'error',
-  /**
-   * @type {string}
-   * @export
-   */
-  INFORMATION: 'information',
-  /**
-   * @type {string}
-   * @export
-   */
-  SUCCESS: 'success',
-  /**
-   * @type {string}
-   * @export
-   */
-  WARNING: 'warning'
-};
+goog.require('ngeo.Message');
 
 
 /**
@@ -38,12 +11,15 @@ ngeo.NotificationType = {
  * properly.
  *
  * @constructor
+ * @extends {ngeo.Message}
  * @param {angular.$timeout} $timeout Angular timeout service.
  * @ngdoc service
  * @ngname ngeoNotification
  * @ngInject
  */
 ngeo.Notification = function($timeout) {
+
+  goog.base(this);
 
   /**
    * @type {angular.$timeout}
@@ -67,6 +43,7 @@ ngeo.Notification = function($timeout) {
   this.cache_ = {};
 
 };
+goog.inherits(ngeo.Notification, ngeo.Message);
 
 
 /**
@@ -88,8 +65,7 @@ ngeo.Notification.DEFAULT_DELAY_ = 7000;
  * @export
  */
 ngeo.Notification.prototype.notify = function(object) {
-  var msgObjects = this.getMessageObjects_(object);
-  msgObjects.forEach(this.notifyMessage_, this);
+  this.show(object);
 };
 
 
@@ -104,77 +80,27 @@ ngeo.Notification.prototype.clear = function() {
 };
 
 
-// SHORTCUT METHODS
-
-
 /**
- * Display the given error message or list of error messages.
- * @param {string|Array.<string>} message Message or list of messages.
- * @export
- */
-ngeo.Notification.prototype.error = function(message) {
-  this.notify(this.getMessageObjects_(
-      message, ngeo.NotificationType.ERROR));
-};
-
-
-/**
- * Display the given info message or list of info messages.
- * @param {string|Array.<string>} message Message or list of messages.
- * @export
- */
-ngeo.Notification.prototype.info = function(message) {
-  this.notify(this.getMessageObjects_(
-      message, ngeo.NotificationType.INFORMATION));
-};
-
-
-/**
- * Display the given success message or list of success messages.
- * @param {string|Array.<string>} message Message or list of messages.
- * @export
- */
-ngeo.Notification.prototype.success = function(message) {
-  this.notify(this.getMessageObjects_(
-      message, ngeo.NotificationType.SUCCESS));
-};
-
-
-/**
- * Display the given warning message or list of warning messages.
- * @param {string|Array.<string>} message Message or list of messages.
- * @export
- */
-ngeo.Notification.prototype.warn = function(message) {
-  this.notify(this.getMessageObjects_(
-      message, ngeo.NotificationType.WARNING));
-};
-
-
-// UTILITY METHODS
-
-
-/**
- * Display the message.
+ * Show the message.
  * @param {ngeox.Message} message Message.
- * @private
+ * @protected
  */
-ngeo.Notification.prototype.notifyMessage_ = function(message) {
+ngeo.Notification.prototype.showMessage = function(message) {
   var type = message.type;
   goog.asserts.assertString(type, 'Type should be set.');
 
   var classNames = ['alert', 'fade'];
   switch (type) {
-    case ngeo.NotificationType.ERROR:
+    case ngeo.MessageType.ERROR:
       classNames.push('alert-danger');
       break;
-    case ngeo.NotificationType.INFORMATION:
+    case ngeo.MessageType.INFORMATION:
       classNames.push('alert-info');
       break;
-    case ngeo.NotificationType.SUCCESS:
+    case ngeo.MessageType.SUCCESS:
       classNames.push('alert-success');
       break;
-    case ngeo.NotificationType.WARNING:
+    case ngeo.MessageType.WARNING:
       classNames.push('alert-warning');
       break;
     default:
@@ -231,54 +157,6 @@ ngeo.Notification.prototype.clearMessageByCacheItem_ = function(item) {
 
   // Delete the cache item
   delete this.cache_[uid];
-};
-
-
-/**
- * Returns an array of message object from any given message string, list of
- * message strings, message object or list message objects. The type can be
- * overriden here as well OR defined (if the message(s) is/are string(s),
- * defaults to 'information').
- * @param {string|Array.<string>|ngeox.Message|Array.<ngeox.Message>}
- *     object A message or list of messages as text or configuration objects.
- * @param {string=} opt_type The type of message to override the messages with.
- * @return {Array.<ngeox.Message>} List of message objects.
- * @private
- */
-ngeo.Notification.prototype.getMessageObjects_ = function(object, opt_type) {
-  var msgObjects = [];
-  var msgObject = null;
-  var defaultType = ngeo.NotificationType.INFORMATION;
-
-  if (typeof object === 'string') {
-    msgObjects.push({
-      msg: object,
-      type: opt_type !== undefined ? opt_type : defaultType
-    });
-  } else if (goog.isArray(object)) {
-    object.forEach(function(msg) {
-      if (typeof object === 'string') {
-        msgObject = {
-          msg: msg,
-          type: opt_type !== undefined ? opt_type : defaultType
-        };
-      } else {
-        msgObject = msg;
-        if (opt_type !== undefined) {
-          msgObject.type = opt_type;
-        }
-      }
-      msgObjects.push(msgObject);
-    }, this);
-  } else {
-    msgObject = object;
-    if (opt_type !== undefined) {
-      msgObject.type = opt_type;
-    }
-    msgObjects.push(msgObject);
-  }
-
-  return msgObjects;
 };
 
 


### PR DESCRIPTION
This PR introduces the `ngeo.Disclaimer` service. Since it would have had some method in common with the `ngeo.Notification` service, both extend the same class to avoid copy/pasting code that would be the same.

This PR is the first step towards supporting disclaimers inside the map for layers.  It doesn't do that yet.  This PR is only the section for NGEO.  The layers will be managed in the next PR, for GMF.

## Todo

 * [x] review

## Live example

 * http://adube.github.io/ngeo/disclaimer/examples/disclaimer.html