### PR TITLE
Infobar

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -192,7 +192,7 @@
         module.constant('langUrls', langUrls);
         module.constant('authenticationBaseUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi');
         module.constant('fulltextsearchUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/fulltextsearch?limit=30&partitionlimit=5');
-        module.constant('gmfAltitudeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/raster');
+        module.constant('gmfRasterUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/raster');
         module.constant('gmfPrintUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/printproxy');
         module.constant('gmfWmsUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy');
         module.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');

--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -111,7 +111,7 @@
           </gmf-backgroundlayerselector>
         </div>
         <gmf-map class="gmf-map" gmf-map-map="mainCtrl.map"></gmf-map>
-        
+
         <!--infobar-->
         <div class="footer" ng-class="{'active': mainCtrl.info}">
           <button class="btn btn-sm fa map-info ng-cloak" ng-click="mainCtrl.info = !mainCtrl.info"
@@ -122,36 +122,35 @@
                ngeo-scaleselector-options="mainCtrl.scaleSelectorOptions"></div>
           <div id="scaleline"></div>
           <div class="pull-right">
-            <span ng-show="elevationValue" class="fa fa-arrows-v"></span>
-            <span class="elevation" ng-show="elevationValue"
-              gmf-elevation
-              gmf-elevation-active="mainCtrl.info"
-              gmf-elevation-elevation="elevationValue"
-              gmf-elevation-layer="mainCtrl.elevationLayer"
-              gmf-elevation-layers="::mainCtrl.elevationLayers"
-              gmf-elevation-map="mainCtrl.map">
-              {{elevationValue | number:2}} m
-            </span>
-            <div class="btn-group dropup">
-              <div class="btn btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-                <span class="fa fa-fw fa-ellipsis-v"></span>
-              </div>
-              <ul class="dropdown-menu">
-                <li ng-repeat="elevationItem in ::mainCtrl.elevationLayers">
-                  <a href ng-click="mainCtrl.elevationLayer = elevationItem">
-                    <span class="fa fa-fw" ng-class="{'fa-check': mainCtrl.elevationLayer === elevationItem}"></span>
-                    {{::elevationItem}}
-                  </a>
-                </li>
-              </ul>
-            </div>
-            <span class="fa fa-fw fa-location-arrow"></span>
             <gmf-mouseposition
                  gmf-mouseposition-map="mainCtrl.map"
                  gmf-mouseposition-projections="::mainCtrl.mousePositionProjections">
             </gmf-mouseposition>
+            <div class="elevation form-group form-group-sm pull-right" gmf-elevation
+                    gmf-elevation-active="mainCtrl.info"
+                    gmf-elevation-elevation="elevationValue"
+                    gmf-elevation-layer="mainCtrl.elevationLayer"
+                    gmf-elevation-layers="::mainCtrl.elevationLayers"
+                    gmf-elevation-map="mainCtrl.map">
+              <div class="btn-group btn-block dropup">
+                <button type="button" class="btn btn-default dropdown-toggle form-control" data-toggle="dropdown" aria-expanded="false">
+                  <span class="fa fa-arrows-v"></span>
+                  <small class="elevation-value">{{elevationValue | number:2}}<span ng-show="elevationValue">m</span></small>
+                  <span class="fa fa-fw fa-ellipsis-v"></span>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-right" role="menu">
+                  <li ng-repeat="elevationItem in ::mainCtrl.elevationLayers">
+                    <a href ng-click="mainCtrl.elevationLayer = elevationItem">
+                      <span class="fa fa-fw" ng-class="{'fa-check': mainCtrl.elevationLayer === elevationItem}"></span>
+                      {{::elevationItem}}
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
           </div>
         </div>
+
       </div>
     </main>
     <script src="../../../../node_modules/jquery/dist/jquery.js"></script>

--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -111,6 +111,8 @@
           </gmf-backgroundlayerselector>
         </div>
         <gmf-map class="gmf-map" gmf-map-map="mainCtrl.map"></gmf-map>
+        
+        <!--infobar-->
         <div class="footer" ng-class="{'active': mainCtrl.info}">
           <button class="btn btn-sm fa map-info ng-cloak" ng-click="mainCtrl.info = !mainCtrl.info"
                   ng-class="{'fa-angle-double-up': !mainCtrl.info, 'fa-angle-double-down': mainCtrl.info}"></button>
@@ -118,12 +120,36 @@
           <div ngeo-scaleselector="mainCtrl.scaleSelectorValues"
                ngeo-scaleselector-map="mainCtrl.map"
                ngeo-scaleselector-options="mainCtrl.scaleSelectorOptions"></div>
-
           <div id="scaleline"></div>
-          <gmf-mouseposition gmf-mouseposition-map="mainCtrl.map"></gmf-mouseposition>
-          <div class="pull-right small text">
-            <span class="fa fa-arrows-v"></span>
-            235m
+          <div class="pull-right">
+            <span ng-show="elevationValue" class="fa fa-arrows-v"></span>
+            <span class="elevation" ng-show="elevationValue"
+              gmf-elevation
+              gmf-elevation-active="mainCtrl.info"
+              gmf-elevation-elevation="elevationValue"
+              gmf-elevation-layer="mainCtrl.elevationLayer"
+              gmf-elevation-layers="::mainCtrl.elevationLayers"
+              gmf-elevation-map="mainCtrl.map">
+              {{elevationValue | number:2}} m
+            </span>
+            <div class="btn-group dropup">
+              <div class="btn btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+                <span class="fa fa-fw fa-ellipsis-v"></span>
+              </div>
+              <ul class="dropdown-menu">
+                <li ng-repeat="elevationItem in ::mainCtrl.elevationLayers">
+                  <a href ng-click="mainCtrl.elevationLayer = elevationItem">
+                    <span class="fa fa-fw" ng-class="{'fa-check': mainCtrl.elevationLayer === elevationItem}"></span>
+                    {{::elevationItem}}
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <span class="fa fa-fw fa-location-arrow"></span>
+            <gmf-mouseposition
+                 gmf-mouseposition-map="mainCtrl.map"
+                 gmf-mouseposition-projections="::mainCtrl.mousePositionProjections">
+            </gmf-mouseposition>
           </div>
         </div>
       </div>
@@ -167,6 +193,7 @@
         module.constant('langUrls', langUrls);
         module.constant('authenticationBaseUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi');
         module.constant('fulltextsearchUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/fulltextsearch?limit=30&partitionlimit=5');
+        module.constant('gmfAltitudeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/raster');
         module.constant('gmfPrintUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/printproxy');
         module.constant('gmfWmsUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy');
         module.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');

--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -113,9 +113,9 @@
         <gmf-map class="gmf-map" gmf-map-map="mainCtrl.map"></gmf-map>
 
         <!--infobar-->
-        <div class="footer" ng-class="{'active': mainCtrl.info}">
-          <button class="btn btn-sm fa map-info ng-cloak" ng-click="mainCtrl.info = !mainCtrl.info"
-                  ng-class="{'fa-angle-double-up': !mainCtrl.info, 'fa-angle-double-down': mainCtrl.info}"></button>
+        <div class="footer" ng-class="{'active': mainCtrl.showInfobar}">
+          <button class="btn btn-sm fa map-info ng-cloak" ng-click="mainCtrl.showInfobar = !mainCtrl.showInfobar"
+                  ng-class="{'fa-angle-double-up': !mainCtrl.showInfobar, 'fa-angle-double-down': mainCtrl.showInfobar}"></button>
 
           <div ngeo-scaleselector="mainCtrl.scaleSelectorValues"
                ngeo-scaleselector-map="mainCtrl.map"
@@ -127,7 +127,7 @@
                  gmf-mouseposition-projections="::mainCtrl.mousePositionProjections">
             </gmf-mouseposition>
             <div class="elevation form-group form-group-sm pull-right" gmf-elevation
-                    gmf-elevation-active="mainCtrl.info"
+                    gmf-elevation-active="mainCtrl.showInfobar"
                     gmf-elevation-elevation="elevationValue"
                     gmf-elevation-layer="mainCtrl.elevationLayer"
                     gmf-elevation-layers="::mainCtrl.elevationLayers"

--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -111,6 +111,21 @@
           </gmf-backgroundlayerselector>
         </div>
         <gmf-map class="gmf-map" gmf-map-map="mainCtrl.map"></gmf-map>
+        <div class="footer" ng-class="{'active': mainCtrl.info}">
+          <button class="btn btn-sm fa map-info ng-cloak" ng-click="mainCtrl.info = !mainCtrl.info"
+                  ng-class="{'fa-angle-double-up': !mainCtrl.info, 'fa-angle-double-down': mainCtrl.info}"></button>
+
+          <div ngeo-scaleselector="mainCtrl.scaleSelectorValues"
+               ngeo-scaleselector-map="mainCtrl.map"
+               ngeo-scaleselector-options="mainCtrl.scaleSelectorOptions"></div>
+
+          <div id="scaleline"></div>
+          <gmf-mouseposition gmf-mouseposition-map="mainCtrl.map"></gmf-mouseposition>
+          <div class="pull-right small text">
+            <span class="fa fa-arrows-v"></span>
+            235m
+          </div>
+        </div>
       </div>
     </main>
     <script src="../../../../node_modules/jquery/dist/jquery.js"></script>

--- a/contribs/gmf/apps/desktop/js/controller.js
+++ b/contribs/gmf/apps/desktop/js/controller.js
@@ -54,6 +54,71 @@ app.DesktopController = function($scope, $injector) {
           resolutions: [250, 100, 50, 20, 10, 5, 2, 1, 0.5, 0.25, 0.1, 0.05]
         }
       }, $scope, $injector);
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.showInfobar = false;
+
+  /**
+   * @type {ngeo.ScaleselectorOptions}
+   * @export
+   */
+  this.scaleSelectorOptions = {
+    'dropup': true
+  };
+
+  var $sce = $injector.get('$sce');
+
+  /**
+   * @type {!Object.<string, string>}
+   * @export
+   */
+  this.scaleSelectorValues = {
+    '0': $sce.trustAsHtml('1&nbsp;:&nbsp;250\'000'),
+    '1': $sce.trustAsHtml('1&nbsp;:&nbsp;100\'000'),
+    '2': $sce.trustAsHtml('1&nbsp;:&nbsp;50\'000'),
+    '3': $sce.trustAsHtml('1&nbsp;:&nbsp;20\'000'),
+    '4': $sce.trustAsHtml('1&nbsp;:&nbsp;10\'000'),
+    '5': $sce.trustAsHtml('1&nbsp;:&nbsp;5\'000'),
+    '6': $sce.trustAsHtml('1&nbsp;:&nbsp;2\'000'),
+    '7': $sce.trustAsHtml('1&nbsp;:&nbsp;1\'000'),
+    '8': $sce.trustAsHtml('1&nbsp;:&nbsp;500'),
+    '9': $sce.trustAsHtml('1&nbsp;:&nbsp;250'),
+    '10': $sce.trustAsHtml('1&nbsp;:&nbsp;100'),
+    '11': $sce.trustAsHtml('1&nbsp;:&nbsp;50')
+  };
+
+  /**
+   * @type {Array.<string>}
+   * @export
+   */
+  this.elevationLayers = ['aster', 'srtm'];
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.elevationLayer = this.elevationLayers[0];
+
+  /**
+   * @type {Array.<gmfx.MousePositionProjection>}
+   * @export
+   */
+  this.mousePositionProjections = [{
+    code: 'EPSG:2056',
+    label: 'CH1903+ / LV03',
+    filter: 'ngeoNumberCoordinates::{x}, {y} m:false'
+  }, {
+    code: 'EPSG:21781',
+    label: 'CH1903 / LV03',
+    filter: 'ngeoNumberCoordinates::{x}, {y} m:false'
+  }, {
+    code: 'EPSG:4326',
+    label: 'WGS84',
+    filter: 'ngeoDMSCoordinates:2'
+  }];
 };
 goog.inherits(app.DesktopController, gmf.AbstractDesktopController);
 

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -112,9 +112,9 @@
         <gmf-map class="gmf-map" gmf-map-map="mainCtrl.map"></gmf-map>
 
         <!--infobar-->
-        <div class="footer" ng-class="{'active': mainCtrl.info}">
-          <button class="btn btn-sm fa map-info ng-cloak" ng-click="mainCtrl.info = !mainCtrl.info"
-                  ng-class="{'fa-angle-double-up': !mainCtrl.info, 'fa-angle-double-down': mainCtrl.info}"></button>
+        <div class="footer" ng-class="{'active': mainCtrl.showInfobar}">
+          <button class="btn btn-sm fa map-info ng-cloak" ng-click="mainCtrl.showInfobar = !mainCtrl.showInfobar"
+                  ng-class="{'fa-angle-double-up': !mainCtrl.showInfobar, 'fa-angle-double-down': mainCtrl.showInfobar}"></button>
 
           <div ngeo-scaleselector="mainCtrl.scaleSelectorValues"
                ngeo-scaleselector-map="mainCtrl.map"
@@ -127,7 +127,7 @@
             </gmf-mouseposition>
             <div class="elevation"
               gmf-elevation
-              gmf-elevation-active="mainCtrl.info"
+              gmf-elevation-active="mainCtrl.showInfoBar"
               gmf-elevation-elevation="elevationValue"
               gmf-elevation-layers="::mainCtrl.elevationLayers"
               gmf-elevation-map="mainCtrl.map">

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -110,6 +110,33 @@
           </gmf-backgroundlayerselector>
         </div>
         <gmf-map class="gmf-map" gmf-map-map="mainCtrl.map"></gmf-map>
+
+        <!--infobar-->
+        <div class="footer" ng-class="{'active': mainCtrl.info}">
+          <button class="btn btn-sm fa map-info ng-cloak" ng-click="mainCtrl.info = !mainCtrl.info"
+                  ng-class="{'fa-angle-double-up': !mainCtrl.info, 'fa-angle-double-down': mainCtrl.info}"></button>
+
+          <div ngeo-scaleselector="mainCtrl.scaleSelectorValues"
+               ngeo-scaleselector-map="mainCtrl.map"
+               ngeo-scaleselector-options="mainCtrl.scaleSelectorOptions"></div>
+          <div id="scaleline"></div>
+          <div class="pull-right">
+            <gmf-mouseposition
+                 gmf-mouseposition-map="mainCtrl.map"
+                 gmf-mouseposition-projections="::mainCtrl.mousePositionProjections">
+            </gmf-mouseposition>
+            <div class="elevation"
+              gmf-elevation
+              gmf-elevation-active="mainCtrl.info"
+              gmf-elevation-elevation="elevationValue"
+              gmf-elevation-layers="::mainCtrl.elevationLayers"
+              gmf-elevation-map="mainCtrl.map">
+              <span class="fa fa-arrows-v"></span>
+              <small class="elevation-value">{{elevationValue | number:2}}<span ng-show="elevationValue">m</span></small>
+            </div>
+          </div>
+        </div>
+
       </div>
     </main>
     <script src="../../../../node_modules/jquery/dist/jquery.js"></script>
@@ -151,6 +178,7 @@
         module.constant('langUrls', langUrls);
         module.constant('authenticationBaseUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi');
         module.constant('fulltextsearchUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/fulltextsearch?limit=30&partitionlimit=5');
+        module.constant('gmfAltitudeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/raster');
         module.constant('gmfPrintUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/printproxy');
         module.constant('gmfWmsUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy');
         module.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -178,7 +178,7 @@
         module.constant('langUrls', langUrls);
         module.constant('authenticationBaseUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi');
         module.constant('fulltextsearchUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/fulltextsearch?limit=30&partitionlimit=5');
-        module.constant('gmfAltitudeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/raster');
+        module.constant('gmfRasterUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/raster');
         module.constant('gmfPrintUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/printproxy');
         module.constant('gmfWmsUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy');
         module.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');

--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -52,6 +52,59 @@ app.AlternativeDesktopController = function($scope, $injector) {
           zoom: 3
         }
       }, $scope, $injector);
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.showInfobar = true;
+
+  /**
+   * @type {ngeo.ScaleselectorOptions}
+   * @export
+   */
+  this.scaleSelectorOptions = {
+    'dropup': true
+  };
+
+  var $sce = $injector.get('$sce');
+
+  /**
+   * @type {!Object.<string, string>}
+   * @export
+   */
+  this.scaleSelectorValues = {
+    '0': $sce.trustAsHtml('1&nbsp;:&nbsp;250\'000'),
+    '1': $sce.trustAsHtml('1&nbsp;:&nbsp;100\'000'),
+    '2': $sce.trustAsHtml('1&nbsp;:&nbsp;50\'000'),
+    '3': $sce.trustAsHtml('1&nbsp;:&nbsp;20\'000'),
+    '4': $sce.trustAsHtml('1&nbsp;:&nbsp;10\'000'),
+    '5': $sce.trustAsHtml('1&nbsp;:&nbsp;5\'000'),
+    '6': $sce.trustAsHtml('1&nbsp;:&nbsp;2\'000'),
+    '7': $sce.trustAsHtml('1&nbsp;:&nbsp;1\'000'),
+    '8': $sce.trustAsHtml('1&nbsp;:&nbsp;500'),
+    '9': $sce.trustAsHtml('1&nbsp;:&nbsp;250'),
+    '10': $sce.trustAsHtml('1&nbsp;:&nbsp;100'),
+    '11': $sce.trustAsHtml('1&nbsp;:&nbsp;50')
+  };
+
+  /**
+   * @type {Array.<gmfx.MousePositionProjection>}
+   * @export
+   */
+  this.mousePositionProjections = [{
+    code: 'EPSG:2056',
+    label: 'CH1903+ / LV03',
+    filter: 'ngeoNumberCoordinates::{x}, {y} m:false'
+  }, {
+    code: 'EPSG:21781',
+    label: 'CH1903 / LV03',
+    filter: 'ngeoNumberCoordinates::{x}, {y} m:false'
+  }, {
+    code: 'EPSG:4326',
+    label: 'WGS84',
+    filter: 'ngeoDMSCoordinates:2'
+  }];
 };
 goog.inherits(app.AlternativeDesktopController, gmf.AbstractDesktopController);
 

--- a/contribs/gmf/examples/elevation.html
+++ b/contribs/gmf/examples/elevation.html
@@ -14,9 +14,19 @@
         width: 600px;
         height: 400px;
       }
+      .elevation .dropdown-menu {
+        min-width: 120px;
+      }
+      .elevation button {
+        min-width: 120px;
+      }
+      .elevation-value {
+        display: inline-block;
+        min-width: 60px;
+      }
       .footer {
         text-align: right;
-        min-height: 35px;
+        min-height: 30px;
         background-color: rgba(224, 224, 224, 0.8);
         width: 600px;
       }
@@ -26,23 +36,23 @@
     <gmf-map gmf-map-map="ctrl.map"></gmf-map>
 
     <div class="footer">
-      <div ng-show="elevationValue">
 
-        <span class="fa fa-arrows-v"></span>
-        <span gmf-elevation
-              gmf-elevation-active="elevationActive"
-              gmf-elevation-elevation="elevationValue"
-              gmf-elevation-layer="ctrl.elevationLayer"
-              gmf-elevation-layers="::ctrl.elevationLayers"
-              gmf-elevation-map="::ctrl.map">
-              {{elevationValue | number:2}}m
-        </span>
+      <span gmf-elevation
+            gmf-elevation-active="elevationActive"
+            gmf-elevation-elevation="elevationValue"
+            gmf-elevation-layer="ctrl.elevationLayer"
+            gmf-elevation-layers="::ctrl.elevationLayers"
+            gmf-elevation-map="::ctrl.map">
+      </span>
 
-        <div class="btn-group dropup">
-          <div class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+      <div class="elevation form-group form-group-sm pull-right">
+        <div class="btn-group btn-block dropup">
+          <button type="button" class="btn btn-default form-control" data-toggle="dropdown" aria-expanded="false">
+            <span class="fa fa-arrows-v"></span>
+            <small class="elevation-value">{{elevationValue | number:2}}<span ng-show="elevationValue">m</span></small>
             <span class="fa fa-fw fa-ellipsis-v"></span>
-          </div>
-          <ul class="dropdown-menu">
+          </button>
+          <ul class="dropdown-menu dropdown-menu-right" role="menu">
             <li ng-repeat="elevationItem in ::ctrl.elevationLayers">
               <a href ng-click="ctrl.elevationLayer = elevationItem">
                 <span class="fa fa-fw" ng-class="{'fa-check': ctrl.elevationLayer === elevationItem}"></span>
@@ -52,6 +62,7 @@
           </ul>
         </div>
       </div>
+
     </div>
 
     <input type="checkbox" ng-model="elevationActive"> Get elevation ?</>

--- a/contribs/gmf/examples/elevation.js
+++ b/contribs/gmf/examples/elevation.js
@@ -22,7 +22,7 @@ app.module = angular.module('app', ['gmf']);
 
 
 app.module.constant(
-    'gmfAltitudeUrl',
+    'gmfRasterUrl',
     'https://geomapfish-demo.camptocamp.net/2.1/wsgi/raster');
 
 

--- a/contribs/gmf/examples/mobilemeasure.js
+++ b/contribs/gmf/examples/mobilemeasure.js
@@ -27,7 +27,7 @@ app.module = angular.module('app', ['gmf']);
 
 
 app.module.constant(
-    'gmfAltitudeUrl',
+    'gmfRasterUrl',
     'https://geomapfish-demo.camptocamp.net/2.1/wsgi/raster');
 
 

--- a/contribs/gmf/examples/mouseposition.html
+++ b/contribs/gmf/examples/mouseposition.html
@@ -14,9 +14,11 @@
         height: 400px;
       }
       #mouse-position {
+        font-size: 80%;
         min-width: 210px;
-        margin-top: 0.3rem;
-        text-align: right;
+      }
+      .custom-mouse-position {
+        display: inline-block;
       }
       .footer {
         text-align: right;

--- a/contribs/gmf/examples/mouseposition.html
+++ b/contribs/gmf/examples/mouseposition.html
@@ -13,12 +13,15 @@
         width: 600px;
         height: 400px;
       }
-      #mouse-position {
-        font-size: 80%;
-        min-width: 210px;
+      gmf-mouseposition>div {
+        min-width: 260px;
       }
-      .custom-mouse-position {
+      .dropdown-menu {
+        min-width: 260px;
+      }
+      #mouse-position {
         display: inline-block;
+        min-width: 200px;
       }
       .footer {
         text-align: right;

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -129,6 +129,8 @@ main {
     }
   }
   .elevation {
+    display: inline-block;
+    vertical-align: sub;
     .dropdown-menu {
       min-width: 12rem;
     }

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -66,16 +66,14 @@ main {
   }
 
   .footer {
+    @height: @line-height-computed + 2 * @padding-small-vertical;
     position: absolute;
     bottom:  -@height;
-    background-color: rgba(192, 192, 192, 0.9);
+    background-color: fade(@main-bg-color, 80%);
     width: 100%;
     /* cancel default navbar bottom margin */
     margin-bottom: 0;
     /* buttons or inputs in bar are supposed to be '-sm' */
-    @height: @line-height-computed + 2 * @padding-small-vertical;
-    min-height: @height;
-
     transition: 0.2s ease-out all;
     &.active {
       bottom: 0;
@@ -84,49 +82,53 @@ main {
       display: inline-block;
     }
 
-    .text  {
-      line-height: @height;
-      padding-right: 10px;
-      margin-top: 1px;
-    }
-    button {
-      margin-top: 1px;
-    }
-
     button.map-info {
       position: absolute;
       /* button is supposed to be .btn-sm */
-      top: -( @line-height-computed + 2 * @padding-small-vertical);
-      background-color: rgba(192, 192, 192, 0.9);
+      bottom: @line-height-computed + 2 * @padding-small-vertical;
+      background-color: fade(@main-bg-color, 80%);
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
       right: @app-margin;
       border-bottom: 0;
+      padding: @half-app-margin @app-margin;
     }
     .btn {
-      background-color: @main-bg-color;
+      background-color: lighten(@main-bg-color, 20%);
+      padding: @half-app-margin 0;
+    }
+  }
+
+  [ngeo-scaleselector] {
+    .dropdown {
+      button {
+        min-width:13rem;
+        font-size: @font-size-small
+      }
     }
   }
   #scaleline {
-    display: inline-block;
-    padding-right: 5px;
-  }
-  .ol-scale-line {
-    bottom: auto;
-    left: 5px;
-  }
-  [ngeo-scaleselector] {
-    [data-toggle="dropdown"] {
-      .btn-sm
+    vertical-align: middle;
+    .ol-scale-line, .ol-scale-line-inner {
+      background-color: transparent;
+      bottom: auto;
+      position: relative;
     }
   }
-  .ol-scale-line, .ol-scale-line-inner {
-    position: relative;
-    background-color: transparent;
-  }
   #mouse-position {
+    font-size: @font-size-small;
+    .custom-mouse-position {
+      display: inline-block;
+      min-width: 18rem;
+      text-align: right;
+    }
+  }
+  .elevation {
     text-align: right;
-    min-width: 210px;
+    font-size: @font-size-small;
+    gmf-elevation {
+      min-width: 10rem;
+    }
   }
 }
 

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -64,6 +64,70 @@ main {
     bottom: 0;
     left: 0;
   }
+
+  .footer {
+    position: absolute;
+    bottom:  -@height;
+    background-color: rgba(192, 192, 192, 0.9);
+    width: 100%;
+    /* cancel default navbar bottom margin */
+    margin-bottom: 0;
+    /* buttons or inputs in bar are supposed to be '-sm' */
+    @height: @line-height-computed + 2 * @padding-small-vertical;
+    min-height: @height;
+
+    transition: 0.2s ease-out all;
+    &.active {
+      bottom: 0;
+    }
+    > div {
+      display: inline-block;
+    }
+
+    .text  {
+      line-height: @height;
+      padding-right: 10px;
+      margin-top: 1px;
+    }
+    button {
+      margin-top: 1px;
+    }
+
+    button.map-info {
+      position: absolute;
+      /* button is supposed to be .btn-sm */
+      top: -( @line-height-computed + 2 * @padding-small-vertical);
+      background-color: rgba(192, 192, 192, 0.9);
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+      right: @app-margin;
+      border-bottom: 0;
+    }
+    .btn {
+      background-color: @main-bg-color;
+    }
+  }
+  #scaleline {
+    display: inline-block;
+    padding-right: 5px;
+  }
+  .ol-scale-line {
+    bottom: auto;
+    left: 5px;
+  }
+  [ngeo-scaleselector] {
+    [data-toggle="dropdown"] {
+      .btn-sm
+    }
+  }
+  .ol-scale-line, .ol-scale-line-inner {
+    position: relative;
+    background-color: transparent;
+  }
+  #mouse-position {
+    text-align: right;
+    min-width: 210px;
+  }
 }
 
 .search {

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -97,14 +97,15 @@ main {
       background-color: lighten(@main-bg-color, 20%);
       padding: @half-app-margin 0;
     }
+    .form-group{
+      margin-bottom: 0;
+    }
   }
 
   [ngeo-scaleselector] {
-    .dropdown {
-      button {
-        min-width:13rem;
-        font-size: @font-size-small
-      }
+    min-width: 12rem;
+    .dropdown-menu {
+      min-width: 12rem;
     }
   }
   #scaleline {
@@ -115,19 +116,28 @@ main {
       position: relative;
     }
   }
-  #mouse-position {
-    font-size: @font-size-small;
-    .custom-mouse-position {
+  gmf-mouseposition {
+    &>div {
+      min-width: 24rem;
+    }
+    .dropdown-menu {
+      min-width: 24rem;
+    }
+    #mouse-position {
       display: inline-block;
       min-width: 18rem;
-      text-align: right;
     }
   }
   .elevation {
-    text-align: right;
-    font-size: @font-size-small;
-    gmf-elevation {
-      min-width: 10rem;
+    .dropdown-menu {
+      min-width: 12rem;
+    }
+    button {
+      min-width: 12rem;
+    }
+    .elevation-value {
+      display: inline-block;
+      min-width: 6rem;
     }
   }
 }

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -122,65 +122,6 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
   });
   this.drawFeatureLayer.setMap(this.map);
 
-  var $sce = $injector.get('$sce');
-
-  /**
-   * @type {ngeo.ScaleselectorOptions}
-   * @export
-   */
-  this.scaleSelectorOptions = {
-    'dropup': true
-  };
-
-  /**
-   * @type {!Object.<string, string>}
-   * @export
-   */
-  this.scaleSelectorValues = {
-    '0': $sce.trustAsHtml('1&nbsp;:&nbsp;250\'000'),
-    '1': $sce.trustAsHtml('1&nbsp;:&nbsp;100\'000'),
-    '2': $sce.trustAsHtml('1&nbsp;:&nbsp;50\'000'),
-    '3': $sce.trustAsHtml('1&nbsp;:&nbsp;20\'000'),
-    '4': $sce.trustAsHtml('1&nbsp;:&nbsp;10\'000'),
-    '5': $sce.trustAsHtml('1&nbsp;:&nbsp;5\'000'),
-    '6': $sce.trustAsHtml('1&nbsp;:&nbsp;2\'000'),
-    '7': $sce.trustAsHtml('1&nbsp;:&nbsp;1\'000'),
-    '8': $sce.trustAsHtml('1&nbsp;:&nbsp;500'),
-    '9': $sce.trustAsHtml('1&nbsp;:&nbsp;250'),
-    '10': $sce.trustAsHtml('1&nbsp;:&nbsp;100'),
-    '11': $sce.trustAsHtml('1&nbsp;:&nbsp;50')
-  };
-
-  /**
-   * @type {Array.<string>}
-   * @export
-   */
-  this.elevationLayers = ['aster', 'srtm'];
-
-  /**
-   * @type {string}
-   * @export
-   */
-  this.elevationLayer = this.elevationLayers[0];
-
-  /**
-   * @type {Array.<gmfx.MousePositionProjection>}
-   * @export
-   */
-  this.mousePositionProjections = [{
-    code: 'EPSG:2056',
-    label: 'CH1903+ / LV03',
-    filter: 'ngeoNumberCoordinates::{x}, {y} m:false'
-  }, {
-    code: 'EPSG:21781',
-    label: 'CH1903 / LV03',
-    filter: 'ngeoNumberCoordinates::{x}, {y} m:false'
-  }, {
-    code: 'EPSG:4326',
-    label: 'WGS84',
-    filter: 'ngeoDMSCoordinates:2'
-  }];
-
   goog.base(
       this, config, $scope, $injector);
 

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -7,14 +7,21 @@ goog.require('gmf.backgroundlayerselectorDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.drawfeatureDirective');
 /** @suppress {extraRequire} */
+goog.require('gmf.mousepositionDirective');
+/** @suppress {extraRequire} */
 goog.require('gmf.printDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.btngroupDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.resizemapDirective');
+/** @suppress {extraRequire} */
 goog.require('ngeo.FeatureHelper');
 /** @suppress {extraRequire} */
 goog.require('ngeo.Features');
+/** @suppress {extraRequire} */
+goog.require('ngeo.ScaleselectorOptions');
+/** @suppress {extraRequire} */
+goog.require('ngeo.scaleselectorDirective');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.control.ScaleLine');
@@ -58,7 +65,9 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
     layers: [],
     view: new ol.View(viewConfig),
     controls: config.mapControls || [
-      new ol.control.ScaleLine(),
+      new ol.control.ScaleLine({
+        target: document.getElementById('scaleline')
+      }),
       new ol.control.Zoom()
     ],
     interactions: config.mapInteractions || ol.interaction.defaults({
@@ -110,6 +119,28 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
     })
   });
   this.drawFeatureLayer.setMap(this.map);
+
+  var $sce = $injector.get('$sce');
+
+  /**
+   * @type {ngeo.ScaleselectorOptions}
+   * @export
+   */
+  this.scaleSelectorOptions = {
+    'dropup': true
+  };
+
+  /**
+   * @type {!Object.<string, string>}
+   * @export
+   */
+  this.scaleSelectorValues = {
+    '0': $sce.trustAsHtml('1&nbsp;:&nbsp;200\'000\'000'),
+    '1': $sce.trustAsHtml('1&nbsp;:&nbsp;100\'000\'000'),
+    '2': $sce.trustAsHtml('1&nbsp;:&nbsp;50\'000\'000'),
+    '3': $sce.trustAsHtml('1&nbsp;:&nbsp;25\'000\'000'),
+    '4': $sce.trustAsHtml('1&nbsp;:&nbsp;12\'000\'000')
+  };
 
   goog.base(
       this, config, $scope, $injector);

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -7,6 +7,8 @@ goog.require('gmf.backgroundlayerselectorDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.drawfeatureDirective');
 /** @suppress {extraRequire} */
+goog.require('gmf.elevationDirective');
+/** @suppress {extraRequire} */
 goog.require('gmf.mousepositionDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.printDirective');
@@ -135,12 +137,49 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
    * @export
    */
   this.scaleSelectorValues = {
-    '0': $sce.trustAsHtml('1&nbsp;:&nbsp;200\'000\'000'),
-    '1': $sce.trustAsHtml('1&nbsp;:&nbsp;100\'000\'000'),
-    '2': $sce.trustAsHtml('1&nbsp;:&nbsp;50\'000\'000'),
-    '3': $sce.trustAsHtml('1&nbsp;:&nbsp;25\'000\'000'),
-    '4': $sce.trustAsHtml('1&nbsp;:&nbsp;12\'000\'000')
+    '0': $sce.trustAsHtml('1&nbsp;:&nbsp;250\'000'),
+    '1': $sce.trustAsHtml('1&nbsp;:&nbsp;100\'000'),
+    '2': $sce.trustAsHtml('1&nbsp;:&nbsp;50\'000'),
+    '3': $sce.trustAsHtml('1&nbsp;:&nbsp;20\'000'),
+    '4': $sce.trustAsHtml('1&nbsp;:&nbsp;10\'000'),
+    '5': $sce.trustAsHtml('1&nbsp;:&nbsp;5\'000'),
+    '6': $sce.trustAsHtml('1&nbsp;:&nbsp;2\'000'),
+    '7': $sce.trustAsHtml('1&nbsp;:&nbsp;1\'000'),
+    '8': $sce.trustAsHtml('1&nbsp;:&nbsp;500'),
+    '9': $sce.trustAsHtml('1&nbsp;:&nbsp;250'),
+    '10': $sce.trustAsHtml('1&nbsp;:&nbsp;100'),
+    '11': $sce.trustAsHtml('1&nbsp;:&nbsp;50')
   };
+
+  /**
+   * @type {Array.<string>}
+   * @export
+   */
+  this.elevationLayers = ['aster', 'srtm'];
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.elevationLayer = this.elevationLayers[0];
+
+  /**
+   * @type {Array.<gmfx.MousePositionProjection>}
+   * @export
+   */
+  this.mousePositionProjections = [{
+    code: 'EPSG:2056',
+    label: 'CH1903+ / LV03',
+    filter: 'ngeoNumberCoordinates::{x}, {y} m:false'
+  }, {
+    code: 'EPSG:21781',
+    label: 'CH1903 / LV03',
+    filter: 'ngeoNumberCoordinates::{x}, {y} m:false'
+  }, {
+    code: 'EPSG:4326',
+    label: 'WGS84',
+    filter: 'ngeoDMSCoordinates:2'
+  }];
 
   goog.base(
       this, config, $scope, $injector);

--- a/contribs/gmf/src/controllers/abstractmobile.js
+++ b/contribs/gmf/src/controllers/abstractmobile.js
@@ -31,7 +31,7 @@ goog.require('ol.style.Style');
 gmf.module.constant('isMobile', true);
 
 gmf.module.constant(
-    'gmfAltitudeUrl',
+    'gmfRasterUrl',
     'https://geomapfish-demo.camptocamp.net/2.1/wsgi/raster');
 
 

--- a/contribs/gmf/src/directives/elevation.js
+++ b/contribs/gmf/src/directives/elevation.js
@@ -45,9 +45,9 @@ gmf.elevationDirective = function() {
     controllerAs: 'ctrl',
     bindToController: true,
     scope: {
-      'active': '=gmfElevationActive',
+      'active': '<gmfElevationActive',
       'elevation': '=gmfElevationElevation',
-      'layer': '=?gmfElevationLayer',
+      'layer': '<?gmfElevationLayer',
       'getLayersFn': '&?gmfElevationLayers',
       'getMapFn': '&gmfElevationMap'
     },

--- a/contribs/gmf/src/directives/partials/mouseposition.html
+++ b/contribs/gmf/src/directives/partials/mouseposition.html
@@ -1,14 +1,16 @@
-<div class="btn-group dropup dropdown-menu-right">
-  <small id="mouse-position" class="pull-left"></small>
-  <div class="btn btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-    <span class="fa fa-fw fa-ellipsis-v"></span>
-  </div>
-  <ul class="dropdown-menu" role="menu">
-    <li ng-repeat="projitem in ::ctrl.projections">
-      <a href ng-click="ctrl.setProjection(projitem)">
-        <span class="fa fa-fw" ng-class="{'fa-check': ctrl.projection == projitem}"></span>
-        {{::projitem.label}}
-      </a>
-    </li>
-  </ul>
-</div>
+<span>
+  <span id="mouse-position"></span>
+  <span class="btn-group dropup dropdown-menu-right">
+    <span class="btn btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+      <span class="fa fa-fw fa-ellipsis-v"></span>
+    </span>
+    <ul class="dropdown-menu" role="menu">
+      <li ng-repeat="projitem in ::ctrl.projections">
+        <a href ng-click="ctrl.setProjection(projitem)">
+          <span class="fa fa-fw" ng-class="{'fa-check': ctrl.projection == projitem}"></span>
+          {{::projitem.label}}
+        </a>
+      </li>
+    </ul>
+  </span>
+</span>

--- a/contribs/gmf/src/directives/partials/mouseposition.html
+++ b/contribs/gmf/src/directives/partials/mouseposition.html
@@ -1,10 +1,11 @@
-<span>
-  <span id="mouse-position"></span>
-  <span class="btn-group dropup dropdown-menu-right">
-    <span class="btn btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+<div class="form-group form-group-sm pull-right">
+  <div class="btn-group btn-block dropup">
+    <button type="button" class="btn btn-default dropdown-toggle form-control" data-toggle="dropdown" aria-expanded="false">
+      <span class="fa fa-fw fa-location-arrow"></span>
+      <small id="mouse-position"></small>
       <span class="fa fa-fw fa-ellipsis-v"></span>
-    </span>
-    <ul class="dropdown-menu" role="menu">
+    </button>
+    <ul class="dropdown-menu dropdown-menu-right" role="menu">
       <li ng-repeat="projitem in ::ctrl.projections">
         <a href ng-click="ctrl.setProjection(projitem)">
           <span class="fa fa-fw" ng-class="{'fa-check': ctrl.projection == projitem}"></span>
@@ -12,5 +13,5 @@
         </a>
       </li>
     </ul>
-  </span>
-</span>
+  </div>
+</div>

--- a/contribs/gmf/src/services/altitude.js
+++ b/contribs/gmf/src/services/altitude.js
@@ -18,12 +18,12 @@ gmf.AltitudeParam = {
  * at a specific coordinate.
  * @constructor
  * @param {angular.$http} $http Angular http service.
- * @param {string} gmfAltitudeUrl URL to the altitude server
+ * @param {string} gmfRasterUrl URL to a raster service with altitude layers.
  * @ngInject
  * @ngdoc service
  * @ngname gmfAltitude
  */
-gmf.Altitude = function($http, gmfAltitudeUrl) {
+gmf.Altitude = function($http, gmfRasterUrl) {
 
   /**
    * @type {angular.$http}
@@ -35,7 +35,7 @@ gmf.Altitude = function($http, gmfAltitudeUrl) {
    * @type {string}
    * @private
    */
-  this.url_ = gmfAltitudeUrl;
+  this.url_ = gmfRasterUrl;
 };
 
 

--- a/examples/scaleselector.html
+++ b/examples/scaleselector.html
@@ -14,9 +14,7 @@
       }
       app-scaleselector {
         display: inline-block;
-      }
-      app-scaleselector .dropdown button {
-        min-width: 132px;
+        min-width: 160px;
       }
     </style>
   </head>

--- a/src/directives/partials/scaleselector.html
+++ b/src/directives/partials/scaleselector.html
@@ -1,12 +1,14 @@
-<div ng-class="::{'dropdown': true, 'dropup': scaleselectorCtrl.options.dropup}">
-  <button type="button" class="btn btn-default" data-toggle="dropdown">
-    <span ng-bind-html="scaleselectorCtrl.currentScale"></span>&nbsp;<span class="caret"></span>
-  </button>
-  <ul class="dropdown-menu" role="menu">
-    <li ng-repeat="zoomLevel in ::scaleselectorCtrl.zoomLevels">
-      <a href ng-click="scaleselectorCtrl.changeZoom(zoomLevel)"
-         ng-bind-html="scaleselectorCtrl.getScale(zoomLevel)">
-      </a>
-    </li>
-  </ul>
+<div class="form-group form-group-sm dropdown" ng-class="::{'dropup': scaleselectorCtrl.options.dropup}">
+  <div class="btn-group btn-block">
+    <button type="button" class="btn btn-default dropdown-toggle form-control" data-toggle="dropdown" aria-expanded="false">
+      <span ng-bind-html="scaleselectorCtrl.currentScale"></span>&nbsp;<i class="caret"></i>
+    </button>
+    <ul class="dropdown-menu btn-block" role="menu">
+      <li ng-repeat="zoomLevel in ::scaleselectorCtrl.zoomLevels">
+        <a href ng-click="scaleselectorCtrl.changeZoom(zoomLevel)"
+           ng-bind-html="scaleselectorCtrl.getScale(zoomLevel)">
+        </a>
+      </li>
+    </ul>
+  </div>
 </div>

--- a/src/directives/partials/scaleselector.html
+++ b/src/directives/partials/scaleselector.html
@@ -1,5 +1,5 @@
 <div ng-class="::{'dropdown': true, 'dropup': scaleselectorCtrl.options.dropup}">
-  <button type="button" class="btn btn-primary" data-toggle="dropdown">
+  <button type="button" class="btn btn-default" data-toggle="dropdown">
     <span ng-bind-html="scaleselectorCtrl.currentScale"></span>&nbsp;<span class="caret"></span>
   </button>
   <ul class="dropdown-menu" role="menu">

--- a/src/services/autoprojection.js
+++ b/src/services/autoprojection.js
@@ -13,7 +13,7 @@ ngeo.AutoProjection = function() {};
 
 
 /**
- * Parse a tring and return a coordinate if the result is valid. Given string
+ * Parse a string and return a coordinate if the result is valid. Given string
  * must be a two numbers separated by a space.
  * @param {string} str the string to parse.
  * @return {?ol.Coordinate} A coordinate or null if the format is not valid.


### PR DESCRIPTION
Revival of #1128 

Fix: https://github.com/camptocamp/c2cgeoportal/issues/1668 (without "contextual information" because `Display contextual information on right click. (still to be designed!)`)

Specs: https://github.com/camptocamp/c2cgeoportal/wiki/Spec-%231668-Map-(Info-bar)

Examples: 
 - https://ger-benjamin.github.io/ngeo/infobar/examples/contribs/gmf/apps/desktop
 - https://ger-benjamin.github.io/ngeo/infobar/examples/contribs/gmf/apps/desktop_alt (without choice for elevation)

Must be done in another PR (2.1?):
 - Display contextual information on right click (still to be designed, ping @ybolognini ) 
 - For a same zoom level, scales are not the same in the print panel and in the infobar (perhaps that's normal but this is strange to see).

Must be done in another PR (2.2):
 - Uniforms scaleselector, elevation and mouseposition. Because: 
  - `scaleselector` is old, doesn't use filter for scales, use partial with dropdown included and with one option to configure it (dropup).
  - `mouseposition` use partial with dropdown but without any option to configure it.
  - `elevation` doesn't include any partial so the dropdown is full configurable but the `index.html` is less compact.

Other bugs found and issues that will be open (2.1):
 - We should define what must be defined in the `src/controller` and what must be defined in the `apps controller`.

For the design of the buttons, it was too [hard / manual] to use a dropdown button on the side of a component and the same style for the component but without having the button effect. So I make a unique button (As proposed by @pgiraud).