### PR TITLE
Layout harmonization

### DIFF
--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -63,17 +63,17 @@
       <div class="active slide">
         <ul>
           <li>
-            <a href data-target="#background" data-toggle="slide-in">{{'Background' | translate}}</a>
+            <a href data-target="#background" data-toggle="slide-in" class="nav-button">{{'Background' | translate}}</a>
           </li>
           <li>
-            <a href data-target="#themes" data-toggle="slide-in">{{'Themes' | translate}}</a>
+            <a href data-target="#themes" data-toggle="slide-in" class="nav-button">{{'Themes' | translate}}</a>
           </li>
-          <gmf-layertree
-            gmf-layertree-source="mainCtrl.theme"
-            gmf-layertree-map="::mainCtrl.map"
-            gmf-layertree-openlinksinnewwindow="true">
-          </gmf-layertree>
         </ul>
+        <gmf-layertree
+          gmf-layertree-source="mainCtrl.theme"
+          gmf-layertree-map="::mainCtrl.map"
+          gmf-layertree-openlinksinnewwindow="true">
+        </gmf-layertree>
       </div>
       <gmf-backgroundlayerselector
         id="background"
@@ -100,26 +100,32 @@
       <div class="active slide">
         <ul>
           <li>
-            <a href data-target="#measure-tools" data-toggle="slide-in">{{'Measure tools' | translate}}</a>
-            <a href data-target="#login" data-toggle="slide-in">{{'Login' | translate}}</a>
+            <a href data-target="#measure-tools" data-toggle="slide-in" class="nav-button">{{'Measure tools' | translate}}</a>
+            <a href data-target="#login" data-toggle="slide-in" class="nav-button">{{'Login' | translate}}</a>
           </li>
         </ul>
       </div>
       <div id="measure-tools" class="slide" data-header-title="{{'Measure tools' | translate}}">
-        <a ngeo-btn
-          ng-click="mainCtrl.hideNav()"
-          class="measure-tools-button"
-          ng-model="mainCtrl.measurePointActive">
-          <span class="fa fa-fw" ng-class="{'fa-check': mainCtrl.measurePointActive}"></span>
-          {{'Coordinate' | translate}}
-        </a>
-        <a ngeo-btn
-          ng-click="mainCtrl.hideNav()"
-          class="measure-tools-button"
-          ng-model="mainCtrl.measureLengthActive">
-          <span class="fa fa-fw" ng-class="{'fa-check': mainCtrl.measureLengthActive}"></span>
-          {{'Length' | translate}}
-        </a>
+        <ul>
+          <li>
+            <a ngeo-btn
+              ng-click="mainCtrl.hideNav()"
+              class="nav-button"
+              ng-model="mainCtrl.measurePointActive">
+              <span class="fa fa-fw" ng-class="{'fa-check': mainCtrl.measurePointActive}"></span>
+              {{'Coordinate' | translate}}
+            </a>
+          </li>
+          <li>
+            <a ngeo-btn
+              ng-click="mainCtrl.hideNav()"
+              class="nav-button"
+              ng-model="mainCtrl.measureLengthActive">
+              <span class="fa fa-fw" ng-class="{'fa-check': mainCtrl.measureLengthActive}"></span>
+              {{'Length' | translate}}
+            </a>
+          </li>
+        </ul>
       </div>
       <gmf-authentication id="login" class="slide" data-header-title="{{'Login' | translate}}">
       </gmf-authentication>

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -125,7 +125,6 @@ main {
   .content {
     flex: 1 1 auto;
     overflow-y: auto;
-    margin: @app-margin;
   }
 
   gmf-themeselector {

--- a/contribs/gmf/less/desktoplayertree.less
+++ b/contribs/gmf/less/desktoplayertree.less
@@ -14,9 +14,8 @@ gmf-layertree {
 .gmf-layertree-node {
 
   .right-buttons {
-    visibility: hidden;
+    display: none;
     cursor: pointer;
-    right: @app-margin;
   }
 
   &.depth-1 {
@@ -68,11 +67,15 @@ gmf-layertree {
   .group:hover,
   .leaf:hover {
     .right-buttons {
-      visibility: visible;
+      display: block;
     }
   }
 
-  .leaf .legend:hover {
+  .leaf {
+    padding-right: @half-app-margin;
+  }
+
+  .legend:hover {
     a {
       cursor: pointer;
       display: inline-block;
@@ -81,6 +84,10 @@ gmf-layertree {
 
   .legend-button {
     display: none;
+  }
+
+  .name {
+    white-space: nowrap;
   }
 
   // leave space for the drag handle
@@ -97,6 +104,7 @@ gmf-layertree {
     top: 0;
     height: 100%;
     width : @app-margin;
+    margin: 0;
   }
 
   .sortable-handle-icon {

--- a/contribs/gmf/less/desktoplayertree.less
+++ b/contribs/gmf/less/desktoplayertree.less
@@ -77,7 +77,8 @@ gmf-layertree {
     display: none;
   }
 
-  a.expand-node.fa {
+  // leave space for the drag handle
+  .depth-1 a.expand-node.fa {
     margin-left: @half-app-margin;
   }
 

--- a/contribs/gmf/less/desktoplayertree.less
+++ b/contribs/gmf/less/desktoplayertree.less
@@ -13,7 +13,7 @@ gmf-layertree {
 
 .gmf-layertree-node {
 
-  .rightButtons {
+  .right-buttons {
     visibility: hidden;
     cursor: pointer;
     right: @app-margin;
@@ -67,7 +67,7 @@ gmf-layertree {
 
   .group:hover,
   .leaf:hover {
-    .rightButtons {
+    .right-buttons {
       visibility: visible;
     }
   }
@@ -79,7 +79,7 @@ gmf-layertree {
     }
   }
 
-  .legendButton {
+  .legend-button {
     display: none;
   }
 

--- a/contribs/gmf/less/desktoplayertree.less
+++ b/contribs/gmf/less/desktoplayertree.less
@@ -16,6 +16,7 @@ gmf-layertree {
   .rightButtons {
     visibility: hidden;
     cursor: pointer;
+    right: @app-margin;
   }
 
   &.depth-1 {
@@ -26,6 +27,9 @@ gmf-layertree {
     > ul {
       //adding space after the last li elem of the first level nodes
       padding-bottom: @half-app-margin;
+
+      // no padding for the first list in first level nodes
+      padding-left: 0;
     }
 
     &:hover {

--- a/contribs/gmf/less/desktoplayertree.less
+++ b/contribs/gmf/less/desktoplayertree.less
@@ -1,6 +1,8 @@
 @import 'layertree.less';
 
 gmf-layertree {
+  display: block;
+  margin: @app-margin @half-app-margin @app-margin @app-margin;
   ul {
     padding-top: @micro-app-margin;
   }

--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -4,15 +4,13 @@
   /**
    * Style rules for treenodes in the layertree
    */
-  margin-top: @half-app-margin;
+  margin-left: @app-margin; // left shifting (indentation)
 
   &.depth-1 {
     margin: 0 @micro-app-margin @app-margin @micro-app-margin;
   }
 
   ul {
-    padding: 0 @app-margin 0 2*@app-margin; //shifting child nodes
-
     ul {
       //nested ul (i.e node groups into node groups should not add extra padding)
       padding-right: 0;
@@ -46,7 +44,6 @@
 
   .rightButtons {
     position: absolute;
-    right: 0;
 
     *::before,
     *::after {
@@ -77,6 +74,7 @@
   .group {
     font-size: ceil(@font-size-base * 0.9);
     position: relative;
+    padding: @micro-app-margin;
   }
 
   .leaf .state::after {
@@ -97,9 +95,6 @@
       .name {
         font-weight: bold;
         color: black;
-      }
-      .rightButtons {
-        right: @app-margin;
       }
     }
 

--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -42,7 +42,7 @@
     }
   }
 
-  .rightButtons {
+  .right-buttons {
     position: absolute;
 
     *::before,
@@ -85,7 +85,7 @@
     .state::after {
       content: "\e600";
     }
-    .layerIcon {
+    .layer-icon {
       display: none;
     }
 
@@ -103,7 +103,7 @@
     }
   }
 
-  .layerIcon {
+  .layer-icon {
     display: inline-flex;
     height: @app-margin;
     width: 2 * @app-margin;
@@ -146,22 +146,22 @@
     }
   }
 
-  .noSource {
+  .no-source {
     opacity: 0.3;
     &::after {
       content: "(source not available)";
     }
   }
 
-  .outOfResolution {
+  .out-of-resolution {
     .name em {
       font-style: italic;
     }
     .zoom {
       display: inline;
     }
-    .rightButtons {
-      .legendButton {
+    .right-buttons {
+      .legend-button {
         display: none;
       }
     }
@@ -170,7 +170,7 @@
     }
   }
 
-  .legendButton {
+  .legend-button {
     a {
       padding: 0;
       &::after {

--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -26,9 +26,6 @@
     line-height: inherit;
     padding-left: 0;
     text-decoration: none;
-    &::after {
-      display: none;
-    }
 
     &.expand-node.fa {
       color : @color-light;

--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -75,7 +75,7 @@
 
   .leaf,
   .group {
-    font-size: @font-size-small;
+    font-size: ceil(@font-size-base * 0.9);
     position: relative;
   }
 

--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -170,16 +170,6 @@
     }
   }
 
-  .legend-button {
-    a {
-      padding: 0;
-      &::after {
-        content: @fa-var-align-left;
-        transform: initial;
-      }
-    }
-  }
-
   .legend {
     margin-left: @app-margin + @half-app-margin;
     position: relative;

--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -42,24 +42,6 @@
     }
   }
 
-  .right-buttons {
-    position: absolute;
-
-    *::before,
-    *::after {
-      background: none;
-      position: relative;
-      right: initial;
-    }
-
-    *::after {
-      color: @map-tools-color;
-      display: inline;
-      font-family: FontAwesome;
-    }
-
-  }
-
   .state {
     font-family: gmf-icons;
     color: @color;
@@ -75,6 +57,12 @@
     font-size: ceil(@font-size-base * 0.9);
     position: relative;
     padding: @micro-app-margin;
+    display: flex;
+
+    > * {
+      margin-top: auto;
+      margin-bottom: auto;
+    }
   }
 
   .leaf .state::after {
@@ -104,26 +92,34 @@
   }
 
   .layer-icon {
-    display: inline-flex;
-    height: @app-margin;
-    width: 2 * @app-margin;
     &.no-layer-icon::after {
       font-family: gmf-icons;
       content: "\e907";
       width: 100%;
       text-align: center;
     }
+
+    width: 20px;
+    padding: 0;
+    display: flex;
+
+    img {
+      // don't let the legend icons images to break the layout by being too
+      // tall or too large
+      max-width: 100%;
+      max-height: 20px;
+      vertical-align: initial;
+      margin-left: auto;
+      margin-right: auto;
+    }
   }
 
   .name {
-    // take the full width minus the width for a layer icon, visibility checkbox,
-    // and legend icon
-    width: calc(~'100%' - 6 * @app-margin);
     overflow: hidden;
-    display: inline-block;
     text-overflow: ellipsis;
-    white-space: nowrap;
-    margin-bottom: -4px;
+    flex: 2;
+    padding-left: @half-app-margin;
+    padding-right: @half-app-margin;
   }
 
   .metadata {
@@ -171,7 +167,7 @@
   }
 
   .legend {
-    margin-left: @app-margin + @half-app-margin;
+    margin: 0 @app-margin;
     position: relative;
     border: 1px solid @main-bg-color;
     background-color: lighten(@main-bg-color, 8%);

--- a/contribs/gmf/less/mobile-nav.less
+++ b/contribs/gmf/less/mobile-nav.less
@@ -202,16 +202,6 @@ nav.nav-right {
     }
   }
 
-  ul a[data-toggle=slide-in] {
-    display: block;
-    height: @menu-item-height;
-    line-height: @menu-item-height;
-    color: @link-color;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
   .slide {
     position: fixed;
     height: ~"calc(100% - @{nav-bar-height})";
@@ -221,7 +211,13 @@ nav.nav-right {
     will-change: transform, opacity;
     opacity: 0;
     overflow-y: auto;
-    padding: @app-margin;
+    & > * {
+      padding: @app-margin;
+      margin: 0;
+      // make it so tags like "gmf-layertree" are correctly displayed
+      //  (ie. that padding and margin correctly apply)
+      display: block;
+    }
 
     &.active {
       transform: translateX(0%);
@@ -268,6 +264,20 @@ nav.nav-right {
   right: @app-margin;
   border-left: none;
   box-shadow: -3px 0 5px -2px #bbb;
+}
+
+/**
+ * Buttons for tool buttons (for example measure tools)
+ */
+.nav-button {
+  display: block;
+  padding: @app-margin 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  &:hover {
+    text-decoration: none;
+  }
 }
 
 

--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -37,19 +37,6 @@ gmf-map {
   }
 }
 
-#measure-tools {
-  .measure-tools-button {
-    display: block;
-    padding: @half-app-margin 0;
-    margin: @half-app-margin 0;
-    color: @color;
-    &:hover {
-      cursor: pointer;
-      text-decoration: none;
-    }
-  }
-}
-
 .measure-tools-control {
   bottom: @app-margin;
   right: @app-margin;

--- a/contribs/gmf/less/mobilelayertree.less
+++ b/contribs/gmf/less/mobilelayertree.less
@@ -21,4 +21,8 @@ nav.nav-left .gmf-layertree-node a[data-toggle] {
   .group {
     font-size: @font-size-base;
   }
+
+  .rightButtons {
+    right: @micro-app-margin;
+  }
 }

--- a/contribs/gmf/less/mobilelayertree.less
+++ b/contribs/gmf/less/mobilelayertree.less
@@ -22,7 +22,7 @@ nav.nav-left .gmf-layertree-node a[data-toggle] {
     font-size: @font-size-base;
   }
 
-  .rightButtons {
+  .right-buttons {
     right: @micro-app-margin;
   }
 }

--- a/contribs/gmf/less/mobilelayertree.less
+++ b/contribs/gmf/less/mobilelayertree.less
@@ -1,5 +1,9 @@
 @import 'layertree.less';
 
+gmf-layertree {
+  border-top: 1px solid @back-color;
+}
+
 nav.nav-left .gmf-layertree-node a[data-toggle] {
   //override rule: nav.nav-left a[data-toggle] padding-right: 4rem
   padding-right: 0;

--- a/contribs/gmf/less/mobilelayertree.less
+++ b/contribs/gmf/less/mobilelayertree.less
@@ -21,8 +21,4 @@ nav.nav-left .gmf-layertree-node a[data-toggle] {
   .group {
     font-size: @font-size-base;
   }
-
-  .right-buttons {
-    right: @micro-app-margin;
-  }
 }

--- a/contribs/gmf/less/mobilelayertree.less
+++ b/contribs/gmf/less/mobilelayertree.less
@@ -16,4 +16,9 @@ nav.nav-left .gmf-layertree-node a[data-toggle] {
   .extra-actions {
     display: none;
   }
+
+  .leaf,
+  .group {
+    font-size: @font-size-base;
+  }
 }

--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -429,10 +429,10 @@ gmf.LayertreeController.prototype.listeners = function(scope, treeCtrl) {
 
 
 /**
- * Return 'outOfResolution' if the current resolution of the map is out of
+ * Return 'out-of-resolution' if the current resolution of the map is out of
  * the min/max resolution in the node.
  * @param {GmfThemesNode} node Layer tree node.
- * @return {?string} 'outOfResolution' or null.
+ * @return {?string} 'out-of-resolution' or null.
  * @export
  */
 gmf.LayertreeController.prototype.getResolutionStyle = function(node) {
@@ -442,7 +442,7 @@ gmf.LayertreeController.prototype.getResolutionStyle = function(node) {
   var minExtent = node.minResolutionHint;
   if (minExtent !== undefined && resolution < minExtent ||
       maxExtent !== undefined && resolution > maxExtent) {
-    style = 'outOfResolution';
+    style = 'out-of-resolution';
   }
   return style || null;
 };
@@ -748,10 +748,10 @@ gmf.LayertreeController.prototype.displayMetadata = function(treeCtrl) {
 
 
 /**
- * Return 'noSource' if no source is defined in the given treeCtrl's WMTS layer.
+ * Return 'no-source' if no source is defined in the given treeCtrl's WMTS layer.
  * @param {ngeo.LayertreeController} treeCtrl ngeo layertree controller, from
  *     the current node.
- * @return {?string} 'noSource' or null
+ * @return {?string} 'no-source' or null
  * @export
  */
 gmf.LayertreeController.prototype.getNoSourceStyle = function(treeCtrl) {
@@ -760,7 +760,7 @@ gmf.LayertreeController.prototype.getNoSourceStyle = function(treeCtrl) {
       layer instanceof ol.layer.Tile &&
       layer.getSource !== undefined &&
       !goog.isDefAndNotNull(layer.getSource())) {
-    return 'noSource';
+    return 'no-source';
   }
   return null;
 };

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -10,7 +10,7 @@
         class="fa expand-node fa-fw">
     </a>
   <a href ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)">
-    <span class="layerIcon" ng-if="::!layertreeCtrl.node.children" ng-class="::{'no-layer-icon' : !gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl)}">
+    <span class="layer-icon" ng-if="::!layertreeCtrl.node.children" ng-class="::{'no-layer-icon' : !gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl)}">
       <img ng-if="::(legendIconUrl=gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl))" ng-src="{{::legendIconUrl}}"></img>
     </span>
     <span ng-if="::layertreeCtrl.node.children" ng-class="['fa fa-fw', layertreeCtrl.node.children && !layertreeCtrl.layer.loading ? 'state' : 'fa-refresh fa-spin']"></span>
@@ -23,7 +23,7 @@
          ng-if="gmfLayertreeCtrl.getNodeState(layertreeCtrl) == 'on'"></i>
     </span>
   </a>
-  <span class="rightButtons">
+  <span class="right-buttons">
     <a href="" ng-if="::layertreeCtrl.depth == 1" ng-click="gmfLayertreeCtrl.removeNode(layertreeCtrl.node)">
       <span class="fa fa-trash"></span>
     </a>
@@ -51,7 +51,7 @@
         <a title="{{'More informations'|translate}}" href="" ng-click="gmfLayertreeCtrl.displayMetadata(layertreeCtrl)"></a>
       </span>
     </span>
-    <span class="legendButton" ng-if="::gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend">
+    <span class="legend-button" ng-if="::gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend">
       <a title="{{'Show/hide legend'|translate}}" data-toggle="collapse" href="#node-{{::layertreeCtrl.uid}}-legend"></a>
     </span>
   </span>

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -51,9 +51,11 @@
         <a title="{{'More informations'|translate}}" href="" ng-click="gmfLayertreeCtrl.displayMetadata(layertreeCtrl)"></a>
       </span>
     </span>
-    <span class="legend-button" ng-if="::gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend">
-      <a title="{{'Show/hide legend'|translate}}" data-toggle="collapse" href="#node-{{::layertreeCtrl.uid}}-legend"></a>
-    </span>
+    <a class="fa fa-align-left legend-button"
+       ng-if="::gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend"
+       title="{{'Show/hide legend'|translate}}"
+       data-toggle="collapse"
+       href="#node-{{::layertreeCtrl.uid}}-legend"></a>
   </span>
     <div ng-if="::gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend" id="node-{{::layertreeCtrl.uid}}-legend" class="collapse legend" ng-class="::[layertreeCtrl.node.metadata.isLegendExpanded ? 'in' : '']">
       <a title="{{'Hide legend'|translate}}" data-toggle="collapse" ng-click="::gmfLayertreeCtrl.toggleNodeLegend('#node-' + layertreeCtrl.uid + '-legend')" href="">{{'Hide legend'|translate}}</a>

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -9,19 +9,19 @@
         aria-expanded="{{::layertreeCtrl.node.metadata.isExpanded}}"
         class="fa expand-node fa-fw">
     </a>
-  <a href ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)">
-    <span class="layer-icon" ng-if="::!layertreeCtrl.node.children" ng-class="::{'no-layer-icon' : !gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl)}">
-      <img ng-if="::(legendIconUrl=gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl))" ng-src="{{::legendIconUrl}}"></img>
-    </span>
-    <span ng-if="::layertreeCtrl.node.children" ng-class="['fa fa-fw', layertreeCtrl.node.children && !layertreeCtrl.layer.loading ? 'state' : 'fa-refresh fa-spin']"></span>
-    <span class="name" title="{{layertreeCtrl.node.name | translate}}">
-      <em>{{layertreeCtrl.node.name | translate}}</em>
-      <i class="gmf-icon gmf-icon-search-go zoom"
-         data-toggle="tooltip"
-         data-title="{{'Not visible at current scale. Click to zoom.'|translate}}"
-         ng-click="::gmfLayertreeCtrl.zoomToResolution(layertreeCtrl); $event.preventDefault(); $event.stopPropagation();"
-         ng-if="gmfLayertreeCtrl.getNodeState(layertreeCtrl) == 'on'"></i>
-    </span>
+  <span class="layer-icon" ng-if="::!layertreeCtrl.node.children" ng-class="::{'no-layer-icon' : !gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl)}"
+        ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)">
+    <img ng-if="::(legendIconUrl=gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl))" ng-src="{{::legendIconUrl}}"></img>
+  </span>
+  <span ng-if="::layertreeCtrl.node.children" ng-class="['fa fa-fw', layertreeCtrl.node.children && !layertreeCtrl.layer.loading ? 'state' : 'fa-refresh fa-spin']"></span>
+  <a href ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)"
+     class="name" title="{{layertreeCtrl.node.name | translate}}">
+    <em>{{layertreeCtrl.node.name | translate}}</em>
+    <i class="gmf-icon gmf-icon-search-go zoom"
+       data-toggle="tooltip"
+       data-title="{{'Not visible at current scale. Click to zoom.'|translate}}"
+       ng-click="::gmfLayertreeCtrl.zoomToResolution(layertreeCtrl); $event.preventDefault(); $event.stopPropagation();"
+       ng-if="gmfLayertreeCtrl.getNodeState(layertreeCtrl) == 'on'"></i>
   </a>
   <span class="right-buttons">
     <a href="" ng-if="::layertreeCtrl.depth == 1" ng-click="gmfLayertreeCtrl.removeNode(layertreeCtrl.node)">
@@ -57,10 +57,10 @@
        data-toggle="collapse"
        href="#node-{{::layertreeCtrl.uid}}-legend"></a>
   </span>
-    <div ng-if="::gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend" id="node-{{::layertreeCtrl.uid}}-legend" class="collapse legend" ng-class="::[layertreeCtrl.node.metadata.isLegendExpanded ? 'in' : '']">
-      <a title="{{'Hide legend'|translate}}" data-toggle="collapse" ng-click="::gmfLayertreeCtrl.toggleNodeLegend('#node-' + layertreeCtrl.uid + '-legend')" href="">{{'Hide legend'|translate}}</a>
-      <img ng-src="{{gmfLayertreeCtrl.getLegendURL(layertreeCtrl)}}"></img>
-    </div>
+</div>
+<div ng-if="::!layertreeCtrl.isRoot && gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend" id="node-{{::layertreeCtrl.uid}}-legend" class="collapse legend" ng-class="::[layertreeCtrl.node.metadata.isLegendExpanded ? 'in' : '']">
+  <a title="{{'Hide legend'|translate}}" data-toggle="collapse" ng-click="::gmfLayertreeCtrl.toggleNodeLegend('#node-' + layertreeCtrl.uid + '-legend')" href="">{{'Hide legend'|translate}}</a>
+  <img ng-src="{{gmfLayertreeCtrl.getLegendURL(layertreeCtrl)}}"></img>
 </div>
 <ul id="layer-group-{{::layertreeCtrl.uid}}"
     ng-if="::layertreeCtrl.node.children"

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -9,11 +9,13 @@
         aria-expanded="{{::layertreeCtrl.node.metadata.isExpanded}}"
         class="fa expand-node fa-fw">
     </a>
-  <span class="layer-icon" ng-if="::!layertreeCtrl.node.children" ng-class="::{'no-layer-icon' : !gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl)}"
-        ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)">
+  <a href ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)"
+     ng-if="::!layertreeCtrl.node.children" ng-class="::{'no-layer-icon' : !gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl)}"
+     class="layer-icon">
     <img ng-if="::(legendIconUrl=gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl))" ng-src="{{::legendIconUrl}}"></img>
-  </span>
-  <span ng-if="::layertreeCtrl.node.children" ng-class="['fa fa-fw', layertreeCtrl.node.children && !layertreeCtrl.layer.loading ? 'state' : 'fa-refresh fa-spin']"></span>
+  </a>
+  <a href ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)"
+     ng-if="::layertreeCtrl.node.children" ng-class="['fa fa-fw', layertreeCtrl.node.children && !layertreeCtrl.layer.loading ? 'state' : 'fa-refresh fa-spin']"></a>
   <a href ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)"
      class="name" title="{{layertreeCtrl.node.name | translate}}">
     <em>{{layertreeCtrl.node.name | translate}}</em>


### PR DESCRIPTION
With this pull request, a lot of work is done on the layer tree CSS to harmonize the different sizes.
Font size gets a bit larger without loosing space.
Also the different nodes in the tree now use the flexbox display so that elements are better aligned and distributed. The computed width of labels for example is a lot less hackish and takes the really available space.
Flexbox has an other advantage: no blank space is automatically added between elements. So this fixes #1134.

I also reduced the nesting when possible.

Legend icons size (actually ratio) is taken into account correctly. The layout actually adapts to it. Icons are not cropped to squeezed. Only max limits for width and height are fixed. Fixes #1302.

After / Before
![screenshot from 2016-06-06 09 17 46](https://cloud.githubusercontent.com/assets/319774/15814547/960b876a-2bc7-11e6-9905-aa8c4cdb2c66.png)

On mobile, the font size is also bigger which makes it easier for users. Spaces between navigation items is also more consistent.
The flexbox display is also used and allows us to use several lines for long labels instead of an ellipsis. Elements are still correctly vertically aligned.

After / Before
![screenshot from 2016-06-06 09 24 12](https://cloud.githubusercontent.com/assets/319774/15814668/72fb3bde-2bc8-11e6-88cf-69c2c8cae464.png)

Please have a look at individual commits for more detailed information.
