### PR TITLE
Define z-index for mobile measures tooltip

### DIFF
--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -60,6 +60,7 @@ gmf-map {
   .tooltip-measure {
     opacity: 1;
     font-weight: bold;
+    z-index: @content-index;
   }
   .tooltip-static {
     background-color: #ffcc33;


### PR DESCRIPTION
- place the measures tool-tip on the level of the content (fixes issue #1350)
- [example](https://marionb.github.io/ngeo/mobile-measures-tooltip/examples/contribs/gmf/apps/mobile/?lang=en)