### PR TITLE
Permalink final cut

### DIFF
--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -215,7 +215,7 @@ gmf.LayertreeController = function($http, $sce, $scope, ngeoCreatePopup,
 gmf.LayertreeController.prototype.prepareLayer_ = function(node, layer) {
   var type = gmf.Themes.getNodeType(node);
   var ids =  gmf.LayertreeController.getLayerNodeIds(node);
-  var childNodes = [], childNodesUnchecked;
+  var childNodes = [], allChildNodesUnchecked;
   layer.set('querySourceIds', ids);
   layer.set('layerName', node.name);
   layer.set('disclaimers', this.getNodeDisclaimers_(node));
@@ -226,21 +226,19 @@ gmf.LayertreeController.prototype.prepareLayer_ = function(node, layer) {
   // If layer is 'unchecked', set it to invisible.
   var metadata = node.metadata;
   if (isMerged) {
-    //Case Non Mixed group -> Hide the layer if all child nodes have isCheck set to false
+    //Case Non Mixed group -> Hide the layer if all child nodes have isChecked set to false
     this.getFlatNodes_(node, childNodes);
-    childNodesUnchecked = childNodes.filter(function(childNode) {
+    allChildNodesUnchecked = childNodes.every(function(childNode) {
       return !childNode.metadata || !childNode.metadata['isChecked'];
     });
-    if (childNodesUnchecked.length === childNodes.length) {
+    if (allChildNodesUnchecked) {
       //All children are unchecked
       layer.setVisible(false);
     }
-  } else {
-    if (node.children === undefined && goog.isDefAndNotNull(metadata)) {
-      //Case leaf in a mixed group
-      if (!metadata['isChecked']) {
-        layer.setVisible(false);
-      }
+  } else if (node.children === undefined && goog.isDefAndNotNull(metadata)) {
+    //Case leaf in a mixed group
+    if (!metadata['isChecked']) {
+      layer.setVisible(false);
     }
   }
 };
@@ -728,7 +726,7 @@ gmf.LayertreeController.prototype.updateWMSLayerState_ = function(layer,
     layer.setVisible(true);
     var source = /** @type {ol.source.ImageWMS} */ (layer.getSource());
     if (opt_time) {
-      source.updateParams({'LAYERS': names, 'TIME' : opt_time});
+      source.updateParams({'LAYERS': names, 'TIME': opt_time});
     } else {
       source.updateParams({'LAYERS': names});
     }

--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -215,6 +215,7 @@ gmf.LayertreeController = function($http, $sce, $scope, ngeoCreatePopup,
 gmf.LayertreeController.prototype.prepareLayer_ = function(node, layer) {
   var type = gmf.Themes.getNodeType(node);
   var ids =  gmf.LayertreeController.getLayerNodeIds(node);
+  var childNodes = [], childNodesUnchecked;
   layer.set('querySourceIds', ids);
   layer.set('layerName', node.name);
   layer.set('disclaimers', this.getNodeDisclaimers_(node));
@@ -224,9 +225,22 @@ gmf.LayertreeController.prototype.prepareLayer_ = function(node, layer) {
 
   // If layer is 'unchecked', set it to invisible.
   var metadata = node.metadata;
-  if (node.children === undefined && goog.isDefAndNotNull(metadata)) {
-    if (!metadata['isChecked']) {
+  if (isMerged) {
+    //Case Non Mixed group -> Hide the layer if all child nodes have isCheck set to false
+    this.getFlatNodes_(node, childNodes);
+    childNodesUnchecked = childNodes.filter(function(childNode) {
+      return !childNode.metadata || !childNode.metadata['isChecked'];
+    });
+    if (childNodesUnchecked.length === childNodes.length) {
+      //All children are unchecked
       layer.setVisible(false);
+    }
+  } else {
+    if (node.children === undefined && goog.isDefAndNotNull(metadata)) {
+      //Case leaf in a mixed group
+      if (!metadata['isChecked']) {
+        layer.setVisible(false);
+      }
     }
   }
 };

--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -713,14 +713,10 @@ gmf.LayertreeController.prototype.updateWMSLayerState_ = function(layer,
   } else {
     layer.setVisible(true);
     var source = /** @type {ol.source.ImageWMS} */ (layer.getSource());
-    var prevNames = source.getParams()['LAYERS'];
-    var prevTime = source.getParams()['TIME'];
-    if (names !== prevNames || opt_time !== prevTime) {
-      if (opt_time) {
-        source.updateParams({'LAYERS': names, 'TIME' : opt_time});
-      } else {
-        source.updateParams({'LAYERS': names});
-      }
+    if (opt_time) {
+      source.updateParams({'LAYERS': names, 'TIME' : opt_time});
+    } else {
+      source.updateParams({'LAYERS': names});
     }
   }
 };

--- a/contribs/gmf/src/directives/themeselector.js
+++ b/contribs/gmf/src/directives/themeselector.js
@@ -175,7 +175,7 @@ gmf.ThemeselectorController.prototype.setThemes_ = function() {
       currentTheme = gmf.Themes.findThemeByName(this.themes, this.defaultTheme);
     }
 
-    this.setTheme(/** @type {GmfThemesNode} */ (currentTheme));
+    this.setTheme(/** @type {GmfThemesNode} */ (currentTheme), true);
 
   }.bind(this);
 
@@ -185,11 +185,12 @@ gmf.ThemeselectorController.prototype.setThemes_ = function() {
 
 /**
  * @param {GmfThemesNode} theme Theme.
+ * @param {boolean=} opt_init set to true for initialization phase.
  * @export
  */
-gmf.ThemeselectorController.prototype.setTheme = function(theme) {
+gmf.ThemeselectorController.prototype.setTheme = function(theme, opt_init) {
   if (theme) {
-    this.gmfTreeManager_.addTheme(theme);
+    this.gmfTreeManager_.addTheme(theme, opt_init);
   }
 };
 

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -696,11 +696,21 @@ gmf.Permalink.prototype.initLayerFromGroupNode_ = function(groupNode) {
           groupName, layers.getArray());
       if (layer) {
         this.initMergedLayer_(layer, groupLayers);
+        if (groupLayers !== '') {
+          //Layer must be visible, we found some layers names in the state
+          layer.setVisible(true);
+        }
       } else if (groupLayers !== '') {
         layerNames = groupLayers.split(',');
         this.gmfTreeManager_.addCustomGroups([{
           node: groupNode,
           layers: layerNames
+        }]);
+      } else {
+        //groupLayers === '', we add the group in an inactive state
+        this.gmfTreeManager_.addCustomGroups([{
+          node: groupNode,
+          layers: []
         }]);
       }
     }

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -41,6 +41,12 @@ gmf.PermalinkParam = {
   WFS_SHOW_FEATURES: 'wfs_showFeatures'
 };
 
+/**
+ * @enum {string}
+ */
+gmf.PermalinkOpenLayersLayerProperties = {
+  OPACITY : 'opacity'
+};
 
 /**
  * @enum {string}
@@ -48,6 +54,8 @@ gmf.PermalinkParam = {
 gmf.PermalinkParamPrefix = {
   TREE_ENABLE: 'tree_enable_',
   TREE_GROUP_LAYERS: 'tree_group_layers_',
+  TREE_GROUP_OPACITY: 'tree_group_opacity_',
+  TREE_OPACITY: 'tree_opacity_',
   WFS: 'wfs_'
 };
 
@@ -349,10 +357,12 @@ gmf.Permalink.prototype.addListenerKey_ = function(uid, key, opt_isol) {
  */
 gmf.Permalink.prototype.getMapCenter = function() {
   var center = null;
-  var x = this.ngeoStateManager_.getInitialValue(gmf.PermalinkParam.MAP_X);
-  var y = this.ngeoStateManager_.getInitialValue(gmf.PermalinkParam.MAP_Y);
+  var x = /** @type {number} */ (this.ngeoStateManager_.getInitialValue(
+    gmf.PermalinkParam.MAP_X));
+  var y = /** @type {number} */ (this.ngeoStateManager_.getInitialValue(
+    gmf.PermalinkParam.MAP_Y));
   if (x !== undefined && y !== undefined) {
-    center = [+x, +y];
+    center = [x,y];
   }
   return center;
 };
@@ -365,9 +375,10 @@ gmf.Permalink.prototype.getMapCenter = function() {
  */
 gmf.Permalink.prototype.getMapZoom = function() {
   var zoom = null;
-  var z = this.ngeoStateManager_.getInitialValue(gmf.PermalinkParam.MAP_Z);
+  var z = /** @type {number} */ (this.ngeoStateManager_.getInitialValue(
+    gmf.PermalinkParam.MAP_Z));
   if (z !== undefined) {
-    zoom = +z;
+    zoom = z;
   }
   return zoom;
 };
@@ -398,8 +409,8 @@ gmf.Permalink.prototype.getMapCrosshair = function() {
  * @export
  */
 gmf.Permalink.prototype.getMapTooltip = function() {
-  return this.ngeoStateManager_.getInitialValue(
-      gmf.PermalinkParam.MAP_TOOLTIP) || null;
+  return /** @type {string} */ (this.ngeoStateManager_.getInitialValue(
+      gmf.PermalinkParam.MAP_TOOLTIP)) || null;
 };
 
 
@@ -413,7 +424,8 @@ gmf.Permalink.prototype.getMapTooltip = function() {
  */
 gmf.Permalink.prototype.getFeatures = function() {
   var features = [];
-  var f = this.ngeoStateManager_.getInitialValue(gmf.PermalinkParam.FEATURES);
+  var f = /** @type {string} */ (this.ngeoStateManager_.getInitialValue(
+    gmf.PermalinkParam.FEATURES));
   if (f !== undefined && f !== '') {
     features = this.featureHashFormat_.readFeatures(f);
   }
@@ -667,12 +679,11 @@ gmf.Permalink.prototype.initLayerFromGroupNode_ = function(groupNode) {
       param = this.getLayerStateParamFromNode_(layerNode);
       var enable = this.ngeoStateManager_.getInitialValue(param);
       if (enable !== undefined) {
-        enable = enable === 'true' ? true : false;
         var layerName = layerNode.name;
         layer = this.layerHelper_.getLayerByName(
           layerName, layers.getArray());
         if (layer) {
-          layer.setVisible(enable);
+          this.updateLayerFromState_(layer);
         } else {
           layerNames.push(layerName);
         }
@@ -689,17 +700,14 @@ gmf.Permalink.prototype.initLayerFromGroupNode_ = function(groupNode) {
   } else {
     //group not mixed
     param = this.getLayerStateParamFromNode_(groupNode);
-    var groupLayers = this.ngeoStateManager_.getInitialValue(param);
+    var groupLayers = /** @type {string} */ (this.ngeoStateManager_.getInitialValue(param));
     if (groupLayers !== undefined) {
       var groupName = groupNode.name;
       layer = this.layerHelper_.getLayerByName(
           groupName, layers.getArray());
       if (layer) {
         this.initMergedLayer_(layer, groupLayers);
-        if (groupLayers !== '') {
-          //Layer must be visible, we found some layers names in the state
-          layer.setVisible(true);
-        }
+        this.updateLayerFromState_(layer);
       } else if (groupLayers !== '') {
         layerNames = groupLayers.split(',');
         this.gmfTreeManager_.addCustomGroups([{
@@ -791,6 +799,10 @@ gmf.Permalink.prototype.registerLayer_ = function(layer, opt_init) {
       ol.Object.getChangeEventType(ol.layer.LayerProperty.VISIBLE),
       this.handleLayerVisibleChange_, this));
 
+    this.addListenerKey_(layerUid, ol.events.listen(layer,
+      ol.Object.getChangeEventType(ol.layer.LayerProperty.OPACITY),
+      this.handleLayerOpacityChange_, this));
+
     var isMerged = layer.get('isMerged');
     if (isMerged) {
       goog.asserts.assert(
@@ -823,6 +835,8 @@ gmf.Permalink.prototype.registerLayer_ = function(layer, opt_init) {
         this.updateLayerStateByVisibility_(layer);
       }
     }
+    //Check the application state to update layer properties if needed
+    this.updateLayerFromState_(layer);
   }
 
 };
@@ -855,8 +869,7 @@ gmf.Permalink.prototype.unregisterLayer_ = function(layer) {
       this.initListenerKey_(sourceUid); // clear event listeners
     }
 
-    var param = this.getLayerStateParamFromLayer_(layer);
-    this.ngeoStateManager_.deleteParam(param);
+    this.deleteStateParams_(layer);
   }
 };
 
@@ -871,6 +884,24 @@ gmf.Permalink.prototype.handleLayerVisibleChange_ = function(evt) {
   var layer = evt.target;
   goog.asserts.assertInstanceof(layer, ol.layer.Base);
   this.updateLayerStateByVisibility_(layer);
+};
+
+
+/**
+ * Called when a layer `opacity` property changes. Update the state manager
+ * for that particular layer.
+ * @param {ol.ObjectEvent} evt Event.
+ * @private
+ */
+gmf.Permalink.prototype.handleLayerOpacityChange_ = function(evt) {
+  var layer = evt.target;
+  goog.asserts.assertInstanceof(layer, ol.layer.Base);
+  var state = {};
+  var isMerged = /** @type {boolean} */ (layer.get('isMerged'));
+  var layerName = /** @type {string} */ (layer.get('layerName'));
+  var param = this.getLayerStateParam_(layerName, isMerged, gmf.PermalinkOpenLayersLayerProperties.OPACITY);
+  state[param] = layer.getOpacity();
+  this.ngeoStateManager_.updateState(state);
 };
 
 
@@ -897,6 +928,56 @@ gmf.Permalink.prototype.updateLayerStateByVisibility_ = function(layer) {
     object[param] = visible;
     this.ngeoStateManager_.updateState(object);
   }
+};
+
+
+/**
+ * Update all properties found in the appplication state for the given layer
+ * @param  {ol.layer.Base} layer The layer
+ * @private
+ */
+gmf.Permalink.prototype.updateLayerFromState_ = function(layer) {
+  var layerName = /** @type {string} */ (layer.get('layerName'));
+  var isMerged = /** @type {boolean} */ (layer.get('isMerged'));
+  var param, stateValue;
+  Object.keys(gmf.PermalinkOpenLayersLayerProperties).forEach(function(layerProp) {
+    param = this.getLayerStateParam_(layerName, isMerged, gmf.PermalinkOpenLayersLayerProperties[layerProp]);
+    stateValue = this.ngeoStateManager_.getInitialValue(param);
+    if (stateValue !== undefined) {
+      layer.set(gmf.PermalinkOpenLayersLayerProperties[layerProp], stateValue);
+    }
+  },this);
+
+  // -- Layer Visibility -- //
+  param = this.getLayerStateParam_(layerName, isMerged);
+  stateValue = this.ngeoStateManager_.getInitialValue(param);
+  if (stateValue !== undefined) {
+    //Visibility state of the layer is not the default one -> user interacted with
+    if (isMerged) {
+      //Not mixed case, we fetched layers names, if not empty: layer must be visible
+      layer.setVisible(stateValue.length > 0);
+    } else {
+      //Mixed case, we fetched true or false
+      layer.setVisible(/** @type {boolean} */ (stateValue));
+    }
+  }
+};
+
+/**
+ * Remove all state parameters for the given layer
+ * @param  {ol.layer.Base} layer the layer
+ * @private
+ */
+gmf.Permalink.prototype.deleteStateParams_ = function(layer) {
+  var layerName = /** @type {string} */ (layer.get('layerName'));
+  var isMerged = /** @type {boolean} */ (layer.get('isMerged'));
+  var param;
+  Object.keys(gmf.PermalinkOpenLayersLayerProperties).forEach(function(layerProp) {
+    param = this.getLayerStateParam_(layerName, isMerged, gmf.PermalinkOpenLayersLayerProperties[layerProp]);
+    this.ngeoStateManager_.deleteParam(param);
+  },this);
+  param = this.getLayerStateParam_(layerName, isMerged);
+  this.ngeoStateManager_.deleteParam(param);
 };
 
 
@@ -946,18 +1027,28 @@ gmf.Permalink.prototype.getLayerStateParamFromNode_ = function(layerNode) {
 /**
  * @param {string} layerName The name of the layer.
  * @param {boolean} isMerged Whether the layer is merged or not.
+ * @param {string=} opt_propertyName Whether we are looking for a layer property value
+ * (e.g opacity)
  * @return {string} The state param for the layer
  * @private
  */
 gmf.Permalink.prototype.getLayerStateParam_ = function(layerName,
-    isMerged) {
+    isMerged, opt_propertyName) {
   var param;
   if (isMerged) {
-    param = gmf.PermalinkParamPrefix.TREE_GROUP_LAYERS + layerName;
+    if (opt_propertyName === gmf.PermalinkOpenLayersLayerProperties.OPACITY) {
+      param = gmf.PermalinkParamPrefix.TREE_GROUP_OPACITY;
+    } else {
+      param = gmf.PermalinkParamPrefix.TREE_GROUP_LAYERS;
+    }
   } else {
-    param = gmf.PermalinkParamPrefix.TREE_ENABLE + layerName;
+    if (opt_propertyName === gmf.PermalinkOpenLayersLayerProperties.OPACITY) {
+      param = gmf.PermalinkParamPrefix.TREE_OPACITY;
+    } else {
+      param = gmf.PermalinkParamPrefix.TREE_ENABLE;
+    }
   }
-  return param;
+  return param + layerName;
 };
 
 

--- a/contribs/gmf/src/services/treemanager.js
+++ b/contribs/gmf/src/services/treemanager.js
@@ -28,12 +28,13 @@ gmf.module.value('gmfTreeManagerModeFlush', true);
  * @param {ngeo.Notification} ngeoNotification Ngeo notification service.
  * @param {gmf.Themes} gmfThemes gmf Themes service.
  * @param {boolean} gmfTreeManagerModeFlush Flush mode active?
+ * @param {ngeo.StateManager} ngeoStateManager The ngeo StateManager service.
  * @ngInject
  * @ngdoc service
  * @ngname gmfTreeManager
  */
 gmf.TreeManager = function(gettextCatalog, ngeoNotification, gmfThemes,
-    gmfTreeManagerModeFlush) {
+    gmfTreeManagerModeFlush, ngeoStateManager) {
 
   /**
    * @type {angularGettext.Catalog}
@@ -67,6 +68,12 @@ gmf.TreeManager = function(gettextCatalog, ngeoNotification, gmfThemes,
     children: [],
     name: ''
   });
+
+  /**
+   * @type {ngeo.StateManager}
+   * @private
+   */
+  this.ngeoStateManager_ = ngeoStateManager;
 };
 
 
@@ -98,13 +105,25 @@ gmf.TreeManager.prototype.setModeFlush = function(value) {
  * Set the current theme name (mode 'flush' only) and add its children. Add
  * only groups that are not already in the tree.
  * @param{GmfThemesNode} theme A theme object.
+ * @param{boolean=} opt_init true for the initialization phase (and get previous
+*  configuration from the state manager)
  * @export
  */
-gmf.TreeManager.prototype.addTheme = function(theme) {
+gmf.TreeManager.prototype.addTheme = function(theme, opt_init) {
+  var firstLevelNodes = theme.children;
+  var treeGroups = this.ngeoStateManager_.getInitialValue(gmf.PermalinkParam.TREE_GROUPS);
   if (this.isModeFlush()) {
     this.tree.name = theme.name;
   }
-  this.addGroups(theme.children);
+  if (opt_init && treeGroups !== undefined) {
+    //Init phase and state exists -> first level groups must be red from the stateManager
+    var groupsNames = treeGroups.split(',');
+    groupsNames.forEach(function(name) {
+      this.addGroupByName(name, true);
+    }, this);
+  } else {
+    this.addGroups(firstLevelNodes);
+  }
 };
 
 
@@ -119,8 +138,10 @@ gmf.TreeManager.prototype.addTheme = function(theme) {
  */
 gmf.TreeManager.prototype.addGroups = function(groups, opt_add, opt_silent) {
   var groupNotAdded = [];
+
   if (this.isModeFlush() && opt_add !== true) {
     this.tree.children.length = 0;
+    this.ngeoStateManager_.deleteParam(gmf.PermalinkParam.TREE_GROUPS);
   }
   groups.forEach(function(group) {
     if (!this.addGroup_(group)) {
@@ -130,6 +151,22 @@ gmf.TreeManager.prototype.addGroups = function(groups, opt_add, opt_silent) {
   if (groupNotAdded.length > 0 && !opt_silent) {
     this.notifyCantAddGroups_(groupNotAdded);
   }
+
+  //Update app state
+  this.updateTreeGroupsState_();
+};
+
+
+/**
+ * Update the application state with the list of first level groups in the tree
+ * @private
+ */
+gmf.TreeManager.prototype.updateTreeGroupsState_ = function() {
+  var treeGroupsParam = {};
+  treeGroupsParam[gmf.PermalinkParam.TREE_GROUPS] = this.tree.children.map(function(node) {
+    return node.name;
+  });
+  this.ngeoStateManager_.updateState(treeGroupsParam);
 };
 
 
@@ -166,6 +203,7 @@ gmf.TreeManager.prototype.addGroup_ = function(group) {
  */
 gmf.TreeManager.prototype.addCustomGroups = function(groups, opt_add) {
   var groupNotAdded = [];
+
   if (this.isModeFlush() && opt_add !== true) {
     this.tree.children.length = 0;
   }
@@ -178,6 +216,9 @@ gmf.TreeManager.prototype.addCustomGroups = function(groups, opt_add) {
   if (groupNotAdded.length > 0) {
     this.notifyCantAddGroups_(groupNotAdded);
   }
+
+  //Update app state
+  this.updateTreeGroupsState_();
 };
 
 
@@ -243,6 +284,7 @@ gmf.TreeManager.prototype.addGroupByLayerName = function(layerName, opt_add, opt
 gmf.TreeManager.prototype.removeGroup = function(group) {
   var children = this.tree.children;
   var index = 0, found = false;
+  var treeGroupsParam = {};
   children.some(function(child) {
     if (child.name === group.name) {
       return found = true;
@@ -251,6 +293,10 @@ gmf.TreeManager.prototype.removeGroup = function(group) {
   }.bind(this));
   if (found) {
     children.splice(index, 1);
+    treeGroupsParam[gmf.PermalinkParam.TREE_GROUPS] = children.map(function(node) {
+      return node.name;
+    });
+    this.ngeoStateManager_.updateState(treeGroupsParam);
   }
 };
 

--- a/contribs/gmf/src/services/treemanager.js
+++ b/contribs/gmf/src/services/treemanager.js
@@ -111,12 +111,13 @@ gmf.TreeManager.prototype.setModeFlush = function(value) {
  */
 gmf.TreeManager.prototype.addTheme = function(theme, opt_init) {
   var firstLevelNodes = theme.children;
-  var treeGroups = this.ngeoStateManager_.getInitialValue(gmf.PermalinkParam.TREE_GROUPS);
+  var treeGroups = /** @type {string} */ (this.ngeoStateManager_.getInitialValue(
+    gmf.PermalinkParam.TREE_GROUPS));
   if (this.isModeFlush()) {
     this.tree.name = theme.name;
   }
   if (opt_init && treeGroups !== undefined) {
-    //Init phase and state exists -> first level groups must be red from the stateManager
+    //Init phase and state exists -> first level groups must be read from the stateManager
     var groupsNames = treeGroups.split(',');
     groupsNames.forEach(function(name) {
       this.addGroupByName(name, true);
@@ -153,19 +154,20 @@ gmf.TreeManager.prototype.addGroups = function(groups, opt_add, opt_silent) {
   }
 
   //Update app state
-  this.updateTreeGroupsState_();
+  this.updateTreeGroupsState_(this.tree.children);
 };
 
 
 /**
  * Update the application state with the list of first level groups in the tree
+ * @param {Array.<GmfThemesNode>} groups firstlevel groups of the tree
  * @private
  */
-gmf.TreeManager.prototype.updateTreeGroupsState_ = function() {
+gmf.TreeManager.prototype.updateTreeGroupsState_ = function(groups) {
   var treeGroupsParam = {};
-  treeGroupsParam[gmf.PermalinkParam.TREE_GROUPS] = this.tree.children.map(function(node) {
+  treeGroupsParam[gmf.PermalinkParam.TREE_GROUPS] = groups.map(function(node) {
     return node.name;
-  });
+  }).join(',');
   this.ngeoStateManager_.updateState(treeGroupsParam);
 };
 
@@ -218,7 +220,7 @@ gmf.TreeManager.prototype.addCustomGroups = function(groups, opt_add) {
   }
 
   //Update app state
-  this.updateTreeGroupsState_();
+  this.updateTreeGroupsState_(this.tree.children);
 };
 
 
@@ -284,7 +286,6 @@ gmf.TreeManager.prototype.addGroupByLayerName = function(layerName, opt_add, opt
 gmf.TreeManager.prototype.removeGroup = function(group) {
   var children = this.tree.children;
   var index = 0, found = false;
-  var treeGroupsParam = {};
   children.some(function(child) {
     if (child.name === group.name) {
       return found = true;
@@ -293,10 +294,7 @@ gmf.TreeManager.prototype.removeGroup = function(group) {
   }.bind(this));
   if (found) {
     children.splice(index, 1);
-    treeGroupsParam[gmf.PermalinkParam.TREE_GROUPS] = children.map(function(node) {
-      return node.name;
-    });
-    this.ngeoStateManager_.updateState(treeGroupsParam);
+    this.updateTreeGroupsState_(children);
   }
 };
 

--- a/src/services/statemanager.js
+++ b/src/services/statemanager.js
@@ -45,25 +45,60 @@ ngeo.StateManager = function(ngeoLocation) {
       for (i = 0; i < count; ++i) {
         key = this.localStorage.key(i);
         goog.asserts.assert(key !== null);
-        this.initialState[key] = this.localStorage.get(key);
+        this.initialState[key] = this.getItemFromLocalStorage_(key);
       }
+      this.ngeoLocation.updateParams(this.initialState);
     }
   } else {
     var keys = ngeoLocation.getParamKeys();
     for (i = 0; i < keys.length; ++i) {
       key = keys[i];
-      this.initialState[key] = ngeoLocation.getParam(key);
+      this.initialState[key] = this.getItemFromLocation_(key);
     }
   }
+};
 
-  this.ngeoLocation.updateParams(this.initialState);
+
+/**
+ * Get the item for the given key  from localStorage and try to parse to the appropriate type
+ * If it cannot be parsed, the raw value (string) is returned
+ *
+ * @param  {string} key the localStorage key for the item
+ * @return {*} Param value.
+ * @private
+ */
+ngeo.StateManager.prototype.getItemFromLocalStorage_ = function(key) {
+  var value = this.localStorage.get(key);
+  try {
+    return angular.fromJson(value);
+  } catch (e) {
+    return value;
+  }
+};
+
+
+/**
+ * Get the item for the given key  from Location and try to parse to the appropriate type
+ * If it cannot be parsed, the raw value (string) is returned
+ *
+ * @param  {string} key the localStorage key for the item
+ * @return {*} Param value.
+ * @private
+ */
+ngeo.StateManager.prototype.getItemFromLocation_ = function(key) {
+  var value = this.ngeoLocation.getParam(key);
+  try {
+    return angular.fromJson(value);
+  } catch (e) {
+    return value;
+  }
 };
 
 
 /**
  * Get the state value for `key`.
  * @param {string} key State key.
- * @return {string|undefined} State value.
+ * @return {*} State value.
  */
 ngeo.StateManager.prototype.getInitialValue = function(key) {
   return this.initialState[key];
@@ -79,7 +114,7 @@ ngeo.StateManager.prototype.updateState = function(object) {
   if (this.localStorage.isAvailable()) {
     var key;
     for (key in object) {
-      this.localStorage.set(key, object[key]);
+      this.localStorage.set(key, angular.toJson(object[key]));
     }
   }
 };

--- a/src/services/statemanager.js
+++ b/src/services/statemanager.js
@@ -56,7 +56,7 @@ ngeo.StateManager = function(ngeoLocation) {
     }
   }
 
-  this.ngeoLocation.updateParams({});
+  this.ngeoLocation.updateParams(this.initialState);
 };
 
 


### PR DESCRIPTION
Related to https://github.com/camptocamp/c2cgeoportal/issues/1657, this PR fixes some permalink bugs and complete the missing parameters 'tree_groups', 'tree_group_opacity' and 'tree_opacity'

**Empty your local storage before testing**

Demo:

- desktop : https://oliviersemet.github.io/ngeo/permalink-final-cut/examples/contribs/gmf/apps/desktop/
- desktop alt: https://oliviersemet.github.io/ngeo/permalink-final-cut/examples/contribs/gmf/apps/desktop_alt/

You must be able to retrieve the same state (except for group collapsing) of the application if:

- You copy the permalink to another tab
- Open the default url (without any url query parameter) in a tab

@fredj @pgiraud @sbrunner @ger-benjamin 