### PR TITLE
Mobile login nav

### DIFF
--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -132,7 +132,8 @@
           </li>
         </ul>
       </div>
-      <gmf-authentication id="login" class="slide" data-header-title="{{'Login' | translate}}">
+      <gmf-authentication id="login" class="slide" data-header-title="{{'Login' | translate}}"
+        gmf-mobile-nav-back="authCtrl.gmfUser.username !== null">
       </gmf-authentication>
     </nav>
     <script src="../../../../node_modules/jquery/dist/jquery.js"></script>

--- a/contribs/gmf/src/directives/authenticationdirective.js
+++ b/contribs/gmf/src/directives/authenticationdirective.js
@@ -47,7 +47,7 @@ gmf.module.value('gmfAuthenticationTemplateUrl',
  */
 gmf.authenticationDirective = function(gmfAuthenticationTemplateUrl) {
   return {
-    scope: {},
+    scope: true,
     controller: 'GmfAuthenticationController',
     controllerAs: 'authCtrl',
     templateUrl: gmfAuthenticationTemplateUrl

--- a/contribs/gmf/src/directives/mobilenav.js
+++ b/contribs/gmf/src/directives/mobilenav.js
@@ -243,6 +243,52 @@ gmf.MobileNavController.prototype.backIfActive = function(element) {
 
 /**
  * A directive to be used in conjunction with {@link gmf.mobileNavDirective}.
+ * The directive can be set on a slide element of {@link gmf.mobileNavDirective}
+ * with an expression. When the value of the expression changes and becomes
+ * true, the navigation returns to the previous slide, if the slide is
+ * currently active.
+ *
+ * Example:
+ *
+ *    <nav class="nav-left" gmf-mobile-nav>
+ *      ...
+ *      <gmf-authentication class="slide"
+ *         gmf-mobile-nav-back="authCtrl.gmfUser.username !== null">
+ *      </gmf-authentication>
+ *
+ * If `mainCtrl.gmfUser.username` becomes true and the login-slide is currently
+ * active, the navigation will go back to the last slide.
+ *
+ * @return {angular.Directive} The Directive Definition Object.
+ * @ngInject
+ */
+gmf.mobileNavBackDirective = function() {
+  return {
+    require: '^^gmfMobileNav',
+    restrict: 'A',
+    scope: false,
+    link:
+        /**
+         * @param {angular.Scope} scope Scope.
+         * @param {angular.JQLite} element Element.
+         * @param {angular.Attributes} attrs Atttributes.
+         * @param {gmf.MobileNavController} navCtrl Controller.
+         */
+        function(scope, element, attrs, navCtrl) {
+          scope.$watch(attrs['gmfMobileNavBack'], function(newVal, oldVal) {
+            if (newVal === true) {
+              navCtrl.backIfActive(element[0]);
+            }
+          });
+        }
+  };
+};
+
+gmf.module.directive('gmfMobileNavBack', gmf.mobileNavBackDirective);
+
+
+/**
+ * A directive to be used in conjunction with {@link gmf.mobileNavDirective}.
  * The directive can be set on a slide element of {@link gmf.mobileNavDirective}.
  * When the element is clicked, the navigation returns to the previous slide if
  * the slide is currently active.


### PR DESCRIPTION
Those changes allow to nav back to main menu in right navigation when the user is successfully logged in.

Fixes #1450.

I first reverted 079cd0cd5634e0c9ab6a1227f87da6d2ad9f832d to reintroduce `mobileNavBackDirective` but changed it so that it takes a boolean expression.

I also had to change the scope for the authentication directive. I'm not super happy with this change but couldn't find any better way.

Please review.