### PR TITLE
Add elevation components

### DIFF
--- a/contribs/gmf/examples/elevation.html
+++ b/contribs/gmf/examples/elevation.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>GMF elevation indicator example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../../../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/font-awesome/css/font-awesome.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+    <style>
+      gmf-map > div {
+        width: 600px;
+        height: 400px;
+      }
+      .footer {
+        text-align: right;
+        min-height: 35px;
+        background-color: rgba(224, 224, 224, 0.8);
+        width: 600px;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <gmf-map gmf-map-map="ctrl.map"></gmf-map>
+
+    <div class="footer">
+      <div ng-show="elevationValue">
+
+        <span class="fa fa-arrows-v"></span>
+        <span gmf-elevation
+              gmf-elevation-active="elevationActive"
+              gmf-elevation-elevation="elevationValue"
+              gmf-elevation-layer="ctrl.elevationLayer"
+              gmf-elevation-map="::ctrl.map">
+              {{elevationValue | number:2}}m
+        </span>
+
+        <div class="btn-group dropup">
+          <div class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+            <span class="fa fa-fw fa-ellipsis-v"></span>
+          </div>
+          <ul class="dropdown-menu">
+            <li ng-repeat="elevationItem in ::ctrl.elevationLayers">
+              <a href ng-click="ctrl.elevationLayer = elevationItem">
+                <span class="fa fa-fw" ng-class="{'fa-check': ctrl.elevationLayer === elevationItem}"></span>
+                {{::elevationItem}}
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <input type="checkbox" ng-model="elevationActive"> Get elevation ?</>
+
+    <p id="desc">This example shows how to use the <code>gmf-elevation</code> directive to get elevation under the mouse position.</p>
+
+    <script src="../../../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../../../node_modules/angular/angular.js"></script>
+    <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
+    <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
+    <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="../../../node_modules/angular-ui-date/dist/date.js"></script>
+    <script src="../../../node_modules/angular-ui-slider/src/slider.js"></script>
+    <script src="../../../node_modules/angular-dynamic-locale/dist/tmhDynamicLocale.js" type="text/javascript"></script>
+    <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../../../node_modules/proj4/dist/proj4.js"></script>
+    <script src="/@?main=elevation.js"></script>
+    <script src="default.js"></script>
+    <script src="../../../utils/watchwatchers.js"></script>
+    <script>
+      var gmfModule = angular.module('gmf');
+      gmfModule.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
+    </script>
+  </body>
+</html>

--- a/contribs/gmf/examples/elevation.html
+++ b/contribs/gmf/examples/elevation.html
@@ -33,6 +33,7 @@
               gmf-elevation-active="elevationActive"
               gmf-elevation-elevation="elevationValue"
               gmf-elevation-layer="ctrl.elevationLayer"
+              gmf-elevation-layers="::ctrl.elevationLayers"
               gmf-elevation-map="::ctrl.map">
               {{elevationValue | number:2}}m
         </span>

--- a/contribs/gmf/examples/elevation.js
+++ b/contribs/gmf/examples/elevation.js
@@ -1,0 +1,67 @@
+goog.provide('gmf-elevation');
+
+goog.require('gmf.elevationDirective');
+goog.require('gmf.mapDirective');
+goog.require('ngeo.proj.EPSG21781');
+goog.require('ol.Map');
+goog.require('ol.Observable');
+goog.require('ol.Overlay');
+goog.require('ol.View');
+goog.require('ol.control.ScaleLine');
+goog.require('ol.layer.Tile');
+goog.require('ol.proj');
+goog.require('ol.source.OSM');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['gmf']);
+
+
+app.module.constant(
+    'gmfAltitudeUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/raster');
+
+
+/**
+ * @constructor
+ */
+app.MainController = function() {
+
+  var projection = ol.proj.get('EPSG:21781');
+
+  /**
+   * @type {Array.<string>}
+   * @export
+   */
+  this.elevationLayers = ['aster', 'srtm'];
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.elevationLayer = this.elevationLayers[0];
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      })
+    ],
+    view: new ol.View({
+      projection: projection,
+      resolutions: [200, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5],
+      center: [600000, 200000],
+      zoom: 3
+    })
+  });
+};
+
+app.module.controller('MainController', app.MainController);

--- a/contribs/gmf/src/directives/elevation.js
+++ b/contribs/gmf/src/directives/elevation.js
@@ -1,0 +1,176 @@
+goog.provide('gmf.ElevationController');
+goog.provide('gmf.elevationDirective');
+
+goog.require('gmf');
+goog.require('gmf.Altitude');
+/** @suppress {extraRequire} */
+goog.require('ngeo.Debounce');
+
+
+/**
+ * Provide a directive that set a value each 500ms with the elevation under the
+ * mouse cursor position on the map. The value must come from the elevation
+ * service of a c2cgeoportal server. The server's URL must be defined as
+ * constant of the application.
+ *
+ * Example:
+ *
+ *      <span gmf-elevation
+ *            gmf-elevation-active="elvationActive"
+ *            gmf-elevation-elevation="elevationValue"
+ *            gmf-elevation-layer="mainCtrl.elevationLayer"
+ *            gmf-elevation-map="::mainCtrl.map">
+ *            {{elevationValue | number:2}}m
+ *      </span>
+ *
+ *
+ * @htmlAttribute {boolean} gmf-elevation-active A boolean to set active or
+ *     deactive the component.
+ * @htmlAttribute {number} gmf-elevation-elevation The value to set with the
+ *     elevation value.
+ * @htmlAttribute {string?} gmf-elevation-layer The elevation layer to use as
+ *     named in the server response object. If not provided, take the first
+ *     returned value.
+ * @htmlAttribute {ol.Map} gmf-elevation-map The map.
+ * @return {angular.Directive} Directive Definition Object.
+ * @ngdoc directive
+ * @ngname gmfElevation
+ */
+gmf.elevationDirective = function() {
+  return {
+    restrict: 'A',
+    controller: 'GmfElevationController',
+    controllerAs: 'ctrl',
+    bindToController: true,
+    scope: {
+      'active': '=gmfElevationActive',
+      'elevation': '=gmfElevationElevation',
+      'layer': '=?gmfElevationLayer',
+      'getMapFn': '&gmfElevationMap'
+    },
+    link: function(scope, element, attr) {
+      var ctrl = scope['ctrl'];
+
+      scope.$watch(function() {
+        return ctrl.active;
+      }, function(active) {
+        this.toggleActive_(active);
+      }.bind(ctrl));
+    }
+  };
+};
+
+
+gmf.module.directive('gmfElevation', gmf.elevationDirective);
+
+/**
+ * @param {ngeo.Debounce} ngeoDebounce Ngeo debounce service
+ * @param {gmf.Altitude} gmfAltitude Gmf altitude service
+ * @constructor
+ * @export
+ * @ngInject
+ * @ngdoc controller
+ * @ngname gmfElevationController
+ */
+gmf.ElevationController = function(ngeoDebounce, gmfAltitude) {
+
+  /**
+   * @type {ngeo.Debounce}
+   * @private
+   */
+  this.ngeoDebounce_ = ngeoDebounce;
+
+  /**
+   * @type {gmf.Altitude}
+   * @private
+   */
+  this.gmfAltitude_ = gmfAltitude;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.active = true;
+
+  /**
+   * @type {number|undefined}
+   * @export
+   */
+  this.elevation;
+
+  /**
+   * @type {string|undefined}
+   * @export
+   */
+  this.layer;
+
+  var map = this['getMapFn']();
+  goog.asserts.assertInstanceof(map, ol.Map);
+
+  /**
+   * @type {!ol.Map}
+   * @private
+   */
+  this.map_ = map;
+
+  /**
+   * @type {ol.events.Key}
+   * @private
+   */
+  this.pointerMoveKey_;
+};
+
+/**
+ * Active or deactive the request of the altitude each 500 ms on pointermove.
+ * @param {boolean} active true to make requests.
+ * @private
+ */
+gmf.ElevationController.prototype.toggleActive_ = function(active) {
+  if (active) {
+    this.pointerMoveKey_ = ol.events.listen(this.map_, 'pointermove',
+        this.ngeoDebounce_(this.pointerMove_.bind(this), 500, true)
+      );
+  } else {
+    this.elevation = undefined;
+    ol.Observable.unByKey(this.pointerMoveKey_);
+  }
+};
+
+
+/**
+ * Request altitude for a MapBrowserPointerEvent's coordinates.
+ * @param {ol.MapBrowserPointerEvent} e An ol map browser pointer event.
+ * @private
+ */
+gmf.ElevationController.prototype.pointerMove_ = function(e) {
+  this.gmfAltitude_.getAltitude(e.coordinate).then(
+      this.getAltitudeSuccess_.bind(this),
+      this.getAltitudeError_.bind(this)
+  );
+};
+
+
+/**
+ * @param {Object.<string, number>} resp Response of the get Altitude service.
+ * @private
+ */
+gmf.ElevationController.prototype.getAltitudeSuccess_ = function(resp) {
+  if (resp !== null) {
+    var layer = this.layer ? this.layer : Object.keys(resp)[0];
+    this.elevation = /** @type {number} */ (resp[layer]);
+  } else {
+    this.elevation = undefined;
+  }
+};
+
+
+/**
+ * @private
+ */
+gmf.ElevationController.prototype.getAltitudeError_ = function() {
+  console.error('Error on getting altitude.');
+  this.elevation = undefined;
+};
+
+
+gmf.module.controller('GmfElevationController', gmf.ElevationController);

--- a/contribs/gmf/src/services/altitude.js
+++ b/contribs/gmf/src/services/altitude.js
@@ -41,12 +41,13 @@ gmf.Altitude = function($http, gmfAltitudeUrl) {
 
 /**
  * @param {ol.Coordinate} coordinate Coordinate.
+ * @param {Object=} opt_params Optional parameters for the request.
  * @return {angular.$q.Promise} Promise.
  * @export
  */
-gmf.Altitude.prototype.getAltitude = function(coordinate) {
+gmf.Altitude.prototype.getAltitude = function(coordinate, opt_params) {
 
-  var params = {};
+  var params = opt_params || {};
   params[gmf.AltitudeParam.X] = coordinate[0];
   params[gmf.AltitudeParam.Y] = coordinate[1];
 


### PR DESCRIPTION
Part of: https://github.com/camptocamp/c2cgeoportal/issues/1668

Example: https://ger-benjamin.github.io/ngeo/elevation/examples/contribs/gmf/elevation.html

Example apidoc: https://ger-benjamin.github.io/ngeo/elevation/apidoc/gmf.elevationDirective.html

I've tried to exclude the dropdown of the directive. I think that's not a part of it. So we can display an elevation on any `<element>` and we don't need a partial. But that add two attributes in the html declaration of the directive (`gmf-elevation-elevation` and `gmf-elavation-layer`) and a watch (the layer)