### PR TITLE
Fix disclaimer closing from application

### DIFF
--- a/examples/disclaimer.html
+++ b/examples/disclaimer.html
@@ -52,22 +52,22 @@
     </p>
     <div class="buttons">
       <button
-          ng-click="ctrl.disclaimer.success('Disclaimer with success style')"
+          ng-click="ctrl.success()"
           title="Displays a disclaimer success message using default options."
           type="button"
           class="btn btn-success">Success</button>
       <button
-          ng-click="ctrl.disclaimer.info('Disclaimer with information style')"
+          ng-click="ctrl.info()"
           title="Displays a disclaimer info message using default options."
           type="button"
           class="btn btn-info">Info</button>
       <button
-          ng-click="ctrl.disclaimer.warn('Disclaimer with warning style')"
+          ng-click="ctrl.warn()"
           title="Displays a disclaimer warning message using default options."
           type="button"
           class="btn btn-warning">Warning</button>
       <button
-          ng-click="ctrl.disclaimer.error('Disclaimer with error style')"
+          ng-click="ctrl.error()"
           title="Displays a disclaimer error message using default options."
           type="button"
           class="btn btn-danger">Error</button>
@@ -76,6 +76,11 @@
           title="Displays multiple disclaimer messages inside the map."
           type="button"
           class="btn btn-default">In Map</button>
+      <button
+          ng-click="ctrl.closeAll()"
+          title="Closes all currently visible disclaimer messages"
+          type="button"
+          class="btn btn-danger">Close all</button>
     </div>
 
     <script src="../node_modules/jquery/dist/jquery.js"></script>

--- a/examples/disclaimer.js
+++ b/examples/disclaimer.js
@@ -44,6 +44,40 @@ app.MainController = function(ngeoDisclaimer) {
     })
   });
 
+  /**
+   * @type {string}
+   * @private
+   */
+  this.successMsg_ = 'Disclaimer with success style';
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.infoMsg_ = 'Disclaimer with info style';
+  /**
+   * @type {string}
+   * @private
+   */
+  this.warningMsg_ = 'Disclaimer with warning style';
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.errorMsg_ = 'Disclaimer with error style';
+
+  /**
+   * @type {Array.<string>}
+   * @private
+   */
+  this.inMapMsgs_ = [
+    'Disclaimer inside the map',
+    'An other message ',
+    'Map contributors',
+    'This is a long message inside a map'
+  ];
+
   // initialize tooltips
   $('[data-toggle="tooltip"]').tooltip({
     container: 'body',
@@ -53,25 +87,87 @@ app.MainController = function(ngeoDisclaimer) {
 
 
 /**
+ * @export
+ */
+app.MainController.prototype.success = function() {
+  this.disclaimer.success(this.successMsg_);
+};
+
+
+/**
+ * @export
+ */
+app.MainController.prototype.info = function() {
+  this.disclaimer.info(this.infoMsg_);
+};
+
+
+/**
+ * @export
+ */
+app.MainController.prototype.warn = function() {
+  this.disclaimer.warn(this.warningMsg_);
+};
+
+
+/**
+ * @export
+ */
+app.MainController.prototype.error = function() {
+  this.disclaimer.error(this.errorMsg_);
+};
+
+
+/**
  * Demonstrates how to display a disclaimer message in an other target. In
  * this case, it's shown in the map.
  * @export
  */
 app.MainController.prototype.inMap = function() {
-  var messages = [
-    'Disclaimer inside the map',
-    'An other message ',
-    'Map contributors',
-    'This is a long message inside a map'
-  ];
-
-  messages.forEach(function(message) {
+  this.inMapMsgs_.forEach(function(message) {
     this.disclaimer.alert({
       msg: message,
       target: angular.element('#disclaimers-in-map'),
       type: ngeo.MessageType.WARNING
     });
   }, this);
+};
+
+
+/**
+ * Demonstrates how to close disclaimer messages using JavaScript, i.e.
+ * instead of clicking on the close button.
+ * @export
+ */
+app.MainController.prototype.closeAll = function() {
+
+  this.disclaimer.close({
+    msg: this.successMsg_,
+    type: ngeo.MessageType.SUCCESS
+  });
+
+  this.disclaimer.close({
+    msg: this.infoMsg_,
+    type: ngeo.MessageType.INFO
+  });
+
+  this.disclaimer.close({
+    msg: this.warningMsg_,
+    type: ngeo.MessageType.WARNING
+  });
+
+  this.disclaimer.close({
+    msg: this.errorMsg_,
+    type: ngeo.MessageType.ERROR
+  });
+
+  this.inMapMsgs_.forEach(function(message) {
+    this.disclaimer.close({
+      msg: message,
+      type: ngeo.MessageType.WARNING
+    });
+  }, this);
+
 };
 
 

--- a/examples/disclaimer.js
+++ b/examples/disclaimer.js
@@ -148,7 +148,7 @@ app.MainController.prototype.closeAll = function() {
 
   this.disclaimer.close({
     msg: this.infoMsg_,
-    type: ngeo.MessageType.INFO
+    type: ngeo.MessageType.INFORMATION
   });
 
   this.disclaimer.close({

--- a/src/services/disclaimer.js
+++ b/src/services/disclaimer.js
@@ -143,9 +143,19 @@ ngeo.Disclaimer.prototype.getMessageUid_ = function(message) {
  */
 ngeo.Disclaimer.prototype.closeMessage_ = function(message) {
   var uid = this.getMessageUid_(message);
+
+  // (1) No need to do anything if message doesn't exist
   if (this.messages_[uid] === undefined) {
     return;
   }
+
+  // (2) Check if the message hasn't been closed using the UI, i.e. by
+  //     clicking the close button. If not, then close it.
+  if (this.messages_[uid].hasClass('in')) {
+    this.messages_[uid].alert('close');
+  }
+
+  // (3) Remove message from cache since it's closed now.
   delete this.messages_[uid];
 };
 


### PR DESCRIPTION
This PR fixes the closing of a disclaimer message in the `ngeo-disclaimer` service when done "programmatically", i.e. when using code to close the message instead of the X button.

It also demonstrates it in the example with the addition of a new button: "Close all".

## Todo

 * [ ] review

## Live example

 * http://adube.github.io/ngeo/fix-disclaimer-close/examples/disclaimer.html