### PR TITLE
Profile Integration and dedicated tool to draw profile's line

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -55,6 +55,13 @@
             data-toggle="tooltip" data-placement="left" data-original-title="{{'Draw & Measure'|translate}}">
             <span class="fa fa-pencil"></span>
           </button>
+          <button class="btn btn-default"
+            ng-click="mainCtrl.profileActive = !mainCtrl.profileActive"
+            gmf-drawprofileline
+            gmf-drawprofileline-map="::mainCtrl.map"
+            gmf-drawprofileline-line="mainCtrl.profileLine">
+            <span class="fa fa-area-chart"></span>
+          </button>
         </div>
         <div class="tools-content container-fluid" ng-class="{active: mainCtrl.toolsActive}">
           <div ng-show="mainCtrl.loginActive" class="row">
@@ -127,7 +134,15 @@
           ngeo-map-query-active="mainCtrl.queryActive"
           ngeo-bbox-query=""
           ngeo-bbox-query-map="::mainCtrl.map"
-          ngeo-bbox-query-active="mainCtrl.queryActive"></gmf-map>
+          ngeo-bbox-query-active="mainCtrl.queryActive">
+        </gmf-map>
+
+        <gmf-profile
+          gmf-profile-active="mainCtrl.profileActive"
+          gmf-profile-line="mainCtrl.profileLine"
+          gmf-profile-map="::mainCtrl.map"
+          gmf-profile-linesconfiguration="::mainCtrl.profileLinesconfiguration">
+        </gmf-profile>
 
         <!--infobar-->
         <div class="footer" ng-class="{'active': mainCtrl.showInfobar}">
@@ -196,6 +211,8 @@
         module.constant('authenticationBaseUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi');
         module.constant('fulltextsearchUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/fulltextsearch?limit=30&partitionlimit=5');
         module.constant('gmfRasterUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/raster');
+        module.constant('gmfProfileCsvUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/profile.csv');
+        module.constant('gmfProfileJsonUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/profile.json');
         module.constant('gmfPrintUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/printproxy');
         module.constant('gmfWmsUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy');
         module.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');

--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -55,11 +55,8 @@
             data-toggle="tooltip" data-placement="left" data-original-title="{{'Draw & Measure'|translate}}">
             <span class="fa fa-pencil"></span>
           </button>
-          <button class="btn btn-default"
-            ng-click="mainCtrl.profileActive = !mainCtrl.profileActive"
-            gmf-drawprofileline
-            gmf-drawprofileline-map="::mainCtrl.map"
-            gmf-drawprofileline-line="mainCtrl.profileLine">
+          <button ngeo-btn class="btn btn-default" ng-model="profileActive"
+            data-toggle="tooltip" data-placement="left" data-original-title="{{'Profile'|translate}}">
             <span class="fa fa-area-chart"></span>
           </button>
         </div>
@@ -98,9 +95,35 @@
               </gmf-drawfeature>
             </div>
           </div>
+          <div ng-show="profileActive" class="row">
+            <div class="col-sm-12">
+              <div class="tools-content-heading">
+                {{'Profile'|translate}}
+                <a class="btn close" ng-click="profileActive = false">&times;</a>
+              </div>
+              <div gmf-drawprofileline
+                   gmf-drawprofileline-active="profileActive"
+                   gmf-drawprofileline-map="::mainCtrl.map"
+                   gmf-drawprofileline-line="mainCtrl.profileLine">
+                 <p>
+                  <button class="btn btn-default"
+                    ngeo-btn ng-model="ctrl.interaction.active"
+                    translate>
+                    Draw profile line
+                  </button>
+                </p>
+                <p>
+                  <em translate ng-if="ctrl.interaction.active" class="text-muted small">
+                    Draw a line on the map to display the corresponding elevation profile.
+                    Use double-click to finish the drawing.
+                  </em>
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
-      <div class="map-container" ng-class="{'infobar-active': mainCtrl.showInfobar}">
+      <div class="map-container" ng-class="{'infobar-active': mainCtrl.showInfobar, 'profile-chart-active': !!profileChartActive}">
         <gmf-search gmf-search-map="mainCtrl.map"
           class="search"
           gmf-search-datasources="mainCtrl.searchDatasources"
@@ -168,6 +191,14 @@
           </div>
         </div>
       </div>
+      <gmf-profile
+        gmf-profile-active="profileChartActive"
+        gmf-profile-line="mainCtrl.profileLine"
+        gmf-profile-map="::mainCtrl.map"
+        gmf-profile-linesconfiguration="::mainCtrl.profileLinesconfiguration"
+        ngeo-resizemap="mainCtrl.map"
+        ngeo-resizemap-state="profileChartActive">
+      </gmf-profile>
     </main>
     <script src="../../../../node_modules/jquery/dist/jquery.js"></script>
     <script src="../../third-party/jquery-ui/jquery-ui.min.js"></script>

--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -55,7 +55,7 @@
             data-toggle="tooltip" data-placement="left" data-original-title="{{'Draw & Measure'|translate}}">
             <span class="fa fa-pencil"></span>
           </button>
-          <button ngeo-btn class="btn btn-default" ng-model="profileActive"
+          <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.drawProfilePanelActive"
             data-toggle="tooltip" data-placement="left" data-original-title="{{'Profile'|translate}}">
             <span class="fa fa-area-chart"></span>
           </button>
@@ -95,25 +95,24 @@
               </gmf-drawfeature>
             </div>
           </div>
-          <div ng-show="profileActive" class="row">
+          <div ng-show="mainCtrl.drawProfilePanelActive" class="row">
             <div class="col-sm-12">
               <div class="tools-content-heading">
                 {{'Profile'|translate}}
-                <a class="btn close" ng-click="profileActive = false">&times;</a>
+                <a class="btn close" ng-click="mainCtrl.drawProfilePanelActive = false">&times;</a>
               </div>
               <div gmf-drawprofileline
-                   gmf-drawprofileline-active="profileActive"
+                   gmf-drawprofileline-active="mainCtrl.drawProfilePanelActive"
                    gmf-drawprofileline-map="::mainCtrl.map"
                    gmf-drawprofileline-line="mainCtrl.profileLine">
                  <p>
                   <button class="btn btn-default"
                     ngeo-btn ng-model="ctrl.interaction.active"
-                    translate>
-                    Draw profile line
+                    translate> Draw profile line
                   </button>
                 </p>
                 <p>
-                  <em translate ng-if="ctrl.interaction.active" class="text-muted small">
+                  <em ng-if="ctrl.interaction.active" class="text-muted small">
                     Draw a line on the map to display the corresponding elevation profile.
                     Use double-click to finish the drawing.
                   </em>

--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -160,13 +160,6 @@
           ngeo-bbox-query-active="mainCtrl.queryActive">
         </gmf-map>
 
-        <gmf-profile
-          gmf-profile-active="mainCtrl.profileActive"
-          gmf-profile-line="mainCtrl.profileLine"
-          gmf-profile-map="::mainCtrl.map"
-          gmf-profile-linesconfiguration="::mainCtrl.profileLinesconfiguration">
-        </gmf-profile>
-
         <!--infobar-->
         <div class="footer" ng-class="{'active': mainCtrl.showInfobar}">
           <button class="btn fa map-info ng-cloak" ng-click="mainCtrl.showInfobar = !mainCtrl.showInfobar"

--- a/contribs/gmf/apps/desktop/js/controller.js
+++ b/contribs/gmf/apps/desktop/js/controller.js
@@ -72,6 +72,21 @@ app.DesktopController = function($scope, $injector) {
   this.elevationLayers = ['aster', 'srtm'];
 
   /**
+   * @type {string}
+   * @export
+   */
+  this.selectedElevationLayer = this.elevationLayers[0];
+
+  /**
+   * @type {Object.<string, gmfx.ProfileLineConfiguration>}
+   * @export
+   */
+  this.profileLinesconfiguration = {
+    'aster': {color: '#0000A0'},
+    'srtm': {color: '#00A000'}
+  };
+
+  /**
    * @type {Array.<gmfx.MousePositionProjection>}
    * @export
    */

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -53,6 +53,13 @@
             data-toggle="tooltip" data-placement="left" data-original-title="{{'Draw & Measure'|translate}}">
             <span class="fa fa-pencil"></span>
           </button>
+          <button class="btn btn-default"
+            ng-click="mainCtrl.profileActive = !mainCtrl.profileActive"
+            gmf-drawprofileline
+            gmf-drawprofileline-map="::mainCtrl.map"
+            gmf-drawprofileline-line="mainCtrl.profileLine">
+            <span class="fa fa-area-chart"></span>
+          </button>
         </div>
         <div class="tools-content container-fluid" ng-class="{active: mainCtrl.toolsActive}">
           <div ng-show="mainCtrl.loginActive" class="row">
@@ -117,6 +124,12 @@
           </gmf-disclaimer>
         </div>
         <gmf-map class="gmf-map" gmf-map-map="mainCtrl.map"></gmf-map>
+        <gmf-profile
+          gmf-profile-active="mainCtrl.profileActive"
+          gmf-profile-line="mainCtrl.profileLine"
+          gmf-profile-map="::mainCtrl.map"
+          gmf-profile-linesconfiguration="::mainCtrl.profileLinesconfiguration">
+        </gmf-profile>
 
         <!--infobar-->
         <div class="footer" ng-class="{'active': mainCtrl.showInfobar}">
@@ -186,6 +199,8 @@
         module.constant('fulltextsearchUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/fulltextsearch?limit=30&partitionlimit=5');
         module.constant('gmfRasterUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/raster');
         module.constant('gmfPrintUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/printproxy');
+        module.constant('gmfProfileCsvUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/profile.csv');
+        module.constant('gmfProfileJsonUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/profile.json');
         module.constant('gmfWmsUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy');
         module.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
         module.constant('gmfSearchGroups', ['osm','district']);

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -53,7 +53,7 @@
             data-toggle="tooltip" data-placement="left" data-original-title="{{'Draw & Measure'|translate}}">
             <span class="fa fa-pencil"></span>
           </button>
-          <button ngeo-btn class="btn btn-default" ng-model="profileActive"
+          <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.drawProfilePanelActive"
             data-toggle="tooltip" data-placement="left" data-original-title="{{'Profile'|translate}}">
             <span class="fa fa-area-chart"></span>
           </button>
@@ -94,14 +94,14 @@
               </gmf-drawfeature>
             </div>
           </div>
-          <div ng-show="profileActive" class="row">
+          <div ng-show="mainCtrl.drawProfilePanelActive" class="row">
             <div class="col-sm-12">
               <div class="tools-content-heading">
                 {{'Profile'|translate}}
-                <a class="btn close" ng-click="profileActive = false">&times;</a>
+                <a class="btn close" ng-click="mainCtrl.drawProfilePanelActive = false">&times;</a>
               </div>
               <div gmf-drawprofileline
-                   gmf-drawprofileline-active="profileActive"
+                   gmf-drawprofileline-active="mainCtrl.drawProfilePanelActive"
                    gmf-drawprofileline-map="::mainCtrl.map"
                    gmf-drawprofileline-line="mainCtrl.profileLine">
                  <p>

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -53,11 +53,8 @@
             data-toggle="tooltip" data-placement="left" data-original-title="{{'Draw & Measure'|translate}}">
             <span class="fa fa-pencil"></span>
           </button>
-          <button class="btn btn-default"
-            ng-click="mainCtrl.profileActive = !mainCtrl.profileActive"
-            gmf-drawprofileline
-            gmf-drawprofileline-map="::mainCtrl.map"
-            gmf-drawprofileline-line="mainCtrl.profileLine">
+          <button ngeo-btn class="btn btn-default" ng-model="profileActive"
+            data-toggle="tooltip" data-placement="left" data-original-title="{{'Profile'|translate}}">
             <span class="fa fa-area-chart"></span>
           </button>
         </div>
@@ -97,9 +94,35 @@
               </gmf-drawfeature>
             </div>
           </div>
+          <div ng-show="profileActive" class="row">
+            <div class="col-sm-12">
+              <div class="tools-content-heading">
+                {{'Profile'|translate}}
+                <a class="btn close" ng-click="profileActive = false">&times;</a>
+              </div>
+              <div gmf-drawprofileline
+                   gmf-drawprofileline-active="profileActive"
+                   gmf-drawprofileline-map="::mainCtrl.map"
+                   gmf-drawprofileline-line="mainCtrl.profileLine">
+                 <p>
+                  <button class="btn btn-default"
+                    ngeo-btn ng-model="ctrl.interaction.active"
+                    translate>
+                    Draw profile line
+                  </button>
+                </p>
+                <p>
+                  <em translate ng-if="ctrl.interaction.active" class="text-muted small">
+                    Draw a line on the map to display the corresponding elevation profile.
+                    Use double-click to finish the drawing.
+                  </em>
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
-      <div class="map-container" ng-class="{'infobar-active': mainCtrl.showInfobar}">
+      <div class="map-container" ng-class="{'infobar-active': mainCtrl.showInfobar, 'profile-chart-active': !!profileChartActive}">
         <gmf-search gmf-search-map="mainCtrl.map"
           class="search"
           gmf-search-datasources="mainCtrl.searchDatasources"
@@ -124,12 +147,6 @@
           </gmf-disclaimer>
         </div>
         <gmf-map class="gmf-map" gmf-map-map="mainCtrl.map"></gmf-map>
-        <gmf-profile
-          gmf-profile-active="mainCtrl.profileActive"
-          gmf-profile-line="mainCtrl.profileLine"
-          gmf-profile-map="::mainCtrl.map"
-          gmf-profile-linesconfiguration="::mainCtrl.profileLinesconfiguration">
-        </gmf-profile>
 
         <!--infobar-->
         <div class="footer" ng-class="{'active': mainCtrl.showInfobar}">
@@ -155,6 +172,14 @@
           </div>
         </div>
       </div>
+      <gmf-profile
+        gmf-profile-active="profileChartActive"
+        gmf-profile-line="mainCtrl.profileLine"
+        gmf-profile-map="::mainCtrl.map"
+        gmf-profile-linesconfiguration="::mainCtrl.profileLinesconfiguration"
+        ngeo-resizemap="mainCtrl.map"
+        ngeo-resizemap-state="profileChartActive">
+      </gmf-profile>
     </main>
     <script src="../../../../node_modules/jquery/dist/jquery.js"></script>
     <script src="../../third-party/jquery-ui/jquery-ui.min.js"></script>

--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -78,6 +78,14 @@ app.AlternativeDesktopController = function($scope, $injector) {
   this.elevationLayers = ['srtm'];
 
   /**
+   * @type {Object.<string, gmfx.ProfileLineConfiguration>}
+   * @export
+   */
+  this.profileLinesconfiguration = {
+    'srtm': {}
+  };
+
+  /**
    * @type {Array.<gmfx.MousePositionProjection>}
    * @export
    */

--- a/contribs/gmf/examples/profile.html
+++ b/contribs/gmf/examples/profile.html
@@ -27,16 +27,6 @@
           padding: 0;
           width: 13rem;
         }
-        .profile-container .profile-export {
-          width: 80rem;
-        }
-        .profile-container .profile-export>div {
-          float: right;
-          width: 7rem;
-        }
-        .profile-container .profile-export a {
-          display: inline-block;
-        }
         .tooltip {
           position: relative;
           background: rgba(0, 0, 0, 0.5);

--- a/contribs/gmf/examples/profile.html
+++ b/contribs/gmf/examples/profile.html
@@ -60,13 +60,15 @@
     <p id="desc">This example shows how to use the <code>gmf-profile</code>.
     The draw tool and hover feedback on the map are completely independant of
     the gmf-profile components. This profile relies on the ngeo.profile (d3) and
-    ngeo.ProfileDirective.</p>
+    ngeo.ProfileDirective. It passes a custom css through the optional
+    gmf-profile-options attribute</p>
 
     <gmf-profile
       gmf-profile-active="true"
       gmf-profile-line="ctrl.profileLine"
       gmf-profile-map="::ctrl.map"
-      gmf-profile-linesconfiguration="::ctrl.profileLinesconfiguration">
+      gmf-profile-linesconfiguration="::ctrl.profileLinesconfiguration"
+      gmf-profile-options="::ctrl.profileOptions">
     </gmf-profile>
 
     <script src="../../../node_modules/jquery/dist/jquery.js"></script>

--- a/contribs/gmf/examples/profile.js
+++ b/contribs/gmf/examples/profile.js
@@ -63,6 +63,10 @@ app.MainController = function($scope, ngeoFeatureOverlayMgr) {
     }
   };
 
+  this.profileOptions = {
+    styleDefs: 'svg {background-color: #D3E5D7};'
+  };
+
   /**
    * @type {ol.Map}
    * @export

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -11,6 +11,7 @@
 @import 'popover.less';
 @import 'datepicker.less';
 @import 'displayquerywindow.less';
+@import 'profile.less';
 @import 'timeslider.less';
 
 @map-tools-size: 3rem;

--- a/contribs/gmf/less/profile.less
+++ b/contribs/gmf/less/profile.less
@@ -1,0 +1,38 @@
+.profile-container {
+  @profileLegendWidth: 15rem;
+  position: absolute;
+  bottom: 0;
+  padding: @app-margin;
+  background-color: white;
+  border-top: solid 1px black;
+  z-index: @above-content-index;
+  width: 100%;
+
+  .profile {
+    display: inline-block;
+    height: 20rem;
+    width: ~"calc(100% - @{profileLegendWidth})";
+  }
+
+  .profile-legend {
+    display: inline-block;
+    vertical-align: top;
+    list-style-type: none;
+    padding: 0;
+    width: @profileLegendWidth - 1;
+  }
+
+  .profile-export {
+    height: 1em;
+    display: right;
+  }
+
+  .profile-export > div {
+    float: right;
+    width: 7rem;
+  }
+
+  .profile-export a {
+    display: inline-block;
+  }
+}

--- a/contribs/gmf/less/profile.less
+++ b/contribs/gmf/less/profile.less
@@ -1,38 +1,35 @@
+@profile-height: 20rem;
+.map-container.profile-chart-active {
+  height: calc(~"100% -" @profile-height);
+}
 .profile-container {
-  @profileLegendWidth: 15rem;
-  position: absolute;
-  bottom: 0;
+  position: relative;
+  overflow: hidden;
+  @profile-legend-width: 15rem;
   padding: @app-margin;
-  background-color: white;
   border-top: solid 1px black;
-  z-index: @above-content-index;
-  width: 100%;
+  background-color: white;
+  height: @profile-height;
+  display: flex;
 
   .profile {
-    display: inline-block;
-    height: 20rem;
-    width: ~"calc(100% - @{profileLegendWidth})";
+    width: ~"calc(100% - @{profile-legend-width})";
+    background-color: #f5f5f5;
   }
 
   .profile-legend {
-    display: inline-block;
-    vertical-align: top;
     list-style-type: none;
-    padding: 0;
-    width: @profileLegendWidth - 1;
+    width: @profile-legend-width;
+    padding: @app-margin;
   }
 
   .profile-export {
-    height: 1em;
-    display: right;
+    position: absolute;
+    right: @app-margin;
+    bottom: @app-margin;
   }
 
-  .profile-export > div {
-    float: right;
-    width: 7rem;
-  }
-
-  .profile-export a {
-    display: inline-block;
+  .close {
+    height: 1rem;
   }
 }

--- a/contribs/gmf/less/profile.less
+++ b/contribs/gmf/less/profile.less
@@ -29,6 +29,10 @@
     bottom: @app-margin;
   }
 
+  .profile-error {
+    width: 100%;
+  }
+
   .close {
     height: 1rem;
   }

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -183,6 +183,12 @@ gmf.AbstractController = function(config, $scope, $injector) {
   this.drawFeatureActive = false;
 
   /**
+   * @type {boolean}
+   * @export
+   */
+  this.drawProfilePanelActive = false;
+
+  /**
    * @type {gmfx.User}
    * @export
    */
@@ -261,6 +267,9 @@ gmf.AbstractController = function(config, $scope, $injector) {
 
   var drawFeatureActivate = new ngeo.ToolActivate(this, 'drawFeatureActive');
   ngeoToolActivateMgr.registerTool('mapTools', drawFeatureActivate, false);
+
+  var drawProfilePanelActivate = new ngeo.ToolActivate(this, 'drawProfilePanelActive');
+  ngeoToolActivateMgr.registerTool('mapTools', drawProfilePanelActivate, false);
 
   var backgroundLayerMgr = $injector.get('ngeoBackgroundLayerMgr');
 

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -13,6 +13,10 @@ goog.require('gmf.mousepositionDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.printDirective');
 /** @suppress {extraRequire} */
+goog.require('gmf.profileDirective');
+/** @suppress {extraRequire} */
+goog.require('gmf.drawprofilelineDirective');
+/** @suppress {extraRequire} */
 goog.require('gmf.DatePickerDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.TimeSliderDirective');
@@ -131,6 +135,18 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
   this.scaleSelectorOptions = {
     'dropup': true
   };
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.profileActive = false;
+
+  /**
+   * @type {ol.geom.LineString}
+   * @export
+   */
+  this.profileLine = null;
 
   goog.base(
       this, config, $scope, $injector);

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -137,12 +137,6 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
   };
 
   /**
-   * @type {boolean}
-   * @export
-   */
-  this.profileActive = false;
-
-  /**
    * @type {ol.geom.LineString}
    * @export
    */

--- a/contribs/gmf/src/directives/drawProfileLine.js
+++ b/contribs/gmf/src/directives/drawProfileLine.js
@@ -1,0 +1,167 @@
+goog.provide('gmf.DrawprofilelineController');
+goog.provide('gmf.drawprofilelineDirective');
+
+goog.require('gmf');
+goog.require('ol.Collection');
+goog.require('ol.geom.LineString');
+goog.require('ol.interaction.Draw');
+goog.require('ol.style.Style');
+goog.require('ol.style.Stroke');
+
+
+/**
+ * Simple directive that can be put on any element. The directive listen on
+ *     clicks events to allow/disallow to draw one line (and only one) on the
+ *     map. Typically used to draw the line that will serve the gmf.Profile.
+ *
+ * Example:
+ *
+ *      <gmf-drawprofileline
+ *        gmf-drawprofileline-map="mainCtrl.map"
+ *        gmf-drawprofileline-line="mainCtrl.line"
+ *      </gmf-drawprofileline>
+ *
+ *
+ * @htmlAttribute {ol.Map} gmf-drawprofileline-map The map.
+ * @htmlAttribute {ol.geom.LineString} gmf-drawprofileline-line The variable to
+ *     connect with the drawed line.
+ * @htmlAttribute {boolean=} gmf-drawprofileline-initialstate Optional boolean
+ *     to set the draw fonction to "active" state at initialisation. By default
+ *     it is inactive.
+ * @htmlAttribute {ol.style.Style=} gmf-drawprofileline-style Optional style
+ *     for the drawed line.
+ * @return {angular.Directive} Directive Definition Object.
+ * @ngdoc directive
+ * @ngname gmfDrawprofileline
+ */
+gmf.drawprofilelineDirective = function() {
+  return {
+    bindToController: true,
+    controller: 'GmfDrawprofilelineController',
+    controllerAs: 'ctrl',
+    restrict: 'A',
+    scope: {
+      'getMapFn': '&gmfDrawprofilelineMap',
+      'line': '=gmfDrawprofilelineLine',
+      'getInitialStateFn': '&?gmfDrawprofileLineInitialstate',
+      'getStyleFn': '&?gmfDrawprofilelineStyle'
+    }
+  };
+};
+
+
+gmf.module.directive('gmfDrawprofileline', gmf.drawprofilelineDirective);
+
+/**
+ * @param {!angular.Scope} $scope Scope.
+ * @param {angular.JQLite} $element Element.
+ * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr Feature overlay
+ *     manager.
+ * @constructor
+ * @export
+ * @ngInject
+ * @ngdoc controller
+ * @ngname gmfDrawprofilelineController
+ */
+gmf.DrawprofilelineController = function($scope, $element,
+    ngeoFeatureOverlayMgr) {
+
+  /**
+   * @type {ol.geom.LineString}
+   * @export
+   */
+  this.line;
+
+  var map = this['getMapFn']();
+  goog.asserts.assertInstanceof(map, ol.Map);
+
+  /**
+   * @type {ol.Map}
+   * @private
+   */
+  this.map_ = map;
+
+  /**
+   * @type {ol.Collection}
+   * @private
+   */
+  this.features_ = new ol.Collection();
+
+  var overlay = ngeoFeatureOverlayMgr.getFeatureOverlay();
+  overlay.setFeatures(this.features_);
+
+  var style;
+  var styleFn = this['getStyleFn'];
+  if (styleFn) {
+    style = styleFn();
+    goog.asserts.assertInstanceof(style, ol.style.Style);
+  } else {
+    style = new ol.style.Style({
+      stroke: new ol.style.Stroke({
+        color: '#ffcc33',
+        width: 2
+      })
+    });
+  }
+  overlay.setStyle(style);
+
+  var initialStateFn = this['getInitialStateFn'];
+  var initialState = initialStateFn && initialStateFn() === true;
+
+  /**
+   * @type {ol.interaction.Draw}
+   * @private
+   */
+  this.drawLine_ = new ol.interaction.Draw(
+      /** @type {olx.interaction.DrawOptions} */ ({
+        type: 'LineString',
+        features: this.features_
+      }));
+
+  this.map_.addInteraction(this.drawLine_);
+  this.drawLine_.setActive(initialState);
+
+  // Clear the line to draw a new one.
+  this.drawLine_.on('drawstart', function() {
+    this.clear_();
+  }, this);
+
+  // Update the profile with the new geometry.
+  this.drawLine_.on('drawend', function(e) {
+    this.line = e.feature.getGeometry();
+    $scope.$digest();
+  }, this);
+
+  // Activate or deactive the draw.
+  $element.on('click' , function() {
+    this.toggleActive_();
+  }.bind(this));
+};
+
+
+/**
+ * Toggle activation of the draw line interaction.
+ * @private
+ */
+gmf.DrawprofilelineController.prototype.toggleActive_ = function() {
+  if (this.drawLine_.getActive()) {
+    this.drawLine_.setActive(false);
+    this.clear_();
+  } else {
+    this.drawLine_.setActive(true);
+  }
+};
+
+
+/**
+ * Clear the overlay and profile line.
+ * @private
+ */
+gmf.DrawprofilelineController.prototype.clear_ = function() {
+  this.features_.clear();
+  this.line = null;
+};
+
+
+gmf.module.controller('GmfDrawprofilelineController',
+    gmf.DrawprofilelineController);

--- a/contribs/gmf/src/directives/drawprofileline.js
+++ b/contribs/gmf/src/directives/drawprofileline.js
@@ -12,12 +12,13 @@ goog.require('ngeo.DecorateInteraction');
 
 /**
  * Simple directive that can be put on any element. The directive listen on
- *     clicks events to allow/disallow to draw one line (and only one) on the
- *     map. Typically used to draw the line that will serve the gmf.Profile.
+ * clicks events to allow/disallow to draw one line (and only one) on the
+ * map. Typically used to draw the line that will serve the gmf.Profile.
  *
  * Example:
  *
  *      <gmf-drawprofileline
+ *        gmf-drawprofileline-active="mainCtrl.drawProfileActive"
  *        gmf-drawprofileline-map="mainCtrl.map"
  *        gmf-drawprofileline-line="mainCtrl.line"
  *      </gmf-drawprofileline>
@@ -26,9 +27,7 @@ goog.require('ngeo.DecorateInteraction');
  * @htmlAttribute {ol.Map} gmf-drawprofileline-map The map.
  * @htmlAttribute {ol.geom.LineString} gmf-drawprofileline-line The variable to
  *     connect with the drawed line.
- * @htmlAttribute {boolean=} gmf-drawprofileline-initialstate Optional boolean
- *     to set the draw fonction to "active" state at initialisation. By default
- *     it is inactive.
+ * @htmlAttribute {boolean=} gmf-drawprofileline-active Active the component.
  * @htmlAttribute {ol.style.Style=} gmf-drawprofileline-style Optional style
  *     for the drawed line.
  * @return {angular.Directive} Directive Definition Object.
@@ -44,8 +43,7 @@ gmf.drawprofilelineDirective = function() {
     bindToController: {
       'getMapFn': '&gmfDrawprofilelineMap',
       'line': '=gmfDrawprofilelineLine',
-      'active': '<gmfDrawprofilelineActive',
-      'getInitialStateFn': '&?gmfDrawprofileLineInitialstate',
+      'active': '=gmfDrawprofilelineActive',
       'getStyleFn': '&?gmfDrawprofilelineStyle'
     }
   };
@@ -117,9 +115,6 @@ gmf.DrawprofilelineController = function($scope, $element, $timeout,
   }
   overlay.setStyle(style);
 
-  var initialStateFn = this['getInitialStateFn'];
-  var initialState = initialStateFn && initialStateFn() === true;
-
   /**
    * @type {ol.interaction.Draw}
    * @export
@@ -131,7 +126,6 @@ gmf.DrawprofilelineController = function($scope, $element, $timeout,
       }));
 
   this.map_.addInteraction(this.interaction);
-  this.interaction.setActive(initialState);
   ngeoDecorateInteraction(this.interaction);
 
   // Clear the line as soon as the interaction is activated.
@@ -141,7 +135,8 @@ gmf.DrawprofilelineController = function($scope, $element, $timeout,
       if (this.interaction.getActive()) {
         this.clear_();
       }
-    }, this);
+    }, this
+  );
 
   // Update the profile with the new geometry.
   this.interaction.on(ol.interaction.DrawEventType.DRAWEND, function(e) {
@@ -173,7 +168,7 @@ gmf.DrawprofilelineController = function($scope, $element, $timeout,
         this.clear_();
       }
       // Will activate the interaction automatically the first time
-      this.interaction.setActive(newValue);
+      this.interaction.setActive(this.active);
     }.bind(this)
   );
 };

--- a/contribs/gmf/src/directives/partials/profile.html
+++ b/contribs/gmf/src/directives/partials/profile.html
@@ -1,4 +1,4 @@
-<div class="profile-container">
+<div class="profile-container" ng-show="ctrl.active">
   <div class="profile" ngeo-profile="ctrl.profileData"
       ngeo-profile-highlight="ctrl.profileHighlight"
       ngeo-profile-options="::ctrl.profileOptions">

--- a/contribs/gmf/src/directives/partials/profile.html
+++ b/contribs/gmf/src/directives/partials/profile.html
@@ -1,4 +1,4 @@
-<div class="profile-container" ng-show="ctrl.active">
+<div class="profile-container panel" ng-show="ctrl.active">
   <div class="profile" ngeo-profile="ctrl.profileData"
       ngeo-profile-highlight="ctrl.profileHighlight"
       ngeo-profile-options="::ctrl.profileOptions">
@@ -7,14 +7,13 @@
     <li ng-repeat="name in ::ctrl.getLayersNames()"><i class="fa fa-minus" style="color:{{::ctrl.getColor(name)}};"></i>&nbsp;{{name | translate}}&nbsp;{{ctrl.currentPoint.elevations[name]}}&nbsp;{{ctrl.currentPoint.yUnits}}
     </li>
   </ul>
-  <div class="profile-export form-group form-group-sm">
-    <div class="btn-group btn-block dropup">
-      <a class="dropdown-toggle" href="" ng-show="ctrl.profileData.length !== 0" data-toggle="dropdown" aria-expanded="false">
-        {{'Export' | translate}}&nbsp;<i class="fa fa-caret-up"></i>
-      </a>
-      <ul class="dropdown-menu dropdown-menu-right" role="menu">
-        <li><a href="" ng-click="::ctrl.downloadCsv()"><i class="fa fa-table"></i>&nbsp;{{'Download CSV' | translate}}</a></li>
-      </ul>
-    </div>
+  <div class="profile-export btn-group dropup">
+    <a class="dropdown-toggle" href="" ng-show="ctrl.profileData.length !== 0" data-toggle="dropdown" aria-expanded="false">
+      {{'Export' | translate}}&nbsp;<i class="fa fa-caret-up"></i>
+    </a>
+    <ul class="dropdown-menu dropdown-menu-right" role="menu">
+      <li><a href="" ng-click="::ctrl.downloadCsv()"><i class="fa fa-table"></i>&nbsp;{{'Download CSV' | translate}}</a></li>
+    </ul>
   </div>
+  <div class="close" ng-click="ctrl.line = null">&times;</div>
 </div>

--- a/contribs/gmf/src/directives/partials/profile.html
+++ b/contribs/gmf/src/directives/partials/profile.html
@@ -1,19 +1,22 @@
 <div class="profile-container panel" ng-show="ctrl.active">
-  <div class="profile" ngeo-profile="ctrl.profileData"
+  <div class="profile" ng-show="!ctrl.isErrored" ngeo-profile="ctrl.profileData"
       ngeo-profile-highlight="ctrl.profileHighlight"
       ngeo-profile-options="::ctrl.profileOptions">
   </div>
-  <ul class="profile-legend" ng-show="ctrl.profileData.length > 0">
+  <ul class="profile-legend" ng-show="!ctrl.isErrored">
     <li ng-repeat="name in ::ctrl.getLayersNames()"><i class="fa fa-minus" style="color:{{::ctrl.getColor(name)}};"></i>&nbsp;{{name | translate}}&nbsp;{{ctrl.currentPoint.elevations[name]}}&nbsp;{{ctrl.currentPoint.yUnits}}
     </li>
   </ul>
-  <div class="profile-export btn-group dropup">
+  <div class="profile-export btn-group dropup" ng-show="!ctrl.isErrored">
     <a class="dropdown-toggle" href="" ng-show="ctrl.profileData.length !== 0" data-toggle="dropdown" aria-expanded="false">
       {{'Export' | translate}}&nbsp;<i class="fa fa-caret-up"></i>
     </a>
     <ul class="dropdown-menu dropdown-menu-right" role="menu">
       <li><a href="" ng-click="::ctrl.downloadCsv()"><i class="fa fa-table"></i>&nbsp;{{'Download CSV' | translate}}</a></li>
     </ul>
+  </div>
+  <div class="profile-error" ng-show="ctrl.isErrored">
+    <p>{{'The profile service does not respond, please try later.' | translate}}</p>
   </div>
   <div class="close" ng-click="ctrl.line = null">&times;</div>
 </div>

--- a/contribs/gmf/src/directives/profile.js
+++ b/contribs/gmf/src/directives/profile.js
@@ -31,9 +31,9 @@ ngeo.module.value('gmfProfileTemplateUrl',
  * Provide a directive that display a profile panel. This profile use the given
  * LineString geometry to request the c2cgeoportal profile.json service. The
  * raster used in the request are the keys of the 'linesconfiguration' object.
- * The 'profileActive' and 'map' attributes are optionals and are only used to
- * display on the map the informations that concerne the hovered
- * point (in the profile and on the map) of the line.
+ * The 'map' attribute is optional and are only used to display on the map the
+ * informations that concerne the hovered point (in the profile and on the map)
+ * of the line.
  * This profile relies on the ngeo.profile (d3) and ngeo.ProfileDirective.
  *
  * Example:
@@ -46,7 +46,7 @@ ngeo.module.value('gmfProfileTemplateUrl',
  *      </gmf-profile>
  *
  *
- * @htmlAttribute {boolean?} gmf-profile-active Optional to active the hover
+ * @htmlAttribute {boolean} gmf-profile-active To active th
  *     functions.
  * @htmlAttribute {ol.geom.LineString} gmf-profile-line The linestring geometry
  *     to use to draw the profile.
@@ -289,6 +289,15 @@ gmf.ProfileController = function($scope, $http, $element, $filter,
     });
   }
 
+  /**
+   * @type {ngeox.profile.I18n}
+   * @private
+   */
+  this.profileLabels_ = {
+    xAxis: gettextCatalog.getString('Distance'),
+    yAxis: gettextCatalog.getString('Elevation')
+  };
+
   this.pointHoverOverlay_.setStyle(hoverPointStyle);
 
   /**
@@ -300,7 +309,8 @@ gmf.ProfileController = function($scope, $http, $element, $filter,
     linesConfiguration: this.linesConfiguration_,
     distanceExtractor: this.getDist_,
     hoverCallback: this.hoverCallback_.bind(this),
-    outCallback: this.outCallback_.bind(this)
+    outCallback: this.outCallback_.bind(this),
+    i18n: this.profileLabels_
   });
 
   /**
@@ -358,7 +368,7 @@ gmf.ProfileController.prototype.update_ = function() {
  * @private
  */
 gmf.ProfileController.prototype.updateEventsListening_ = function() {
-  if (this.active === true && this.map_ !== null) {
+  if (this.active && this.map_ !== null) {
     this.pointerMoveKey_ = ol.events.listen(this.map_, 'pointermove',
         this.onPointerMove_.bind(this));
   } else {
@@ -478,13 +488,14 @@ gmf.ProfileController.prototype.outCallback_ = function() {
  * @private
  */
 gmf.ProfileController.prototype.getTooltipHTML_ = function() {
-  var distance = this.gettextCatalog_.getString('Distance : ');
+  var separator = ' : ';
   var elevationName, translatedElevationName;
   var innerHTML = [];
   var number = this.$filter_('number');
   var DistDecimal = this.currentPoint.xUnits === 'm' ? 0 : 2;
   innerHTML.push(
-      distance +
+      this.profileLabels_.xAxis +
+      separator +
       number(this.currentPoint.distance, DistDecimal) +
       ' ' +
       this.currentPoint.xUnits
@@ -493,7 +504,7 @@ gmf.ProfileController.prototype.getTooltipHTML_ = function() {
     translatedElevationName = this.gettextCatalog_.getString(elevationName);
     innerHTML.push(
         translatedElevationName +
-        ' : ' +
+        separator +
         number(this.currentPoint.elevations[elevationName], 0) +
         ' ' + this.currentPoint.yUnits
     );

--- a/contribs/gmf/src/directives/profile.js
+++ b/contribs/gmf/src/directives/profile.js
@@ -75,8 +75,8 @@ gmf.profileDirective = function(gmfProfileTemplateUrl) {
     replace: true,
     restrict: 'E',
     scope: {
-      'active': '<?gmfProfileActive',
-      'line': '<gmfProfileLine',
+      'active': '=gmfProfileActive',
+      'line': '=gmfProfileLine',
       'getMapFn': '&?gmfProfileMap',
       'getLinesConfigurationFn': '&gmfProfileLinesconfiguration',
       'getHoverPointStyleFn': '&?gmfProfileHoverpointstyle',
@@ -320,7 +320,7 @@ gmf.ProfileController = function($scope, $http, $element, $filter,
     function() {
       return this.active;
     }.bind(this),
-    function(oldValue, newValue) {
+    function(newValue, oldValue) {
       if (oldValue !== newValue) {
         this.updateEventsListening_();
       }
@@ -331,7 +331,7 @@ gmf.ProfileController = function($scope, $http, $element, $filter,
     function() {
       return this.line;
     }.bind(this),
-    function(oldLine, newLine) {
+    function(newLine, oldLine) {
       if (oldLine !== newLine) {
         this.update_();
       }
@@ -350,6 +350,7 @@ gmf.ProfileController.prototype.update_ = function() {
   } else {
     this.profileData = [];
   }
+  this.active = !!this.line;
 };
 
 

--- a/contribs/gmf/src/directives/profile.js
+++ b/contribs/gmf/src/directives/profile.js
@@ -58,8 +58,11 @@ ngeo.module.value('gmfProfileTemplateUrl',
  *     for the 'on Hover' point on the line.
  * @htmlAttribute {number?} gmf-profile-numberofpoints Optional maximum limit of
  *     points to request. Default to 100.
- * @htmlAttribute {string?} gmf-profile-css Inline Optional CSS style definition
- *     to inject in the SVG.
+ * @htmlAttribute {Object.<string, *>?} gmf-profile-options Optional options
+ *     object like {@link ngeox.profile.ProfileOptions} but without any
+ *     mandatory value. Will be passed to the ngeo profile directive. Providing
+ *     'linesConfiguration', 'distanceExtractor', hoverCallback, outCallback
+ *     or i18n will override native gmf profile values.
  * @param {string} gmfProfileTemplateUrl URL to a template.
  * @return {angular.Directive} Directive Definition Object.
  * @ngInject
@@ -81,7 +84,7 @@ gmf.profileDirective = function(gmfProfileTemplateUrl) {
       'getLinesConfigurationFn': '&gmfProfileLinesconfiguration',
       'getHoverPointStyleFn': '&?gmfProfileHoverpointstyle',
       'getNbPointsFn': '&?gmfProfileNumberofpoints',
-      'getCssFn': '&?gmfProfileCss'
+      'getOptionsFn': '&?gmfProfileOptions'
     }
   };
 };
@@ -197,19 +200,6 @@ gmf.ProfileController = function($scope, $http, $element, $filter,
     }
   }
 
-  var css;
-  var cssFn = this['getCssFn'];
-  if (cssFn) {
-    css = cssFn();
-    goog.asserts.assertString(css);
-  }
-
-  /**
-   * @type {string|undefined}
-   * @private
-   */
-  this.css_ = css;
-
   var nbPoints = 100;
   var nbPointsFn = this['getNbPointsFn'];
   if (nbPointsFn) {
@@ -305,13 +295,19 @@ gmf.ProfileController = function($scope, $http, $element, $filter,
    * @export
    */
   this.profileOptions = /** @type {ngeox.profile.ProfileOptions} */ ({
-    styleDefs: this.css_,
     linesConfiguration: this.linesConfiguration_,
     distanceExtractor: this.getDist_,
     hoverCallback: this.hoverCallback_.bind(this),
     outCallback: this.outCallback_.bind(this),
     i18n: this.profileLabels_
   });
+
+  var optionsFn = this['getOptionsFn'];
+  if (optionsFn) {
+    var options = optionsFn();
+    goog.asserts.assertObject(options);
+    goog.object.extend(this.profileOptions, options);
+  }
 
   /**
    * @type {boolean}

--- a/contribs/gmf/src/directives/profile.js
+++ b/contribs/gmf/src/directives/profile.js
@@ -321,6 +321,13 @@ gmf.ProfileController = function($scope, $http, $element, $filter,
    */
   this.pointerMoveKey_;
 
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.isErrored = false;
+
+
   // Watch the active value to activate/deactive events listening.
   $scope.$watch(
     function() {
@@ -351,6 +358,7 @@ gmf.ProfileController = function($scope, $http, $element, $filter,
  * @private
  */
 gmf.ProfileController.prototype.update_ = function() {
+  this.isErrored = false;
   if (this.line) {
     this.getJsonProfile_();
   } else {
@@ -649,6 +657,7 @@ gmf.ProfileController.prototype.getProfileDataSuccess_ = function(resp) {
  * @private
  */
 gmf.ProfileController.prototype.getProfileDataError_ = function(resp) {
+  this.isErrored = true;
   console.error('Can not get JSON profile.');
 };
 
@@ -706,6 +715,7 @@ gmf.ProfileController.prototype.getCsvSuccess_ = function(resp) {
  * @private
  */
 gmf.ProfileController.prototype.getCsvError_ = function(resp) {
+  this.isErrored = true;
   console.error('Can not get CSV profile.');
 };
 

--- a/contribs/gmf/src/directives/profile.js
+++ b/contribs/gmf/src/directives/profile.js
@@ -46,8 +46,7 @@ ngeo.module.value('gmfProfileTemplateUrl',
  *      </gmf-profile>
  *
  *
- * @htmlAttribute {boolean} gmf-profile-active To active th
- *     functions.
+ * @htmlAttribute {boolean} gmf-profile-active Active the component.
  * @htmlAttribute {ol.geom.LineString} gmf-profile-line The linestring geometry
  *     to use to draw the profile.
  * @htmlAttribute {ol.Map?} gmf-profile-map An optional map.

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -810,7 +810,8 @@ ngeox.profile;
  *   lightXAxis: (boolean|undefined),
  *   scaleModifier: (function(function(), function(), number, number)|undefined),
  *   hoverCallback: (function(Object)|undefined),
- *   outCallback: (function()|undefined)
+ *   outCallback: (function()|undefined),
+ *   i18n: (ngeox.profile.I18n|undefined)
  * }} ngeox.profile.ProfileOptions
  */
 ngeox.profile.ProfileOptions;
@@ -1010,6 +1011,30 @@ ngeox.profile.ProfileFormatter.prototype.xtick;
  * @type {function(number, string): (string|number)}
  */
 ngeox.profile.ProfileFormatter.prototype.ytick;
+
+
+/**
+ * @typedef {{
+ *   xAxis: (string|undefined),
+ *   yAxis: (string|undefined)
+ * }}
+ */
+ngeox.profile.I18n;
+
+
+/**
+ * Text for the x axis. Will be completed by ` km` or ' m' (for kilometers or
+ * meters).
+ * @type {string|undefined}
+ */
+ngeox.profile.I18n.prototype.xAxis;
+
+
+/**
+ * Text for the y axis. Will be completed by ' m' (for meters).
+ * @type {string|undefined}
+ */
+ngeox.profile.I18n.prototype.yAxis;
 
 
 /**

--- a/src/d3-ext/profile.js
+++ b/src/d3-ext/profile.js
@@ -121,6 +121,21 @@ ngeo.profile = function(options) {
       options.poiLabelAngle : -60;
 
   /**
+   * @type {Object.<string, string>}
+   */
+  var i18n = options.i18n || {};
+
+  /**
+   * @type {string}
+   */
+  var xAxisLabel = (i18n.xAxis || 'Distance');
+
+  /**
+   * @type {string}
+   */
+  var yAxisLabel = (i18n.yAxis || 'Elevation');
+
+  /**
    * @type {ngeox.profile.ProfileFormatter}
    */
   var formatter = {
@@ -291,7 +306,7 @@ ngeo.profile = function(options) {
           .attr('dy', '.75em')
           .attr('transform', 'rotate(-90)')
           .style('fill', 'grey')
-          .text('elevation (m)');
+          .text(yAxisLabel + ' (m)');
 
         gEnter.append('g')
           .attr('class', 'metas')
@@ -414,7 +429,7 @@ ngeo.profile = function(options) {
           .call(xAxis);
 
         g.select('.x.label')
-          .text('distance (' + xUnits + ')')
+          .text(xAxisLabel + ' (' + xUnits + ')')
           .style('fill', 'grey')
           .style('shape-rendering', 'crispEdges');
 

--- a/src/d3-ext/profile.js
+++ b/src/d3-ext/profile.js
@@ -233,8 +233,8 @@ ngeo.profile = function(options) {
 
   var profile = function(selection) {
     selection.each(function(data) {
+      d3.select(this).selectAll('svg').remove();
       if (data === undefined) {
-        d3.select(this).selectAll('svg').remove();
         return;
       }
 
@@ -306,7 +306,7 @@ ngeo.profile = function(options) {
           .attr('dy', '.75em')
           .attr('transform', 'rotate(-90)')
           .style('fill', 'grey')
-          .text(yAxisLabel + ' (m)');
+          .text(yAxisLabel + ' [m]');
 
         gEnter.append('g')
           .attr('class', 'metas')
@@ -429,7 +429,7 @@ ngeo.profile = function(options) {
           .call(xAxis);
 
         g.select('.x.label')
-          .text(xAxisLabel + ' (' + xUnits + ')')
+          .text(xAxisLabel + ' [' + xUnits + ']')
           .style('fill', 'grey')
           .style('shape-rendering', 'crispEdges');
 


### PR DESCRIPTION
Fix: camptocamp/c2cgeoportal#1661
Specs: https://github.com/camptocamp/c2cgeoportal/wiki/Spec-%231661-Profiles

Example: 
 - 1 elevation raster: https://ger-benjamin.github.io/ngeo/profile21/examples/contribs/gmf/apps/desktop_alt
 - Multiple elevations rasters: https://ger-benjamin.github.io/ngeo/profile21/examples/contribs/gmf/apps/desktop

(See just the last commit for the intergration and the new tool)

@pgiraud I need some specifications for the "Draw profile tool", the activation, the placement and some differences that come from the profile with more than 1 line. Can you take a look please ?
Edit: Integrated. Thanks

---

**Issue to create and resolve later** :
- Reload the profile on screen size change.
- It exists any tests for ngeo and gmf profile.