### PR TITLE
Hiding opacity slider on mixed groups

### DIFF
--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -38,7 +38,7 @@
     <a href="" ng-if="::layertreeCtrl.depth == 1" ng-click="gmfLayertreeCtrl.removeNode(layertreeCtrl.node)">
       <span class="fa fa-trash"></span>
     </a>
-    <span ngeo-popover ng-if="::(layertreeCtrl.depth === 1 && !layertreeCtrl.node.mixed) || (layertreeCtrl.depth > 1 && layertreeCtrl.parent.node.mixed) || (gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend)" ngeo-popover-dismiss=".content">
+    <span ngeo-popover ng-if="::(layertreeCtrl.depth === 1 && !layertreeCtrl.node.mixed) || (layertreeCtrl.depth > 1 && layertreeCtrl.parent.node.mixed && !layertreeCtrl.node.children) || (gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend)" ngeo-popover-dismiss=".content">
       <span ngeo-popover-anchor class="extra-actions fa fa-cog"></span>
       <div ngeo-popover-content>
         <ul>


### PR DESCRIPTION
Related to c2cgeoportal issue [#2364](https://github.com/camptocamp/c2cgeoportal/issues/2364)

Demo: https://oliviersemet.github.io/ngeo/opacity-on-mixed-groups-must-not-be-possible/examples/contribs/gmf/apps/desktop/

**Select OSM theme:**

- [ ] Group _OSM Time_ in _OSM Functions mixed_ doesn't have a right action button 

- [ ] Each child of _OSM Time_ has a right action button for changing opacity

@sbrunner @pgiraud 