### PR TITLE
Store the name of the selected theme in localStorage

### DIFF
--- a/contribs/gmf/src/directives/themeselector.js
+++ b/contribs/gmf/src/directives/themeselector.js
@@ -48,6 +48,7 @@ gmf.module.directive('gmfThemeselector', gmf.themeselectorDirective);
  * @param {ngeo.Location} ngeoLocation ngeo Location service.
  * @param {gmf.TreeManager} gmfTreeManager Tree manager service.
  * @param {gmf.Themes} gmfThemes Themes service.
+ * @param {ngeo.StateManager} ngeoStateManager The ngeo StateManager service.
  * @constructor
  * @export
  * @ngInject
@@ -55,7 +56,7 @@ gmf.module.directive('gmfThemeselector', gmf.themeselectorDirective);
  * @ngname gmfThemeselectorController
  */
 gmf.ThemeselectorController = function($scope, ngeoLocation, gmfTreeManager,
-    gmfThemes) {
+    gmfThemes, ngeoStateManager) {
 
   /**
    * @type {ngeo.Location}
@@ -98,6 +99,12 @@ gmf.ThemeselectorController = function($scope, ngeoLocation, gmfTreeManager,
    * @export
    */
   this.filter;
+
+  /**
+   * @type {ngeo.StateManager}
+   * @private
+   */
+  this.ngeoStateManager_ = ngeoStateManager;
 
   $scope.$watchCollection(function() {
     return this.currentTheme;
@@ -161,7 +168,8 @@ gmf.ThemeselectorController.prototype.setThemes_ = function() {
     // Then set current theme by looking first in the URL (only in,
     // otherwise use the default theme and add it to the URL.
     var currentTheme;
-    var themeName = this.defaultTheme;
+    var themeName = /** @type {string} */
+      (this.ngeoStateManager_.getInitialValue('theme') || this.defaultTheme);
     if (this.gmfTreeManager_.isModeFlush()) {
       var pathElements = this.ngeoLocation_.getPath().split('/');
       if (gmf.ThemeselectorController.themeInUrl(pathElements)) {

--- a/contribs/gmf/src/services/treemanager.js
+++ b/contribs/gmf/src/services/treemanager.js
@@ -114,6 +114,9 @@ gmf.TreeManager.prototype.addTheme = function(theme, opt_init) {
   var treeGroups = /** @type {string} */ (this.ngeoStateManager_.getInitialValue(
     gmf.PermalinkParam.TREE_GROUPS));
   if (this.isModeFlush()) {
+    this.ngeoStateManager_.updateState({
+      'theme' : theme.name
+    });
     this.tree.name = theme.name;
   }
   if (opt_init && treeGroups !== undefined) {


### PR DESCRIPTION
Close #1026 

**Flush you localStorage before test**

Demo: https://oliviersemet.github.io/ngeo/store-theme-in-localstorage/examples/contribs/gmf/apps/desktop/

1. Load the [app](https://oliviersemet.github.io/ngeo/store-theme-in-localstorage/examples/contribs/gmf/apps/desktop/) with the default theme
2. Select any theme but not the default one (OSM)
3. Open the [app](https://oliviersemet.github.io/ngeo/store-theme-in-localstorage/examples/contribs/gmf/apps/desktop/) into an other tab

- [x] The name of the theme displayed matches the previous selected theme 
- [x] Url contains the good theme

@fredj @pgiraud @sbrunner 