### PR TITLE
Split mobile search and overwrite search style for narrow desktop browsers.

### DIFF
--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -4,7 +4,7 @@
 @import 'font.less';
 @import 'base.less';
 @import 'map.less';
-@import 'search.less';
+@import 'searchmobile.less';
 @import 'mobilelayertree.less';
 @import 'fullscreenpopup.less';
 @import 'mobile-nav.less';

--- a/contribs/gmf/less/search.less
+++ b/contribs/gmf/less/search.less
@@ -113,14 +113,12 @@
   }
 }
 
-// Overrides for phone devices
+// Overrides for small browser widths
 @media (max-width: @screen-sm-min) {
   .search {
-    left: 0;
-    right: 0;
-    margin: 0 @app-margin + @map-tools-size;
+    margin: 0;
+    left: 2 * @app-margin + @map-tools-size;
     .gmf-search {
-      border-width: 1px 0;
       width: 100%;
     }
   }

--- a/contribs/gmf/less/searchmobile.less
+++ b/contribs/gmf/less/searchmobile.less
@@ -1,0 +1,14 @@
+@import "search.less";
+
+// Overrides for phone devices
+@media (max-width: @screen-sm-min) {
+  .search {
+    left: 0;
+    right: 0;
+    margin: 0 @app-margin + @map-tools-size;
+    .gmf-search {
+      border-width: 1px 0;
+      width: 100%;
+    }
+  }
+}


### PR DESCRIPTION
fixes #1295.
Examples
- desktop: https://marionb.github.io/ngeo/split_search_styling/examples/contribs/gmf/apps/desktop/
- mobile: https://marionb.github.io/ngeo/split_search_styling/examples/contribs/gmf/apps/mobile/