### PR TITLE
Print mask race condition

### DIFF
--- a/contribs/gmf/src/directives/print.js
+++ b/contribs/gmf/src/directives/print.js
@@ -156,6 +156,11 @@ gmf.PrintController = function($scope, $timeout, $q, $injector, gettextCatalog,
   this.ngeoFeatureHelper_ = ngeoFeatureHelper;
 
   /**
+   * @type {boolean}
+   */
+  this.active;
+
+  /**
    * @type{boolean}
    * @private
    */
@@ -368,6 +373,10 @@ gmf.PrintController.prototype.togglePrintPanel_ = function(active) {
       this.getCapabilities_();
     }
     this.capabilities_.then(function(resp) {
+      // make sure the panel is still open
+      if (!this.active) {
+        return;
+      }
       this.printState = gmf.PrintState.NOT_IN_USE;
       // Get capabilities - On success
       this.parseCapabilities_(resp);


### PR DESCRIPTION
Fixes #1133.

With this pull request I address two different things:
 - the race condition which in certain circumstances the print mask was displayed even if the print panel was already closed. See #1133.
 - the fact that the capabilities promise is recreated each time the print panel is open. I gave it a new try and it's now taking into account the roleId change.
https://github.com/camptocamp/ngeo/commit/a7e53c966f6294eaa328370feaeb928b5047505d
https://github.com/camptocamp/ngeo/commit/92a284a1cce57efbc52a7cb0de08127dddae151a

Please review.

Démo https://pgiraud.github.io/ngeo/print_mask_race_condition/examples/contribs/gmf/apps/desktop_alt
