### PR TITLE
Replace label by placeholder in feature style form

### DIFF
--- a/contribs/gmf/src/directives/partials/featurestyle.html
+++ b/contribs/gmf/src/directives/partials/featurestyle.html
@@ -1,9 +1,9 @@
 <div ng-if="fsCtrl.feature && fsCtrl.type">
   <div class="form-group form-group-sm">
-    <label class="control-label">{{'Name' | translate}}</label>
     <input
         ng-model="fsCtrl.getSetName"
         ng-model-options="{getterSetter: true}"
+        placeholder="{{'Name' | translate}}"
         class="form-control"/>
   </div>
 </div>


### PR DESCRIPTION
Removes the "name" label in the drawing style editor and replaces it by a placeholder.