### PR TITLE
Keep size ratio for legend icon

### DIFF
--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -48,9 +48,18 @@ gmf-layertree ul .treenode {
   }
 
   .layerIcon {
-    display: inline-flex;
-    height: @app-margin;
     width: 2 * @app-margin;
+    display: inline-flex;
+
+    img {
+      // don't let the legend icons images to break the layout by being too
+      // tall or too large
+      max-width: 100%;
+      max-height: 20px;
+      vertical-align: initial;
+      margin-left: auto;
+      margin-right: auto;
+    }
   }
   .name {
     white-space: normal;


### PR DESCRIPTION
Fixed in a very simple way. This breaks alignments though.

![screenshot from 2016-06-14 16 25 32](https://cloud.githubusercontent.com/assets/319774/16046451/d075ec0c-324c-11e6-92f1-93bf6cd35325.png)

@ybolognini please review.
