### PR TITLE
Infobar layout

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -93,7 +93,7 @@
           </div>
         </div>
       </div>
-      <div class="map-container">
+      <div class="map-container" ng-class="{'infobar-active': mainCtrl.showInfobar}">
         <gmf-search gmf-search-map="mainCtrl.map"
           class="search"
           gmf-search-datasources="mainCtrl.searchDatasources"
@@ -134,7 +134,7 @@
                     gmf-elevation-map="mainCtrl.map">
               <a type="button" class="btn btn-default dropdown-toggle btn-sm" data-toggle="dropdown" aria-expanded="false">
                 <span class="elevation-value">
-                  {{elevationValue | number}}<span ng-show="elevationValue">m</span>
+                  {{elevationValue | number}}<span ng-show="elevationValue"> m</span>
                   <span ng-show="elevationLoading" class="fa fa-spinner"></span>
                   <span ng-show="!elevationValue && !elevationLoading" translate>Elevation…</span>
                 </span><span class="caret"></span>

--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -117,8 +117,8 @@
         </gmf-disclaimer>
 
         <!--infobar-->
-        <div class="footer" ng-class="{'active': mainCtrl.showInfobar}">
-          <button class="btn btn-sm fa map-info ng-cloak" ng-click="mainCtrl.showInfobar = !mainCtrl.showInfobar"
+        <div class="footer small" ng-class="{'active': mainCtrl.showInfobar}">
+          <button class="btn fa map-info ng-cloak" ng-click="mainCtrl.showInfobar = !mainCtrl.showInfobar"
                   ng-class="{'fa-angle-double-up': !mainCtrl.showInfobar, 'fa-angle-double-down': mainCtrl.showInfobar}"></button>
 
           <div ngeo-scaleselector="mainCtrl.scaleSelectorValues"
@@ -126,32 +126,29 @@
                ngeo-scaleselector-options="mainCtrl.scaleSelectorOptions"></div>
           <div id="scaleline"></div>
           <div class="pull-right">
-            <gmf-mouseposition
-                 gmf-mouseposition-map="mainCtrl.map"
-                 gmf-mouseposition-projections="::mainCtrl.mousePositionProjections">
-            </gmf-mouseposition>
-            <div class="elevation form-group form-group-sm pull-right" gmf-elevation
+            <div class="elevation text-center btn-group dropup" gmf-elevation
                     gmf-elevation-active="mainCtrl.showInfobar"
                     gmf-elevation-elevation="elevationValue"
                     gmf-elevation-selectedlayer="mainCtrl.selectedElevationLayer"
                     gmf-elevation-layers="::mainCtrl.elevationLayers"
                     gmf-elevation-map="mainCtrl.map">
-              <div class="btn-group btn-block dropup">
-                <button type="button" class="btn btn-default dropdown-toggle form-control" data-toggle="dropdown" aria-expanded="false">
-                  <span class="fa fa-arrows-v"></span>
-                  <small class="elevation-value">{{elevationValue | number:2}}<span ng-show="elevationValue">m</span></small>
-                  <span class="fa fa-fw fa-ellipsis-v"></span>
-                </button>
-                <ul class="dropdown-menu dropdown-menu-right" role="menu">
-                  <li ng-repeat="elevationItem in ::mainCtrl.elevationLayers">
-                    <a href ng-click="mainCtrl.selectedElevationLayer = elevationItem">
-                      <span class="fa fa-fw" ng-class="{'fa-check': mainCtrl.selectedElevationLayer === elevationItem}"></span>
-                      {{::elevationItem}}
-                    </a>
-                  </li>
-                </ul>
-              </div>
+              <a type="button" class="btn btn-default dropdown-toggle btn-sm" data-toggle="dropdown" aria-expanded="false">
+                <span class="elevation-value">{{elevationValue | number}}<span ng-show="elevationValue">m</span></span><span ng-if="!elevationValue">{{'Elevation' | translate}}<span ng-show="elevationValue">m</span></span><span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu dropdown-menu-right" role="menu">
+                <li ng-repeat="elevationItem in ::mainCtrl.elevationLayers">
+                  <a href ng-click="mainCtrl.selectedElevationLayer = elevationItem">
+                    <span class="fa fa-fw" ng-class="{'fa-check': mainCtrl.selectedElevationLayer === elevationItem}"></span>
+                    {{::elevationItem}}
+                  </a>
+                </li>
+              </ul>
             </div>
+            <gmf-mouseposition
+                 gmf-mouseposition-map="mainCtrl.map"
+                 gmf-mouseposition-projections="::mainCtrl.mousePositionProjections"
+                 class="text-center">
+            </gmf-mouseposition>
           </div>
         </div>
       </div>

--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -140,6 +140,7 @@
                 </span><span class="caret"></span>
               </a>
               <ul class="dropdown-menu dropdown-menu-right" role="menu">
+                <li class="dropdown-header" translate>Elevation data sources</li>
                 <li ng-repeat="elevationItem in ::mainCtrl.elevationLayers">
                   <a href ng-click="mainCtrl.selectedElevationLayer = elevationItem">
                     <span class="fa fa-fw" ng-class="{'fa-check': mainCtrl.selectedElevationLayer === elevationItem}"></span>

--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -117,7 +117,7 @@
         </gmf-disclaimer>
 
         <!--infobar-->
-        <div class="footer small" ng-class="{'active': mainCtrl.showInfobar}">
+        <div class="footer" ng-class="{'active': mainCtrl.showInfobar}">
           <button class="btn fa map-info ng-cloak" ng-click="mainCtrl.showInfobar = !mainCtrl.showInfobar"
                   ng-class="{'fa-angle-double-up': !mainCtrl.showInfobar, 'fa-angle-double-down': mainCtrl.showInfobar}"></button>
 
@@ -129,11 +129,15 @@
             <div class="elevation text-center btn-group dropup" gmf-elevation
                     gmf-elevation-active="mainCtrl.showInfobar"
                     gmf-elevation-elevation="elevationValue"
-                    gmf-elevation-selectedlayer="mainCtrl.selectedElevationLayer"
-                    gmf-elevation-layers="::mainCtrl.elevationLayers"
+                    gmf-elevation-loading="elevationLoading"
+                    gmf-elevation-layer="mainCtrl.selectedElevationLayer"
                     gmf-elevation-map="mainCtrl.map">
               <a type="button" class="btn btn-default dropdown-toggle btn-sm" data-toggle="dropdown" aria-expanded="false">
-                <span class="elevation-value">{{elevationValue | number}}<span ng-show="elevationValue">m</span></span><span ng-if="!elevationValue">{{'Elevation' | translate}}<span ng-show="elevationValue">m</span></span><span class="caret"></span>
+                <span class="elevation-value">
+                  {{elevationValue | number}}<span ng-show="elevationValue">m</span>
+                  <span ng-show="elevationLoading" class="fa fa-spinner"></span>
+                  <span ng-show="!elevationValue && !elevationLoading" translate>Elevation…</span>
+                </span><span class="caret"></span>
               </a>
               <ul class="dropdown-menu dropdown-menu-right" role="menu">
                 <li ng-repeat="elevationItem in ::mainCtrl.elevationLayers">

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -125,19 +125,23 @@
                ngeo-scaleselector-options="mainCtrl.scaleSelectorOptions"></div>
           <div id="scaleline"></div>
           <div class="pull-right">
+            <span class="elevation text-center small btn btn-default btn-sm" gmf-elevation
+                    gmf-elevation-active="mainCtrl.showInfobar"
+                    gmf-elevation-elevation="elevationValue"
+                    gmf-elevation-loading="elevationLoading"
+                    gmf-elevation-layer="::mainCtrl.elevationLayer"
+                    gmf-elevation-map="mainCtrl.map">
+              <span class="elevation-value">
+                {{elevationValue | number}}<span ng-show="elevationValue">m</span>
+                <span ng-show="elevationLoading" class="fa fa-spinner text-muted"></span>
+                <span ng-show="!elevationValue && !elevationLoading" translate>Elevation…</span>
+              </span>
+            </span>
             <gmf-mouseposition
                  gmf-mouseposition-map="mainCtrl.map"
-                 gmf-mouseposition-projections="::mainCtrl.mousePositionProjections">
+                 gmf-mouseposition-projections="::mainCtrl.mousePositionProjections"
+                 class="text-center">
             </gmf-mouseposition>
-            <div class="elevation"
-              gmf-elevation
-              gmf-elevation-active="mainCtrl.showInfoBar"
-              gmf-elevation-elevation="elevationValue"
-              gmf-elevation-layers="::mainCtrl.elevationLayers"
-              gmf-elevation-map="mainCtrl.map">
-              <span class="fa fa-arrows-v"></span>
-              <small class="elevation-value">{{elevationValue | number:2}}<span ng-show="elevationValue">m</span></small>
-            </div>
           </div>
         </div>
       </div>

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -92,7 +92,7 @@
           </div>
         </div>
       </div>
-      <div class="map-container">
+      <div class="map-container" ng-class="{'infobar-active': mainCtrl.showInfobar}">
         <gmf-search gmf-search-map="mainCtrl.map"
           class="search"
           gmf-search-datasources="mainCtrl.searchDatasources"
@@ -132,7 +132,7 @@
                     gmf-elevation-layer="::mainCtrl.elevationLayer"
                     gmf-elevation-map="mainCtrl.map">
               <span class="elevation-value">
-                {{elevationValue | number}}<span ng-show="elevationValue">m</span>
+                {{elevationValue | number}}<span ng-show="elevationValue"> m</span>
                 <span ng-show="elevationLoading" class="fa fa-spinner text-muted"></span>
                 <span ng-show="!elevationValue && !elevationLoading" translate>Elevation…</span>
               </span>

--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -72,6 +72,12 @@ app.AlternativeDesktopController = function($scope, $injector) {
   };
 
   /**
+   * @type {string}
+   * @export
+   */
+  this.elevationLayer = 'srtm';
+
+  /**
    * @type {Array.<gmfx.MousePositionProjection>}
    * @export
    */

--- a/contribs/gmf/examples/elevation.html
+++ b/contribs/gmf/examples/elevation.html
@@ -15,58 +15,43 @@
         width: 600px;
         height: 400px;
       }
-      .elevation .dropdown-menu {
-        min-width: 120px;
-      }
-      .elevation button {
-        min-width: 120px;
-      }
-      .elevation-value {
-        display: inline-block;
-        min-width: 60px;
-      }
-      .footer {
-        text-align: right;
-        min-height: 30px;
-        background-color: rgba(224, 224, 224, 0.8);
-        width: 600px;
-      }
     </style>
   </head>
   <body ng-controller="MainController as ctrl">
     <gmf-map gmf-map-map="ctrl.map"></gmf-map>
 
-    <div class="footer">
+    <span gmf-elevation
+          gmf-elevation-active="elevationActive"
+          gmf-elevation-elevation="elevationValue"
+          gmf-elevation-loading="elevationLoading"
+          gmf-elevation-layer="ctrl.selectedElevationLayer"
+          gmf-elevation-map="::ctrl.map">
+    </span>
 
-      <span gmf-elevation
-            gmf-elevation-active="elevationActive"
-            gmf-elevation-elevation="elevationValue"
-            gmf-elevation-selectedlayer="ctrl.selectedElevationLayer"
-            gmf-elevation-layers="::ctrl.elevationLayers"
-            gmf-elevation-map="::ctrl.map">
-      </span>
-
-      <div class="elevation form-group form-group-sm pull-right">
-        <div class="btn-group btn-block dropup">
-          <button type="button" class="btn btn-default form-control" data-toggle="dropdown" aria-expanded="false">
-            <span class="fa fa-arrows-v"></span>
-            <small class="elevation-value">{{elevationValue | number:2}}<span ng-show="elevationValue">m</span></small>
-            <span class="fa fa-fw fa-ellipsis-v"></span>
-          </button>
-          <ul class="dropdown-menu dropdown-menu-right" role="menu">
-            <li ng-repeat="elevationItem in ::ctrl.elevationLayers">
-              <a href ng-click="ctrl.selectedElevationLayer = elevationItem">
-                <span class="fa fa-fw" ng-class="{'fa-check': ctrl.selectedElevationLayer === elevationItem}"></span>
-                {{::elevationItem}}
-              </a>
-            </li>
-          </ul>
-        </div>
-      </div>
-
+    <div class="btn-group dropdown">
+      <button type="button" class="btn btn-default" data-toggle="dropdown" aria-expanded="false">
+        Raster layer
+        <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" role="menu">
+        <li ng-repeat="elevationItem in ::ctrl.elevationLayers">
+          <a href ng-click="ctrl.selectedElevationLayer = elevationItem">
+            <span class="fa fa-fw" ng-class="{'fa-check': ctrl.selectedElevationLayer === elevationItem}"></span>
+            {{::elevationItem}}
+          </a>
+        </li>
+      </ul>
     </div>
-
-    <input type="checkbox" ng-model="elevationActive"> Get elevation ?</>
+    <div>
+      Elevation: {{elevationValue}}<span ng-show="elevationValue">m</span>
+      <span class="loading" ng-if="elevationLoading">Loading</span>
+    </div>
+    <div class="checkbox">
+      <label>
+        <input type="checkbox" ng-model="elevationActive" />
+        Elevation active
+      </label>
+    </div>
 
     <p id="desc">This example shows how to use the <code>gmf-elevation</code> directive to get elevation under the mouse position.</p>
 

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -47,6 +47,8 @@ main {
   background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAAAAABzHgM7AAAAAnRSTlMAAHaTzTgAAAARSURBVHgBY3iKBFEAOp/+MgB+UQnYeBZPWAAAAABJRU5ErkJggg==');
 }
 
+@footer-height: @line-height-computed + 4 * @padding-small-vertical;
+
 .map-container {
   width: auto;
   height: 100%;
@@ -66,15 +68,19 @@ main {
   }
 
   .footer {
-    @height: @line-height-computed + 2 * @padding-small-vertical;
+    padding: @padding-small-vertical;
     position: absolute;
-    bottom:  -@height;
+    bottom:  -@footer-height;
+    // prevent footer to be displayed on 2 lines when screen width is small
+    max-height: @footer-height;
     background-color: fade(@main-bg-color, 90%);
     width: 100%;
     /* cancel default navbar bottom margin */
     margin-bottom: 0;
     /* buttons or inputs in bar are supposed to be '-sm' */
     transition: 0.2s ease-out all;
+    border: solid @border-color;
+    border-width: 1px 0 0;
     &.active {
       bottom: 0;
     }
@@ -85,14 +91,21 @@ main {
     button.map-info {
       position: absolute;
       /* button is supposed to be .btn-sm */
-      bottom: @line-height-computed + 2 * @padding-small-vertical;
+      bottom: @footer-height - 1;
       background-color: fade(@main-bg-color, 80%);
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
       right: @app-margin;
       border-bottom: 0;
       padding: @half-app-margin @app-margin;
+      border: solid @border-color;
+      border-width: 1px 1px 0 1px;
     }
+  }
+
+  [ngeo-scaleselector] .btn > span {
+    min-width: 8rem;
+    display: inline-block;
   }
 
   #scaleline {
@@ -439,7 +452,11 @@ gmf-featurestyle {
  * Background layer button (selector)
  */
 .gmf-backgroundlayerbutton {
-  bottom: 4rem;
+  .infobar-active & {
+    bottom: ~"calc(@{footer-height} + @{app-margin})";
+  }
+  bottom: @app-margin;
+  transition: 0.2s ease-out bottom;
   left: @app-margin;
   position: absolute;
   z-index: 2;

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -69,7 +69,7 @@ main {
     @height: @line-height-computed + 2 * @padding-small-vertical;
     position: absolute;
     bottom:  -@height;
-    background-color: fade(@main-bg-color, 80%);
+    background-color: fade(@main-bg-color, 90%);
     width: 100%;
     /* cancel default navbar bottom margin */
     margin-bottom: 0;
@@ -93,21 +93,8 @@ main {
       border-bottom: 0;
       padding: @half-app-margin @app-margin;
     }
-    .btn {
-      background-color: lighten(@main-bg-color, 20%);
-      padding: @half-app-margin 0;
-    }
-    .form-group{
-      margin-bottom: 0;
-    }
   }
 
-  [ngeo-scaleselector] {
-    min-width: 12rem;
-    .dropdown-menu {
-      min-width: 12rem;
-    }
-  }
   #scaleline {
     vertical-align: middle;
     .ol-scale-line, .ol-scale-line-inner {
@@ -116,31 +103,20 @@ main {
       position: relative;
     }
   }
+
   gmf-mouseposition {
-    &>div {
-      min-width: 24rem;
-    }
-    .dropdown-menu {
-      min-width: 24rem;
-    }
-    #mouse-position {
-      display: inline-block;
-      min-width: 18rem;
-    }
+    display: inline-block;
+  }
+  #mouse-position {
+    display: inline-block;
+    min-width: 18rem;
   }
   .elevation {
     display: inline-block;
-    vertical-align: sub;
-    .dropdown-menu {
-      min-width: 12rem;
-    }
-    button {
-      min-width: 12rem;
-    }
-    .elevation-value {
-      display: inline-block;
-      min-width: 6rem;
-    }
+  }
+  .elevation-value {
+    display: inline-block;
+    min-width: 8rem;
   }
 }
 

--- a/contribs/gmf/src/directives/mouseposition.js
+++ b/contribs/gmf/src/directives/mouseposition.js
@@ -44,13 +44,14 @@ gmf.module.directive('gmfMouseposition', gmf.mousepositionDirective);
 
 /**
  * @param {angular.$filter} $filter Angular filter
+ * @param {gettext} gettext Gettext service.
  * @constructor
  * @export
  * @ngInject
  * @ngdoc controller
  * @ngname gmfMousepositionController
  */
-gmf.MousepositionController = function($filter) {
+gmf.MousepositionController = function($filter, gettext) {
   /**
    * @type {ol.Map}
    * @export
@@ -83,7 +84,7 @@ gmf.MousepositionController = function($filter) {
     className: 'custom-mouse-position',
     coordinateFormat: formatFn.bind(this),
     target: document.getElementById('mouse-position'),
-    undefinedHTML: '&nbsp;'
+    undefinedHTML: gettext('Coordinates')
   });
 
   this.setProjection(this.projections[0]);

--- a/contribs/gmf/src/directives/partials/mouseposition.html
+++ b/contribs/gmf/src/directives/partials/mouseposition.html
@@ -3,6 +3,7 @@
     <span id="mouse-position"></span><span class="caret"></span>
   </a>
   <ul class="dropdown-menu dropdown-menu-right" role="menu">
+    <li class="dropdown-header" translate>Coordinate systems</li>
     <li ng-repeat="projitem in ::ctrl.projections">
       <a href ng-click="ctrl.setProjection(projitem)">
         <span class="fa fa-fw" ng-class="{'fa-check': ctrl.projection == projitem}"></span>

--- a/contribs/gmf/src/directives/partials/mouseposition.html
+++ b/contribs/gmf/src/directives/partials/mouseposition.html
@@ -1,17 +1,13 @@
-<div class="form-group form-group-sm pull-right">
-  <div class="btn-group btn-block dropup">
-    <button type="button" class="btn btn-default dropdown-toggle form-control" data-toggle="dropdown" aria-expanded="false">
-      <span class="fa fa-fw fa-location-arrow"></span>
-      <small id="mouse-position"></small>
-      <span class="fa fa-fw fa-ellipsis-v"></span>
-    </button>
-    <ul class="dropdown-menu dropdown-menu-right" role="menu">
-      <li ng-repeat="projitem in ::ctrl.projections">
-        <a href ng-click="ctrl.setProjection(projitem)">
-          <span class="fa fa-fw" ng-class="{'fa-check': ctrl.projection == projitem}"></span>
-          {{::projitem.label}}
-        </a>
-      </li>
-    </ul>
-  </div>
+<div class="btn-group dropup">
+  <a type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+    <span id="mouse-position"></span><span class="caret"></span>
+  </a>
+  <ul class="dropdown-menu dropdown-menu-right" role="menu">
+    <li ng-repeat="projitem in ::ctrl.projections">
+      <a href ng-click="ctrl.setProjection(projitem)">
+        <span class="fa fa-fw" ng-class="{'fa-check': ctrl.projection == projitem}"></span>
+        {{::projitem.label}}
+      </a>
+    </li>
+  </ul>
 </div>

--- a/src/directives/partials/scaleselector.html
+++ b/src/directives/partials/scaleselector.html
@@ -1,14 +1,12 @@
-<div class="form-group form-group-sm dropdown" ng-class="::{'dropup': scaleselectorCtrl.options.dropup}">
-  <div class="btn-group btn-block">
-    <button type="button" class="btn btn-default dropdown-toggle form-control" data-toggle="dropdown" aria-expanded="false">
-      <span ng-bind-html="scaleselectorCtrl.currentScale"></span>&nbsp;<i class="caret"></i>
-    </button>
-    <ul class="dropdown-menu btn-block" role="menu">
-      <li ng-repeat="zoomLevel in ::scaleselectorCtrl.zoomLevels">
-        <a href ng-click="scaleselectorCtrl.changeZoom(zoomLevel)"
-           ng-bind-html="scaleselectorCtrl.getScale(zoomLevel)">
-        </a>
-      </li>
-    </ul>
-  </div>
+<div class="btn-group btn-block" ng-class="::{'dropup': scaleselectorCtrl.options.dropup}">
+  <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+    <span ng-bind-html="scaleselectorCtrl.currentScale"></span>&nbsp;<i class="caret"></i>
+  </button>
+  <ul class="dropdown-menu btn-block" role="menu">
+    <li ng-repeat="zoomLevel in ::scaleselectorCtrl.zoomLevels">
+      <a href ng-click="scaleselectorCtrl.changeZoom(zoomLevel)"
+         ng-bind-html="scaleselectorCtrl.getScale(zoomLevel)">
+      </a>
+    </li>
+  </ul>
 </div>


### PR DESCRIPTION
With this pull request I improved the look&feel of the info bar.

The not exhaustive list of improvements is:
 - alignments are more consistent,
 - icons where removed because they take a lot of space and are not self explanatory,
 - more space is added around component, this is more airy,
 - info bar don't break layout if screen width is small,
 - background selector position depends on whether the info bar is displayed or not.

![screenshot from 2016-06-17 12 00 32](https://cloud.githubusercontent.com/assets/319774/16147651/bc43891c-3484-11e6-87d2-9a1e6b5582e2.png)

Please also notice that I changed the behavior of the elevation directive. Now we call the service with only one layer at a time. And the elevation is displayed only when the mouse cursor is not moving. No elevation is displayed when the mouse is out of the map.

Démos:
https://pgiraud.github.io/ngeo/infobar_layout/examples/contribs/gmf/apps/desktop
https://pgiraud.github.io/ngeo/infobar_layout/examples/contribs/gmf/apps/desktop_alt