### PR TITLE
Share permalink feature

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -42,23 +42,32 @@
       </div>
       <div class="tools" ngeo-resizemap="mainCtrl.map"
         ngeo-resizemap-state="mainCtrl.toolsActive">
-        <div ngeo-btn-group class="bar btn-group-vertical" ngeo-btn-group-active="mainCtrl.toolsActive">
-          <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.loginActive"
-            data-toggle="tooltip" data-placement="left" data-original-title="{{'Login'|translate}}">
-            <span class="fa fa-user"></span>
-          </button>
-          <button ngeo-btn class="btn btn-default" ng-model="printActive"
-            data-toggle="tooltip" data-placement="left" data-original-title="{{'Print'|translate}}">
-            <span class="fa fa-print"></span>
-          </button>
-          <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.drawFeatureActive"
-            data-toggle="tooltip" data-placement="left" data-original-title="{{'Draw & Measure'|translate}}">
-            <span class="fa fa-pencil"></span>
-          </button>
-          <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.drawProfilePanelActive"
-            data-toggle="tooltip" data-placement="left" data-original-title="{{'Profile'|translate}}">
-            <span class="fa fa-area-chart"></span>
-          </button>
+        <div class="bar">
+          <div ngeo-btn-group class="btn-group-vertical" ngeo-btn-group-active="mainCtrl.toolsActive">
+            <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.loginActive"
+              data-toggle="tooltip" data-placement="left" data-original-title="{{'Login'|translate}}">
+              <span class="fa fa-user"></span>
+            </button>
+            <button ngeo-btn class="btn btn-default" ng-model="printActive"
+              data-toggle="tooltip" data-placement="left" data-original-title="{{'Print'|translate}}">
+              <span class="fa fa-print"></span>
+            </button>
+            <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.drawFeatureActive"
+              data-toggle="tooltip" data-placement="left" data-original-title="{{'Draw & Measure'|translate}}">
+              <span class="fa fa-pencil"></span>
+            </button>
+            <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.drawProfilePanelActive"
+              data-toggle="tooltip" data-placement="left" data-original-title="{{'Profile'|translate}}">
+              <span class="fa fa-area-chart"></span>
+            </button>
+          </div>
+          <br/>
+          <br/>
+          <span data-toggle="tooltip" data-placement="left" data-original-title="{{'Share this map'|translate}}">
+            <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.modalShareShown">
+              <span class="fa fa-share-alt"></span>
+            </button>
+          </span>
         </div>
         <div class="tools-content container-fluid" ng-class="{active: mainCtrl.toolsActive}">
           <div ng-show="mainCtrl.loginActive" class="row">
@@ -183,6 +192,9 @@
           </div>
         </div>
       </div>
+      <ngeo-modal ng-model="mainCtrl.modalShareShown" ngeo-modal-destroy-content-on-hide="true">
+        <gmf-share gmf-share-email="true"/>
+      </ngeo-modal>
     </main>
     <footer>
       <gmf-profile
@@ -241,6 +253,7 @@
         module.constant('gmfPrintUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/printproxy');
         module.constant('gmfWmsUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy');
         module.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
+        module.constant('gmfShortenerCreateUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/short/create');
         module.constant('gmfSearchGroups', ['osm','district']);
         // Requires that the gmfSearchGroups is specified
         module.constant('gmfSearchActions', ['add_theme', 'add_group', 'add_layer']);

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -40,23 +40,32 @@
       </div>
       <div class="tools" ngeo-resizemap="mainCtrl.map"
         ngeo-resizemap-state="mainCtrl.toolsActive">
-        <div ngeo-btn-group class="bar btn-group-vertical" ngeo-btn-group-active="mainCtrl.toolsActive">
-          <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.loginActive"
-            data-toggle="tooltip" data-placement="left" data-original-title="{{'Login'|translate}}">
-            <span class="fa fa-user"></span>
-          </button>
-          <button ngeo-btn class="btn btn-default" ng-model="printActive"
-            data-toggle="tooltip" data-placement="left" data-original-title="{{'Print'|translate}}">
-            <span class="fa fa-print"></span>
-          </button>
-          <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.drawFeatureActive"
-            data-toggle="tooltip" data-placement="left" data-original-title="{{'Draw & Measure'|translate}}">
-            <span class="fa fa-pencil"></span>
-          </button>
-          <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.drawProfilePanelActive"
-            data-toggle="tooltip" data-placement="left" data-original-title="{{'Profile'|translate}}">
-            <span class="fa fa-area-chart"></span>
-          </button>
+        <div class="bar">
+          <div ngeo-btn-group class="btn-group-vertical" ngeo-btn-group-active="mainCtrl.toolsActive">
+            <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.loginActive"
+              data-toggle="tooltip" data-placement="left" data-original-title="{{'Login'|translate}}">
+              <span class="fa fa-user"></span>
+            </button>
+            <button ngeo-btn class="btn btn-default" ng-model="printActive"
+              data-toggle="tooltip" data-placement="left" data-original-title="{{'Print'|translate}}">
+              <span class="fa fa-print"></span>
+            </button>
+            <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.drawFeatureActive"
+              data-toggle="tooltip" data-placement="left" data-original-title="{{'Draw & Measure'|translate}}">
+              <span class="fa fa-pencil"></span>
+            </button>
+            <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.drawProfilePanelActive"
+              data-toggle="tooltip" data-placement="left" data-original-title="{{'Profile'|translate}}">
+              <span class="fa fa-area-chart"></span>
+            </button>
+          </div>
+          <br/>
+          <br/>
+          <span data-toggle="tooltip" data-placement="left" data-original-title="{{'Share this map'|translate}}">
+            <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.modalShareShown">
+              <span class="fa fa-share-alt"></span>
+            </button>
+          </span>
         </div>
         <div class="tools-content container-fluid" ng-class="{active: mainCtrl.toolsActive}">
           <div ng-show="mainCtrl.loginActive" class="row">
@@ -172,6 +181,9 @@
           </div>
         </div>
       </div>
+      <ngeo-modal ng-model="mainCtrl.modalShareShown" ngeo-modal-destroy-content-on-hide="true">
+        <gmf-share gmf-share-email="false"/>
+      </ngeo-modal>
     </main>
     <footer>
       <gmf-profile
@@ -230,6 +242,7 @@
         module.constant('gmfProfileJsonUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/profile.json');
         module.constant('gmfWmsUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy');
         module.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
+        module.constant('gmfShortenerCreateUrl', '');
         module.constant('gmfSearchGroups', ['osm','district']);
         // Requires that the gmfSearchGroups is specified
         module.constant('gmfSearchActions', ['add_theme', 'add_group', 'add_layer']);

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -180,6 +180,7 @@
         module.constant('fulltextsearchUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/fulltextsearch?limit=20');
         module.constant('gmfWmsUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy');
         module.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
+        module.constant('gmfShortenerCreateUrl', '');
         module.constant('gmfSearchGroups', []);
         // Requires that the gmfSearchGroups is specified
         module.constant('gmfSearchActions', []);

--- a/contribs/gmf/examples/share.html
+++ b/contribs/gmf/examples/share.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>GMF Share permalink example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../../../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/font-awesome/css/font-awesome.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+    <link rel="stylesheet" href="../third-party/jquery-ui/jquery-ui.min.css">
+    <style>
+      .share {
+        margin: 3rem 0;
+        width: 20vw;
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <p id="desc">This example shows how to use the <code>gmf-share</code> directive to get a shorten permalink</p>
+
+    <div class="share">
+      <strong>
+        Share the permalink
+      </strong>
+      <button class="btn btn-default" ng-click="ctrl.modalShareShown = true">
+        <span class="fa fa-share-alt"></span>
+      </button>
+    </div>
+    <div class="share">
+      <strong>
+        Share with emailing capability
+      </strong>
+      <button class="btn btn-default" ng-click="ctrl.modalShareWithEmailShown = true">
+        <span class="fa fa-share-alt"></span>
+      </button>
+    </div>
+
+    <ngeo-modal ng-model="ctrl.modalShareShown" ngeo-modal-destroy-content-on-hide="true">
+      <gmf-share gmf-share-email="false"/>
+    </ngeo-modal>
+    <ngeo-modal ng-model="ctrl.modalShareWithEmailShown" ngeo-modal-destroy-content-on-hide="true">
+      <gmf-share gmf-share-email="true"/>
+    </ngeo-modal>
+
+    <script src="../../../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../third-party/jquery-ui/jquery-ui.min.js"></script>
+    <script src="../../../node_modules/angular/angular.js"></script>
+    <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
+    <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
+    <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="../../../node_modules/angular-ui-date/dist/date.js"></script>
+    <script src="../../../node_modules/angular-ui-slider/src/slider.js"></script>
+    <script src="../../../node_modules/angular-dynamic-locale/dist/tmhDynamicLocale.js" type="text/javascript"></script>
+    <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../../../node_modules/proj4/dist/proj4.js"></script>
+    <script src="/@?main=share.js"></script>
+    <script src="default.js"></script>
+    <script src="../../../utils/watchwatchers.js"></script>
+    <script>
+      var gmfModule = angular.module('gmf');
+      gmfModule.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
+      gmfModule.constant('gmfShortenerCreateUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/short/create');
+    </script>
+  </body>
+</html>

--- a/contribs/gmf/examples/share.js
+++ b/contribs/gmf/examples/share.js
@@ -1,0 +1,39 @@
+goog.provide('gmf-share');
+
+goog.require('gmf.shareDirective');
+goog.require('ngeo.modalDirective');
+goog.require('ngeo.Location');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['gmf']);
+
+
+/**
+ * @constructor
+ */
+app.MainController = function() {
+
+
+  /**
+   * Model attached to the modal to toggle it
+   * @type {boolean}
+   * @export
+   */
+  this.modalShareWithEmailShown = false;
+
+  /**
+   * Model attached to the modal to toggle it
+   * @type {boolean}
+   * @export
+   */
+  this.modalShareShown = false;
+
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/contribs/gmf/externs/gmfx.js
+++ b/contribs/gmf/externs/gmfx.js
@@ -473,6 +473,7 @@ gmfx.TimePropertyWidgetEnum = {
   DATEPICKER : 'datepicker'
 };
 
+
 /**
  * Enum for the time property of a GmfThemesNode
  * Mode of the widget
@@ -483,6 +484,7 @@ gmfx.TimePropertyModeEnum = {
   VALUE : 'value',
   DISABLED : 'disabled'
 };
+
 
 /**
  * Enum for the time property of a GmfThemesNode
@@ -495,6 +497,7 @@ gmfx.TimePropertyResolutionEnum = {
   YEAR : 'year',
   SECOND : 'second'
 };
+
 
 /**
  * Time object for WMS layer
@@ -528,3 +531,43 @@ gmfx.DataSourceTableObject;
  * }}
  */
 gmfx.DataSourcePrintReportObject;
+
+/**
+ * @typedef {{
+ *  data: gmfx.ShortenerAPIResponseData,
+ *  status: number
+ * }}
+ */
+gmfx.ShortenerAPIResponse;
+
+
+/**
+ * Response payload to the shortener API
+ * @type {gmfx.ShortenerAPIResponseData}
+ */
+gmfx.ShortenerAPIResponse.data;
+
+
+/**
+ * HTTP status
+ * @type {number|undefined}
+ */
+gmfx.ShortenerAPIResponse.status;
+
+
+/**
+ * @typedef {{
+ *  short_url: string
+ * }}
+ */
+gmfx.ShortenerAPIResponseData;
+
+
+/**
+ * @typedef {{
+ *  url: string,
+ *  email: (string|undefined),
+ *  message : (string|undefined)
+ * }}
+ */
+gmfx.ShortenerAPIRequestParams;

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -285,25 +285,32 @@ gmf-backgroundlayerselector {
     }
 
     .btn {
+      width: 100%;
+      border-width: 0;
       background-color: @brand-primary;
       margin-left: 0;
-      border-right-width: 0;
-      border-left-width: 0;
       border-radius: 0 !important;
-      border-color: @border-color;
-
       &:hover {
         background-color: lighten(@brand-primary, @standard-variation);
       }
+    }
 
-      &.active,
-      &:active {
-        box-shadow: none;
-      }
-      &.active {
-        background-color: @brand-secondary;
-        border-left: 1px solid @brand-secondary;
-        margin-left: -1px;
+    .btn-group-vertical {
+      width: 100%;
+      .btn {
+        border: 1px solid @border-color;
+        border-right-width: 0;
+        border-left-width: 0;
+
+        &.active,
+        &:active {
+          box-shadow: none;
+        }
+        &.active {
+          background-color: @brand-secondary;
+          border-left: 1px solid @brand-secondary;
+          margin-left: -1px;
+        }
       }
     }
   }

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -21,6 +21,8 @@ goog.require('gmf.DatePickerDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.TimeSliderDirective');
 /** @suppress {extraRequire} */
+goog.require('gmf.shareDirective');
+/** @suppress {extraRequire} */
 goog.require('ngeo.btngroupDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.resizemapDirective');
@@ -99,6 +101,12 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
    * @export
    */
   this.toolsActive = false;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.modalShareShown = false;
 
   // initialize tooltips
   $('body').tooltip({

--- a/contribs/gmf/src/directives/partials/share.html
+++ b/contribs/gmf/src/directives/partials/share.html
@@ -1,0 +1,53 @@
+<div class="modal-header">
+  <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+  <h4 class="modal-title" translate>Share this map</h4>
+</div>
+<div class="modal-body">
+  <form role="form" name="gmfShareForm" novalidate>
+    <div class="form-group">
+      <label for="gmfShareInputShortLink" translate>Permalink</label>
+      <input type="text" class="form-control" id="gmfShareInputShortLink" onclick="this.select()" ng-model="shareCtrl.shortLink" readonly="True">
+      <p class="help-block" translate>Copy this link to share it.</p>
+      <p class="text-danger" ng-if="shareCtrl.showLenghtWarning">
+        <span class="fa fa-exclamation-triangle"></span>
+        {{'You have a lot of drawn elements in this map. The above link may not be correctly supported by some browsers.' | translate}}
+      </p>
+      <p class="text-danger" ng-if="::shareCtrl.errorOnGetShortUrl">
+        <span class="fa fa-exclamation"></span>
+        {{'Error, cannot get the shortened URL.' | translate}}
+      </p>
+    </div>
+    <hr>
+    <div class="share-email" ng-if="::shareCtrl.enableEmail">
+      <div class="form-group">
+        <label for="gmfShareInputEmail" translate>Send this link to</label>
+        <input type="email" class="form-control"  name="inputEmail" id="gmfShareInputEmail" placeholder="Email" ng-model="shareCtrl.email" required>
+        <span ng-show="gmfShareForm.$submitted || gmfShareForm.inputEmail.$touched">
+          <span class="text-danger" ng-show="gmfShareForm.inputEmail.$error.email || gmfShareForm.inputEmail.$error.required">
+            <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+            {{'Invalid email.' | translate}}</span>
+        </span>
+      </div>
+      <div class="form-group">
+        <textarea class="form-control" placeholder="{{'Message (optional)' | translate }}" ng-model="shareCtrl.message"></textarea>
+      </div>
+      <span class="text-success" ng-if="shareCtrl.successfullySent">
+        <i class="fa fa-check" aria-hidden="true"></i>
+          {{ 'Link successfully sent.' | translate }}
+      </span>
+      <span class="text-danger" ng-if="shareCtrl.errorOnsend">
+        <i class="fa fa-exclamation" aria-hidden="true"></i>
+          {{ 'Error, the link has not been sent.' | translate }}
+      </span>
+    </div>
+    <div class="text-right">
+      <button type="button" class="btn btn-default" data-dismiss="modal" translate>Close</button>
+      <button ng-if="::shareCtrl.enableEmail"
+        type="submit" class="btn btn-default btn-primary"
+        ng-click="shareCtrl.sendShortUrl()"
+        ng-disabled="!gmfShareForm.$valid"
+        translate>Send
+      </button>
+    </div>
+  </form>
+</div>

--- a/contribs/gmf/src/directives/share.js
+++ b/contribs/gmf/src/directives/share.js
@@ -1,0 +1,201 @@
+goog.provide('gmf.shareDirective');
+goog.provide('gmf.ShareController');
+
+goog.require('gmf');
+goog.require('gmf.ShareService');
+
+
+/**
+ * Directive to display a shortened permalink and share it by email
+ * Example:
+ *
+ *      <gmf-share
+ *        gmf-share-email="true">
+ *      </gmf-share>
+ *
+ * @htmlAttribute {boolean} gmf-share-email Enable emailing capability.
+ * @return {angular.Directive}  The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname gmfShare
+ */
+gmf.shareDirective = function() {
+  return {
+    restrict: 'E',
+    controller: 'GmfShareController',
+    controllerAs: 'shareCtrl',
+    templateUrl: gmf.baseTemplateUrl + '/share.html'
+  };
+};
+
+
+/**
+* The controller for the share directive
+* @param {angular.Scope} $scope Scope.
+* @param {ngeo.Location} ngeoLocation ngeo Location service.
+* @param {gmf.ShareService} gmfShareService service for sharing map.
+* @param {angular.$q} $q Angular q service
+* @param {angular.Attributes} $attrs Attributes.
+* @constructor
+* @ngInject
+* @export
+* @ngdoc controller
+* @ngname GmfShareController
+*/
+gmf.ShareController = function($scope, ngeoLocation, gmfShareService, $q, $attrs) {
+
+
+  /**
+   * @type {angular.Scope}
+   * @private
+   */
+  this.$scope_ = $scope;
+
+  /**
+   * @type {gmf.ShareService}
+   * @private
+   */
+  this.gmfShareService_ = gmfShareService;
+
+  /**
+   * @type {angular.$q}
+   * @private
+   */
+  this.$q_ = $q;
+
+  /**
+   * @type {ngeo.Location}
+   * @private
+   */
+  this.ngeoLocation_ = ngeoLocation;
+
+  /**
+   * @type boolean
+   * @export
+   */
+  this.enableEmail = $attrs['gmfShareEmail'] === 'true';
+
+  /**
+   * @type string
+   * @export
+   */
+  this.permalink = ngeoLocation.getUriString();
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.shortLink;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.email;
+
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.message;
+
+  /**
+   * @type boolean
+   * @export
+   */
+  this.showLenghtWarning = this.permalink.length > gmf.ShareService.URL_MAX_LEN ||
+  ngeoLocation.getPath() > gmf.ShareService.URL_PATH_MAX_LEN;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.successfullySent = false;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.errorOnsend = false;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.errorOnGetShortUrl;
+
+  this.getShortUrl();
+
+};
+
+
+/**
+ * Get the short version of the permalink if the email is not provided
+ * @export
+ */
+gmf.ShareController.prototype.getShortUrl = function() {
+  this.$q_.when(this.gmfShareService_.getShortUrl(this.permalink))
+    .then(
+      onSuccess_.bind(this),
+      onError_.bind(this)
+    );
+
+  /**
+   * Success handler when trying to fetch a short url for the permalink
+   * @param  {gmfx.ShortenerAPIResponse|angular.$http.HttpPromise} resp service response
+   * @private
+   */
+  function onSuccess_(resp) {
+    this.shortLink = resp.data.short_url;
+  }
+
+  /**
+   * Error handler when trying to fetch a short url for the permalink
+   * @param  {gmfx.ShortenerAPIResponse|angular.$http.HttpPromise} resp service response
+   * @private
+   */
+  function onError_(resp) {
+    this.shortLink = this.permalink;
+    this.errorOnGetShortUrl = true;
+  }
+
+};
+
+
+/**
+ * Send the short version of the permalink if the email is provided
+ * @export
+ */
+gmf.ShareController.prototype.sendShortUrl = function() {
+  if (this.$scope_['gmfShareForm'].$valid) {
+    this.$q_.when(this.gmfShareService_.sendShortUrl(this.permalink, this.email, this.message))
+      .then(
+        onSuccess_.bind(this),
+        onError_.bind(this)
+      );
+  }
+
+  /**
+   * Success handler when trying to send the short version of the permalink
+   * @param  {gmfx.ShortenerAPIResponse|angular.$http.HttpPromise} resp service response
+   * @private
+   */
+  function onSuccess_(resp) {
+    this.successfullySent = true;
+  }
+
+  /**
+   * Error handler when trying to to send the short version of the permalink
+   * @param  {gmfx.ShortenerAPIResponse|angular.$http.HttpPromise} resp service response
+   * @private
+   */
+  function onError_(resp) {
+    this.errorOnsend_ = true;
+  }
+
+};
+
+
+gmf.module.directive('gmfShare', gmf.shareDirective);
+gmf.module.controller('GmfShareController', gmf.ShareController);

--- a/contribs/gmf/src/services/share.js
+++ b/contribs/gmf/src/services/share.js
@@ -1,0 +1,112 @@
+goog.provide('gmf.ShareService');
+
+goog.require('gmf');
+
+
+/**
+ * Service to handle the sharing of the permalink.
+ * @param {angular.$http} $http Angular http service.
+ * @param  {string} gmfShortenerCreateUrl URL for the shortener API
+ * @constructor
+ * @ngInject
+ * @export
+ * @ngname gmfShareService
+ */
+gmf.ShareService = function($http, gmfShortenerCreateUrl) {
+
+  /**
+   * @type {angular.$http}
+   * @private
+   */
+  this.$http_ = $http;
+
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.gmfShortenerCreateUrl_ = gmfShortenerCreateUrl;
+
+};
+
+
+/**
+ * Get a short URL of the permalink by calling the url shortener service.
+ * - If no shortener API url have been specified, it returns the permalink itself.
+ * @param  {string} url the permalink
+ * @return {gmfx.ShortenerAPIResponse|angular.$http.HttpPromise} an object containing the permalink not shortened or
+ * the promise attached to the shortener API request
+ */
+gmf.ShareService.prototype.getShortUrl = function(url) {
+  var params = /** @type {gmfx.ShortenerAPIRequestParams} */ ({
+    url : url
+  });
+
+  if (!this.gmfShortenerCreateUrl_) {
+    return {
+      data : {
+        short_url : url
+      },
+      status : 200
+    };
+  }
+
+  return this.postShortUrl_(params);
+};
+
+
+/**
+ * Send the short permalink to the email provided
+ * - If email is provided, the short permalink will be sent to this email
+ * @param  {string} shortUrl the short permalink to send
+ * @param  {string} email the email to which the short url must be send
+ * @param  {string=} opt_message message for the email
+ * @return {angular.$http.HttpPromise} the promise attached to the shortener API request
+ */
+gmf.ShareService.prototype.sendShortUrl = function(shortUrl, email, opt_message) {
+  var params = /** @type {gmfx.ShortenerAPIRequestParams} */ ({
+    url : shortUrl,
+    email : email
+  });
+
+  if (opt_message) {
+    params['message'] = opt_message;
+  }
+
+  return this.postShortUrl_(params);
+};
+
+
+/**
+ * @param  {gmfx.ShortenerAPIRequestParams} params parameters for the request
+ * @return {angular.$http.HttpPromise} the promise attached to the shortener API request
+ * @private
+ */
+gmf.ShareService.prototype.postShortUrl_ = function(params) {
+  //Override default behavior of $http.post method (sending data in json format)
+  return this.$http_.post(this.gmfShortenerCreateUrl_, $.param(params), {
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'}
+  });
+};
+
+
+/**
+ * Max length defined for the complete url
+ * @constant
+ * @type {number}
+ * Check IE limits
+ * @see {@link http://support.microsoft.com/kb/208427}
+ */
+gmf.ShareService.URL_MAX_LEN = 2083;
+
+/**
+ * Max length defined for the url parth section
+ * @constant
+ * @type {number}
+ * Check IE limits
+ * @see {@link http://support.microsoft.com/kb/208427}
+ */
+gmf.ShareService.URL_PATH_MAX_LEN = 2048;
+
+
+gmf.module.service('gmfShareService', gmf.ShareService);

--- a/contribs/gmf/test/spec/beforeeach.js
+++ b/contribs/gmf/test/spec/beforeeach.js
@@ -5,6 +5,7 @@ beforeEach(function() {
   module('gmf', function($provide) {
     $provide.value('gmfTreeUrl', 'http://fake/gmf/themes');
     $provide.value('gmfWmsUrl', 'http://fake/gmf/mapserver');
+    $provide.value('gmfShortenerCreateUrl', 'http://fake/gmf/short/create');
     $provide.value('authenticationBaseUrl', 'https://fake/gmf/authentication');
   });
 });

--- a/contribs/gmf/test/spec/services/share.spec.js
+++ b/contribs/gmf/test/spec/services/share.spec.js
@@ -1,0 +1,58 @@
+/*global describe afterEach inject it*/
+/*eslint no-undef: "error"*/
+goog.require('gmf.ShareService');
+
+describe('gmf.ShareService', function() {
+  var gmfShareService;
+  var $httpBackend;
+  var shortenerUrl;
+  var successResponse = {
+    short_url : 'http://fake/gmf'
+  };
+
+  afterEach(function() {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  it('Should get a short version of the permalink', function() {
+    inject(function($injector) {
+      $httpBackend = $injector.get('$httpBackend');
+      $httpBackend.when('POST', shortenerUrl).respond(successResponse);
+      gmfShareService = $injector.get('gmfShareService');
+      shortenerUrl = $injector.get('gmfShortenerCreateUrl');
+    });
+
+    var permalink = 'htpp://fake/c2c/permalink';
+    var params = /** @type {gmfx.ShortenerAPIRequestParams} */ ({
+      url : permalink
+    });
+
+    $httpBackend.expectPOST(shortenerUrl, $.param(params));
+    gmfShareService.getShortUrl(permalink);
+    $httpBackend.flush();
+
+    params.email = 'fake@c2c.com';
+    $httpBackend.expectPOST(shortenerUrl, $.param(params));
+    gmfShareService.sendShortUrl(permalink, params.email);
+    $httpBackend.flush();
+
+  });
+
+  it('Should return the permalink if no URL for the shorten service has been provided', function() {
+    module(function($provide) {
+      $provide.value('gmfShortenerCreateUrl', '');
+    });
+
+    inject(function($injector) {
+      $httpBackend = $injector.get('$httpBackend');
+      $httpBackend.when('POST', shortenerUrl).respond(successResponse);
+      gmfShareService = $injector.get('gmfShareService');
+      shortenerUrl = $injector.get('gmfShortenerCreateUrl');
+    });
+
+    gmfShareService.getShortUrl(shortenerUrl);
+    $httpBackend.verifyNoOutstandingExpectation();
+
+  });
+});


### PR DESCRIPTION
Related to https://github.com/camptocamp/c2cgeoportal/issues/2071

**Demo:** 
- Desktop: https://oliviersemet.github.io/ngeo/share-permalink-feature/examples/contribs/gmf/apps/desktop/

- Desktop alt: https://oliviersemet.github.io/ngeo/share-permalink-feature/examples/contribs/gmf/apps/desktop_alt/

**Important**

- Currently the call to the Shortener API does not work (HTTP Bad request) because of a security reason. Indeed, the server check if the URL sended to be shortened is part of the domain  `geomapfish-demo.camptocamp.net` . Therefore it cannot work on my gh pages. @sbrunner will work on it.

- The _Desktop_ app use the Shortener API whereas the _Desktop Alt_ app does not (Testing the case when no Shortener API is available for the customer).

- In case of error, I display the following message ` Error, cannot get the shortened URL.` I'm not sure this is a good message for the customer. Please fill free to suggest an alternative.

- Despite the error when trying to get a short URL, a first review of the code can be done now.

**Test**

- [ ]  Shortener API calls are triggered only when the modal is shown. (Desktop)

- [ ]  Cannot share the shortened url as long as the email provided is invalid (Desktop)

- [ ]  In case of error when trying to get a short URL, the permalink field is filled with the original URL + error message (Desktop)

- [ ] A valid URL must be shortened (Desktop) _(currently not available)_

- [ ]  the permalink field is filled with the original URL because there is no Shortener API available  (Desktop Alt)

- [ ] A warning must be displayed when a very long URL (length > 2083) is provided (Both apps) 

@pgiraud @fredj @sbrunner could you have a look please? 