### PR TITLE
Displaying loader when source is not available for a layer

### DIFF
--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -67,6 +67,7 @@
   }
 
   .group {
+    padding-left: @half-app-margin;
     .state::after {
       content: "\e600";
     }
@@ -136,13 +137,6 @@
     padding-left: 4px;
     &:hover {
       cursor: pointer;
-    }
-  }
-
-  .no-source {
-    opacity: 0.3;
-    &::after {
-      content: "(source not available)";
     }
   }
 

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -1,4 +1,4 @@
-<div ng-if="::!layertreeCtrl.isRoot" id="node-{{::layertreeCtrl.uid}}" ng-class="[layertreeCtrl.node.children ? 'group' : 'leaf', 'depth-' + layertreeCtrl.depth, gmfLayertreeCtrl.getResolutionStyle(layertreeCtrl.node), gmfLayertreeCtrl.getNoSourceStyle(layertreeCtrl), gmfLayertreeCtrl.getNodeState(layertreeCtrl)]">
+<div ng-if="::!layertreeCtrl.isRoot" id="node-{{::layertreeCtrl.uid}}" ng-class="[layertreeCtrl.node.children ? 'group' : 'leaf', 'depth-' + layertreeCtrl.depth, gmfLayertreeCtrl.getResolutionStyle(layertreeCtrl.node), gmfLayertreeCtrl.getNodeState(layertreeCtrl)]">
   <div class="sortable-handle" ng-show="layertreeCtrl.depth === 1 && gmfLayertreeCtrl.layers.length > 1">
     <i class="sortable-handle-icon fa fa-ellipsis-v"></i>
   </div>
@@ -15,7 +15,7 @@
     <img ng-if="::(legendIconUrl=gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl))" ng-src="{{::legendIconUrl}}"></img>
   </a>
   <a href ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)"
-     ng-if="::layertreeCtrl.node.children" ng-class="['fa fa-fw', layertreeCtrl.node.children && !layertreeCtrl.layer.loading ? 'state' : 'fa-refresh fa-spin']"></a>
+     ng-class="['fa fa-fw', layertreeCtrl.layer && layertreeCtrl.layer.loading || gmfLayertreeCtrl.getNoSourceStyle(layertreeCtrl) === 'no-source' ? 'fa-refresh fa-spin' : 'state']"></a>
   <a href ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)"
      class="name" title="{{layertreeCtrl.node.name | translate}}">
     <em>{{layertreeCtrl.node.name | translate}}</em>


### PR DESCRIPTION
closes #1114 
closes #1057 

demo:
- desktop app: https://oliviersemet.github.io/ngeo/source-not-available-wmts-layer/examples/contribs/gmf/apps/desktop/index.html

- mobile app: https://oliviersemet.github.io/ngeo/source-not-available-wmts-layer/examples/contribs/gmf/apps/mobile/index.html

@fredj @pgiraud 