### PR TITLE
Support geometry attribute in XSDAttribute format

### DIFF
--- a/contribs/gmf/examples/xsdattributes.html
+++ b/contribs/gmf/examples/xsdattributes.html
@@ -34,6 +34,10 @@
             ng-options="layer.name for layer in ctrl.layers">
             <option value="">-- Choose a layer --</option>
           </select>
+          <div>
+            Geometry type:
+            <span>{{ ctrl.getGeomType() }}</span>
+          </div>
         </div>
         <div class="col-sm-6">
           <ngeo-attributes

--- a/contribs/gmf/examples/xsdattributes.js
+++ b/contribs/gmf/examples/xsdattributes.js
@@ -123,6 +123,24 @@ app.MainController.prototype.setAttributes_ = function(attributes) {
 
 
 /**
+ * @return {string} Type of geometry.
+ * @export
+ */
+app.MainController.prototype.getGeomType = function() {
+  var type = 'N/A';
+  if (this.attributes) {
+    var geomAttr = ngeo.format.XSDAttribute.getGeometryAttribute(
+      this.attributes
+    );
+    if (geomAttr && geomAttr.geomType) {
+      type = geomAttr.geomType;
+    }
+  }
+  return type;
+};
+
+
+/**
  * Just for this example
  * @param {GmfThemesNode} node A theme, group or layer node.
  * @param {Array.<GmfThemesNode>} nodes An Array of nodes.

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -13,6 +13,7 @@ var ngeox;
  * A feature attribute definition.
  * @typedef {{
  *     choices: (Array.<string>|undefined),
+ *     geomType: (string|undefined),
  *     name: (string),
  *     required: (boolean|undefined),
  *     type: (string)
@@ -26,6 +27,14 @@ ngeox.Attribute;
  * @type {Array.<string>|undefined}
  */
 ngeox.Attribute.prototype.choices;
+
+
+/**
+ * Set only if the attribute is a geometry type. Determines the type of
+ * geometry.
+ * @type {string|undefined}
+ */
+ngeox.Attribute.prototype.geomType;
 
 
 /**

--- a/src/directives/partials/attributes.html
+++ b/src/directives/partials/attributes.html
@@ -2,27 +2,29 @@
   <div
       class="form-group"
       ng-repeat="attribute in ::attrCtrl.attributes">
-    <label>{{ attribute.name }}:</label>
-    <div ng-switch="attribute.type">
-      <select
-          ng-switch-when="select"
-          ng-model="attrCtrl.properties[attribute.name]"
-          ng-change="attrCtrl.handleInputChange(attribute.name);"
-          class="form-control"
-          type="text">
-        <option
-            ng-repeat="attribute in ::attribute.choices"
-            value="{{ ::attribute }}">
-          {{ ::attribute }}
-        </option>
-      </select>
-      <input
-          ng-switch-default
-          ng-model="attrCtrl.properties[attribute.name]"
-          ng-change="attrCtrl.handleInputChange(attribute.name);"
-          class="form-control"
-          type="text">
-      </input>
+    <div ng-if="attribute.type !== 'geometry'">
+      <label>{{ attribute.name }}:</label>
+      <div ng-switch="attribute.type">
+        <select
+            ng-switch-when="select"
+            ng-model="attrCtrl.properties[attribute.name]"
+            ng-change="attrCtrl.handleInputChange(attribute.name);"
+            class="form-control"
+            type="text">
+          <option
+              ng-repeat="attribute in ::attribute.choices"
+              value="{{ ::attribute }}">
+            {{ ::attribute }}
+          </option>
+        </select>
+        <input
+            ng-switch-default
+            ng-model="attrCtrl.properties[attribute.name]"
+            ng-change="attrCtrl.handleInputChange(attribute.name);"
+            class="form-control"
+            type="text">
+        </input>
+      </div>
     </div>
   </div>
 </form>

--- a/src/ol-ext/format/xsdattribute.js
+++ b/src/ol-ext/format/xsdattribute.js
@@ -89,14 +89,18 @@ ngeo.format.XSDAttribute.prototype.readFromElementNode_ = function(node) {
 
   var type = node.getAttribute('type');
   if (type) {
-    // Skip attribute of any 'geometry' type
     var geomRegex =
       /gml:((Multi)?(Point|Line|Polygon|Curve|Surface|Geometry)).*/;
     if (geomRegex.exec(type)) {
-      return null;
-    }
-
-    if (type === 'xsd:string') {
+      attribute.type = ngeo.format.XSDAttributeType.GEOMETRY;
+      if (/^gml:Point/.exec(type)) {
+        attribute.geomType = ol.geom.GeometryType.POINT;
+      } else if (/^gml:LineString/.exec(type)) {
+        attribute.geomType = ol.geom.GeometryType.LINE_STRING;
+      } else if (/^gml:Polygon/.exec(type)) {
+        attribute.geomType = ol.geom.GeometryType.POLYGON;
+      }
+    } else if (type === 'xsd:string') {
       attribute.type = ngeo.format.XSDAttributeType.TEXT;
     } else if (type === 'xsd:date') {
       attribute.type = ngeo.format.XSDAttributeType.DATE;
@@ -126,6 +130,24 @@ ngeo.format.XSDAttribute.prototype.readFromElementNode_ = function(node) {
 
 
 /**
+ * Returns the first geometry attribute among a given list of attributes.
+ * @param {Array.<ngeox.Attribute>} attributes The list of attributes.
+ * @return {?ngeox.Attribute} A geometry attribute object.
+ * @export
+ */
+ngeo.format.XSDAttribute.getGeometryAttribute = function(attributes) {
+  var geomAttribute = null;
+  for (var i = 0, ii = attributes.length; i < ii; i++) {
+    if (attributes[i].type === ngeo.format.XSDAttributeType.GEOMETRY) {
+      geomAttribute = attributes[i];
+      break;
+    }
+  }
+  return geomAttribute;
+};
+
+
+/**
  * @enum {string}
  */
 ngeo.format.XSDAttributeType = {
@@ -137,6 +159,10 @@ ngeo.format.XSDAttributeType = {
    * @type {string}
    */
   DATETIME: 'datetime',
+  /**
+   * @type {string}
+   */
+  GEOMETRY: 'geometry',
   /**
    * @type {string}
    */


### PR DESCRIPTION
This PR introduces the support of geometry attributes in the XSDAttribute format.  They used to be completely ignored.  Now, they are added alongside other attributes.

The `ngeo.Attributes` directive is now the one that ignores the geometry attributes.

The example featuring the `gmf.XSDAttributes` directive demonstrate that one can detect the type of geometry used by a layer using the XSDAttribute format.

## Todo

 * [x] review

## Live example

 * https://adube.github.io/ngeo/xsd-attribute-support-geom/examples/contribs/gmf/xsdattributes.html