### PR TITLE
Add gmf.XSDAttributes service

### DIFF
--- a/contribs/gmf/examples/xsdattributes.html
+++ b/contribs/gmf/examples/xsdattributes.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>XSD Attributes in GeoMapFish example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../../../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+    <link rel="stylesheet" href="../third-party/jquery-ui/jquery-ui.min.css">
+    <style>
+      .layers-list {
+        max-width: 100%;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-6">
+          <p id="desc">
+            This example shows how to use the <code>gmf.XSDAttributes</code>
+            service, which is used to obtain the attributes from a GeoMapFish
+            server using a given layer id. The attributes received are read
+            and transformed into a form using the <code>ngeo-attributes</code>
+            directive.
+          </p>
+          <select
+            class="layers-list"
+            ng-model="ctrl.getSetLayers"
+            ng-model-options="{getterSetter: true}"
+            ng-options="layer.name for layer in ctrl.layers">
+            <option value="">-- Choose a layer --</option>
+          </select>
+        </div>
+        <div class="col-sm-6">
+          <ngeo-attributes
+            ng-if="ctrl.attributes"
+            ngeo-attributes-attributes="::ctrl.attributes"
+            ngeo-attributes-feature="::ctrl.feature">
+          </ngeo-attributes>
+        </div>
+      </div>
+    </div>
+
+    <script src="../../../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../third-party/jquery-ui/jquery-ui.min.js"></script>
+    <script src="../../../node_modules/angular/angular.js"></script>
+    <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
+    <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
+    <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="../../../node_modules/angular-ui-date/dist/date.js"></script>
+    <script src="../../../node_modules/angular-ui-slider/src/slider.js"></script>
+    <script src="../../../node_modules/angular-dynamic-locale/dist/tmhDynamicLocale.js" type="text/javascript"></script>
+    <script src="/@?main=xsdattributes.js"></script>
+    <script src="default.js"></script>
+    <script src="../../../utils/watchwatchers.js"></script>
+    <script>
+      var gmfModule = angular.module('gmf');
+      gmfModule.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
+    </script>
+  </body>
+</html>

--- a/contribs/gmf/examples/xsdattributes.js
+++ b/contribs/gmf/examples/xsdattributes.js
@@ -1,0 +1,151 @@
+goog.provide('gmf-xsdattributes');
+
+goog.require('gmf');
+goog.require('gmf.Themes');
+goog.require('gmf.XSDAttributes');
+goog.require('ngeo');
+goog.require('ngeo.attributesDirective');
+goog.require('ol.Feature');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['gmf']);
+
+
+app.module.constant('gmfTreeUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
+
+
+app.module.constant('gmfLayersUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/layers/');
+
+
+/**
+ * @param {angular.$timeout} $timeout Angular timeout service.
+ * @param {gmf.Themes} gmfThemes The gmf themes service.
+ * @param {gmf.XSDAttributes} gmfXSDAttributes The gmf XSDAttributes service.
+ * @constructor
+ */
+app.MainController = function($timeout, gmfThemes, gmfXSDAttributes) {
+
+  /**
+   * @type {angular.$timeout}
+   * @private
+   */
+  this.timeout_ = $timeout;
+
+  /**
+   * @type {gmf.XSDAttributes}
+   * @private
+   */
+  this.xsdAttributes_ = gmfXSDAttributes;
+
+  /**
+   * @type {?Array.<ngeox.Attribute>}
+   * @export
+   */
+  this.attributes = null;
+
+  /**
+   * @type {?ol.Feature}
+   * @export
+   */
+  this.feature = null;
+
+  /**
+   * @type {Array.<GmfThemesNode>}
+   * @export
+   */
+  this.layers = [];
+
+  // TMP - The list of layer names to use. We'll keep this until we can use
+  //       those that are editable.
+  var layerNames = ['line', 'point', 'polygon'];
+
+  gmfThemes.loadThemes();
+
+  gmfThemes.getThemesObject().then(function(themes) {
+    if (!themes) {
+      return;
+    }
+    // Get an array with all nodes entities existing in "themes".
+    var flatNodes = [];
+    themes.forEach(function(theme) {
+      theme.children.forEach(function(group) {
+        this.getDistinctFlatNodes_(group, flatNodes);
+      }.bind(this));
+    }.bind(this));
+    flatNodes.forEach(function(node) {
+      // Get an array of all layers
+      if (node.children === undefined && layerNames.indexOf(node.name) !== -1) {
+        this.layers.push(node);
+      }
+    }.bind(this));
+
+  }.bind(this));
+};
+
+
+/**
+ * @param {GmfThemesNode|undefined} value A layer or undefined to get layers.
+ * @return {Array.<GmfThemesNode>} All layers in all themes.
+ * @export
+ */
+app.MainController.prototype.getSetLayers = function(value) {
+  if (value !== undefined) {
+    this.xsdAttributes_.getAttributes(value.id).then(
+      this.setAttributes_.bind(this));
+  }
+  return this.layers;
+};
+
+
+/**
+ * @param {Array.<ngeox.Attribute>} attributes Attributes.
+ * @export
+ */
+app.MainController.prototype.setAttributes_ = function(attributes) {
+
+  // (1) Reset first
+  this.feature = null;
+  this.attributes = null;
+
+  // (2) Then set
+  this.timeout_(function() {
+    this.feature = new ol.Feature();
+    this.attributes = attributes;
+  }.bind(this), 0);
+};
+
+
+/**
+ * Just for this example
+ * @param {GmfThemesNode} node A theme, group or layer node.
+ * @param {Array.<GmfThemesNode>} nodes An Array of nodes.
+ * @export
+ */
+app.MainController.prototype.getDistinctFlatNodes_ = function(node, nodes) {
+  var i;
+  var children = node.children;
+  if (children !== undefined) {
+    for (i = 0; i < children.length; i++) {
+      this.getDistinctFlatNodes_(children[i], nodes);
+    }
+  }
+  var alreadyAdded = false;
+  nodes.some(function(n) {
+    if (n.id === node.id) {
+      return alreadyAdded = true;
+    }
+  });
+  if (!alreadyAdded) {
+    nodes.push(node);
+  }
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/contribs/gmf/src/services/xsdattributes.js
+++ b/contribs/gmf/src/services/xsdattributes.js
@@ -1,0 +1,67 @@
+goog.provide('gmf.XSDAttributes');
+
+goog.require('gmf');
+goog.require('goog.uri.utils');
+goog.require('ngeo.format.XSDAttribute');
+
+
+/**
+ * An service used to fetch the XSD attribute definition of layers using their
+ * id from a GeoMapFish server.
+ *
+ * @constructor
+ * @param {angular.$http} $http Angular http service.
+ * @param {string} gmfLayersUrl Url to the GeoMapFish layers service.
+ * @ngInject
+ */
+gmf.XSDAttributes = function($http, gmfLayersUrl) {
+
+  /**
+   * @type {angular.$http}
+   * @private
+   */
+  this.http_ = $http;
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.baseUrl_ = gmfLayersUrl;
+
+  /**
+   * @type {Object.<number, !angular.$q.Promise>}
+   * @private
+   */
+  this.promises_ = {};
+
+};
+
+
+/**
+ * @param {number} id Layer id.
+ * @return {angular.$q.Promise} Promise.
+ * @export
+ */
+gmf.XSDAttributes.prototype.getAttributes = function(id) {
+  if (!this.promises_[id]) {
+    var url = goog.uri.utils.appendPath(
+      this.baseUrl_,
+      id.toString()
+    ) + '/md.xsd';
+    this.promises_[id] = this.http_.get(url).then(
+      this.handleGetAttributes_.bind(this));
+  }
+  return this.promises_[id];
+};
+
+/**
+ * @param {angular.$http.Response} resp Ajax response.
+ * @return {Array.<ngeox.Attribute>} List of attributes.
+ * @export
+ */
+gmf.XSDAttributes.prototype.handleGetAttributes_ = function(resp) {
+  return new ngeo.format.XSDAttribute().read(resp.data);
+};
+
+
+gmf.module.service('gmfXSDAttributes', gmf.XSDAttributes);


### PR DESCRIPTION
This PR introduces the `gmf.XSDAttributes` service, which is responsible of communicating with a GeoMapFish server to get the attributes of a layer in XSD format, convert them to an array of `ngeox.Attribute` objects.

It only sends the request for a single layer once using a promise.

## Todo

That's the 3rd PR which completes the work of the "XSD Parser" task.  It currently includes the other 2 as well because none of them have been merged yet.  Let's wait for them to be merged before reviewing.

 * [x] Wait for #1439 to be merged
 * [x] Wait for #1440 to be merged
 * [x] Review

## Live example

 * https://adube.github.io/ngeo/gmf-xsdattributes-service/examples/contribs/gmf/xsdattributes.html