### PR TITLE
Support modal disclaimers

### DIFF
--- a/contribs/gmf/examples/layertree.html
+++ b/contribs/gmf/examples/layertree.html
@@ -155,6 +155,7 @@
     <div style="position: relative;">
       <gmf-map gmf-map-map="ctrl.map"></gmf-map>
       <gmf-disclaimer
+          gmf-disclaimer-modal="::ctrl.modal"
           gmf-disclaimer-map="::ctrl.map">
       </gmf-disclaimer>
     </div>

--- a/contribs/gmf/examples/layertree.js
+++ b/contribs/gmf/examples/layertree.js
@@ -70,7 +70,7 @@ app.MainController = function(gmfThemes, gmfTreeManager, ngeoLocation) {
    * @type {boolean}
    * @export
    */
-  this.modal = modal === 'true' ? true : false;
+  this.modal = modal === 'true';
 
   /**
    * @type {gmf.TreeManager}

--- a/contribs/gmf/examples/layertree.js
+++ b/contribs/gmf/examples/layertree.js
@@ -65,17 +65,12 @@ app.MainController = function(gmfThemes, gmfTreeManager, ngeoLocation) {
 
   // How should disclaimer message be displayed: in modals or alerts
   var modal = ngeoLocation.getParam('modal');
-  if (modal !== undefined) {
-    modal = modal === 'true' ? true : false;
-  } else {
-    modal = false;
-  }
 
   /**
    * @type {boolean}
    * @export
    */
-  this.modal = modal;
+  this.modal = modal === 'true' ? true : false;
 
   /**
    * @type {gmf.TreeManager}

--- a/contribs/gmf/examples/layertree.js
+++ b/contribs/gmf/examples/layertree.js
@@ -7,6 +7,7 @@ goog.require('gmf.TreeManager');
 goog.require('gmf.disclaimerDirective');
 goog.require('gmf.layertreeDirective');
 goog.require('gmf.mapDirective');
+goog.require('ngeo.Location');
 goog.require('ngeo.proj.EPSG21781');
 goog.require('ol.Map');
 goog.require('ol.View');
@@ -35,8 +36,9 @@ app.module.value('gmfWmsUrl',
  * @constructor
  * @param {gmf.Themes} gmfThemes The gme themes service.
  * @param {gmf.TreeManager} gmfTreeManager gmf Tree Manager service.
+ * @param {ngeo.Location} ngeoLocation ngeo location service.
  */
-app.MainController = function(gmfThemes, gmfTreeManager) {
+app.MainController = function(gmfThemes, gmfTreeManager, ngeoLocation) {
 
   gmfThemes.loadThemes();
 
@@ -60,6 +62,20 @@ app.MainController = function(gmfThemes, gmfTreeManager) {
       zoom: 3
     })
   });
+
+  // How should disclaimer message be displayed: in modals or alerts
+  var modal = ngeoLocation.getParam('modal');
+  if (modal !== undefined) {
+    modal = modal === 'true' ? true : false;
+  } else {
+    modal = false;
+  }
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.modal = modal;
 
   /**
    * @type {gmf.TreeManager}

--- a/contribs/gmf/src/directives/disclaimer.js
+++ b/contribs/gmf/src/directives/disclaimer.js
@@ -30,7 +30,7 @@ gmf.disclaimerDirective = function() {
   return {
     restrict: 'E',
     scope: {
-      'modal': '<?gmfDisclaimerModal',
+      'modalIn': '<?gmfDisclaimerModal',
       'map': '=gmfDisclaimerMap'
     },
     bindToController: true,
@@ -63,9 +63,7 @@ gmf.DisclaimerController = function($element, $scope, ngeoCreatePopup,
    * @type {boolean}
    * @export
    */
-  this.modal;
-
-  this.modal = this.modal !== undefined ? this.modal : false;
+  this.modal = this['modalIn'] === true;
 
   /**
    * @type {ol.Map}

--- a/contribs/gmf/src/directives/disclaimer.js
+++ b/contribs/gmf/src/directives/disclaimer.js
@@ -17,6 +17,8 @@ goog.require('ngeo.LayerHelper');
  *        gmf-disclaimer-map="::ctrl.map">
  *      </gmf-disclaimer>
  *
+ * @htmlAttribute {boolean} gmf-disclaimer-modal Whether to show the disclaimer
+ *     messages in modals or not. Defaults to `false`.
  * @htmlAttribute {ol.Map=} gmf-disclaimer-map The map.
  * @return {angular.Directive} The Directive Definition Object.
  * @ngInject
@@ -28,6 +30,7 @@ gmf.disclaimerDirective = function() {
   return {
     restrict: 'E',
     scope: {
+      'modal': '<?gmfDisclaimerModal',
       'map': '=gmfDisclaimerMap'
     },
     bindToController: true,
@@ -44,6 +47,7 @@ gmf.module.directive('gmfDisclaimer', gmf.disclaimerDirective);
  * @constructor
  * @param {angular.JQLite} $element Element.
  * @param {!angular.Scope} $scope Angular scope.
+ * @param {ngeo.CreatePopup} ngeoCreatePopup Popup service.
  * @param {ngeo.Disclaimer} ngeoDisclaimer Ngeo Disclaimer service.
  * @param {ngeo.EventHelper} ngeoEventHelper Ngeo Event Helper.
  * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
@@ -52,8 +56,16 @@ gmf.module.directive('gmfDisclaimer', gmf.disclaimerDirective);
  * @ngdoc controller
  * @ngname GmfDisclaimerController
  */
-gmf.DisclaimerController = function($element, $scope, ngeoDisclaimer,
-     ngeoEventHelper, ngeoLayerHelper) {
+gmf.DisclaimerController = function($element, $scope, ngeoCreatePopup,
+    ngeoDisclaimer, ngeoEventHelper, ngeoLayerHelper) {
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.modal;
+
+  this.modal = this.modal !== undefined ? this.modal : false;
 
   /**
    * @type {ol.Map}
@@ -66,6 +78,12 @@ gmf.DisclaimerController = function($element, $scope, ngeoDisclaimer,
    * @private
    */
   this.element_ = $element;
+
+  /**
+   * @private
+   * @type {ngeo.CreatePopup}
+   */
+  this.createPopup_ = ngeoCreatePopup;
 
   /**
    * @type {ngeo.Disclaimer}
@@ -155,11 +173,7 @@ gmf.DisclaimerController.prototype.registerLayer_ = function(layer) {
     var disclaimers = layer.get('disclaimers');
     if (disclaimers && Array.isArray(disclaimers)) {
       disclaimers.forEach(function(disclaimer) {
-        this.disclaimer_.alert({
-          msg: disclaimer,
-          target: this.element_,
-          type: ngeo.MessageType.WARNING
-        });
+        this.showDisclaimerMessage_(disclaimer);
       }, this);
     }
   }
@@ -188,11 +202,7 @@ gmf.DisclaimerController.prototype.unregisterLayer_ = function(layer) {
     var disclaimers = layer.get('disclaimers');
     if (disclaimers && Array.isArray(disclaimers)) {
       disclaimers.forEach(function(disclaimer) {
-        this.disclaimer_.close({
-          msg: disclaimer,
-          target: this.element_,
-          type: ngeo.MessageType.WARNING
-        });
+        this.closeDisclaimerMessage_(disclaimer);
       }, this);
     }
   }
@@ -205,6 +215,34 @@ gmf.DisclaimerController.prototype.unregisterLayer_ = function(layer) {
  */
 gmf.DisclaimerController.prototype.handleDestroy_ = function() {
   this.unregisterLayer_(this.dataLayerGroup_);
+};
+
+
+/**
+ * @param {string} msg Disclaimer message.
+ * @private
+ */
+gmf.DisclaimerController.prototype.showDisclaimerMessage_ = function(msg) {
+  this.disclaimer_.alert({
+    modal: this.modal,
+    msg: msg,
+    target: this.element_,
+    type: ngeo.MessageType.WARNING
+  });
+};
+
+
+/**
+ * @param {string} msg Disclaimer message.
+ * @private
+ */
+gmf.DisclaimerController.prototype.closeDisclaimerMessage_ = function(msg) {
+  this.disclaimer_.close({
+    modal: this.modal,
+    msg: msg,
+    target: this.element_,
+    type: ngeo.MessageType.WARNING
+  });
 };
 
 

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -90,6 +90,7 @@ ngeox.MenuActionOptions.prototype.name;
  * A message to display by the Ngeo notification service.
  * @typedef {{
  *     delay: (number|undefined),
+ *     modal: (boolean|undefined),
  *     msg: (string),
  *     target: (angular.JQLite|Element|string|undefined),
  *     type: (string|undefined)
@@ -103,6 +104,14 @@ ngeox.Message;
  * @type {number|undefined}
  */
 ngeox.Message.prototype.delay;
+
+
+/**
+ * Whether the message should be displayed inside a modal window or not.
+ * Defaults to `false`.
+ * @type {string}
+ */
+ngeox.Message.prototype.modal;
 
 
 /**

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -109,7 +109,7 @@ ngeox.Message.prototype.delay;
 /**
  * Whether the message should be displayed inside a modal window or not.
  * Defaults to `false`.
- * @type {string}
+ * @type {boolean|undefined}
  */
 ngeox.Message.prototype.modal;
 

--- a/src/directives/partials/popup.html
+++ b/src/directives/partials/popup.html
@@ -1,5 +1,5 @@
 <h4 class="popover-title ngeo-popup-title">
-  <span>{{title}}</span>
+  <span ng-bind-html="title"></span>
   <button type="button" class="close" ng-click="open = false"> &times;</button>
 </h4>
 <div class="popover-content" ng-bind-html="content"></div>

--- a/src/services/disclaimer.js
+++ b/src/services/disclaimer.js
@@ -12,6 +12,7 @@ goog.require('ngeo.Message');
  * properly.
  *
  * @param {angular.$sce} $sce Angular sce service.
+ * @param {angularGettext.Catalog} gettextCatalog Gettext service.
  * @param {ngeo.CreatePopup} ngeoCreatePopup Popup service.
  * @constructor
  * @extends {ngeo.Message}
@@ -19,13 +20,19 @@ goog.require('ngeo.Message');
  * @ngname ngeoDisclaimer
  * @ngInject
  */
-ngeo.Disclaimer = function($sce, ngeoCreatePopup) {
+ngeo.Disclaimer = function($sce, gettextCatalog, ngeoCreatePopup) {
 
   /**
    * @private
    * @type {angular.$sce}
    */
   this.sce_ = $sce;
+
+  /**
+   * @type {angularGettext.Catalog}
+   * @private
+   */
+  this.gettextCatalog_ = gettextCatalog;
 
   /**
    * @private
@@ -95,7 +102,7 @@ ngeo.Disclaimer.prototype.showMessage = function(message) {
     return;
   }
 
-  var showInModal = message.modal !== undefined ? message.modal : false;
+  var showInModal = message.modal === true;
 
   if (showInModal) {
     // display the message in a modal, i.e. using the ngeo create popup
@@ -140,7 +147,7 @@ ngeo.Disclaimer.prototype.showMessage = function(message) {
       '<div role="alert" class="' + classNames.join(' ') + '"></div>');
     var button = angular.element(
       '<button type="button" class="close" data-dismiss="alert" aria-label="' +
-        'Close' +  // FIXME i18n
+        this.gettextCatalog_.getString('Close') +
         '"><span aria-hidden="true">&times;</span></button>');
     var msg = angular.element('<span />').html(message.msg);
     el.append(button).append(msg);

--- a/src/services/popup.js
+++ b/src/services/popup.js
@@ -41,14 +41,14 @@ ngeo.Popup = function($compile, $rootScope, $sce, $timeout) {
   /**
    * The scope the compiled element is link to.
    * @type {angular.Scope}
-   * @private
+   * @export
    */
-  this.scope_ = $rootScope.$new(true);
+  this.scope = $rootScope.$new(true);
 
   // manage the auto destruction of the popup
-  this.scope_.$watch(
+  this.scope.$watch(
     function() {
-      return this.scope_['open'];
+      return this.scope['open'];
     }.bind(this),
     function(open) {
       if (!open && this.autoDestroy_) {
@@ -86,7 +86,7 @@ ngeo.Popup = function($compile, $rootScope, $sce, $timeout) {
 
 
   // Compile the element, link it to the scope and add it to the document.
-  $compile(this.element_)(this.scope_);
+  $compile(this.element_)(this.scope);
   angular.element(document.body).append(this.element_);
 };
 
@@ -97,7 +97,7 @@ ngeo.Popup = function($compile, $rootScope, $sce, $timeout) {
  * @export
  */
 ngeo.Popup.prototype.getOpen = function() {
-  return this.scope_['open'];
+  return this.scope['open'];
 };
 
 
@@ -107,7 +107,7 @@ ngeo.Popup.prototype.getOpen = function() {
  * @export
  */
 ngeo.Popup.prototype.setOpen = function(open) {
-  this.scope_['open'] = open;
+  this.scope['open'] = open;
 };
 
 
@@ -116,7 +116,7 @@ ngeo.Popup.prototype.setOpen = function(open) {
  * @export
  */
 ngeo.Popup.prototype.destroy = function() {
-  this.scope_.$destroy();
+  this.scope.$destroy();
   this.element_.remove();
 };
 
@@ -127,7 +127,8 @@ ngeo.Popup.prototype.destroy = function() {
  * @export
  */
 ngeo.Popup.prototype.setTitle = function(title) {
-  this.scope_['title'] = title;
+  var trustedTitle = this.sce_.trustAsHtml(title);
+  this.scope['title'] = trustedTitle;
 };
 
 
@@ -139,7 +140,7 @@ ngeo.Popup.prototype.setTitle = function(title) {
  * @export
  */
 ngeo.Popup.prototype.setContent = function(content) {
-  this.scope_['content'] = content;
+  this.scope['content'] = content;
 };
 
 


### PR DESCRIPTION
This PR adds the possibility to display disclaimer messages as modals instead of alerts in the disclaimer service (ngeo).  The `gmf.disclaimer` directive now has an option that allows to turn this feature on (defaults to off).

The gmf layer tree example has been modified to be able to show this in action using a url parameter.

Note: this PR currently includes the content of #1341, since it hasn't been merged yet.

## Todo

 * [x] wait for #1341 to be merged
 * [x] review
 * [x] apply reviewer's corrections

## Live demos

 * (use modals) https://adube.github.io/ngeo/gmf-modal-disclaimer/examples/contribs/gmf/layertree.html?modal=true
 * (use alerts, default behavior) https://adube.github.io/ngeo/gmf-modal-disclaimer/examples/contribs/gmf/layertree.html?modal=false