### PR TITLE
Add gmf.EditFeature service with example

### DIFF
--- a/contribs/gmf/examples/editfeature.html
+++ b/contribs/gmf/examples/editfeature.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>EditFeature GeoMapFish example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../../../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../third-party/jquery-ui/jquery-ui.min.css">
+    <link rel="stylesheet" href="../../../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css" />
+    <style>
+      body {
+        padding: 0.5rem;
+      }
+      gmf-map > div {
+        width: 60rem;
+        height: 40rem;
+      }
+      .panel {
+        display: block;
+        width: 30rem;
+      }
+      .no-feature:before {
+        content: "No feature";
+      }
+      .pending:before {
+        content: "Query in progress...";
+      }
+      .form {
+        margin: 1rem 0 0 0;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <gmf-map gmf-map-map="ctrl.map"></gmf-map>
+    <p id="desc">
+      This example shows how to use the <code>gmf.EditFeature</code>
+      service to insert, update and delete features from a layer using
+      a GeoMapFish server. First, you must log in. Then, you can either
+      click on the <em>Insert</em> button to insert a random feature, or
+      click on a feature on the map to either <em>Update</em> or
+      <em>Delete</em> it.
+    </p>
+    <gmf-authentication
+        class="panel panel-default panel-body">
+    </gmf-authentication>
+
+    <div
+        ng-if="ctrl.gmfUser.username"
+        class="panel panel-default panel-body">
+      <div>
+        <a
+            href
+            class="btn btn-success"
+            ng-click="ctrl.insertFeature()"
+            title="Insert a new feature at a random location">Insert</a>
+        <a
+            href
+            class="btn btn-primary"
+            ng-class="{disabled: !ctrl.feature}"
+            ng-click="ctrl.updateFeature()"
+            title="Update current feature with a new name">Update</a>
+        <a
+            href
+            class="btn btn-danger"
+            ng-class="{disabled: !ctrl.feature}"
+            ng-click="ctrl.deleteFeature()"
+            title="Delete current feature">Delete</a>
+      </div>
+      <div class="form">
+        <div class="form-group">
+          <label>Feature id</label>
+          <span
+              class="form-control"
+              ng-switch="ctrl.feature">
+            <span
+                ng-switch-when="null"
+                class="no-feature"
+                ng-class="{'pending': ctrl.pending === true}">
+            </span>
+            <span ng-switch-default>{{ ctrl.feature.getId() }}</span>
+          </span>
+        </div>
+      </div>
+    </div>
+    <script src="../../../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../third-party/jquery-ui/jquery-ui.min.js"></script>
+    <script src="../../../node_modules/angular/angular.js"></script>
+    <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
+    <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
+    <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="../../../node_modules/proj4/dist/proj4.js"></script>
+    <script src="../../../node_modules/angular-ui-date/dist/date.js"></script>
+    <script src="../../../node_modules/angular-ui-slider/src/slider.js"></script>
+    <script src="../../../node_modules/angular-dynamic-locale/dist/tmhDynamicLocale.js" type="text/javascript"></script>
+    <script src="/@?main=editfeature.js"></script>
+    <script src="default.js"></script>
+    <script src="../../../utils/watchwatchers.js"></script>
+    <script>
+      var gmfModule = angular.module('gmf');
+      gmfModule.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
+    </script>
+  </body>
+</html>

--- a/contribs/gmf/examples/editfeature.js
+++ b/contribs/gmf/examples/editfeature.js
@@ -4,6 +4,7 @@ goog.require('ngeo.proj.EPSG21781');
 goog.require('gmf.authenticationDirective');
 goog.require('gmf.mapDirective');
 goog.require('gmf.EditFeature');
+goog.require('goog.asserts');
 goog.require('ol.Feature');
 goog.require('ol.Map');
 goog.require('ol.View');

--- a/contribs/gmf/examples/editfeature.js
+++ b/contribs/gmf/examples/editfeature.js
@@ -1,0 +1,290 @@
+goog.provide('gmf-editfeature');
+
+goog.require('ngeo.proj.EPSG21781');
+goog.require('gmf.authenticationDirective');
+goog.require('gmf.mapDirective');
+goog.require('gmf.EditFeature');
+goog.require('ol.Feature');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.extent');
+goog.require('ol.geom.Point');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['gmf']);
+
+
+app.module.constant(
+    'authenticationBaseUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi');
+
+
+app.module.constant('gmfLayersUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/layers/');
+
+
+/**
+ * @param {!angular.Scope} $scope Angular scope.
+ * @param {gmf.EditFeature} gmfEditFeature Gmf edit feature service.
+ * @param {gmfx.User} gmfUser User.
+ * @constructor
+ */
+app.MainController = function($scope, gmfEditFeature, gmfUser) {
+
+  /**
+   * @type {!angular.Scope}
+   * @private
+   */
+  this.scope_ = $scope;
+
+  /**
+   * @type {gmf.EditFeature}
+   * @export
+   */
+  this.editFeature_ = gmfEditFeature;
+
+  /**
+   * @type {gmfx.User}
+   * @export
+   */
+  this.gmfUser = gmfUser;
+
+  var projection = ol.proj.get('EPSG:21781');
+  projection.setExtent([485869.5728, 76443.1884, 837076.5648, 299941.7864]);
+
+  /**
+   * @type {ol.source.ImageWMS}
+   * @private
+   */
+  this.wmsSource_ = new ol.source.ImageWMS({
+    url: 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy',
+    params: {'LAYERS': 'point'}
+  });
+
+  /**
+   * @type {ol.layer.Image}
+   * @private
+   */
+  this.wmsLayer_ = new ol.layer.Image({
+    source: this.wmsSource_
+  });
+
+  /**
+   * @type {number}
+   * @private
+   */
+  this.pixelBuffer_ = 10;
+
+  /**
+   * @type {number}
+   * @private
+   */
+  this.layerId_ = 113;
+
+  /**
+   * @type {ol.Feature}
+   * @export
+   */
+  this.feature = null;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.pending = false;
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      }),
+      this.wmsLayer_
+    ],
+    view: new ol.View({
+      projection: projection,
+      resolutions: [200, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5],
+      center: [537635, 152640],
+      zoom: 2
+    })
+  });
+
+  this.map.on('singleclick', this.handleMapSingleClick_, this);
+
+  // initialize tooltips
+  $('[data-toggle="tooltip"]').tooltip({
+    container: 'body',
+    trigger: 'hover'
+  });
+};
+
+
+/**
+ * @param {ol.MapBrowserEvent} evt MapBrowser event
+ * @private
+ */
+app.MainController.prototype.handleMapSingleClick_ = function(evt) {
+
+  // (1) Launch query to fetch new features
+  var coordinate = evt.coordinate;
+  var map = this.map;
+  var view = map.getView();
+  var resolution = view.getResolution();
+  var buffer = resolution * this.pixelBuffer_;
+  var extent = ol.extent.buffer(
+    [coordinate[0], coordinate[1], coordinate[0], coordinate[1]],
+    buffer
+  );
+
+  this.editFeature_.getFeatures([this.layerId_], extent).then(
+    this.handleGetFeatures_.bind(this));
+
+  // (2) Clear any previously selected feature
+  this.feature = null;
+
+  // (3) Pending
+  this.pending = true;
+
+  this.scope_.$apply();
+};
+
+
+/**
+ * @param {Array.<ol.Feature>} features Features.
+ * @private
+ */
+app.MainController.prototype.handleGetFeatures_ = function(features) {
+  this.pending = false;
+
+  if (features.length) {
+    this.feature = features[0];
+  }
+};
+
+
+/**
+ * Insert a new feature at a random location.
+ * @export
+ */
+app.MainController.prototype.insertFeature = function() {
+
+  this.pending = true;
+
+  // (1) Create a randomly located feature
+  var map = this.map;
+  var view = map.getView();
+  var resolution = view.getResolution();
+  var buffer = resolution * -50; // 50 pixel buffer inside the extent
+  var size = map.getSize();
+  goog.asserts.assert(size);
+  var extent = ol.extent.buffer(
+    view.calculateExtent(size),
+    buffer
+  );
+  var bottomLeft = ol.extent.getBottomLeft(extent);
+  var topRight = ol.extent.getTopRight(extent);
+  var left = bottomLeft[0];
+  var bottom = bottomLeft[1];
+  var right = topRight[0];
+  var top = topRight[1];
+  var deltaX = right - left;
+  var deltaY = top - bottom;
+  var coordinate = [
+    left + Math.random() * deltaX,
+    right + Math.random() * deltaY
+  ];
+
+  var feature = new ol.Feature({
+    'geometry': new ol.geom.Point(coordinate),
+    'name': 'New point'
+  });
+
+  // (2) Launch request
+  this.editFeature_.insertFeatures(
+    this.layerId_,
+    [feature]
+  ).then(
+    this.handleEditFeature_.bind(this)
+  );
+};
+
+
+/**
+ * Update the currently selected feature with a new name.
+ * @export
+ */
+app.MainController.prototype.updateFeature = function() {
+
+  goog.asserts.assert(this.feature);
+
+  this.pending = true;
+
+  // (1) Update name
+  this.feature.set('name', 'Updated name');
+
+  // (2) Launch request
+  this.editFeature_.updateFeature(
+    this.layerId_,
+    this.feature
+  ).then(
+    this.handleEditFeature_.bind(this)
+  );
+
+  // (3) Reset selected feature
+  this.feature = null;
+};
+
+
+/**
+ * Delete currently selected feature.
+ * @export
+ */
+app.MainController.prototype.deleteFeature = function() {
+
+  goog.asserts.assert(this.feature);
+
+  // (1) Launch request
+  this.editFeature_.deleteFeature(
+    this.layerId_,
+    this.feature
+  ).then(
+    this.handleEditFeature_.bind(this)
+  );
+
+  // (2) Reset selected feature
+  this.feature = null;
+};
+
+
+/**
+ * Called after an insert, update or delete request.
+ * @param {angular.$http.Response} resp Ajax response.
+ * @private
+ */
+app.MainController.prototype.handleEditFeature_ = function(resp) {
+  this.pending = false;
+  this.refreshWMSLayer_();
+};
+
+
+/**
+ * @private
+ */
+app.MainController.prototype.refreshWMSLayer_ = function() {
+  this.wmsSource_.updateParams({
+    'random': Math.random()
+  });
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/contribs/gmf/src/services/editfeature.js
+++ b/contribs/gmf/src/services/editfeature.js
@@ -1,0 +1,116 @@
+goog.provide('gmf.EditFeature');
+
+goog.require('gmf');
+goog.require('goog.uri.utils');
+goog.require('ol.format.GeoJSON');
+
+
+/**
+ * Service that provides methods to get, insert, update and delete vector
+ * features with the use of a GeoMapFish server as back-end.
+ *
+ * The GeoJSON format is used when obtaining or sending features.
+ *
+ * @constructor
+ * @param {angular.$http} $http Angular http service.
+ * @param {string} gmfLayersUrl Url to the GeoMapFish layers service.
+ * @ngInject
+ */
+gmf.EditFeature = function($http, gmfLayersUrl) {
+
+  /**
+   * @type {angular.$http}
+   * @private
+   */
+  this.http_ = $http;
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.baseUrl_ = gmfLayersUrl;
+
+};
+
+
+/**
+ * @param {Array.<number>} layerIds List of layer ids to get the features from.
+ * @param {ol.Extent} extent The extent where to get the features from.
+ * @return {angular.$q.Promise} Promise.
+ * @export
+ */
+gmf.EditFeature.prototype.getFeatures = function(layerIds, extent) {
+  var ids = layerIds.join(',');
+  var url = goog.uri.utils.appendParam(
+    goog.uri.utils.appendPath(this.baseUrl_, ids),
+    'bbox',
+    extent.join(',')
+  );
+  return this.http_.get(url).then(this.handleGetFeatures_.bind(this));
+};
+
+
+/**
+ * @param {angular.$http.Response} resp Ajax response.
+ * @return {Array.<ol.Feature>} List of features.
+ * @private
+ */
+gmf.EditFeature.prototype.handleGetFeatures_ = function(resp) {
+  return new ol.format.GeoJSON().readFeatures(resp.data);
+};
+
+
+/**
+ * @param {number} layerId The layer id that contains the feature.
+ * @param {Array.<ol.Feature>} features List of features to insert.
+ * @return {angular.$q.Promise} Promise.
+ * @export
+ */
+gmf.EditFeature.prototype.insertFeatures = function(layerId, features) {
+  var url = goog.uri.utils.appendPath(this.baseUrl_, layerId.toString());
+  var geoJSON = new ol.format.GeoJSON().writeFeatures(features);
+  return this.http_.post(url, geoJSON, {
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    withCredentials: true
+  });
+};
+
+
+/**
+ * @param {number} layerId The layer id that contains the feature.
+ * @param {ol.Feature} feature The feature to update.
+ * @return {angular.$q.Promise} Promise.
+ * @export
+ */
+gmf.EditFeature.prototype.updateFeature = function(layerId, feature) {
+  var url = goog.uri.utils.appendPath(
+    this.baseUrl_,
+    layerId.toString() + '/' + feature.getId()
+  );
+  var geoJSON = new ol.format.GeoJSON().writeFeature(feature);
+  return this.http_.put(url, geoJSON, {
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    withCredentials: true
+  });
+};
+
+
+/**
+ * @param {number} layerId The layer id that contains the feature.
+ * @param {ol.Feature} feature The feature to delete.
+ * @return {angular.$q.Promise} Promise.
+ * @export
+ */
+gmf.EditFeature.prototype.deleteFeature = function(layerId, feature) {
+  var url = goog.uri.utils.appendPath(
+    this.baseUrl_,
+    layerId.toString() + '/' + feature.getId()
+  );
+  return this.http_.delete(url, {
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    withCredentials: true
+  });
+};
+
+
+gmf.module.service('gmfEditFeature', gmf.EditFeature);


### PR DESCRIPTION
This PR introduces the `gmf.EditFeature` service along with a simple example that demonstrates what you can do with it. The example should be replaced in the incoming days with one that uses the "coming soon" directives that allows the user to actually select an editable layer first.

## Same origin issues

When trying to insert, update or delete, we get errors:

> XMLHttpRequest cannot load https://geomapfish-demo.camptocamp.net/2.1/wsgi/layers/113. No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://localhost:3000' is therefore not allowed access. The response had HTTP status code 404.

## Todo

 * ~~Fix the "Same origin" issues~~, moved to: https://github.com/camptocamp/c2cgeoportal/issues/2368
 * [x] Review

## Live example

 * https://adube.github.io/ngeo/gmf-editfeature-service/examples/contribs/gmf/editfeature.html