### PR TITLE
Position of bg selector, disclaimer, features window relative to info…

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -100,28 +100,30 @@
           gmf-search-coordinatesprojections="mainCtrl.searchCoordinatesProjections"
           gmf-search-clearbutton="true">
         </gmf-search>
-        <div class="gmf-backgroundlayerbutton btn-group dropup">
-          <button
-              class="btn btn-default dropdown-toggle"
-              data-toggle="dropdown">
-            <img src="image/background-layer-button.png" alt="" />
-          </button>
-          <gmf-backgroundlayerselector
-            gmf-backgroundlayerselector-map="::mainCtrl.map"
-            class="dropdown-menu">
-          </gmf-backgroundlayerselector>
+        <div class="map-bottom-controls">
+          <div class="gmf-backgroundlayerbutton btn-group dropup">
+            <button
+                class="btn btn-default dropdown-toggle"
+                data-toggle="dropdown">
+              <img src="image/background-layer-button.png" alt="" />
+            </button>
+            <gmf-backgroundlayerselector
+              gmf-backgroundlayerselector-map="::mainCtrl.map"
+              class="dropdown-menu">
+            </gmf-backgroundlayerselector>
+          </div>
+          <gmf-disclaimer
+            gmf-disclaimer-map="::mainCtrl.map">
+          </gmf-disclaimer>
+          <gmf-displayqueries
+            gmf-displayqueries-featuresstyle="::mainCtrl.queryFeatureStyle"
+            gmf-displayqueries-desktop="true">
+          </gmf-displayqueries>
         </div>
         <gmf-map class="gmf-map" gmf-map-map="mainCtrl.map"
           ngeo-map-query=""
           ngeo-map-query-map="::mainCtrl.map"
           ngeo-map-query-active="mainCtrl.queryActive"></gmf-map>
-        <gmf-displayqueries
-          gmf-displayqueries-featuresstyle="::mainCtrl.queryFeatureStyle"
-          gmf-displayqueries-desktop="true">
-        </gmf-displayqueries>
-        <gmf-disclaimer
-          gmf-disclaimer-map="::mainCtrl.map">
-        </gmf-disclaimer>
 
         <!--infobar-->
         <div class="footer" ng-class="{'active': mainCtrl.showInfobar}">

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -99,21 +99,23 @@
           gmf-search-coordinatesprojections="mainCtrl.searchCoordinatesProjections"
           gmf-search-clearbutton="true">
         </gmf-search>
-        <div class="gmf-backgroundlayerbutton btn-group dropup">
-          <button
-              class="btn btn-default dropdown-toggle"
-              data-toggle="dropdown">
-            <img src="image/background-layer-button.png" alt="" />
-          </button>
-          <gmf-backgroundlayerselector
-            gmf-backgroundlayerselector-map="::mainCtrl.map"
-            class="dropdown-menu">
-          </gmf-backgroundlayerselector>
+        <div class="map-bottom-controls">
+          <div class="gmf-backgroundlayerbutton btn-group dropup">
+            <button
+                class="btn btn-default dropdown-toggle"
+                data-toggle="dropdown">
+              <img src="image/background-layer-button.png" alt="" />
+            </button>
+            <gmf-backgroundlayerselector
+              gmf-backgroundlayerselector-map="::mainCtrl.map"
+              class="dropdown-menu">
+            </gmf-backgroundlayerselector>
+          </div>
+          <gmf-disclaimer
+            gmf-disclaimer-map="::mainCtrl.map">
+          </gmf-disclaimer>
         </div>
         <gmf-map class="gmf-map" gmf-map-map="mainCtrl.map"></gmf-map>
-        <gmf-disclaimer
-          gmf-disclaimer-map="::mainCtrl.map">
-        </gmf-disclaimer>
 
         <!--infobar-->
         <div class="footer" ng-class="{'active': mainCtrl.showInfobar}">

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -71,6 +71,7 @@ main {
   .footer {
     padding: @padding-small-vertical;
     position: absolute;
+    z-index: 2;
     bottom:  -@footer-height;
     // prevent footer to be displayed on 2 lines when screen width is small
     max-height: @footer-height;
@@ -450,17 +451,25 @@ gmf-featurestyle {
 
 
 /**
+ * Controls at the bottom of the map
+ */
+.map-bottom-controls {
+  .infobar-active & {
+    bottom: @footer-height;
+  }
+  transition: 0.2s ease-out bottom;
+  position: absolute;
+  bottom: 0;
+  z-index: 1;
+  width: 100%;
+}
+
+/**
  * Background layer button (selector)
  */
 .gmf-backgroundlayerbutton {
-  .infobar-active & {
-    bottom: ~"calc(@{footer-height} + @{app-margin})";
-  }
   bottom: @app-margin;
-  transition: 0.2s ease-out bottom;
   left: @app-margin;
-  position: absolute;
-  z-index: 2;
 
   button {
     padding: 3px;
@@ -474,4 +483,16 @@ gmf-featurestyle {
   ul.gmf-backgroundlayerselector {
     margin: 0 0.5rem;
   }
+}
+
+.displayqueries {
+  position: absolute;
+  right: @app-margin;
+}
+
+/** Disclaimer */
+gmf-disclaimer {
+  position: relative;
+  display: inline-block;
+  vertical-align: bottom;
 }

--- a/contribs/gmf/less/map.less
+++ b/contribs/gmf/less/map.less
@@ -106,14 +106,14 @@ button[ngeo-mobile-geolocation] {
 /** Disclaimer */
 gmf-disclaimer {
   position: absolute;
-  bottom: @half-app-margin;
+  bottom: @app-margin;
   left: @app-margin;
   width: 30rem;
   z-index: @above-content-index;
 
   .alert {
     padding: @half-app-margin @app-margin;
-    margin: 0 0@half-app-margin  0;
+    margin: @half-app-margin 0 0 0;
   }
 
   .alert-dismissable .close,


### PR DESCRIPTION
… bar

With this pull request background selector button, disclaimer and query results window are positioned relatively to the info bar. They move if the info bar is opened. And the disclaimer are positioned next to the background selector.

![screenshot from 2016-06-21 17 10 42](https://cloud.githubusercontent.com/assets/319774/16234900/2e1365e8-37d3-11e6-9b64-b31ab90a5015.png)
![screenshot from 2016-06-21 17 10 30](https://cloud.githubusercontent.com/assets/319774/16234903/2fcd8c2e-37d3-11e6-976d-96fb0c5a849f.png)

Demo: https://pgiraud.github.io/ngeo/disclaimer/examples/contribs/gmf/apps/desktop
