### PR TITLE
Add missing require for `gmf.WMSTime`

### DIFF
--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -5,6 +5,7 @@ goog.require('ngeo.SyncArrays');
 goog.require('gmf');
 goog.require('gmf.Themes');
 goog.require('gmf.TreeManager');
+goog.require('gmf.WMSTime');
 goog.require('ngeo.CreatePopup');
 goog.require('ngeo.LayerHelper');
 goog.require('ngeo.LayertreeController');


### PR DESCRIPTION
The mobile application is currently broken:

    Error: [$injector:unpr] Unknown provider: gmfWMSTimeProvider <- gmfWMSTime <- GmfLayertreeController

This PR adds a missing `goog.require('gmf.WMSTime')` for the layer-tree.