### PR TITLE
Use 90% of the viewport width on small mobile devices

### DIFF
--- a/contribs/gmf/less/mobile-nav.less
+++ b/contribs/gmf/less/mobile-nav.less
@@ -230,6 +230,31 @@ nav.nav-right {
   }
 }
 
+// For small devices (in portrait mode) we want the navigation menus to take
+// 90% of the viewport width
+@media (max-width: @screen-xs) {
+  main {
+    .nav-left-is-visible & {
+      transform: translateX(90vw);
+    }
+    .nav-right-is-visible & {
+      transform: translateX(-90vw);
+    }
+  }
+  nav.nav-left,
+  nav.nav-right {
+    width: 90vw;
+    .slide {
+      width: 90vw;
+    }
+
+    header > nav {
+      width: 90vw;
+      left: 90vw;
+    }
+  }
+}
+
 .nav-left {
   left: 0;
   right: auto;

--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -102,20 +102,6 @@ button[ngeo-mobile-geolocation] {
   top: 3 * @map-tools-size + 2 * @app-margin + 2 * @micro-app-margin;
 }
 
-.gmf-theme-selector,
-.gmf-backgroundlayerselector {
-  .gmf-check {
-    top: 0.5rem;
-  }
-  .gmf-text {
-    margin: @half-app-margin @app-margin 0 0;
-    width: calc(~"100% -" @app-margin + 2 * @map-tools-size);
-  }
-  .gmf-thumb {
-    width: 25%;
-  }
-}
-
 .ngeo-notification {
   left: 50%;
   margin: 0 0 0 -10rem;

--- a/contribs/gmf/less/vars.less
+++ b/contribs/gmf/less/vars.less
@@ -22,7 +22,7 @@
 @above-search-index: 6;
 
 
-@nav-width: 26rem;
+@nav-width: 32rem;
 
 @border-radius-base: 0;
 @border-color: black;


### PR DESCRIPTION
#1338 should be merged first.
The idea is to use as much space as possible for navigation panels on small devices on portrait mode.
![screenshot from 2016-06-06 09 38 57](https://cloud.githubusercontent.com/assets/319774/15815053/ad70f77a-2bca-11e6-998d-244a3e65de76.png)

This unfortunately breaks background and theme selectors layout since they use fixed sizes.
