### PR TITLE
Rename 'displayqueries' to 'displayquerywindow'

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -116,10 +116,10 @@
           <gmf-disclaimer
             gmf-disclaimer-map="::mainCtrl.map">
           </gmf-disclaimer>
-          <gmf-displayqueries
-            gmf-displayqueries-featuresstyle="::mainCtrl.queryFeatureStyle"
-            gmf-displayqueries-desktop="true">
-          </gmf-displayqueries>
+          <gmf-displayquerywindow
+            gmf-displayquerywindow-featuresstyle="::mainCtrl.queryFeatureStyle"
+            gmf-displayquerywindow-desktop="true">
+          </gmf-displayquerywindow>
         </div>
         <gmf-map class="gmf-map" gmf-map-map="mainCtrl.map"
           ngeo-map-query=""

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -16,9 +16,9 @@
         ngeo-map-query=""
         ngeo-map-query-map="::mainCtrl.map"
         ngeo-map-query-active="mainCtrl.queryActive"></gmf-map>
-      <gmf-displayqueries
-        gmf-displayqueries-featuresstyle="::mainCtrl.queryFeatureStyle">
-      </gmf-displayqueries>
+      <gmf-displayquerywindow
+        gmf-displayquerywindow-featuresstyle="::mainCtrl.queryFeatureStyle">
+      </gmf-displayquerywindow>
       <div
         class="measure-tools-control"
         gmf-mobile-measurelength

--- a/contribs/gmf/examples/displayquerywindow.html
+++ b/contribs/gmf/examples/displayquerywindow.html
@@ -24,7 +24,7 @@
       }
 
       /* Display queries */
-      .displayqueries {
+      .displayquerywindow {
         max-height: 400px;
         width: 350px;
         max-width: 350px;
@@ -34,7 +34,7 @@
         left: 50%;
         right: 50%;
       }
-      .displayqueries .collapse-button {
+      .displayquerywindow .collapse-button {
         background-color: white;
         border: solid 1px black;
         border-bottom-width: 0;
@@ -44,27 +44,27 @@
         width: 48px;
         margin-left: calc(50% - 24px);
       }
-      .displayqueries .collapse-button.up:after {
+      .displayquerywindow .collapse-button.up:after {
         content: "\f077";
       }
-      .displayqueries .collapse-button.down:after {
+      .displayquerywindow .collapse-button.down:after {
         content: "\f078";
       }
-      .displayqueries .displayqueries-container {
+      .displayquerywindow .displayquerywindow-container {
         background-color: white;
         border: solid 1px black;
       }
-      .displayqueries .animation-container {
+      .displayquerywindow .animation-container {
         position: relative;
         overflow: hidden;
         height: 60px;
         margin: 0 15px;
         transition: 0.3s ease-in all;
       }
-      .displayqueries .animation-container.detailed {
+      .displayquerywindow .animation-container.detailed {
         height: 160px;
       }
-      .displayqueries .animation-container .slide-animation {
+      .displayquerywindow .animation-container .slide-animation {
         height: 100%;
         padding: 5px 5px 0;
         text-align: left;
@@ -75,91 +75,91 @@
         left: 0;
         right: 0;
       }
-      .displayqueries .slide-animation.ng-enter, .slide-animation.ng-leave {
+      .displayquerywindow .slide-animation.ng-enter, .slide-animation.ng-leave {
         transition: 0.3s ease-in all;
       }
       /* Left to right animation */
-      .displayqueries .next .slide-animation.ng-enter {
+      .displayquerywindow .next .slide-animation.ng-enter {
         left: 100%;
       }
-      .displayqueries .next .slide-animation.ng-enter-active {
+      .displayquerywindow .next .slide-animation.ng-enter-active {
         left: 0;
       }
-      .displayqueries .next .slide-animation.ng-leave {
+      .displayquerywindow .next .slide-animation.ng-leave {
         left: 0;
       }
-      .displayqueries .next .slide-animation.ng-leave-active {
+      .displayquerywindow .next .slide-animation.ng-leave-active {
         left: -100%;
       }
       /* Right to left animation */
-      .displayqueries .previous .slide-animation.ng-enter {
+      .displayquerywindow .previous .slide-animation.ng-enter {
         left: -100%;
       }
-      .displayqueries .previous .slide-animation.ng-enter-active {
+      .displayquerywindow .previous .slide-animation.ng-enter-active {
         left: 0;
       }
-      .displayqueries .previous .slide-animation.ng-leave {
+      .displayquerywindow .previous .slide-animation.ng-leave {
         left: 0;
       }
-      .displayqueries .previous .slide-animation.ng-leave-active {
+      .displayquerywindow .previous .slide-animation.ng-leave-active {
         left: 100%;
       }
-      .displayqueries .header .title {
+      .displayquerywindow .header .title {
         font-weight: bold;
       }
-      .displayqueries .header .subtitle {
+      .displayquerywindow .header .subtitle {
         margin-left: 10px;
         height: 2ex;
       }
-      .displayqueries .details {
+      .displayquerywindow .details {
         height: 65%;
         overflow-x: hidden;
         overflow-y: auto;
         margin-left: 10px;
         padding-bottom: 10px
       }
-      .displayqueries .details table {
+      .displayquerywindow .details table {
         font-size: 0.9em;
       }
-      .displayqueries .details .key {
+      .displayquerywindow .details .key {
         padding-right: 25px;
       }
-      .displayqueries .slide-animation.ng-enter-active .details .value {
+      .displayquerywindow .slide-animation.ng-enter-active .details .value {
         white-space: nowrap;
       }
-      .displayqueries .navigate {
+      .displayquerywindow .navigate {
         border-top: solid 1px black;
         text-align: center;
         margin-top: 10px;
         padding-top: 5px;
         height: 32px;
       }
-      .displayqueries button {
+      .displayquerywindow button {
         background: none;
         border: none;
         font-family: FontAwesome;
         width: 32px;
       }
-      .displayqueries button.close {
+      .displayquerywindow button.close {
         padding: 5px 5px 0 0;
       }
-      .displayqueries button.close:after {
+      .displayquerywindow button.close:after {
         content: "\f00d";
       }
-      .displayqueries .navigate .previous {
+      .displayquerywindow .navigate .previous {
         float: left;
       }
-      .displayqueries .navigate .previous:after {
+      .displayquerywindow .navigate .previous:after {
         content: "\f053";
       }
-      .displayqueries .navigate .next {
+      .displayquerywindow .navigate .next {
         float: right;
       }
-      .displayqueries .navigate .next:after {
+      .displayquerywindow .navigate .next:after {
         content: "\f054";
       }
       @media (max-width: 768px) {
-        .displayqueries {
+        .displayquerywindow {
           width: 100%;
           max-width: 100%;
           margin-left: -50%;
@@ -311,7 +311,7 @@
       example, the layer tree is responsible of creating the layer. You can
       switch theme and turn on/off layers to see the impact it has on results
       returned by the query service.
-      To display results, this example use the <code>gmf-displayqueries
+      To display results, this example use the <code>gmf-displayquerywindow
       </code> componant. Here, this last directive uses a custom style to
       display all selected features.</p>
     </p>
@@ -319,9 +319,9 @@
     <input type="checkbox"
        ng-model="ctrl.queryActive" /> Query-Tool active
 
-    <gmf-displayqueries
-      gmf-displayqueries-featuresstyle="ctrl.featureStyle">
-    </gmf-displayqueries>
+    <gmf-displayquerywindow
+      gmf-displayquerywindow-featuresstyle="ctrl.featureStyle">
+    </gmf-displayquerywindow>
 
     <script src="../../../node_modules/jquery/dist/jquery.js"></script>
     <script src="../third-party/jquery-ui/jquery-ui.min.js"></script>
@@ -335,7 +335,7 @@
     <script src="../../../node_modules/angular-ui-slider/src/slider.js"></script>
     <script src="../../../node_modules/angular-dynamic-locale/dist/tmhDynamicLocale.js" type="text/javascript"></script>
     <script src="../../../node_modules/proj4/dist/proj4.js"></script>
-    <script src="/@?main=mapquery.js"></script>
+    <script src="/@?main=displayquerywindow.js"></script>
     <script src="default.js"></script>
     <script src="../../../utils/watchwatchers.js"></script>
     <script>

--- a/contribs/gmf/examples/displayquerywindow.js
+++ b/contribs/gmf/examples/displayquerywindow.js
@@ -1,8 +1,8 @@
-goog.provide('gmf-mapquery');
+goog.provide('gmf-displayquerywindow');
 
 goog.require('gmf.QueryManager');
 goog.require('gmf.Themes');
-goog.require('gmf.displayqueriesDirective');
+goog.require('gmf.displayquerywindowDirective');
 goog.require('gmf.layertreeDirective');
 goog.require('gmf.mapDirective');
 goog.require('ngeo.proj.EPSG21781');
@@ -103,7 +103,7 @@ app.MainController = function(gmfThemes, gmfQueryManager,
   var stroke = new ol.style.Stroke({color: [255, 170, 0, 1], width: 2});
 
   /**
-   * FeatureStyle used by the displayqueries directive
+   * FeatureStyle used by the displayquerywindow directive
    * @type {ol.style.Style}
    * @export
    */

--- a/contribs/gmf/examples/wfs-permalink.html
+++ b/contribs/gmf/examples/wfs-permalink.html
@@ -17,7 +17,7 @@
       }
 
       /* Display queries */
-      .displayqueries {
+      .displayquerywindow {
         max-height: 400px;
         width: 350px;
         max-width: 350px;
@@ -26,7 +26,7 @@
         top: 20px;
         right: 0px;
       }
-      .displayqueries .collapse-button {
+      .displayquerywindow .collapse-button {
         background-color: white;
         border: solid 1px black;
         border-bottom-width: 0;
@@ -36,27 +36,27 @@
         width: 48px;
         margin-left: calc(50% - 24px);
       }
-      .displayqueries .collapse-button.up:after {
+      .displayquerywindow .collapse-button.up:after {
         content: "\f077";
       }
-      .displayqueries .collapse-button.down:after {
+      .displayquerywindow .collapse-button.down:after {
         content: "\f078";
       }
-      .displayqueries .displayqueries-container {
+      .displayquerywindow .displayquerywindow-container {
         background-color: white;
         border: solid 1px black;
       }
-      .displayqueries .animation-container {
+      .displayquerywindow .animation-container {
         position: relative;
         overflow: hidden;
         height: 60px;
         margin: 0 15px;
         transition: 0.3s ease-in all;
       }
-      .displayqueries .animation-container.detailed {
+      .displayquerywindow .animation-container.detailed {
         height: 160px;
       }
-      .displayqueries .animation-container .slide-animation {
+      .displayquerywindow .animation-container .slide-animation {
         height: 100%;
         padding: 5px 5px 0;
         text-align: left;
@@ -67,91 +67,91 @@
         left: 0;
         right: 0;
       }
-      .displayqueries .slide-animation.ng-enter, .slide-animation.ng-leave {
+      .displayquerywindow .slide-animation.ng-enter, .slide-animation.ng-leave {
         transition: 0.3s ease-in all;
       }
       /* Left to right animation */
-      .displayqueries .next .slide-animation.ng-enter {
+      .displayquerywindow .next .slide-animation.ng-enter {
         left: 100%;
       }
-      .displayqueries .next .slide-animation.ng-enter-active {
+      .displayquerywindow .next .slide-animation.ng-enter-active {
         left: 0;
       }
-      .displayqueries .next .slide-animation.ng-leave {
+      .displayquerywindow .next .slide-animation.ng-leave {
         left: 0;
       }
-      .displayqueries .next .slide-animation.ng-leave-active {
+      .displayquerywindow .next .slide-animation.ng-leave-active {
         left: -100%;
       }
       /* Right to left animation */
-      .displayqueries .previous .slide-animation.ng-enter {
+      .displayquerywindow .previous .slide-animation.ng-enter {
         left: -100%;
       }
-      .displayqueries .previous .slide-animation.ng-enter-active {
+      .displayquerywindow .previous .slide-animation.ng-enter-active {
         left: 0;
       }
-      .displayqueries .previous .slide-animation.ng-leave {
+      .displayquerywindow .previous .slide-animation.ng-leave {
         left: 0;
       }
-      .displayqueries .previous .slide-animation.ng-leave-active {
+      .displayquerywindow .previous .slide-animation.ng-leave-active {
         left: 100%;
       }
-      .displayqueries .header .title {
+      .displayquerywindow .header .title {
         font-weight: bold;
       }
-      .displayqueries .header .subtitle {
+      .displayquerywindow .header .subtitle {
         margin-left: 10px;
         height: 2ex;
       }
-      .displayqueries .details {
+      .displayquerywindow .details {
         height: 65%;
         overflow-x: hidden;
         overflow-y: auto;
         margin-left: 10px;
         padding-bottom: 10px
       }
-      .displayqueries .details table {
+      .displayquerywindow .details table {
         font-size: 0.9em;
       }
-      .displayqueries .details .key {
+      .displayquerywindow .details .key {
         padding-right: 25px;
       }
-      .displayqueries .slide-animation.ng-enter-active .details .value {
+      .displayquerywindow .slide-animation.ng-enter-active .details .value {
         white-space: nowrap;
       }
-      .displayqueries .navigate {
+      .displayquerywindow .navigate {
         border-top: solid 1px black;
         text-align: center;
         margin-top: 10px;
         padding-top: 5px;
         height: 32px;
       }
-      .displayqueries button {
+      .displayquerywindow button {
         background: none;
         border: none;
         font-family: FontAwesome;
         width: 32px;
       }
-      .displayqueries button.close {
+      .displayquerywindow button.close {
         padding: 5px 5px 0 0;
       }
-      .displayqueries button.close:after {
+      .displayquerywindow button.close:after {
         content: "\f00d";
       }
-      .displayqueries .navigate .previous {
+      .displayquerywindow .navigate .previous {
         float: left;
       }
-      .displayqueries .navigate .previous:after {
+      .displayquerywindow .navigate .previous:after {
         content: "\f053";
       }
-      .displayqueries .navigate .next {
+      .displayquerywindow .navigate .next {
         float: right;
       }
-      .displayqueries .navigate .next:after {
+      .displayquerywindow .navigate .next:after {
         content: "\f054";
       }
       @media (max-width: 768px) {
-        .displayqueries {
+        .displayquerywindow {
           width: 100%;
           max-width: 100%;
           margin-left: -50%;
@@ -198,9 +198,9 @@
       </ul>
     </p>
 
-    <gmf-displayqueries
-      gmf-displayqueries-featuresstyle="ctrl.featureStyle">
-    </gmf-displayqueries>
+    <gmf-displayquerywindow
+      gmf-displayquerywindow-featuresstyle="ctrl.featureStyle">
+    </gmf-displayquerywindow>
 
     <script src="../../../node_modules/jquery/dist/jquery.js"></script>
     <script src="../third-party/jquery-ui/jquery-ui.min.js"></script>

--- a/contribs/gmf/examples/wfs-permalink.js
+++ b/contribs/gmf/examples/wfs-permalink.js
@@ -1,7 +1,7 @@
 goog.provide('gmf-wfspermalink');
 
 goog.require('gmf.mapDirective');
-goog.require('gmf.displayqueriesDirective');
+goog.require('gmf.displayquerywindowDirective');
 goog.require('ngeo.proj.EPSG21781');
 goog.require('ngeo');
 goog.require('ol.Map');
@@ -62,7 +62,7 @@ app.MainController = function() {
   var stroke = new ol.style.Stroke({color: [255, 170, 0, 1], width: 2});
 
   /**
-   * FeatureStyle used by the displayqueries directive
+   * FeatureStyle used by the displayquerywindow directive
    * @type {ol.style.Style}
    * @export
    */

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -10,7 +10,7 @@
 @import 'search.less';
 @import 'popover.less';
 @import 'datepicker.less';
-@import 'displayqueries.less';
+@import 'displayquerywindow.less';
 @import 'timeslider.less';
 
 @map-tools-size: 3rem;
@@ -504,7 +504,7 @@ gmf-featurestyle {
   }
 }
 
-.displayqueries {
+.displayquerywindow {
   position: absolute;
   right: @app-margin;
 }

--- a/contribs/gmf/less/displayquerywindow.less
+++ b/contribs/gmf/less/displayquerywindow.less
@@ -1,10 +1,10 @@
 @import "../../../node_modules/font-awesome/less/variables.less";
 
-@displayqueries-tablet-width: 8 * @map-tools-size;
-.displayqueries {
-  width: @displayqueries-tablet-width;
-  max-width: @displayqueries-tablet-width;
-  margin-left: -@displayqueries-tablet-width / 2;
+@displayquerywindow-tablet-width: 8 * @map-tools-size;
+.displayquerywindow {
+  width: @displayquerywindow-tablet-width;
+  max-width: @displayquerywindow-tablet-width;
+  margin-left: -@displayquerywindow-tablet-width / 2;
   right: @app-margin + @map-tools-size + @app-margin;
   left: initial;
   bottom: @app-margin;
@@ -26,7 +26,7 @@
       content: @fa-var-chevron-down;
     }
   }
-  .displayqueries-container {
+  .displayquerywindow-container {
     background-color: @nav-bg;
     border: solid 1px @border-color;
     position: relative;
@@ -107,8 +107,8 @@
     .key {
       padding-right: @app-margin;
       /** prevent glitch for swipe animation **/
-      min-width: @displayqueries-tablet-width * 0.3 - @app-margin;
-      max-width: @displayqueries-tablet-width * 0.3 - @app-margin;
+      min-width: @displayquerywindow-tablet-width * 0.3 - @app-margin;
+      max-width: @displayquerywindow-tablet-width * 0.3 - @app-margin;
       overflow-x: hidden;
       text-overflow: ellipsis;
     }
@@ -116,8 +116,8 @@
       white-space: pre-wrap;
       word-break: break-all;
       /** prevent glitch for swipe animation **/
-      min-width: @displayqueries-tablet-width * 0.7 - @app-margin;
-      max-width: @displayqueries-tablet-width * 0.7 - @app-margin;
+      min-width: @displayquerywindow-tablet-width * 0.7 - @app-margin;
+      max-width: @displayquerywindow-tablet-width * 0.7 - @app-margin;
     }
     .slide-animation.ng-enter-active .details .value {
       white-space: nowrap;
@@ -181,7 +181,7 @@
   }
 }
 
-.displayqueries-mobile {
+.displayquerywindow-mobile {
   button.close {
     font-size: 21px;
   }
@@ -191,7 +191,7 @@
 }
 
 @media (max-width: @screen-sm-min) {
-  .displayqueries-mobile {
+  .displayquerywindow-mobile {
     width: 100%;
     max-width: 100%;
     margin-left: -50%;

--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -9,7 +9,7 @@
 @import 'fullscreenpopup.less';
 @import 'mobile-nav.less';
 @import 'icons.less';
-@import 'displayqueries.less';
+@import 'displayquerywindow.less';
 
 /**
  * Mobile specific css only !

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -14,7 +14,7 @@ goog.require('gmf.Themes');
 /** @suppress {extraRequire} */
 goog.require('gmf.disclaimerDirective');
 /** @suppress {extraRequire} */
-goog.require('gmf.displayqueriesDirective');
+goog.require('gmf.displayquerywindowDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.layertreeDirective');
 /** @suppress {extraRequire} */
@@ -144,7 +144,7 @@ gmf.AbstractController = function(config, $scope, $injector) {
   var queryStroke = new ol.style.Stroke({color: [255, 170, 0, 1], width: 2});
 
   /**
-   * FeatureStyle used by the displayqueries directive
+   * FeatureStyle used by the displayquerywindow directive
    * @type {ol.style.Style}
    * @export
    */

--- a/contribs/gmf/src/controllers/abstractmobile.js
+++ b/contribs/gmf/src/controllers/abstractmobile.js
@@ -3,7 +3,7 @@ goog.provide('gmf.AbstractMobileController');
 goog.require('gmf');
 goog.require('gmf.AbstractController');
 /** @suppress {extraRequire} */
-goog.require('gmf.displayqueriesDirective');
+goog.require('gmf.displayquerywindowDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.mobileMeasurelengthDirective');
 /** @suppress {extraRequire} */

--- a/contribs/gmf/src/directives/displayquerywindow.js
+++ b/contribs/gmf/src/directives/displayquerywindow.js
@@ -1,5 +1,5 @@
-goog.provide('gmf.DisplayqueriesController');
-goog.provide('gmf.displayqueriesDirective');
+goog.provide('gmf.DisplayquerywindowController');
+goog.provide('gmf.displayquerywindowDirective');
 
 goog.require('gmf');
 goog.require('ngeo.FeatureOverlay');
@@ -11,16 +11,16 @@ goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 
 
-ngeo.module.value('gmfDisplayqueriesTemplateUrl',
+ngeo.module.value('gmfDisplayquerywindowTemplateUrl',
     /**
      * @param {angular.JQLite} element Element.
      * @param {angular.Attributes} attrs Attributes.
      * @return {string} Template.
      */
     function(element, attrs) {
-      var templateUrl = attrs['gmfDisplayqueriesTemplateurl'];
+      var templateUrl = attrs['gmfDisplayquerywindowTemplateurl'];
       return templateUrl !== undefined ? templateUrl :
-          gmf.baseTemplateUrl + '/displayqueries.html';
+          gmf.baseTemplateUrl + '/displayquerywindow.html';
     });
 
 
@@ -29,19 +29,19 @@ ngeo.module.value('gmfDisplayqueriesTemplateUrl',
  * and shows related features on the map using the {@link ngeo.FeatureOverlayMgr}.
  *
  * You can override the default directive's template by setting the
- * value `gmfDisplayqueriesTemplateUrl`.
+ * value `gmfDisplayquerywindowTemplateUrl`.
  *
  * Features displayed on the map use a default style but you can override these
  * styles by passing ol.style.Style objects as attributes of this directive.
  *
  * Example:
  *
- *      <gmf-displayqueries
- *        gmf-displayqueries-featuresstyle="ctrl.styleForAllFeatures"
- *        gmf-displayqueries-selectedfeaturestyle="ctrl.styleForTheCurrentFeature">
- *      </gmf-displayqueries>
+ *      <gmf-displayquerywindow
+ *        gmf-displayquerywindow-featuresstyle="ctrl.styleForAllFeatures"
+ *        gmf-displayquerywindow-selectedfeaturestyle="ctrl.styleForTheCurrentFeature">
+ *      </gmf-displayquerywindow>
  *
- * @htmlAttribute {ol.style.Style} gmf-displayqueries-featuresstyle A style
+ * @htmlAttribute {ol.style.Style} gmf-displayquerywindow-featuresstyle A style
  *     object for all features from the result of the query.
  * @htmlAttribute {ol.style.Style} selectedfeaturestyle A style
  *     object for the current displayed feature.
@@ -49,32 +49,32 @@ ngeo.module.value('gmfDisplayqueriesTemplateUrl',
  *     application.
  * @htmlAttribute {boolean} showunqueriedlayers If also layers, that have not
  *     been queried for the last query, should be shown in the filter.
- * @param {string} gmfDisplayqueriesTemplateUrl URL to a template.
+ * @param {string} gmfDisplayquerywindowTemplateUrl URL to a template.
  * @return {angular.Directive} Directive Definition Object.
  * @ngInject
  * @ngdoc directive
- * @ngname gmfDisplayqueries
+ * @ngname gmfDisplayquerywindow
  */
-gmf.displayqueriesDirective = function(
-    gmfDisplayqueriesTemplateUrl) {
+gmf.displayquerywindowDirective = function(
+    gmfDisplayquerywindowTemplateUrl) {
   return {
     bindToController: true,
-    controller: 'GmfDisplayqueriesController',
+    controller: 'GmfDisplayquerywindowController',
     controllerAs: 'ctrl',
-    templateUrl: gmfDisplayqueriesTemplateUrl,
+    templateUrl: gmfDisplayquerywindowTemplateUrl,
     replace: true,
     restrict: 'E',
     scope: {
-      'featuresStyleFn': '&gmfDisplayqueriesFeaturesstyle',
-      'selectedFeatureStyleFn': '&gmfDisplayqueriesSelectedfeaturestyle',
-      'desktopIn': '=gmfDisplayqueriesDesktop',
-      'showUnqueriedLayersIn': '=gmfDisplayqueriesShowunqueriedlayers'
+      'featuresStyleFn': '&gmfDisplayquerywindowFeaturesstyle',
+      'selectedFeatureStyleFn': '&gmfDisplayquerywindowSelectedfeaturestyle',
+      'desktopIn': '=gmfDisplayquerywindowDesktop',
+      'showUnqueriedLayersIn': '=gmfDisplayquerywindowShowunqueriedlayers'
     }
   };
 };
 
 
-gmf.module.directive('gmfDisplayqueries', gmf.displayqueriesDirective);
+gmf.module.directive('gmfDisplayquerywindow', gmf.displayquerywindowDirective);
 
 
 /**
@@ -86,9 +86,9 @@ gmf.module.directive('gmfDisplayqueries', gmf.displayqueriesDirective);
  * @export
  * @ngInject
  * @ngdoc Controller
- * @ngname GmfDisplayqueriesController
+ * @ngname GmfDisplayquerywindowController
  */
-gmf.DisplayqueriesController = function($scope, ngeoQueryResult,
+gmf.DisplayquerywindowController = function($scope, ngeoQueryResult,
     ngeoFeatureOverlayMgr) {
 
   /**
@@ -234,7 +234,7 @@ gmf.DisplayqueriesController = function($scope, ngeoQueryResult,
  * highlight the first feature.
  * @export
  */
-gmf.DisplayqueriesController.prototype.show = function() {
+gmf.DisplayquerywindowController.prototype.show = function() {
   this.clear();
   this.updateFeatures_();
 };
@@ -243,7 +243,7 @@ gmf.DisplayqueriesController.prototype.show = function() {
 /**
  * @private
  */
-gmf.DisplayqueriesController.prototype.updateFeatures_ = function() {
+gmf.DisplayquerywindowController.prototype.updateFeatures_ = function() {
   this.setCurrentResult_(0, false);
   if (this.source !== null) {
     this.collectFeatures_();
@@ -261,7 +261,7 @@ gmf.DisplayqueriesController.prototype.updateFeatures_ = function() {
  * @return {boolean} True if result has changed. False else.
  * @private
  */
-gmf.DisplayqueriesController.prototype.setCurrentResult_ = function(
+gmf.DisplayquerywindowController.prototype.setCurrentResult_ = function(
     position, setHighlight) {
   var hasChanged = false;
   if (position !== this.currentResult) {
@@ -298,7 +298,7 @@ gmf.DisplayqueriesController.prototype.setCurrentResult_ = function(
  * the map.
  * @export
  */
-gmf.DisplayqueriesController.prototype.previous = function() {
+gmf.DisplayquerywindowController.prototype.previous = function() {
   var position = this.currentResult - 1;
   if (position < 0) {
     position = this.getResultLength() - 1;
@@ -315,7 +315,7 @@ gmf.DisplayqueriesController.prototype.previous = function() {
  * the map.
  * @export
  */
-gmf.DisplayqueriesController.prototype.next = function() {
+gmf.DisplayquerywindowController.prototype.next = function() {
   var position = this.currentResult + 1;
   var positionMax = this.getResultLength() - 1;
   if (position > positionMax) {
@@ -334,7 +334,7 @@ gmf.DisplayqueriesController.prototype.next = function() {
  * @return {number} Total number of features.
  * @export
  */
-gmf.DisplayqueriesController.prototype.getResultLength = function() {
+gmf.DisplayquerywindowController.prototype.getResultLength = function() {
   if (this.selectedSource === null) {
     return this.ngeoQueryResult.total;
   } else {
@@ -347,7 +347,7 @@ gmf.DisplayqueriesController.prototype.getResultLength = function() {
  * @return {boolean} If the first result is active.
  * @export
  */
-gmf.DisplayqueriesController.prototype.isFirst = function() {
+gmf.DisplayquerywindowController.prototype.isFirst = function() {
   return this.currentResult == 0;
 };
 
@@ -356,7 +356,7 @@ gmf.DisplayqueriesController.prototype.isFirst = function() {
  * @return {boolean} If the last result is active.
  * @export
  */
-gmf.DisplayqueriesController.prototype.isLast = function() {
+gmf.DisplayquerywindowController.prototype.isLast = function() {
   return this.currentResult == this.getResultLength() - 1;
 };
 
@@ -367,7 +367,7 @@ gmf.DisplayqueriesController.prototype.isLast = function() {
  * @return {Object?} Filtered properties of the current feature or null.
  * @export
  */
-gmf.DisplayqueriesController.prototype.getFeatureValues = function() {
+gmf.DisplayquerywindowController.prototype.getFeatureValues = function() {
   if (!this.feature) {
     return null;
   }
@@ -387,7 +387,7 @@ gmf.DisplayqueriesController.prototype.getFeatureValues = function() {
  * or the previous result.
  * @private
  */
-gmf.DisplayqueriesController.prototype.animate_ = function(isNext) {
+gmf.DisplayquerywindowController.prototype.animate_ = function(isNext) {
   this.isNext = isNext;
   this.scope_.$evalAsync(function() {
     this.animate++;
@@ -399,7 +399,7 @@ gmf.DisplayqueriesController.prototype.animate_ = function(isNext) {
  * Collect all features in the queryResult object.
  * @private
  */
-gmf.DisplayqueriesController.prototype.collectFeatures_ = function() {
+gmf.DisplayquerywindowController.prototype.collectFeatures_ = function() {
   var sources = this.ngeoQueryResult.sources;
   this.features_.clear();
   for (var i = 0; i < sources.length; i++) {
@@ -422,7 +422,7 @@ gmf.DisplayqueriesController.prototype.collectFeatures_ = function() {
  * it exists because it must be added to the 'non-selected' features collection.
  * @private
  */
-gmf.DisplayqueriesController.prototype.highlightCurrentFeature_ =
+gmf.DisplayquerywindowController.prototype.highlightCurrentFeature_ =
 function(opt_lastFeature) {
   this.highlightFeatures_.clear();
   this.features_.remove(this.feature);
@@ -438,7 +438,7 @@ function(opt_lastFeature) {
  * from the map.
  * @export
  */
-gmf.DisplayqueriesController.prototype.close = function() {
+gmf.DisplayquerywindowController.prototype.close = function() {
   this.open = false;
   this.clear();
 };
@@ -449,7 +449,7 @@ gmf.DisplayqueriesController.prototype.close = function() {
  * from the map.
  * @export
  */
-gmf.DisplayqueriesController.prototype.clear = function() {
+gmf.DisplayquerywindowController.prototype.clear = function() {
   this.feature = null;
   this.source = null;
   this.currentResult = -1;
@@ -463,7 +463,7 @@ gmf.DisplayqueriesController.prototype.clear = function() {
  * @param {ngeox.QueryResultSource} source The source to select.
  * @export
  */
-gmf.DisplayqueriesController.prototype.setSelectedSource = function(source) {
+gmf.DisplayquerywindowController.prototype.setSelectedSource = function(source) {
   if (source !== null && source.features.length <= 0) {
     // sources with no results can not be selected
     return;
@@ -474,4 +474,4 @@ gmf.DisplayqueriesController.prototype.setSelectedSource = function(source) {
 };
 
 
-gmf.module.controller('GmfDisplayqueriesController', gmf.DisplayqueriesController);
+gmf.module.controller('GmfDisplayquerywindowController', gmf.DisplayquerywindowController);

--- a/contribs/gmf/src/directives/partials/displayquerywindow.html
+++ b/contribs/gmf/src/directives/partials/displayquerywindow.html
@@ -1,8 +1,8 @@
-<div class="displayqueries" ng-class="{'displayqueries-desktop': ctrl.desktop, 'displayqueries-mobile': !ctrl.desktop}"
+<div class="displayquerywindow" ng-class="{'displayquerywindow-desktop': ctrl.desktop, 'displayquerywindow-mobile': !ctrl.desktop}"
      ng-show="ctrl.open" ng-swipe-disable-mouse ng-swipe-left="ctrl.next()" ng-swipe-right="ctrl.previous()">
   <button class="collapse-button" type="button" ng-show="::!ctrl.desktop"
           ng-click="ctrl.collapsed = !ctrl.collapsed" ng-class="[ctrl.collapsed ? 'up' : 'down']"></button>
-  <div class="displayqueries-container">
+  <div class="displayquerywindow-container">
     <button type="button" class="btn fa-close close" ng-click="ctrl.close()"></button>
     <div class="animation-container" ng-class="[ctrl.collapsed ? '' : 'detailed', ctrl.isNext ? 'next' : 'previous']">
       <div ng-animate-swap="ctrl.animate" class="slide-animation">

--- a/contribs/gmf/test/spec/directives/displayqueries.spec.js
+++ b/contribs/gmf/test/spec/directives/displayqueries.spec.js
@@ -1,6 +1,6 @@
-goog.require('gmf.displayqueriesDirective');
+goog.require('gmf.displayquerywindowDirective');
 
-describe('gmf.displayqueriesDirective', function() {
+describe('gmf.displayquerywindowDirective', function() {
 
   var displayQueriesController;
   var ngeoQueryResult;
@@ -21,7 +21,7 @@ describe('gmf.displayqueriesDirective', function() {
       }
     };
     displayQueriesController = $controller(
-        'GmfDisplayqueriesController', {$scope: $scope}, data);
+        'GmfDisplayquerywindowController', {$scope: $scope}, data);
   }));
 
   describe('#show', function() {


### PR DESCRIPTION
Fix #1534 

Example: http://ger-benjamin.github.io/ngeo/displayquerynames/examples/contribs/gmf/
Apidoc: http://ger-benjamin.github.io/ngeo/displayquerynames/apidoc