### PR TITLE
Add gmf-disclaimer directive

### DIFF
--- a/contribs/gmf/examples/layertree.html
+++ b/contribs/gmf/examples/layertree.html
@@ -147,7 +147,7 @@
       }
       gmf-disclaimer .alert-dismissable .close,
       gmf-disclaimer .alert-dismissible .close {
-        right: -5px;
+        right: -0.5rem;
       }
     </style>
   </head>

--- a/contribs/gmf/examples/layertree.html
+++ b/contribs/gmf/examples/layertree.html
@@ -133,10 +133,31 @@
       .treenode a.expand-node.fa[aria-expanded="true"]::before {
           content: "\f078";
       }
+
+      /** Disclaimer */
+      gmf-disclaimer {
+        position: absolute;
+        bottom: 0.5rem;
+        left: 0.5rem;
+        width: 30rem;
+      }
+      gmf-disclaimer .alert {
+        padding: 0.5rem 1rem;
+        margin: 0 0 0.5rem 0;
+      }
+      gmf-disclaimer .alert-dismissable .close,
+      gmf-disclaimer .alert-dismissible .close {
+        right: -5px;
+      }
     </style>
   </head>
   <body ng-controller="MainController as ctrl">
-    <gmf-map gmf-map-map="ctrl.map"></gmf-map>
+    <div style="position: relative;">
+      <gmf-map gmf-map-map="ctrl.map"></gmf-map>
+      <gmf-disclaimer
+          gmf-disclaimer-map="::ctrl.map">
+      </gmf-disclaimer>
+    </div>
     <p id="desc">This example shows how to use the <code>gmf.Layertree</code> directive. This layertree needs a source object (that can change) that describes layers like the c2cgeoportal themes service. The wmsUrl is used by internals WMS layers but you can use WMS externals layers and WMTS layers too.</p>
     <div id="selections">
         <div>Mode:

--- a/contribs/gmf/examples/layertree.js
+++ b/contribs/gmf/examples/layertree.js
@@ -4,6 +4,7 @@ goog.provide('gmf-layertree');
 goog.require('gmf.Themes');
 /** @suppress {extraRequire} */
 goog.require('gmf.TreeManager');
+goog.require('gmf.disclaimerDirective');
 goog.require('gmf.layertreeDirective');
 goog.require('gmf.mapDirective');
 goog.require('ngeo.proj.EPSG21781');

--- a/contribs/gmf/src/directives/disclaimer.js
+++ b/contribs/gmf/src/directives/disclaimer.js
@@ -1,0 +1,211 @@
+goog.provide('gmf.DisclaimerController');
+goog.provide('gmf.disclaimerDirective');
+
+goog.require('gmf');
+goog.require('ngeo.Disclaimer');
+goog.require('ngeo.EventHelper');
+goog.require('ngeo.LayerHelper');
+
+
+/**
+ * Provide a "disclaimer" directive for GeoMapFish that is bound to the
+ * layers added and removed from a map.
+ *
+ * Example:
+ *
+ *      <gmf-disclaimer
+ *        gmf-disclaimer-map="::ctrl.map">
+ *      </gmf-disclaimer>
+ *
+ * @htmlAttribute {ol.Map=} gmf-disclaimer-map The map.
+ * @return {angular.Directive} The Directive Definition Object.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname gmfDisclaimer
+ */
+gmf.disclaimerDirective = function() {
+
+  return {
+    restrict: 'E',
+    scope: {
+      'map': '=gmfDisclaimerMap'
+    },
+    bindToController: true,
+    controller: 'GmfDisclaimerController',
+    controllerAs: 'dclCtrl'
+  };
+};
+
+
+gmf.module.directive('gmfDisclaimer', gmf.disclaimerDirective);
+
+
+/**
+ * @constructor
+ * @param {angular.JQLite} $element Element.
+ * @param {!angular.Scope} $scope Angular scope.
+ * @param {ngeo.Disclaimer} ngeoDisclaimer Ngeo Disclaimer service.
+ * @param {ngeo.EventHelper} ngeoEventHelper Ngeo Event Helper.
+ * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
+ * @export
+ * @ngInject
+ * @ngdoc controller
+ * @ngname GmfDisclaimerController
+ */
+gmf.DisclaimerController = function($element, $scope, ngeoDisclaimer,
+     ngeoEventHelper, ngeoLayerHelper) {
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
+
+  /**
+   * @type {angular.JQLite}
+   * @private
+   */
+  this.element_ = $element;
+
+  /**
+   * @type {ngeo.Disclaimer}
+   * @private
+   */
+  this.disclaimer_ = ngeoDisclaimer;
+
+  /**
+   * @type {ngeo.EventHelper}
+   * @private
+   */
+  this.eventHelper_ = ngeoEventHelper;
+
+  /**
+   * @type {?ol.layer.Group}
+   * @private
+   */
+  this.dataLayerGroup_ = ngeoLayerHelper.getGroupFromMap(this.map,
+      gmf.DATALAYERGROUP_NAME);
+
+  this.registerLayer_(this.dataLayerGroup_);
+
+  $scope.$on('$destroy', this.handleDestroy_.bind(this));
+};
+
+
+/**
+ * @param {ol.CollectionEvent} evt Event.
+ * @private
+ */
+gmf.DisclaimerController.prototype.handleLayersAdd_ = function(evt) {
+  var layer = evt.element;
+  goog.asserts.assertInstanceof(layer, ol.layer.Base);
+  this.registerLayer_(layer);
+};
+
+
+/**
+ * @param {ol.CollectionEvent} evt Event.
+ * @private
+ */
+gmf.DisclaimerController.prototype.handleLayersRemove_ = function(evt) {
+  var layer = evt.element;
+  goog.asserts.assertInstanceof(layer, ol.layer.Base);
+  this.unregisterLayer_(layer);
+};
+
+
+/**
+ * @param {ol.layer.Base} layer Layer.
+ * @private
+ */
+gmf.DisclaimerController.prototype.registerLayer_ = function(layer) {
+
+  var layerUid = goog.getUid(layer);
+
+  if (layer instanceof ol.layer.Group) {
+
+    // (1) Listen to added/removed layers to this group
+    this.eventHelper_.addListenerKey(
+      layerUid,
+      ol.events.listen(
+        layer.getLayers(),
+        ol.CollectionEventType.ADD,
+        this.handleLayersAdd_,
+        this
+      )
+    );
+    this.eventHelper_.addListenerKey(
+      layerUid,
+      ol.events.listen(
+        layer.getLayers(),
+        ol.CollectionEventType.REMOVE,
+        this.handleLayersRemove_,
+        this
+      )
+    );
+
+    // (2) Register existing layers in the group
+    layer.getLayers().forEach(function(layer) {
+      this.registerLayer_(layer);
+    }, this);
+
+  } else {
+
+    // Show disclaimer messages for this layer
+    var disclaimers = layer.get('disclaimers');
+    if (disclaimers && Array.isArray(disclaimers)) {
+      disclaimers.forEach(function(disclaimer) {
+        this.disclaimer_.alert({
+          msg: disclaimer,
+          target: this.element_,
+          type: ngeo.MessageType.WARNING
+        });
+      }, this);
+    }
+  }
+};
+
+
+/**
+ * @param {ol.layer.Base} layer Layer.
+ * @private
+ */
+gmf.DisclaimerController.prototype.unregisterLayer_ = function(layer) {
+
+  var layerUid = goog.getUid(layer);
+
+  if (layer instanceof ol.layer.Group) {
+
+    // (1) Clear event listeners
+    this.eventHelper_.clearListenerKey(layerUid);
+
+    // (2) Unregister existing layers in the group
+    layer.getLayers().forEach(this.unregisterLayer_, this);
+
+  } else {
+
+    // Close disclaimer messages for this layer
+    var disclaimers = layer.get('disclaimers');
+    if (disclaimers && Array.isArray(disclaimers)) {
+      disclaimers.forEach(function(disclaimer) {
+        this.disclaimer_.close({
+          msg: disclaimer,
+          target: this.element_,
+          type: ngeo.MessageType.WARNING
+        });
+      }, this);
+    }
+  }
+
+};
+
+
+/**
+ * @private
+ */
+gmf.DisclaimerController.prototype.handleDestroy_ = function() {
+  this.unregisterLayer_(this.dataLayerGroup_);
+};
+
+
+gmf.module.controller('GmfDisclaimerController', gmf.DisclaimerController);

--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -926,7 +926,7 @@ gmf.LayertreeController.prototype.getNodeDisclaimers_ = function(node) {
       });
     }, this);
   } else if (node.metadata !== undefined &&
-             node.metadata.disclaimer !== undefined &&
+             node.metadata['disclaimer'] !== undefined &&
              disclaimers.indexOf(node.metadata['disclaimer']) === -1) {
     disclaimers.push(node.metadata['disclaimer']);
   }

--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -208,6 +208,7 @@ gmf.LayertreeController.prototype.prepareLayer_ = function(node, layer) {
   var ids =  gmf.LayertreeController.getLayerNodeIds(node);
   layer.set('querySourceIds', ids);
   layer.set('layerName', node.name);
+  layer.set('disclaimers', this.getNodeDisclaimers_(node));
 
   var isMerged = type === gmf.Themes.NodeType.NOT_MIXED_GROUP;
   layer.set('isMerged', isMerged);
@@ -902,6 +903,34 @@ gmf.LayertreeController.prototype.toggleNodeLegend = function(legendNodeId) {
   $(legendNodeId).toggle({
     toggle : true
   });
+};
+
+
+/**
+ * Collect and return all disclaimer strings of this node and all child nodes
+ * as well.
+ * @param {GmfThemesNode} node Layer tree node.
+ * @return {Array.<number|string>} Disclaimer strings
+ * @private
+ */
+gmf.LayertreeController.prototype.getNodeDisclaimers_ = function(node) {
+  var disclaimers = [];
+  var children = node.children || node;
+  if (children && children.length) {
+    children.forEach(function(childNode) {
+      var childDisclaimers = this.getNodeDisclaimers_(childNode);
+      childDisclaimers.forEach(function(childDisclaimer) {
+        if (disclaimers.indexOf(childDisclaimer) === -1) {
+          disclaimers.push(childDisclaimer);
+        }
+      });
+    }, this);
+  } else if (node.metadata !== undefined &&
+             node.metadata.disclaimer !== undefined &&
+             disclaimers.indexOf(node.metadata['disclaimer']) === -1) {
+    disclaimers.push(node.metadata['disclaimer']);
+  }
+  return disclaimers;
 };
 
 

--- a/src/services/eventhelper.js
+++ b/src/services/eventhelper.js
@@ -1,0 +1,102 @@
+goog.provide('ngeo.EventHelper');
+
+goog.require('ngeo');
+
+
+/**
+ * Provides methods to manage the listening/unlistening of all sorts of
+ * events:
+ * - events from OpenLayers
+ * - events from Closure Library
+ *
+ * @constructor
+ * @ngdoc service
+ * @ngname ngeoEventHelper
+ * @ngInject
+ */
+ngeo.EventHelper = function() {
+
+  /**
+   * @type {Object.<number, ngeo.EventHelper.ListenerKeys>}
+   * @private
+   */
+  this.listenerKeys_ = {};
+
+};
+
+
+/**
+ * Utility method to add a listener key bound to a unique id. The key can
+ * come from an `ol.events` (default) or `goog.events`.
+ * @param {number} uid Unique id.
+ * @param {ol.events.Key|goog.events.Key} key Key.
+ * @param {boolean=} opt_isol Whether it's an OpenLayers event or not. Defaults
+ *     to true.
+ * @export
+ */
+ngeo.EventHelper.prototype.addListenerKey = function(uid, key, opt_isol) {
+  if (!this.listenerKeys_[uid]) {
+    this.initListenerKey_(uid);
+  }
+
+  var isol = opt_isol !== undefined ? opt_isol : true;
+  if (isol) {
+    this.listenerKeys_[uid].ol.push(/** @type {ol.events.Key} */ (key));
+  } else {
+    this.listenerKeys_[uid].goog.push(/** @type {goog.events.Key} */ (key));
+  }
+};
+
+
+/**
+ * Clear all listener keys from the given unique id.
+ * @param {number} uid Unique id.
+ * @export
+ */
+ngeo.EventHelper.prototype.clearListenerKey = function(uid) {
+  this.initListenerKey_(uid);
+};
+
+
+/**
+ * Utility method that does 2 things:
+ * - initialize the listener keys of a given uid with an array (if that key
+ *   has not array set yet)
+ * - unlisten any events if the array already exists for the given uid and
+ *   empty the array.
+ * @param {number} uid Unique id.
+ * @private
+ */
+ngeo.EventHelper.prototype.initListenerKey_ = function(uid) {
+  if (!this.listenerKeys_[uid]) {
+    this.listenerKeys_[uid] = {
+      goog: [],
+      ol: []
+    };
+  } else {
+    if (this.listenerKeys_[uid].goog.length) {
+      this.listenerKeys_[uid].goog.forEach(function(key) {
+        goog.events.unlistenByKey(key);
+      }, this);
+      this.listenerKeys_[uid].goog.length = 0;
+    }
+    if (this.listenerKeys_[uid].ol.length) {
+      this.listenerKeys_[uid].ol.forEach(function(key) {
+        ol.events.unlistenByKey(key);
+      }, this);
+      this.listenerKeys_[uid].ol.length = 0;
+    }
+  }
+};
+
+
+/**
+ * @typedef {{
+ *     goog: (Array.<goog.events.Key>),
+ *     ol: (Array.<ol.events.Key>)
+ * }}
+ */
+ngeo.EventHelper.ListenerKeys;
+
+
+ngeo.module.service('ngeoEventHelper', ngeo.EventHelper);


### PR DESCRIPTION
This PR introduces the `gmf-disclaimer` directive, which is added to the layer tree example to demonstrate how it works.

It also introduces a `ngeo.EventHelper` that can be used to register and unregister events from OpenLayers or the Closure Library.  This may seem simple, but sometimes it's a little bit more complex.  For example, let's say you want to listen events from a collection.  If one of the items in the collection is also a collection, you want to listen to it as well.  This sort of complexity becomes hard to manage (the unlistening is what matters).  That's where the event helper comes in handy.  By giving it a uid, you can manage them more easily.

## Todo

 * [x] fix the example (not working with minimized version, it would seem...)
 * [x] review
 * [x] apply reviewer's required corrections

## Live example

 * https://adube.github.io/ngeo/gmf-disclaimer/examples/contribs/gmf/layertree.html