### PR TITLE
gmf-drawfeature: Recenter map to selected feature from list

### DIFF
--- a/contribs/gmf/src/directives/drawfeature.js
+++ b/contribs/gmf/src/directives/drawfeature.js
@@ -301,6 +301,10 @@ gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
       if (newFeature) {
         this.featureHelper_.setStyle(newFeature, true);
         this.selectedFeatures.push(newFeature);
+        if (this.listSelectionInProgress_) {
+          this.featureHelper_.panMapToFeature(newFeature, this.map);
+          this.listSelectionInProgress_ = false;
+        }
       } else {
         this.menu_.close();
       }
@@ -412,6 +416,19 @@ gmf.DrawfeatureController.prototype.handleActiveChange_ = function(active) {
     this.menu_.close();
   }
 
+};
+
+
+/**
+ * Method called when a selection occurs from the list, i.e. when an item in
+ * the list of features is clicked. Called from the template, so no need to
+ * update Angular's scope.
+ * @param {ol.Feature} feature Feature to select.
+ * @export
+ */
+gmf.DrawfeatureController.prototype.selectFeatureFromList = function(feature) {
+  this.listSelectionInProgress_ = true;
+  this.selectedFeature = feature;
 };
 
 

--- a/contribs/gmf/src/directives/drawfeature.js
+++ b/contribs/gmf/src/directives/drawfeature.js
@@ -271,6 +271,15 @@ gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
    */
   this.listenerKeys_ = [];
 
+  /**
+   * Flag used to determine whether the selection of a feature was made
+   * from the selection of an item from the list or not (the map, contextual
+   * menu, etc.)
+   * @type {boolean}
+   * @private
+   */
+  this.listSelectionInProgress_ = false;
+
   $scope.$watch(
     function() {
       return this.active;

--- a/contribs/gmf/src/directives/partials/drawfeature.html
+++ b/contribs/gmf/src/directives/partials/drawfeature.html
@@ -105,7 +105,7 @@
           <li
               class="list-group-item"
               ng-repeat="feature in efCtrl.getFeaturesArray()"
-              ng-click="efCtrl.selectedFeature = feature;">
+              ng-click="efCtrl.selectFeatureFromList(feature);">
             {{ feature.get(efCtrl.nameProperty) }}
           </li>
         </ul>


### PR DESCRIPTION
This PR introduces the following behavior: in the draw tools (`gmf-drawfeature` directive), when a feature is selected from the list, if it's not currently visible on the map, recenter the map to the center of the feature.  The map zoom level never changes due to this behavior.  Clicking on the feature from the map to select it will not trigger that behavior either.

## Todo

 * [ ] review


## Live example

Click on the list item to see the behavior in action.

 * http://adube.github.io/ngeo/1178-ensure-feature-visible/examples/contribs/gmf/drawfeature.html?rl_features=Fa(65ca*q37d-v6yGa1x8!bpgc!ya6Cya6Cbpgc!~n*Polygon%25201%27c*%2523DB4436%27a*0%27o*0.2%27m*false%27s*10%27k*1)&map_x=7983695&map_y=-1271912&map_zoom=3