### PR TITLE
Add ngeo-attributes directive

### DIFF
--- a/examples/attributes.html
+++ b/examples/attributes.html
@@ -8,9 +8,6 @@
     <meta name="mobile-web-app-capable" content="yes">
     <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
     <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
-    <style>
-
-    </style>
   </head>
   <body ng-controller="MainController as ctrl">
 

--- a/examples/attributes.html
+++ b/examples/attributes.html
@@ -7,10 +7,40 @@
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="mobile-web-app-capable" content="yes">
     <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+    <style>
+
+    </style>
   </head>
   <body ng-controller="MainController as ctrl">
-    <p id="desc">This example shows how to use the <code>ngeo-attributes</code> directive.</p>
-    <code id="list-of-attributes"></code>
+
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-6">
+          <p id="desc">
+            This example shows how to use the <code>ngeo-attributes</code>
+            directive, which binds a form to the inner properties of a
+            <code>ol.Feature</code> object. Changes made through the form are
+            applied to the feature and vice-versa. Try playing with the form
+            or click
+            <input
+                type="button"
+                ng-click="ctrl.updateName()"
+                value="Change name" >
+            </input>
+            to change the name.
+          </p>
+        </div>
+        <div class="col-sm-6">
+          <ngeo-attributes
+            ng-if="ctrl.attributes"
+            ngeo-attributes-attributes="::ctrl.attributes"
+            ngeo-attributes-feature="::ctrl.feature">
+          </ngeo-attributes>
+        </div>
+      </div>
+    </div>
+
     <script src="../node_modules/angular/angular.js"></script>
     <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="/@?main=attributes.js"></script>

--- a/examples/attributes.js
+++ b/examples/attributes.js
@@ -2,6 +2,7 @@ goog.provide('attributes');
 
 goog.require('ngeo.mapDirective');
 goog.require('ngeo.format.XSDAttribute');
+goog.require('ngeo.attributesDirective');
 
 
 /** @const **/
@@ -14,24 +15,57 @@ app.module = angular.module('app', ['ngeo']);
 
 /**
  * @param {angular.$http} $http Angular http service.
+ * @param {angular.$timeout} $timeout Angular timeout service.
  * @constructor
  */
-app.MainController = function($http) {
+app.MainController = function($http, $timeout) {
+
+  /**
+   * @type {angular.$timeout}
+   * @private
+   */
+  this.timeout_ = $timeout;
+
+  /**
+   * @type {?Array.<ngeox.Attribute>}
+   * @export
+   */
+  this.attributes = null;
+
+  /**
+   * @type {ol.Feature}
+   * @export
+   */
+  this.feature = new ol.Feature({
+    'name': 'A feature',
+    'kind': 'house'
+  });
 
   $http.get('data/xsdattributes.xml').then(
-    /**
-     * @param {angular.$http.Response} resp Ajax response.
-     * @return {Array.<ngeox.Attribute>} List of attributes.
-     * @private
-     */
-    function(resp) {
-      var format = new ngeo.format.XSDAttribute();
-      var attributes = format.read(resp.data);
-      document.getElementById('list-of-attributes').innerHTML =
-        JSON.stringify(attributes);
-      return attributes;
-    }
-  );
+    this.handleXSDAttributeGet_.bind(this));
+};
+
+
+/**
+ * @param {angular.$http.Response} resp Ajax response.
+ * @return {Array.<ngeox.Attribute>} List of attributes.
+ * @private
+ */
+app.MainController.prototype.handleXSDAttributeGet_ = function(resp) {
+  var format = new ngeo.format.XSDAttribute();
+  var attributes = format.read(resp.data);
+  this.attributes = attributes;
+  return attributes;
+};
+
+
+/**
+ * @export
+ */
+app.MainController.prototype.updateName = function() {
+  this.timeout_(function() {
+    this.feature.set('name', 'An alternate name');
+  }.bind(this), 0);
 };
 
 

--- a/src/directives/attributes.js
+++ b/src/directives/attributes.js
@@ -1,0 +1,149 @@
+goog.provide('ngeo.AttributesController');
+goog.provide('ngeo.attributesDirective');
+
+goog.require('ngeo');
+goog.require('ngeo.EventHelper');
+
+
+/**
+ * Directive used to render the attributes of a feature into a form.
+ * Example:
+ *
+ * Todo...
+ *
+ * @htmlAttribute {Array.<ngeox.Attribute>} ngeo-attributes-attributes The
+ *     list of attributes to use.
+ * @htmlAttribute {ol.Feature} ngeo-attributes-feature The feature.
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname ngeoAttributes
+ */
+ngeo.attributesDirective = function() {
+  return {
+    controller: 'ngeoAttributesController',
+    scope: true,
+    bindToController: {
+      'attributes': '=ngeoAttributesAttributes',
+      'feature': '=ngeoAttributesFeature'
+    },
+    controllerAs: 'attrCtrl',
+    templateUrl: ngeo.baseTemplateUrl + '/attributes.html'
+  };
+};
+
+ngeo.module.directive('ngeoAttributes', ngeo.attributesDirective);
+
+
+/**
+ * @param {!angular.Scope} $scope Angular scope.
+ * @param {ngeo.EventHelper} ngeoEventHelper Ngeo event helper service
+ * @constructor
+ * @ngInject
+ * @ngdoc controller
+ * @ngname ngeoAttributesController
+ */
+ngeo.AttributesController = function($scope, ngeoEventHelper) {
+
+  /**
+   * The list of attributes to create the form with.
+   * @type {Array.<ngeox.Attribute>}
+   * @export
+   */
+  this.attributes;
+
+  /**
+   * The feature containing the values.
+   * @type {ol.Feature}
+   * @export
+   */
+  this.feature;
+
+  /**
+   * The properties bound to the form, initialized with the inner properties
+   * of the feature.
+   * @type {Object.<string, *>}
+   * @export
+   */
+  this.properties = this.feature.getProperties();
+
+  /**
+   * @type {!angular.Scope}
+   * @private
+   */
+  this.scope_ = $scope;
+
+  /**
+   * @type {ngeo.EventHelper}
+   * @private
+   */
+  this.ngeoEventHelper_ = ngeoEventHelper;
+
+  // Listen to the feature inner properties change and apply them to the form
+  var uid = goog.getUid(this);
+  this.ngeoEventHelper_.addListenerKey(
+    uid,
+    ol.events.listen(
+      this.feature,
+      ol.ObjectEventType.PROPERTYCHANGE,
+      this.handleFeaturePropertyChange_,
+      this
+    ),
+    true
+  );
+
+  /**
+   * While changes happen from the form (from the template), they are applied
+   * to the feature inner properties. The 'propertychange' event registered
+   * above does the opposite, i.e. it listens to the feature inner properties
+   * changes and apply them to the form. To prevent circular issues, while
+   * applying changes coming from the form, this flag is set. While set, changes
+   * from the feature inner properties are ignored.
+   * @type {boolean}
+   * @private
+   */
+  this.updating_ = false;
+
+  $scope.$on('$destroy', this.handleDestroy_.bind(this));
+
+};
+
+
+/**
+ * Called when an input node value changes
+ * @param {string} name Attribute name
+ */
+ngeo.AttributesController.prototype.handleInputChange = function(name) {
+  this.updating_ = true;
+  var value = this.properties[name];
+  this.feature.set(name, value);
+  this.updating_ = false;
+};
+
+
+/**
+ * Cleanup event listeners.
+ * @private
+ */
+ngeo.AttributesController.prototype.handleDestroy_ = function() {
+  var uid = goog.getUid(this);
+  this.ngeoEventHelper_.clearListenerKey(uid);
+};
+
+
+/**
+ * @param {ol.ObjectEvent} evt Event.
+ * @private
+ */
+ngeo.AttributesController.prototype.handleFeaturePropertyChange_ = function(
+  evt
+) {
+  if (this.updating_) {
+    return;
+  }
+  this.properties[evt.key] = evt.target.get(evt.key);
+  this.scope_.$apply();
+};
+
+
+ngeo.module.controller('ngeoAttributesController', ngeo.AttributesController);

--- a/src/directives/attributes.js
+++ b/src/directives/attributes.js
@@ -9,7 +9,10 @@ goog.require('ngeo.EventHelper');
  * Directive used to render the attributes of a feature into a form.
  * Example:
  *
- * Todo...
+ *     <ngeo-attributes
+ *       ngeo-attributes-attributes="::ctrl.attributes"
+ *       ngeo-attributes-feature="::ctrl.feature">
+ *     </ngeo-attributes>
  *
  * @htmlAttribute {Array.<ngeox.Attribute>} ngeo-attributes-attributes The
  *     list of attributes to use.
@@ -112,6 +115,7 @@ ngeo.AttributesController = function($scope, ngeoEventHelper) {
 /**
  * Called when an input node value changes
  * @param {string} name Attribute name
+ * @export
  */
 ngeo.AttributesController.prototype.handleInputChange = function(name) {
   this.updating_ = true;

--- a/src/directives/partials/attributes.html
+++ b/src/directives/partials/attributes.html
@@ -1,0 +1,28 @@
+<form class="form">
+  <div
+      class="form-group"
+      ng-repeat="attribute in ::attrCtrl.attributes">
+    <label>{{ attribute.name }}:</label>
+    <div ng-switch="attribute.type">
+      <select
+          ng-switch-when="select"
+          ng-model="attrCtrl.properties[attribute.name]"
+          ng-change="attrCtrl.handleInputChange(attribute.name);"
+          class="form-control"
+          type="text">
+        <option
+            ng-repeat="attribute in ::attribute.choices"
+            value="{{ ::attribute }}">
+          {{ ::attribute }}
+        </option>
+      </select>
+      <input
+          ng-switch-default
+          ng-model="attrCtrl.properties[attribute.name]"
+          ng-change="attrCtrl.handleInputChange(attribute.name);"
+          class="form-control"
+          type="text">
+      </input>
+    </div>
+  </div>
+</form>


### PR DESCRIPTION
This PR introduces the `ngeo-attributes` directive, which produces a form to edit the properties of a feature.

This PR doesn't include a date picker. It should come in the next PR.

## Todo

 * [x] wait for #1439 to be merged
 * [x] review
 * [x] apply reviewer's required corrections

## Live example

 * http://adube.github.io/ngeo/ngeo-attributes/examples/attributes.html