### PR TITLE
Fixing redlining

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -99,7 +99,7 @@
               </div>
               <gmf-drawfeature
                   gmf-drawfeature-active="mainCtrl.drawFeatureActive"
-                  gmf-drawfeature-layer="::mainCtrl.drawFeatureLayer"
+                  gmf-drawfeature-feature-overlay="::mainCtrl.drawFeatureLayer"
                   gmf-drawfeature-map="::mainCtrl.map">
               </gmf-drawfeature>
             </div>

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -98,7 +98,7 @@
               </div>
               <gmf-drawfeature
                   gmf-drawfeature-active="mainCtrl.drawFeatureActive"
-                  gmf-drawfeature-layer="::mainCtrl.drawFeatureLayer"
+                  gmf-drawfeature-feature-overlay="::mainCtrl.drawFeatureLayer"
                   gmf-drawfeature-map="::mainCtrl.map">
               </gmf-drawfeature>
             </div>

--- a/contribs/gmf/examples/drawfeature.html
+++ b/contribs/gmf/examples/drawfeature.html
@@ -197,7 +197,7 @@
     <gmf-drawfeature
       ng-show="ctrl.drawFeatureActive === true"
       gmf-drawfeature-active="ctrl.drawFeatureActive"
-      gmf-drawfeature-layer="::ctrl.vectorLayer"
+      gmf-drawfeature-feature-overlay="::ctrl.featureOverlay"
       gmf-drawfeature-map="::ctrl.map">
     </gmf-drawfeature>
 

--- a/contribs/gmf/examples/drawfeature.js
+++ b/contribs/gmf/examples/drawfeature.js
@@ -31,11 +31,13 @@ app.module.constant('ngeoExportFeatureFormats', [
  * @param {ngeo.FeatureHelper} ngeoFeatureHelper Gmf feature helper service.
  * @param {ol.Collection.<ol.Feature>} ngeoFeatures Collection of features.
  * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
+ * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr Ngeo FeatureOverlay
+ * manager
  *     service.
  * @constructor
  */
 app.MainController = function($scope, ngeoFeatureHelper, ngeoFeatures,
-    ngeoToolActivateMgr) {
+    ngeoToolActivateMgr, ngeoFeatureOverlayMgr) {
 
   /**
    * @type {!angular.Scope}
@@ -50,16 +52,14 @@ app.MainController = function($scope, ngeoFeatureHelper, ngeoFeatures,
 
   ngeoFeatureHelper.setProjection(view.getProjection());
 
+
   /**
-   * @type {ol.layer.Vector}
+   * @type {ngeo.FeatureOverlay}
    * @export
    */
-  this.vectorLayer = new ol.layer.Vector({
-    source: new ol.source.Vector({
-      wrapX: false,
-      features: ngeoFeatures
-    })
-  });
+  this.featureOverlay = ngeoFeatureOverlayMgr.getFeatureOverlay();
+
+  this.featureOverlay.setFeatures(ngeoFeatures);
 
   /**
    * @type {ol.Map}
@@ -70,7 +70,7 @@ app.MainController = function($scope, ngeoFeatureHelper, ngeoFeatures,
       new ol.layer.Tile({
         source: new ol.source.OSM()
       }),
-      this.vectorLayer
+      this.featureOverlay.getLayer()
     ],
     view: view
   });

--- a/contribs/gmf/src/directives/drawfeature.js
+++ b/contribs/gmf/src/directives/drawfeature.js
@@ -441,6 +441,7 @@ gmf.DrawfeatureController.prototype.handleActiveChange_ = function(active) {
 gmf.DrawfeatureController.prototype.selectFeatureFromList = function(feature) {
   this.listSelectionInProgress_ = true;
   this.selectedFeature = feature;
+  this.drawActive = false;
 };
 
 

--- a/contribs/gmf/src/directives/drawfeature.js
+++ b/contribs/gmf/src/directives/drawfeature.js
@@ -29,13 +29,14 @@ goog.require('ol.style.Text');
  *
  *     <gmf-drawfeature
  *         gmf-drawfeature-active="ctrl.drawFeatureActive"
- *         gmf-drawfeature-layer="::ctrl.vectorLayer"
+ *         gmf-drawfeature-feature-overlay="::ctrl.featureOverlay"
  *         gmf-drawfeature-map="::ctrl.map">
  *     </gmf-drawfeature>
  *
  * @htmlAttribute {boolean} gmf-drawfeature-active Whether the directive is
  *     active or not.
- * @htmlAttribute {ol.layer.Vector} gmf-drawfeature-layer The vector layer.
+ * @htmlAttribute {ngeo.FeatureOverlay} gmf-drawfeature-feature-overlay The ngeo
+ * feature overlay service.
  * @htmlAttribute {ol.Map} gmf-drawfeature-map The map.
  * @return {angular.Directive} The directive specs.
  * @ngInject
@@ -47,7 +48,7 @@ gmf.drawfeatureDirective = function() {
     controller: 'GmfDrawfeatureController',
     scope: {
       'active': '=gmfDrawfeatureActive',
-      'layer': '<gmfDrawfeatureLayer',
+      'featureOverlay': '<gmfDrawfeatureFeatureOverlay',
       'map': '<gmfDrawfeatureMap'
     },
     bindToController: true,
@@ -79,10 +80,10 @@ gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
     ngeoToolActivateMgr) {
 
   /**
-   * @type {ol.layer.Vector}
+   * @type {ngeo.FeatureOverlay}
    * @export
    */
-  this.layer;
+  this.featureOverlay;
 
   /**
    * @type {ol.Map}
@@ -221,7 +222,6 @@ gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
    */
   this.translate_ = new ngeo.interaction.Translate({
     features: this.selectedFeatures,
-    layers: [this.layer],
     style: new ol.style.Style({
       text: new ol.style.Text({
         text: '\uf047',
@@ -240,7 +240,6 @@ gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
    */
   this.rotate_ = new ngeo.interaction.Rotate({
     features: this.selectedFeatures,
-    layers: [this.layer],
     style: new ol.style.Style({
       text: new ol.style.Text({
         text: '\uf01e',
@@ -567,7 +566,7 @@ gmf.DrawfeatureController.prototype.handleMapClick_ = function(evt) {
     }.bind(this),
     null,
     function(layer) {
-      return layer === this.layer;
+      return layer === this.featureOverlay.getLayer();
     }.bind(this)
   );
 
@@ -625,7 +624,7 @@ gmf.DrawfeatureController.prototype.handleMapContextMenu_ = function(evt) {
     }.bind(this),
     null,
     function(layer) {
-      return layer === this.layer;
+      return layer === this.featureOverlay.getLayer();
     }.bind(this)
   );
 

--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -302,7 +302,8 @@ ngeo.FeatureHelper.prototype.getVertexStyle = function(opt_incGeomFunc) {
       stroke: new ol.style.Stroke({
         color: [0, 0, 0, 1]
       })
-    })
+    }),
+    zIndex : 10000
   };
 
   if (incGeomFunc) {

--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -747,6 +747,7 @@ ngeo.FeatureHelper.prototype.panMapToFeature = function(feature, map,
   var view = map.getView();
   var extent = view.calculateExtent(size);
   var geometry = feature.getGeometry();
+  var mapSize = /** @type {!ol.Size} */ (map.getSize());
 
   if (!geometry.intersectsExtent(extent)) {
     var mapCenter = view.getCenter();
@@ -756,18 +757,7 @@ ngeo.FeatureHelper.prototype.panMapToFeature = function(feature, map,
       source: mapCenter,
       duration: panDuration
     }));
-
-    var featureCenter;
-    if (geometry instanceof ol.geom.LineString) {
-      featureCenter = geometry.getCoordinateAt(0.5);
-    } else if (geometry instanceof ol.geom.Polygon) {
-      featureCenter = geometry.getInteriorPoint().getCoordinates();
-    } else if (geometry instanceof ol.geom.Point) {
-      featureCenter = geometry.getCoordinates();
-    } else {
-      featureCenter = ol.extent.getCenter(geometry.getExtent());
-    }
-    map.getView().setCenter(featureCenter);
+    map.getView().fit(geometry.getExtent(), mapSize);
   }
 };
 

--- a/src/services/featureoverlay.js
+++ b/src/services/featureoverlay.js
@@ -242,6 +242,15 @@ ngeo.FeatureOverlay.prototype.clear = function() {
 
 
 /**
+ * Get the layer
+ * @return {ol.layer.Vector} The vector layer used internally
+ * @export
+ */
+ngeo.FeatureOverlay.prototype.getLayer = function() {
+  return this.manager_.getLayer();
+};
+
+/**
  * Configure this feature overlay with a feature collection. Features added
  * to the collection are also added to the overlay. Same for removal. If you
  * configure the feature overlay with a feature collection you will use the


### PR DESCRIPTION
Close #1471 #1579 #1580 #1581 #1590 

**demo:** 

- https://oliviersemet.github.io/ngeo/fixing-redlining/examples/contribs/gmf/apps/desktop_alt/

**test**

- Deleting a vertex on a feature of type "linestring" **must not** unselect the feature
- Clicking on a feature when the redlining panel is open **must** select the feature
- The map **must** fit (applying the right map center and zoom to display the entire feature) the selected feature if the feature is out of the view 
- When mousing over a line of a selected feature, the square symbol **must** on top of the line
- The drawing tools must be deactivated when user selects a feature in the list

@ger-benjamin @sbrunner @pgiraud could you review?