### PR TITLE
Remove specific style for no-source

### DIFF
--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -139,13 +139,6 @@
     }
   }
 
-  .no-source {
-    opacity: 0.3;
-    &::after {
-      content: "(source not available)";
-    }
-  }
-
   .out-of-resolution {
     .name {
       font-style: italic;

--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -831,25 +831,6 @@ gmf.LayertreeController.prototype.displayMetadata = function(treeCtrl) {
 
 
 /**
- * Return 'no-source' if no source is defined in the given treeCtrl's WMTS layer.
- * @param {ngeo.LayertreeController} treeCtrl ngeo layertree controller, from
- *     the current node.
- * @return {?string} 'no-source' or null
- * @export
- */
-gmf.LayertreeController.prototype.getNoSourceStyle = function(treeCtrl) {
-  var layer = treeCtrl.layer;
-  if (layer !== undefined &&
-      layer instanceof ol.layer.Tile &&
-      layer.getSource !== undefined &&
-      !goog.isDefAndNotNull(layer.getSource())) {
-    return 'no-source';
-  }
-  return null;
-};
-
-
-/**
  * @param {GmfThemesNode} node Layer tree node to remove.
  * @export
  */

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -1,4 +1,4 @@
-<div ng-if="::!layertreeCtrl.isRoot" id="node-{{::layertreeCtrl.uid}}" ng-class="[layertreeCtrl.node.children ? 'group' : 'leaf', 'depth-' + layertreeCtrl.depth, gmfLayertreeCtrl.getResolutionStyle(layertreeCtrl.node), gmfLayertreeCtrl.getNoSourceStyle(layertreeCtrl), gmfLayertreeCtrl.getNodeState(layertreeCtrl)]">
+<div ng-if="::!layertreeCtrl.isRoot" id="node-{{::layertreeCtrl.uid}}" ng-class="[layertreeCtrl.node.children ? 'group' : 'leaf', 'depth-' + layertreeCtrl.depth, gmfLayertreeCtrl.getResolutionStyle(layertreeCtrl.node), gmfLayertreeCtrl.getNodeState(layertreeCtrl)]">
   <div class="sortable-handle" ng-show="layertreeCtrl.depth === 1 && gmfLayertreeCtrl.layers.length > 1">
     <i class="sortable-handle-icon fa fa-ellipsis-v"></i>
   </div>


### PR DESCRIPTION
ie. for when the WMTS capabilities are loading

Supersedes #1359
Fixes #1114
Fixes #1057 

After discussion with @ybolognini, we decided to fix this issue by simply not showing anything to the user when the capabilities are loading. The capabilities request doesn't last long enough to require a loader to be displayed.
Managing this in a more elegant way is a nice to have but requires more work.

Please review.