### PR TITLE
Add ngeo-createfeature directive

### DIFF
--- a/examples/createfeature.html
+++ b/examples/createfeature.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>Create Feature Example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+
+    <style>
+      #map {
+        width: 60rem;
+        height: 40rem;
+      }
+      .ngeo-createfeature-point:before {
+        content: 'Point'
+      }
+      .ngeo-createfeature-linestring:before {
+        content: 'Line'
+      }
+      .ngeo-createfeature-polygon:before {
+        content: 'Polygon'
+      }
+      .tooltip {
+        position: relative;
+        background: rgba(0, 0, 0, 0.5);
+        border-radius: 4px;
+        color: white;
+        padding: 4px 8px;
+        opacity: 0.7;
+        white-space: nowrap;
+      }
+      .tooltip-measure {
+        opacity: 1;
+        font-weight: bold;
+      }
+      .tooltip-static {
+        display: none;
+      }
+      .tooltip-measure:before,
+      .tooltip-static:before {
+        border-top: 6px solid rgba(0, 0, 0, 0.5);
+        border-right: 6px solid transparent;
+        border-left: 6px solid transparent;
+        content: "";
+        position: absolute;
+        bottom: -6px;
+        margin-left: -7px;
+        left: 50%;
+      }
+      .tooltip-static:before {
+        border-top-color: #ffcc33;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <div id="map" ngeo-map="ctrl.map"></div>
+
+    <div
+        ngeo-btn-group
+        class="btn-group">
+      <a
+        href
+        translate
+        ngeo-btn
+        ngeo-createfeature
+        ngeo-createfeature-active="ctrl.createPointActive"
+        ngeo-createfeature-features="ctrl.features"
+        ngeo-createfeature-geom-type="ctrl.pointGeomType"
+        ngeo-createfeature-map="::ctrl.map"
+        class="btn btn-default ngeo-createfeature-point"
+        ng-class="{active: ctrl.createPointActive}"
+        ng-model="ctrl.createPointActive">
+      </a>
+      <a
+        href
+        translate
+        ngeo-btn
+        ngeo-createfeature
+        ngeo-createfeature-active="ctrl.createLineStringActive"
+        ngeo-createfeature-features="ctrl.features"
+        ngeo-createfeature-geom-type="ctrl.lineStringGeomType"
+        ngeo-createfeature-map="::ctrl.map"
+        class="btn btn-default ngeo-createfeature-linestring"
+        ng-class="{active: ctrl.createLineStringActive}"
+        ng-model="ctrl.createLineStringActive">
+      </a>
+      <a
+        href
+        translate
+        ngeo-btn
+        ngeo-createfeature
+        ngeo-createfeature-active="ctrl.createPolygonActive"
+        ngeo-createfeature-features="ctrl.features"
+        ngeo-createfeature-geom-type="ctrl.polygonGeomType"
+        ngeo-createfeature-map="::ctrl.map"
+        class="btn btn-default ngeo-createfeature-polygon"
+        ng-class="{active: ctrl.createPolygonActive}"
+        ng-model="ctrl.createPolygonActive">
+      </a>
+    </div>
+
+    <input type="checkbox"
+       ng-model="ctrl.dummyActive" /> Dummy
+
+    <p id="desc">
+      This example shows how to use the <code>ngeo-createfeature</code>
+      directive to draw point, linestring or polygon vector features on
+      a map.
+    </p>
+
+    <script src="../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../node_modules/angular-touch/angular-touch.js"></script>
+    <script src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="/@?main=createfeature.js"></script>
+    <script src="default.js"></script>
+    <script src="../utils/watchwatchers.js"></script>
+  </body>
+</html>

--- a/examples/createfeature.js
+++ b/examples/createfeature.js
@@ -1,0 +1,145 @@
+goog.provide('createfeature');
+
+goog.require('ngeo.ToolActivate');
+goog.require('ngeo.ToolActivateMgr');
+goog.require('ngeo.btngroupDirective');
+goog.require('ngeo.btnDirective');
+goog.require('ngeo.createfeatureDirective');
+goog.require('ngeo.mapDirective');
+goog.require('ol.Collection');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['ngeo']);
+
+
+/**
+ * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
+ *     service.
+ * @constructor
+ */
+app.MainController = function(ngeoToolActivateMgr) {
+
+  /**
+   * @type {ol.Collection}
+   * @export
+   */
+  this.features = new ol.Collection();
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.pointGeomType = ngeo.GeometryType.POINT;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.lineStringGeomType = ngeo.GeometryType.LINE_STRING;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.polygonGeomType = ngeo.GeometryType.POLYGON;
+
+  var vector = new ol.layer.Vector({
+    source: new ol.source.Vector({
+      wrapX: false,
+      features: this.features
+    })
+  });
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      }),
+      vector
+    ],
+    view: new ol.View({
+      center: [0, 0],
+      zoom: 3
+    })
+  });
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.createPointActive = false;
+
+  var createPointToolActivate = new ngeo.ToolActivate(
+    this,
+    'createPointActive'
+  );
+  ngeoToolActivateMgr.registerTool(
+    'mapTools',
+    createPointToolActivate,
+    false
+  );
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.createLineStringActive = false;
+
+  var createLineStringToolActivate = new ngeo.ToolActivate(
+    this,
+    'createLineStringActive'
+  );
+  ngeoToolActivateMgr.registerTool(
+    'mapTools',
+    createLineStringToolActivate,
+    false
+  );
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.createPolygonActive = false;
+
+  var createPolygonToolActivate = new ngeo.ToolActivate(
+    this,
+    'createPolygonActive'
+  );
+  ngeoToolActivateMgr.registerTool(
+    'mapTools',
+    createPolygonToolActivate,
+    false
+  );
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.dummyActive = true;
+
+  var dummyToolActivate = new ngeo.ToolActivate(
+    this,
+    'dummyActive'
+  );
+  ngeoToolActivateMgr.registerTool(
+    'mapTools',
+    dummyToolActivate,
+    true
+  );
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/src/directives/createfeature.js
+++ b/src/directives/createfeature.js
@@ -1,0 +1,234 @@
+goog.provide('ngeo.CreatefeatureController');
+goog.provide('ngeo.createfeatureDirective');
+
+goog.require('ngeo');
+goog.require('ngeo.EventHelper');
+/** @suppress {extraRequire} */
+goog.require('ngeo.filters');
+goog.require('ngeo.interaction.MeasureArea');
+goog.require('ngeo.interaction.MeasureLength');
+goog.require('ol.Feature');
+goog.require('ol.geom.GeometryType');
+goog.require('ol.interaction.Draw');
+goog.require('ol.style.Style');
+
+
+/**
+ * A directive used to draw vector features of a single geometry type using
+ * either a 'draw' or 'measure' interaction. Once a feature is finished being
+ * drawn, it is added to a collection of features.
+ *
+ * The geometry types supported are:
+ *  - Point
+ *  - LineString
+ *  - Polygon
+ *
+ * Example:
+ *
+ *     <a
+ *       href
+ *       translate
+ *       ngeo-btn
+ *       ngeo-createfeature
+ *       ngeo-createfeature-active="ctrl.createPointActive"
+ *       ngeo-createfeature-features="ctrl.features"
+ *       ngeo-createfeature-geom-type="ctrl.pointGeomType"
+ *       ngeo-createfeature-map="::ctrl.map"
+ *       class="btn btn-default ngeo-createfeature-point"
+ *       ng-class="{active: ctrl.createPointActive}"
+ *       ng-model="ctrl.createPointActive">
+ *     </a>
+ *
+ * @htmlAttribute {boolean} ngeo-createfeature-active Whether the directive is
+ *     active or not.
+ * @htmlAttribute {ol.Collection} ngeo-createfeature-features The collection of
+ *     features where to add those created by this directive.
+ * @htmlAttribute {string} ngeo-createfeature-geom-type Determines the type
+ *     of geometry this directive should draw.
+ * @htmlAttribute {ol.Map} ngeo-createfeature-map The map.
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname ngeoCreatefeature
+ */
+ngeo.createfeatureDirective = function() {
+  return {
+    controller: 'ngeoCreatefeatureController',
+    bindToController: true,
+    scope: {
+      'active': '=ngeoCreatefeatureActive',
+      'features': '=ngeoCreatefeatureFeatures',
+      'geomType': '=ngeoCreatefeatureGeomType',
+      'map': '=ngeoCreatefeatureMap'
+    },
+    controllerAs: 'cfCtrl'
+  };
+};
+
+ngeo.module.directive('ngeoCreatefeature', ngeo.createfeatureDirective);
+
+
+/**
+ * @param {gettext} gettext Gettext service.
+ * @param {angular.$compile} $compile Angular compile service.
+ * @param {angular.$filter} $filter Angular filter
+ * @param {!angular.Scope} $scope Scope.
+ * @param {ngeo.EventHelper} ngeoEventHelper Ngeo event helper service
+ * @constructor
+ * @ngInject
+ * @ngdoc controller
+ * @ngname ngeoCreatefeatureController
+ */
+ngeo.CreatefeatureController = function(gettext, $compile, $filter, $scope,
+    ngeoEventHelper) {
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.active = this.active === true;
+
+  /**
+   * @type {ol.Collection.<ol.Feature>}
+   * @export
+   */
+  this.features;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.geomType;
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
+
+  /**
+   * @type {ngeo.EventHelper}
+   * @private
+   */
+  this.ngeoEventHelper_ = ngeoEventHelper;
+
+  // Create the draw or measure interaction depending on the geometry type
+  var interaction;
+  var helpMsg;
+  var contMsg;
+  if (this.geomType === ngeo.GeometryType.POINT) {
+    interaction = new ol.interaction.Draw({
+      type: ol.geom.GeometryType.POINT
+    });
+  } else if (this.geomType === ngeo.GeometryType.LINE_STRING) {
+    helpMsg = gettext('Click to start drawing length');
+    contMsg = gettext(
+      'Click to continue drawing<br/>' +
+      'Double-click or click last point to finish'
+    );
+
+    interaction = new ngeo.interaction.MeasureLength(
+      $filter('ngeoUnitPrefix'),
+      {
+        style: new ol.style.Style(),
+        startMsg: $compile('<div translate>' + helpMsg + '</div>')($scope)[0],
+        continueMsg: $compile('<div translate>' + contMsg + '</div>')($scope)[0]
+      }
+    );
+  } else if (this.geomType === ngeo.GeometryType.POLYGON) {
+    helpMsg = gettext('Click to start drawing area');
+    contMsg = gettext(
+      'Click to continue drawing<br/>' +
+      'Double-click or click last starting point to finish'
+    );
+
+    interaction = new ngeo.interaction.MeasureArea(
+      $filter('ngeoUnitPrefix'),
+      {
+        style: new ol.style.Style(),
+        startMsg: $compile('<div translate>' + helpMsg + '</div>')($scope)[0],
+        continueMsg: $compile('<div translate>' + contMsg + '</div>')($scope)[0]
+      }
+    );
+  }
+
+  goog.asserts.assert(interaction);
+
+  interaction.setActive(this.active);
+  this.map.addInteraction(interaction);
+
+  /**
+   * The draw or measure interaction responsible of drawing the vector feature.
+   * The actual type depends on the geometry type.
+   * @type {ol.interaction.Interaction}
+   * @private
+   */
+  this.interaction_ = interaction;
+
+
+  // == Event listeners ==
+  $scope.$watch(
+    function() {
+      return this.active;
+    }.bind(this),
+    function(newVal) {
+      this.interaction_.setActive(newVal);
+    }.bind(this)
+  );
+
+  var uid = goog.getUid(this);
+  if (interaction instanceof ol.interaction.Draw) {
+    this.ngeoEventHelper_.addListenerKey(
+      uid,
+      ol.events.listen(
+        interaction,
+        ol.interaction.DrawEventType.DRAWEND,
+        this.handleDrawEnd_,
+        this
+      ),
+      true
+    );
+  } else if (interaction instanceof ngeo.interaction.MeasureLength ||
+     interaction instanceof ngeo.interaction.MeasureArea) {
+    this.ngeoEventHelper_.addListenerKey(
+      uid,
+      ol.events.listen(
+        interaction,
+        ngeo.MeasureEventType.MEASUREEND,
+        this.handleDrawEnd_,
+        this
+      ),
+      true
+    );
+  }
+
+  $scope.$on('$destroy', this.handleDestroy_.bind(this));
+
+};
+
+
+/**
+ * Called when a feature is finished being drawn. Add the feature to the
+ * collection.
+ * @param {ol.interaction.DrawEvent|ngeo.MeasureEvent} event Event.
+ * @export
+ */
+ngeo.CreatefeatureController.prototype.handleDrawEnd_ = function(event) {
+  var feature = new ol.Feature(event.feature.getGeometry());
+  this.features.push(feature);
+};
+
+
+/**
+ * Cleanup event listeners and remove the interaction from the map.
+ * @private
+ */
+ngeo.CreatefeatureController.prototype.handleDestroy_ = function() {
+  var uid = goog.getUid(this);
+  this.ngeoEventHelper_.clearListenerKey(uid);
+  this.map.removeInteraction(this.interaction_);
+};
+
+
+ngeo.module.controller(
+  'ngeoCreatefeatureController', ngeo.CreatefeatureController);


### PR DESCRIPTION
This PR introduces the `ngeo-createfeature` directive, which allows the creation of vector features (point, line, polygon) using draw or measure interaction from a map.  Drawn features are added to a collection of features.

It is similar to the `ngeo-drawfeature` directive, but has the following things different:

 * it only support drawing one type of geometry at a time (`ngeo-drawfeature` allows 6 types: point, line, polygon, text, circle, rectangle)
 * it doesn't set any style to the feature
 * it will be used for the purpose of editing features from real layers, while the `ngeo-drawfeature` only draw "sketchs" that are not saved

## Todo

 * [ ] review

## Live example

 * http://adube.github.io/ngeo/ngeo-createfeature/examples/createfeature.html