### PR TITLE
Put info bar expand in the center

### DIFF
--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -101,9 +101,12 @@ main {
       background-color: fade(@main-bg-color, 80%);
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
-      right: @app-margin;
+      padding: 0;
+      left: 50%;
+      @width: 4rem;
+      width: @width;
+      margin-left: -(@width / 2);
       border-bottom: 0;
-      padding: @half-app-margin @app-margin;
       border: solid @border-color;
       border-width: 1px 1px 0 1px;
     }


### PR DESCRIPTION
Here's a pull request to prevent the conflict between the info bar collapse/expand button and the features window.
![screenshot from 2016-06-30 13 37 29](https://cloud.githubusercontent.com/assets/319774/16486907/df12e792-3ec7-11e6-9966-f2f0bcb81049.png)


Before
![screenshot from 2016-06-30 13 36 13](https://cloud.githubusercontent.com/assets/319774/16486860/ae750a8e-3ec7-11e6-8d43-2aef28160c78.png)
After
![screenshot from 2016-06-30 13 35 59](https://cloud.githubusercontent.com/assets/319774/16486862/af99ef06-3ec7-11e6-90af-e50293fdc1bd.png)
