### PR TITLE
Admin value isChecked is now taken in account in all cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@
 /contribs/gmf/fonts/gmf-icons.ttf
 /contribs/gmf/fonts/gmf-icons.woff
 /.tx/config
-/.tx/.tx/ngeo.ngeo-*
-/.tx/.tx/ngeo.gmf-*
+/.tx/ngeo.ngeo-*
+/.tx/ngeo.gmf-*
 /examples/simple.min.js
 contribs/gmf/fonts/FontAwesome*
 contribs/gmf/fonts/fontawesome*

--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -288,15 +288,16 @@ gmf.LayertreeController.prototype.getLayer = function(node, opt_depth,
 
     this.dataLayerGroup_.getLayers().insertAt(0, layer);
 
-    // by default a layer is not visible
-    var visible = false;
-    var metadata = node.metadata;
-    if (goog.isDefAndNotNull(metadata)) {
-      if (metadata['isChecked'] == 'true') {
+    // Set visiblity for not mixed group (mixed groups depends on its children)
+    if (type !== gmf.LayertreeController.TYPE_NOTMIXEDGROUP) {
+      // by default a layer is not visible
+      var visible = false;
+      var metadata = node.metadata;
+      if (metadata && metadata['isChecked'] === 'true') {
         visible = true;
       }
+      layer.setVisible(visible);
     }
-    layer.setVisible(visible);
   }
 
   return layer;
@@ -407,7 +408,7 @@ gmf.LayertreeController.prototype.retrieveNodeNames_ = function(node,
     n = nodes[i];
     metadata = n.metadata;
     if (!opt_onlyChecked ||
-        (goog.isDefAndNotNull(metadata) && metadata['isChecked'] != 'false')) {
+        (goog.isDefAndNotNull(metadata) && metadata['isChecked'] === 'true')) {
       names.push(n.name);
     }
   }


### PR DESCRIPTION
Fix: https://github.com/camptocamp/c2cgeoportal/issues/2219 (Fix 2.0: must be merged on the 2.0 only., nothing to do in 2.1 (already works))

Example: https://ger-benjamin.github.io/ngeo/admin_value_2.0/examples/contribs/gmf/apps/mobile/theme/OSM?lang=en&baselayer_ref=map

(For example, hotel is not checked, some layer in the same group are checked and so on. You can compare with the admin interface of the demo 2.0 (ui_metadatas): https://geomapfish-demo.camptocamp.net/2.0/wsgi/admin/  