### PR TITLE
Display azimuth of circles in the redlining tools

### DIFF
--- a/contribs/gmf/examples/featurestyle.html
+++ b/contribs/gmf/examples/featurestyle.html
@@ -91,6 +91,7 @@
   <body ng-controller="MainController as ctrl">
     <gmf-map gmf-map-map="ctrl.map"></gmf-map>
     <gmf-featurestyle
+      gmf-featurestyle-map="ctrl.map"
       gmf-featurestyle-feature="ctrl.selectedFeature">
     </gmf-featurestyle>
 

--- a/contribs/gmf/src/directives/drawfeature.js
+++ b/contribs/gmf/src/directives/drawfeature.js
@@ -304,11 +304,11 @@ gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
     }.bind(this),
     function(newFeature, previousFeature) {
       if (previousFeature) {
-        this.featureHelper_.setStyle(previousFeature);
+        this.featureHelper_.setStyle(previousFeature, undefined, this.map);
         this.selectedFeatures.clear();
       }
       if (newFeature) {
-        this.featureHelper_.setStyle(newFeature, true);
+        this.featureHelper_.setStyle(newFeature, true, this.map);
         this.selectedFeatures.push(newFeature);
         if (this.listSelectionInProgress_) {
           this.featureHelper_.panMapToFeature(newFeature, this.map);

--- a/contribs/gmf/src/directives/featurestyle.js
+++ b/contribs/gmf/src/directives/featurestyle.js
@@ -13,10 +13,12 @@ goog.require('ngeo.colorpickerDirective');
  * Example:
  *
  *     <gmf-featurestyle
- *         gmf-featurestyle-feature="ctrl.selectedFeature">
+ *         gmf-featurestyle-feature="ctrl.selectedFeature"
+ *         gmf-featurestyle-map="ctrl.map">
  *     </gmf-featurestyle>
  *
  * @htmlAttribute {ol.Feature} gmf-featurestyle-feature The feature.
+ * @htmlAttribute {ol.Map} gmf-featurestyle-map map.
  * @return {angular.Directive} The directive specs.
  * @ngInject
  * @ngdoc directive
@@ -26,7 +28,8 @@ gmf.featurestyleDirective = function() {
   return {
     controller: 'GmfFeaturestyleController',
     scope: {
-      'feature': '=gmfFeaturestyleFeature'
+      'feature': '=gmfFeaturestyleFeature',
+      'map': '=gmfFeaturestyleMap'
     },
     bindToController: true,
     controllerAs: 'fsCtrl',
@@ -46,6 +49,12 @@ gmf.module.directive('gmfFeaturestyle', gmf.featurestyleDirective);
  * @ngname GmfFeaturestyleController
  */
 gmf.FeaturestyleController = function($scope, ngeoFeatureHelper) {
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
 
   /**
    * @type {?ol.Feature}
@@ -102,6 +111,12 @@ gmf.FeaturestyleController = function($scope, ngeoFeatureHelper) {
     }.bind(this),
     this.handleFeatureSet_.bind(this)
   );
+
+  ol.events.listen(
+      this.map,
+      'moveend',
+      this.handleMoveEnd_,
+      this);
 
 };
 
@@ -272,7 +287,24 @@ gmf.FeaturestyleController.prototype.handleFeatureChange_ = function() {
     return;
   }
 
-  this.featureHelper_.setStyle(feature, true);
+  this.featureHelper_.setStyle(feature, true, this.map);
+};
+
+
+/**
+ * @private
+ */
+gmf.FeaturestyleController.prototype.handleMoveEnd_ = function() {
+  var feature = this.feature;
+
+  if (!feature) {
+    return;
+  }
+
+  // If we zoom in or out we need to update the circle's measure labels offsets
+  if (this.featureHelper_.getType(feature) === ngeo.GeometryType.CIRCLE) {
+    this.featureHelper_.setStyle(feature, true, this.map);
+  }
 };
 
 

--- a/contribs/gmf/src/directives/partials/drawfeature.html
+++ b/contribs/gmf/src/directives/partials/drawfeature.html
@@ -145,6 +145,7 @@
     <div class="gmf-eol"></div>
 
     <gmf-featurestyle
+      gmf-featurestyle-map="efCtrl.map"
       gmf-featurestyle-feature="efCtrl.selectedFeature">
     </gmf-featurestyle>
   </div>

--- a/contribs/gmf/src/directives/partials/featurestyle.html
+++ b/contribs/gmf/src/directives/partials/featurestyle.html
@@ -119,7 +119,7 @@
           for="gmf-featurestyle-showmeasure"
           class="control-label">
         <span ng-switch-when="Circle">
-          {{'Display surface' | translate}}
+          {{'Display azimuth and radius' | translate}}
         </span>
         <span ng-switch-when="Polygon">
           {{'Display surface' | translate}}

--- a/src/directives/drawfeature.js
+++ b/src/directives/drawfeature.js
@@ -266,6 +266,9 @@ ngeo.DrawfeatureController.prototype.handleDrawEnd = function(type, event) {
   switch (type) {
     case ngeo.GeometryType.CIRCLE:
       feature.set(prop.IS_CIRCLE, true);
+      if (event.feature.get('radiusGeom')) {
+        feature.set(prop.RADIUS_GEOM, event.feature.get('radiusGeom'));
+      }
       break;
     case ngeo.GeometryType.TEXT:
       feature.set(prop.IS_TEXT, true);
@@ -296,7 +299,7 @@ ngeo.DrawfeatureController.prototype.handleDrawEnd = function(type, event) {
   feature.set(prop.STROKE, 1);
 
   // set style
-  this.featureHelper_.setStyle(feature);
+  this.featureHelper_.setStyle(feature, undefined, this.map);
 
   // push in collection
   this.features_.push(feature);

--- a/src/directives/measureazimut.js
+++ b/src/directives/measureazimut.js
@@ -59,6 +59,8 @@ ngeo.measureazimutDirective = function($compile, gettext, $filter) {
                 geometry.getGeometries()[1]);
             var polygon = ol.geom.Polygon.fromCircle(circle, 64);
             event.feature = new ol.Feature(polygon);
+            event.feature.set('radiusGeom', geometry.getGeometries()[0]);
+
             drawFeatureCtrl.handleDrawEnd(ngeo.GeometryType.CIRCLE, event);
           },
           drawFeatureCtrl

--- a/src/ngeo.js
+++ b/src/ngeo.js
@@ -56,6 +56,12 @@ ngeo.FeatureProperties = {
    */
   OPACITY: 'o',
   /**
+   * Needed for circles to keep their azimuths
+   * @type {ol.geom.LineString}
+   * @export
+   */
+  RADIUS_GEOM: 'g',
+  /**
    * @type {string}
    * @export
    */

--- a/src/ol-ext/interaction/measureazimut.js
+++ b/src/ol-ext/interaction/measureazimut.js
@@ -78,18 +78,42 @@ ngeo.interaction.MeasureAzimut.prototype.handleMeasure = function(callback) {
   var geom = /** @type {ol.geom.GeometryCollection} */
       (this.sketchFeature.getGeometry());
   var line = /** @type {ol.geom.LineString} */ (geom.getGeometries()[0]);
-  var output = this.formatMeasure_(line);
+  var output = ngeo.interaction.MeasureAzimut.getFormattedAzimuthRadius(line, this.getMap().getView().getProjection(), this.decimals, this.format);
   callback(output, line.getLastCoordinate());
 };
 
 
 /**
- * Format measure output.
+ * Format measure output of azimuth and radius.
  * @param {ol.geom.LineString} line LineString.
+ * @param {ol.proj.Projection} projection Projection of the polygon coords.
+ * @param {?number} decimals Decimals.
+ * @param {ngeox.unitPrefix} format The format function.
  * @return {string} Formated measure.
- * @private
  */
-ngeo.interaction.MeasureAzimut.prototype.formatMeasure_ = function(line) {
+ngeo.interaction.MeasureAzimut.getFormattedAzimuthRadius = function(
+    line, projection, decimals, format) {
+
+  var output = ngeo.interaction.MeasureAzimut.getFormattedAzimuth(
+    line, projection, decimals, format);
+
+  output += ', ' + ngeo.interaction.Measure.getFormattedLength(
+      line, projection, decimals, format);
+
+  return output;
+};
+
+
+/**
+ * Format measure output of azimuth.
+ * @param {ol.geom.LineString} line LineString.
+ * @param {ol.proj.Projection} projection Projection of the polygon coords.
+ * @param {?number} decimals Decimals.
+ * @param {ngeox.unitPrefix} format The format function.
+ * @return {string} Formated measure.
+ */
+ngeo.interaction.MeasureAzimut.getFormattedAzimuth = function(
+    line, projection, decimals, format) {
   var coords = line.getCoordinates();
   var dx = coords[1][0] - coords[0][0];
   var dy = coords[1][1] - coords[0][1];
@@ -97,10 +121,6 @@ ngeo.interaction.MeasureAzimut.prototype.formatMeasure_ = function(line) {
   var factor = dx > 0 ? 1 : -1;
   var azimut = Math.round(factor * rad * 180 / Math.PI) % 360;
   var output = azimut + '°';
-  var proj = this.getMap().getView().getProjection();
-  var dec = this.decimals;
-  output += '<br/>' + ngeo.interaction.Measure.getFormattedLength(
-      line, proj, dec, this.format);
   return output;
 };
 
@@ -390,6 +410,7 @@ ngeo.interaction.DrawAzimut.prototype.finishDrawing_ = function() {
   if (this.source_ !== null) {
     this.source_.addFeature(sketchFeature);
   }
+
   this.dispatchEvent(new ol.interaction.DrawEvent(
       ol.interaction.DrawEventType.DRAWEND, sketchFeature));
 };


### PR DESCRIPTION
This commit is a work in progress for the following ticket: https://github.com/camptocamp/c2cgeoportal/issues/2258

This change replaces the Display surface with a "Display azimuth and radius" checkbox in the gmf feature style.

When you draw a new circle in the gmf drawfeature, you can now check that new box and the azimuth will be displayed in the corner nearest to the azimuth angle. It'll also display the line of the radius and it's length. It'll look like this:

![image](https://cloud.githubusercontent.com/assets/4561544/16861557/cbc4b4d8-4a0f-11e6-93d2-952fade922aa.png)

To be able to do this the circle feature had to "remember" where it's radius is, so it's saved as a property of the feature. I tried keeping it as a geometry collection but it caused a ton of problem, notably in the permalink when it tries to hash the feature.

You can test it out here: http://jlap.github.io/ngeo/azimuth/examples/contribs/gmf/drawfeature.html

This is incomplete work, as you cannot modify the azimuth. So if you modify a circle it's radius line will hang being awkwardly. That'll be the next step to complete the ticket.

I am available tomorrow, then I will be unavailable for a couple of weeks (back August 1st), so this PR could be merged as-is, picked up by somebody else, or stay open until I come back, @ybolognini 