### PR TITLE
Use filter to format coordinates in draw component

### DIFF
--- a/contribs/gmf/apps/desktop/js/controller.js
+++ b/contribs/gmf/apps/desktop/js/controller.js
@@ -26,6 +26,8 @@ app.module.constant('ngeoExportFeatureFormats', [
   ngeo.FeatureHelper.FormatType.GPX
 ]);
 
+// Filter to apply by default on all coordinates.
+app.module.constant('ngeoPointfilter', 'ngeoNumberCoordinates:0:{x} E, {y} N');
 
 app.module.constant('ngeoQueryOptions', {
   'limit': 20

--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -26,6 +26,8 @@ app.module.constant('ngeoExportFeatureFormats', [
   ngeo.FeatureHelper.FormatType.GPX
 ]);
 
+// Filter to apply by default on all coordinates.
+app.module.constant('ngeoPointfilter', 'ngeoNumberCoordinates:0:{x} E, {y} N');
 
 app.module.constant('ngeoQueryOptions', {
   'limit': 20

--- a/contribs/gmf/apps/mobile/js/controller.js
+++ b/contribs/gmf/apps/mobile/js/controller.js
@@ -23,6 +23,9 @@ goog.require('ngeo.mobileGeolocationDirective');
 
 /* global app */
 
+// Filter to apply by default on all coordinates.
+app.module.constant('ngeoPointfilter', 'ngeoNumberCoordinates:0:{x} E, {y} N');
+
 app.module.constant('ngeoQueryOptions', {
   'limit': 20
 });


### PR DESCRIPTION
Revival of #1262 

Fix https://github.com/camptocamp/c2cgeoportal/issues/2256

Example: http://ger-benjamin.github.io/ngeo/redliningcoodinates/examples/contribs/gmf/apps/desktop/index.html