### PR TITLE
Add configuration variable to decide if the query result window is open or closed.

### DIFF
--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -17,7 +17,8 @@
         ngeo-map-query-map="::mainCtrl.map"
         ngeo-map-query-active="mainCtrl.queryActive"></gmf-map>
       <gmf-displayquerywindow
-        gmf-displayquerywindow-featuresstyle="::mainCtrl.queryFeatureStyle">
+        gmf-displayquerywindow-featuresstyle="::mainCtrl.queryFeatureStyle"
+        gmf-displayquerywindow-defaultcollapsed="false">
       </gmf-displayquerywindow>
       <div
         class="measure-tools-control"

--- a/contribs/gmf/src/directives/displayquerywindow.js
+++ b/contribs/gmf/src/directives/displayquerywindow.js
@@ -45,7 +45,7 @@ ngeo.module.value('gmfDisplayquerywindowTemplateUrl',
  *     object for all features from the result of the query.
  * @htmlAttribute {ol.style.Style} selectedfeaturestyle A style
  *     object for the current displayed feature.
- * @htmlAttribute {boolean} defaultcollapsed If the query result window is
+ * @htmlAttribute {boolean=} defaultcollapsed If the query result window is
  *     collapsed.
  * @htmlAttribute {boolean} desktop If the directive is used in the desktop
  *     application.
@@ -69,7 +69,7 @@ gmf.displayquerywindowDirective = function(
     scope: {
       'featuresStyleFn': '&gmfDisplayquerywindowFeaturesstyle',
       'selectedFeatureStyleFn': '&gmfDisplayquerywindowSelectedfeaturestyle',
-      'defaultCollapsed': '=gmfDisplayquerywindowDefaultcollapsed',
+      'defaultCollapsedFn': '&?gmfDisplayquerywindowDefaultcollapsed',
       'desktopIn': '=gmfDisplayquerywindowDesktop',
       'showUnqueriedLayersIn': '=gmfDisplayquerywindowShowunqueriedlayers'
     }
@@ -112,8 +112,8 @@ gmf.DisplayquerywindowController = function($scope, ngeoQueryResult,
    * @type {boolean}
    * @export
    */
-  this.collapsed = this['defaultCollapsed'] !== undefined ?
-    this['defaultCollapsed'] === true : !this.desktop;
+  this.collapsed = this['defaultCollapsedFn'] !== undefined ?
+    this['defaultCollapsedFn']() === true : !this.desktop;
 
   /**
    * @type {boolean}

--- a/contribs/gmf/src/directives/displayquerywindow.js
+++ b/contribs/gmf/src/directives/displayquerywindow.js
@@ -45,6 +45,8 @@ ngeo.module.value('gmfDisplayquerywindowTemplateUrl',
  *     object for all features from the result of the query.
  * @htmlAttribute {ol.style.Style} selectedfeaturestyle A style
  *     object for the current displayed feature.
+ * @htmlAttribute {boolean} defaultcollapsed If the query result window is
+ *     collapsed.
  * @htmlAttribute {boolean} desktop If the directive is used in the desktop
  *     application.
  * @htmlAttribute {boolean} showunqueriedlayers If also layers, that have not
@@ -67,6 +69,7 @@ gmf.displayquerywindowDirective = function(
     scope: {
       'featuresStyleFn': '&gmfDisplayquerywindowFeaturesstyle',
       'selectedFeatureStyleFn': '&gmfDisplayquerywindowSelectedfeaturestyle',
+      'defaultCollapsed': '=gmfDisplayquerywindowDefaultcollapsed',
       'desktopIn': '=gmfDisplayquerywindowDesktop',
       'showUnqueriedLayersIn': '=gmfDisplayquerywindowShowunqueriedlayers'
     }
@@ -109,7 +112,8 @@ gmf.DisplayquerywindowController = function($scope, ngeoQueryResult,
    * @type {boolean}
    * @export
    */
-  this.collapsed = !this.desktop;
+  this.collapsed = this['defaultCollapsed'] !== undefined ?
+    this['defaultCollapsed'] === true : !this.desktop;
 
   /**
    * @type {boolean}


### PR DESCRIPTION
fixes issue #781.

(Example: https://marionb.github.io/ngeo/default_open_query/examples/contribs/gmf/apps/mobile/index.html)