### PR TITLE
Add gmf-editfeature and gmf-editfeatureselector directives

### DIFF
--- a/contribs/gmf/examples/editfeatureselector.html
+++ b/contribs/gmf/examples/editfeatureselector.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>GeoMapFish EditFeature selector example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../../../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/font-awesome/css/font-awesome.css" type="text/css">
+    <link rel="stylesheet" href="../third-party/jquery-ui/jquery-ui.min.css">
+    <style>
+      body {
+        padding: 1rem;
+      }
+      .panel {
+        display: block;
+        float: left;
+        margin: 0 1rem 0 0;
+        width: 35rem;
+      }
+      gmf-map > div {
+        width: 60rem;
+        height: 40rem;
+      }
+      gmf-editfeatureselector {
+        display: block;
+        width: 30rem;
+      }
+      .gmf-editfeatureselector-stopediting {
+        float: right;
+      }
+      ngeo-attributes {
+        border-top: 0.1rem solid black;
+        display: block;
+        padding: 1rem 0;
+      }
+      .gmf-editfeature-btn-delete {
+        float: right;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <gmf-map gmf-map-map="ctrl.map"></gmf-map>
+
+    <p id="desc">
+      This example shows how to use the <code>gmf-editfeatureselector</code>
+      directive to edit vector features from editable layers that are defined
+      in the GeoMapFish themes. First, you need to login. Then, select the
+      layer you wish to edit. Finally, you can either click on an existing
+      feature on map to modify or delete it, or you can create a new one using
+      the "Draw" button.
+    </p>
+
+    <gmf-authentication
+        class="panel panel-default panel-body">
+    </gmf-authentication>
+
+    <div
+        ng-if="ctrl.gmfUser.username"
+        class="panel panel-default panel-body">
+
+    <input type="checkbox"
+       id="checkbox-editfeatureselector"
+       ng-model="ctrl.editFeatureSelectorActive" />
+    <label for="checkbox-editfeatureselector"> EditFeatureSelector</label>
+
+    <input type="checkbox"
+       id="checkbox-dummy"
+       ng-model="ctrl.dummyActive" />
+    <label for="checkbox-dummy"> Dummy tool</label>
+
+    <gmf-editfeatureselector
+        ng-show="ctrl.editFeatureSelectorActive === true"
+        gmf-editfeatureselector-active="ctrl.editFeatureSelectorActive"
+        gmf-editfeatureselector-map="::ctrl.map"
+        gmf-editfeatureselector-vector="::ctrl.vectorLayer">
+    </gmf-editfeatureselector>
+
+    </div>
+
+    <script src="../../../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../third-party/jquery-ui/jquery-ui.min.js"></script>
+    <script src="../../../node_modules/angular/angular.js"></script>
+    <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
+    <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
+    <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="../../../node_modules/proj4/dist/proj4.js"></script>
+    <script src="../../../node_modules/angular-ui-date/dist/date.js"></script>
+    <script src="../../../node_modules/angular-ui-slider/src/slider.js"></script>
+    <script src="../../../node_modules/angular-dynamic-locale/dist/tmhDynamicLocale.js" type="text/javascript"></script>
+    <script src="/@?main=editfeatureselector.js"></script>
+    <script src="default.js"></script>
+    <script src="../../../utils/watchwatchers.js"></script>
+    <script>
+      var gmfModule = angular.module('gmf');
+      gmfModule.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
+    </script>
+  </body>
+</html>

--- a/contribs/gmf/examples/editfeatureselector.js
+++ b/contribs/gmf/examples/editfeatureselector.js
@@ -1,0 +1,186 @@
+goog.provide('gmf-editfeatureselector');
+
+goog.require('gmf');
+goog.require('gmf.Themes');
+goog.require('gmf.authenticationDirective');
+goog.require('gmf.editfeatureselectorDirective');
+goog.require('gmf.mapDirective');
+goog.require('ngeo.ToolActivate');
+goog.require('ngeo.ToolActivateMgr');
+goog.require('ngeo.proj.EPSG21781');
+goog.require('ol.Collection');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.layer.Vector');
+goog.require('ol.source.OSM');
+goog.require('ol.source.Vector');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['gmf']);
+
+
+app.module.constant(
+    'authenticationBaseUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi');
+
+
+app.module.constant('gmfTreeUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
+
+
+app.module.constant('gmfLayersUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/layers/');
+
+
+/**
+ * @param {!angular.Scope} $scope Angular scope.
+ * @param {gmf.Themes} gmfThemes The gmf themes service.
+ * @param {gmfx.User} gmfUser User.
+ * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
+ *     service.
+ * @constructor
+ */
+app.MainController = function($scope, gmfThemes, gmfUser, ngeoToolActivateMgr) {
+
+  /**
+   * @type {!angular.Scope}
+   * @private
+   */
+  this.scope_ = $scope;
+
+  /**
+   * @type {gmfx.User}
+   * @export
+   */
+  this.gmfUser = gmfUser;
+
+  gmfThemes.loadThemes();
+
+  var projection = ol.proj.get('EPSG:21781');
+  projection.setExtent([485869.5728, 76443.1884, 837076.5648, 299941.7864]);
+
+  var proxyUrl =
+      'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy';
+
+  /**
+   * @type {ol.source.ImageWMS}
+   * @private
+   */
+  this.polygonWMSSource_ = new ol.source.ImageWMS({
+    url: proxyUrl,
+    params: {'LAYERS': 'polygon'}
+  });
+
+  /**
+   * @type {ol.layer.Image}
+   * @private
+   */
+  this.polygonWMSLayer_ = new ol.layer.Image({
+    source: this.polygonWMSSource_
+  });
+
+  /**
+   * @type {ol.source.ImageWMS}
+   * @private
+   */
+  this.lineWMSSource_ = new ol.source.ImageWMS({
+    url: proxyUrl,
+    params: {'LAYERS': 'line'}
+  });
+
+  /**
+   * @type {ol.layer.Image}
+   * @private
+   */
+  this.lineWMSLayer_ = new ol.layer.Image({
+    source: this.lineWMSSource_
+  });
+
+  /**
+   * @type {ol.source.ImageWMS}
+   * @private
+   */
+  this.pointWMSSource_ = new ol.source.ImageWMS({
+    url: proxyUrl,
+    params: {'LAYERS': 'point'}
+  });
+
+  /**
+   * @type {ol.layer.Image}
+   * @private
+   */
+  this.pointWMSLayer_ = new ol.layer.Image({
+    source: this.pointWMSSource_
+  });
+
+  /**
+   * @type {ol.layer.Vector}
+   * @export
+   */
+  this.vectorLayer = new ol.layer.Vector({
+    source: new ol.source.Vector({
+      wrapX: false,
+      features: new ol.Collection()
+    })
+  });
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      }),
+      this.polygonWMSLayer_,
+      this.lineWMSLayer_,
+      this.pointWMSLayer_,
+      this.vectorLayer
+    ],
+    view: new ol.View({
+      projection: projection,
+      resolutions: [200, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5],
+      center: [537635, 152640],
+      zoom: 2
+    })
+  });
+
+ /**
+   * @type {boolean}
+   * @export
+   */
+  this.editFeatureSelectorActive = true;
+
+  var editFeatureSelectorToolActivate = new ngeo.ToolActivate(
+      this, 'editFeatureSelectorActive');
+  ngeoToolActivateMgr.registerTool(
+      'mapTools', editFeatureSelectorToolActivate, true);
+
+ /**
+   * @type {boolean}
+   * @export
+   */
+  this.dummyActive = false;
+
+  var dummyToolActivate = new ngeo.ToolActivate(
+      this, 'dummyActive');
+  ngeoToolActivateMgr.registerTool(
+      'mapTools', dummyToolActivate, false);
+
+  // initialize tooltips
+  $('[data-toggle="tooltip"]').tooltip({
+    container: 'body',
+    trigger: 'hover'
+  });
+
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -19,7 +19,7 @@ goog.require('ol.format.GeoJSON');
 
 /**
  * Directive used to insert, modify and delete features from a single layer.
- * It allows you can modify the geometry of the feature in addition to its
+ * It allows you to modify the geometry of the feature in addition to its
  * attributes.
  *
  * In order to modify or delete a feature, you must click on the map at the
@@ -36,9 +36,12 @@ goog.require('ol.format.GeoJSON');
  *         gmf-editfeature-vector="::ctrl.vectorLayer">
  *     </gmf-editfeature>
  *
+ * @htmlAttribute {GmfThemesNode} gmf-editfeature-layer The GMF node of the
+ *     editable layer.
  * @htmlAttribute {ol.Map} gmf-editfeature-map The map.
+ * @htmlAttribute {ol.layer.Vector} gmf-editfeature-vector The vector layer in
+ *     which to draw the vector features.
  * @return {angular.Directive} The directive specs.
- * @ngInject
  * @ngdoc directive
  * @ngname gmfEditfeature
  */
@@ -108,7 +111,7 @@ gmf.EditfeatureController = function($scope, $timeout, gmfEditFeature,
 
   /**
    * @type {gmf.EditFeature}
-   * @export
+   * @private
    */
   this.editFeatureService_ = gmfEditFeature;
 
@@ -259,9 +262,7 @@ gmf.EditfeatureController.prototype.delete = function() {
   );
 
   // (2) Reset selected feature
-  this.feature = null;
-  this.features.clear();
-
+  this.cancel();
 };
 
 
@@ -273,9 +274,7 @@ gmf.EditfeatureController.prototype.delete = function() {
 gmf.EditfeatureController.prototype.handleEditFeature_ = function(resp) {
   var features = new ol.format.GeoJSON().readFeatures(resp.data);
   if (features.length) {
-    var feature = features[0];
-    var id = feature.getId();
-    this.feature.setId(id);
+    this.feature.setId(features[0].getId());
   }
 };
 
@@ -292,21 +291,19 @@ gmf.EditfeatureController.prototype.handleDeleteFeature_ = function(resp) {
 
 /**
  * @param {Array.<ngeox.Attribute>} attributes Attributes.
- * @export
+ * @private
  */
 gmf.EditfeatureController.prototype.setAttributes_ = function(attributes) {
-  this.timeout_(function() {
-    // Set attributes
-    this.attributes = attributes;
+  // Set attributes
+  this.attributes = attributes;
 
-    // Get geom type from attributes and set
-    var geomAttr = ngeo.format.XSDAttribute.getGeometryAttribute(
-      this.attributes
-    );
-    if (geomAttr && geomAttr.geomType) {
-      this.geomType = geomAttr.geomType;
-    }
-  }.bind(this), 0);
+  // Get geom type from attributes and set
+  var geomAttr = ngeo.format.XSDAttribute.getGeometryAttribute(
+    this.attributes
+  );
+  if (geomAttr && geomAttr.geomType) {
+    this.geomType = geomAttr.geomType;
+  }
 };
 
 
@@ -356,8 +353,7 @@ gmf.EditfeatureController.prototype.toggle_ = function(active) {
     this.createActive = false;
     //this.modify_.setActive(false);
     this.mapSelectActive = false;
-    this.feature = null;
-    this.features.clear();
+    this.cancel();
   }
 
 };
@@ -402,8 +398,7 @@ gmf.EditfeatureController.prototype.handleMapClick_ = function(evt) {
     this.handleGetFeatures_.bind(this));
 
   // (2) Clear any previously selected feature
-  this.feature = null;
-  this.features.clear();
+  this.cancel();
 
   // (3) Pending
   //this.pending = true;

--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -1,0 +1,446 @@
+goog.provide('gmf.EditfeatureController');
+goog.provide('gmf.editfeatureDirective');
+
+
+goog.require('gmf');
+goog.require('gmf.EditFeature');
+goog.require('gmf.XSDAttributes');
+/** @suppress {extraRequire} */
+goog.require('ngeo.attributesDirective');
+/** @suppress {extraRequire} */
+goog.require('ngeo.btnDirective');
+/** @suppress {extraRequire} */
+goog.require('ngeo.createfeatureDirective');
+goog.require('ngeo.EventHelper');
+goog.require('ngeo.ToolActivate');
+goog.require('ngeo.ToolActivateMgr');
+goog.require('ol.format.GeoJSON');
+
+
+/**
+ * Directive used to insert, modify and delete features from a single layer.
+ * It allows you can modify the geometry of the feature in addition to its
+ * attributes.
+ *
+ * In order to modify or delete a feature, you must click on the map at the
+ * location of the feature to select it first.
+ *
+ * In order to create a new feature, you use the "Draw" button and digitalize
+ * the feature on the map.
+ *
+ * Example:
+ *
+ *     <gmf-editfeature
+ *         gmf-editfeature-layer="::ctrl.layer">
+ *         gmf-editfeature-map="::ctrl.map"
+ *         gmf-editfeature-vector="::ctrl.vectorLayer">
+ *     </gmf-editfeature>
+ *
+ * @htmlAttribute {ol.Map} gmf-editfeature-map The map.
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname gmfEditfeature
+ */
+gmf.editfeatureDirective = function() {
+  return {
+    controller: 'GmfEditfeatureController',
+    scope: {
+      'layer': '=gmfEditfeatureLayer',
+      'map': '<gmfEditfeatureMap',
+      'vectorLayer': '<gmfEditfeatureVector'
+    },
+    bindToController: true,
+    controllerAs: 'efCtrl',
+    templateUrl: gmf.baseTemplateUrl + '/editfeature.html'
+  };
+};
+
+gmf.module.directive(
+  'gmfEditfeature', gmf.editfeatureDirective);
+
+
+/**
+ * @param {!angular.Scope} $scope Angular scope.
+ * @param {angular.$timeout} $timeout Angular timeout service.
+ * @param {gmf.EditFeature} gmfEditFeature Gmf edit feature service.
+ * @param {gmf.XSDAttributes} gmfXSDAttributes The gmf XSDAttributes service.
+ * @param {ngeo.EventHelper} ngeoEventHelper Ngeo Event Helper.
+ * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
+ *     service.
+ * @constructor
+ * @ngInject
+ * @ngdoc controller
+ * @ngname GmfEditfeatureController
+ */
+gmf.EditfeatureController = function($scope, $timeout, gmfEditFeature,
+    gmfXSDAttributes, ngeoEventHelper, ngeoToolActivateMgr) {
+
+  /**
+   * @type {GmfThemesNode}
+   * @export
+   */
+  this.layer;
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
+
+  /**
+   * @type {ol.layer.Vector}
+   * @export
+   */
+  this.vectorLayer;
+
+  /**
+   * @type {!angular.Scope}
+   * @private
+   */
+  this.scope_ = $scope;
+
+  /**
+   * @type {angular.$timeout}
+   * @private
+   */
+  this.timeout_ = $timeout;
+
+  /**
+   * @type {gmf.EditFeature}
+   * @export
+   */
+  this.editFeatureService_ = gmfEditFeature;
+
+  /**
+   * @type {gmf.XSDAttributes}
+   * @private
+   */
+  this.xsdAttributes_ = gmfXSDAttributes;
+
+  /**
+   * @type {ngeo.EventHelper}
+   * @private
+   */
+  this.eventHelper_ = ngeoEventHelper;
+
+  /**
+   * @type {ngeo.ToolActivateMgr}
+   * @private
+   */
+  this.ngeoToolActivateMgr_ = ngeoToolActivateMgr;
+
+  /**
+   * @type {number}
+   * @private
+   */
+  this.pixelBuffer_ = 10;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.createActive = false;
+
+  /**
+   * @type {ngeo.ToolActivate}
+   * @export
+   */
+  this.createToolActivate = new ngeo.ToolActivate(this, 'createActive');
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.mapSelectActive = true;
+
+  $scope.$watch(
+    function() {
+      return this.mapSelectActive;
+    }.bind(this),
+    this.handleMapSelectActiveChange_.bind(this)
+  );
+
+  /**
+   * @type {ngeo.ToolActivate}
+   * @export
+   */
+  this.mapSelectToolActivate = new ngeo.ToolActivate(this, 'mapSelectActive');
+
+  /**
+   * @type {?ol.Feature}
+   * @export
+   */
+  this.feature = null;
+
+  /**
+   * @type {ol.Collection}
+   * @export
+   */
+  this.features = this.vectorLayer.getSource().getFeaturesCollection();
+
+  /**
+   * @type {?Array.<ngeox.Attribute>}
+   * @export
+   */
+  this.attributes = null;
+
+  /**
+   * @type {?string}
+   * @export
+   */
+  this.geomType = null;
+
+  gmfXSDAttributes.getAttributes(this.layer.id).then(
+    this.setAttributes_.bind(this));
+
+  var uid = goog.getUid(this);
+  this.eventHelper_.addListenerKey(
+    uid,
+    ol.events.listen(
+      this.features,
+      ol.CollectionEventType.ADD,
+      this.handleFeatureAdd_,
+      this
+    )
+  );
+
+  $scope.$on('$destroy', this.handleDestroy_.bind(this));
+
+  this.toggle_(true);
+};
+
+
+/**
+ * Save the currently selected feature modifications.
+ * @export
+ */
+gmf.EditfeatureController.prototype.save = function() {
+  var feature = this.feature;
+  var id = feature.getId();
+
+  if (id) {
+    this.editFeatureService_.updateFeature(
+      this.layer.id,
+      feature
+    ).then(
+      this.handleEditFeature_.bind(this)
+    );
+  } else {
+    this.editFeatureService_.insertFeatures(
+      this.layer.id,
+      [feature]
+    ).then(
+      this.handleEditFeature_.bind(this)
+    );
+  }
+};
+
+
+/**
+ * @export
+ */
+gmf.EditfeatureController.prototype.cancel = function() {
+  this.feature = null;
+  this.features.clear();
+};
+
+
+/**
+ * @export
+ */
+gmf.EditfeatureController.prototype.delete = function() {
+  // (1) Launch request
+  this.editFeatureService_.deleteFeature(
+    this.layer.id,
+    this.feature
+  ).then(
+    this.handleDeleteFeature_.bind(this)
+  );
+
+  // (2) Reset selected feature
+  this.feature = null;
+  this.features.clear();
+
+};
+
+
+/**
+ * Called after an insert, update or delete request.
+ * @param {angular.$http.Response} resp Ajax response.
+ * @private
+ */
+gmf.EditfeatureController.prototype.handleEditFeature_ = function(resp) {
+  var features = new ol.format.GeoJSON().readFeatures(resp.data);
+  if (features.length) {
+    var feature = features[0];
+    var id = feature.getId();
+    this.feature.setId(id);
+  }
+};
+
+
+/**
+ * Called after an insert, update or delete request.
+ * @param {angular.$http.Response} resp Ajax response.
+ * @private
+ */
+gmf.EditfeatureController.prototype.handleDeleteFeature_ = function(resp) {
+  console.log('ok, deleted');
+};
+
+
+/**
+ * @param {Array.<ngeox.Attribute>} attributes Attributes.
+ * @export
+ */
+gmf.EditfeatureController.prototype.setAttributes_ = function(attributes) {
+  this.timeout_(function() {
+    // Set attributes
+    this.attributes = attributes;
+
+    // Get geom type from attributes and set
+    var geomAttr = ngeo.format.XSDAttribute.getGeometryAttribute(
+      this.attributes
+    );
+    if (geomAttr && geomAttr.geomType) {
+      this.geomType = geomAttr.geomType;
+    }
+  }.bind(this), 0);
+};
+
+
+/**
+ * @param {ol.CollectionEvent} evt Event.
+ * @private
+ */
+gmf.EditfeatureController.prototype.handleFeatureAdd_ = function(evt) {
+  this.timeout_(function() {
+    var feature = evt.element;
+    goog.asserts.assertInstanceof(feature, ol.Feature);
+    this.feature = feature;
+    this.createActive = false;
+    this.scope_.$apply();
+  }.bind(this), 0);
+};
+
+
+/**
+ * Activate or deactivate this directive.
+ * @param {boolean} active Whether to activate this directive or not.
+ * @private
+ */
+gmf.EditfeatureController.prototype.toggle_ = function(active) {
+
+  var createUid = ['create-', goog.getUid(this)].join('-');
+  //var otherUid = ['other-', goog.getUid(this)].join('-');
+  var toolMgr = this.ngeoToolActivateMgr_;
+
+  if (active) {
+    toolMgr.registerTool(createUid, this.createToolActivate, false);
+    toolMgr.registerTool(createUid, this.mapSelectToolActivate, true);
+
+    //toolMgr.registerTool(otherUid, this.createToolActivate, false);
+    //toolMgr.registerTool(otherUid, this.modifyToolActivate, true);
+
+    this.mapSelectActive = true;
+    //this.modify_.setActive(true);
+  } else {
+
+    toolMgr.unregisterTool(createUid, this.createToolActivate);
+    toolMgr.unregisterTool(createUid, this.mapSelectToolActivate);
+
+    //toolMgr.unregisterTool(otherUid, this.createToolActivate);
+    //toolMgr.unregisterTool(otherUid, this.modifyToolActivate);
+
+    this.createActive = false;
+    //this.modify_.setActive(false);
+    this.mapSelectActive = false;
+    this.feature = null;
+    this.features.clear();
+  }
+
+};
+
+
+/**
+ * Called when the mapSelectActive property changes.
+ * @param {boolean} active Whether the map select is active or not.
+ * @private
+ */
+gmf.EditfeatureController.prototype.handleMapSelectActiveChange_ = function(
+    active) {
+
+  if (active) {
+    ol.events.listen(this.map, ol.MapBrowserEvent.EventType.CLICK,
+        this.handleMapClick_, this);
+  } else {
+    ol.events.unlisten(this.map, ol.MapBrowserEvent.EventType.CLICK,
+        this.handleMapClick_, this);
+  }
+};
+
+
+/**
+ * @param {ol.MapBrowserEvent} evt Event.
+ * @private
+ */
+gmf.EditfeatureController.prototype.handleMapClick_ = function(evt) {
+
+  // (1) Launch query to fetch features
+  var coordinate = evt.coordinate;
+  var map = this.map;
+  var view = map.getView();
+  var resolution = view.getResolution();
+  var buffer = resolution * this.pixelBuffer_;
+  var extent = ol.extent.buffer(
+    [coordinate[0], coordinate[1], coordinate[0], coordinate[1]],
+    buffer
+  );
+
+  this.editFeatureService_.getFeatures([this.layer.id], extent).then(
+    this.handleGetFeatures_.bind(this));
+
+  // (2) Clear any previously selected feature
+  this.feature = null;
+  this.features.clear();
+
+  // (3) Pending
+  //this.pending = true;
+
+  this.scope_.$apply();
+
+};
+
+
+/**
+ * @param {Array.<ol.Feature>} features Features.
+ * @private
+ */
+gmf.EditfeatureController.prototype.handleGetFeatures_ = function(features) {
+  //this.pending = false;
+
+  this.timeout_(function() {
+    if (features.length) {
+      var feature = features[0];
+      this.feature = feature;
+      this.features.push(feature);
+    }
+  }.bind(this), 0);
+};
+
+
+/**
+ * @private
+ */
+gmf.EditfeatureController.prototype.handleDestroy_ = function() {
+  this.features.clear();
+  var uid = goog.getUid(this);
+  this.eventHelper_.clearListenerKey(uid);
+  this.toggle_(false);
+  this.handleMapSelectActiveChange_(false);
+};
+
+
+gmf.module.controller(
+  'GmfEditfeatureController', gmf.EditfeatureController);

--- a/contribs/gmf/src/directives/editfeatureselector.js
+++ b/contribs/gmf/src/directives/editfeatureselector.js
@@ -27,7 +27,6 @@ goog.require('gmf.editfeatureDirective');
  * @htmlAttribute {ol.layer.Vector} gmf-editfeatureselector-vector The vector
  *     layer where the selected or created features are drawn.
  * @return {angular.Directive} The directive specs.
- * @ngInject
  * @ngdoc directive
  * @ngname gmfEditfeatureselector
  */
@@ -141,7 +140,7 @@ gmf.EditfeatureselectorController.prototype.getSetLayers = function(value) {
 /**
  * @param {GmfThemesNode} node A theme, group or layer node.
  * @param {Array.<GmfThemesNode>} nodes An Array of nodes.
- * @export
+ * @private
  */
 gmf.EditfeatureselectorController.prototype.getDistinctFlatNodes_ = function(
   node, nodes

--- a/contribs/gmf/src/directives/editfeatureselector.js
+++ b/contribs/gmf/src/directives/editfeatureselector.js
@@ -1,0 +1,184 @@
+goog.provide('gmf.EditfeatureselectorController');
+goog.provide('gmf.editfeatureselectorDirective');
+
+goog.require('gmf');
+goog.require('gmf.Themes');
+/** @suppress {extraRequire} */
+goog.require('gmf.editfeatureDirective');
+
+
+/**
+ * Directive that uses the GMF Theme service to collect the editable layers
+ * and create a drop-down list out of them. When the user selects one of the
+ * layer from the list, a `gmf-editfeature` directive is created and shown,
+ * which allows the user to edit that layer.
+ *
+ * Example:
+ *
+ *     <gmf-editfeatureselector
+ *         gmf-editfeatureselector-active="ctrl.editFeatureSelectorActive"
+ *         gmf-editfeatureselector-map="::ctrl.map"
+ *         gmf-editfeatureselector-vector="::ctrl.vectorLayer">
+ *     </gmf-editfeatureselector>
+ *
+ * @htmlAttribute {boolean} gmf-editfeatureselector-active Whether the
+ *     directive is active or not.
+ * @htmlAttribute {ol.Map} gmf-editfeatureselector-map The map.
+ * @htmlAttribute {ol.layer.Vector} gmf-editfeatureselector-vector The vector
+ *     layer where the selected or created features are drawn.
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname gmfEditfeatureselector
+ */
+gmf.editfeatureselectorDirective = function() {
+  return {
+    controller: 'GmfEditfeatureselectorController',
+    scope: {
+      'active': '=gmfEditfeatureselectorActive',
+      'map': '<gmfEditfeatureselectorMap',
+      'vectorLayer': '<gmfEditfeatureselectorVector'
+    },
+    bindToController: true,
+    controllerAs: 'efsCtrl',
+    templateUrl: gmf.baseTemplateUrl + '/editfeatureselector.html'
+  };
+};
+
+gmf.module.directive(
+  'gmfEditfeatureselector', gmf.editfeatureselectorDirective);
+
+
+/**
+ * @param {!angular.Scope} $scope Angular scope.
+ * @param {gmf.Themes} gmfThemes The gmf themes service.
+ * @constructor
+ * @ngInject
+ * @ngdoc controller
+ * @ngname GmfEditfeatureselectorController
+ */
+gmf.EditfeatureselectorController = function($scope, gmfThemes) {
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.active = this.active === true;
+
+  $scope.$watch(
+    function() {
+      return this.active;
+    }.bind(this),
+    this.handleActiveChange_.bind(this)
+  );
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
+
+  /**
+   * @type {ol.layer.Vector}
+   * @export
+   */
+  this.vectorLayer;
+
+  /**
+   * List of editable layers (theme nodes)
+   * @type {Array.<GmfThemesNode>}
+   * @export
+   */
+  this.layers = [];
+
+  /**
+   * The currently selected layer
+   * @type {?GmfThemesNode}
+   * @export
+   */
+  this.selectedLayer = null;
+
+  // TMP - The list of layer names to use. We'll keep this until we can use
+  //       those that are editable.
+  var layerNames = ['line', 'point', 'polygon'];
+
+  gmfThemes.getThemesObject().then(function(themes) {
+    if (!themes) {
+      return;
+    }
+    // Get an array with all nodes entities existing in "themes".
+    var flatNodes = [];
+    themes.forEach(function(theme) {
+      theme.children.forEach(function(group) {
+        this.getDistinctFlatNodes_(group, flatNodes);
+      }.bind(this));
+    }.bind(this));
+    flatNodes.forEach(function(node) {
+      // Get an array of all layers
+      if (node.children === undefined && layerNames.indexOf(node.name) !== -1) {
+        this.layers.push(node);
+      }
+    }.bind(this));
+
+  }.bind(this));
+
+};
+
+
+/**
+ * @param {GmfThemesNode|undefined} value A layer or undefined to get layers.
+ * @return {Array.<GmfThemesNode>} All layers in all themes.
+ * @export
+ */
+gmf.EditfeatureselectorController.prototype.getSetLayers = function(value) {
+  if (value !== undefined) {
+    this.selectedLayer = value;
+  }
+  return this.layers;
+};
+
+
+/**
+ * @param {GmfThemesNode} node A theme, group or layer node.
+ * @param {Array.<GmfThemesNode>} nodes An Array of nodes.
+ * @export
+ */
+gmf.EditfeatureselectorController.prototype.getDistinctFlatNodes_ = function(
+  node, nodes
+) {
+  var i;
+  var children = node.children;
+  if (children !== undefined) {
+    for (i = 0; i < children.length; i++) {
+      this.getDistinctFlatNodes_(children[i], nodes);
+    }
+  }
+  var alreadyAdded = false;
+  nodes.some(function(n) {
+    if (n.id === node.id) {
+      return alreadyAdded = true;
+    }
+  });
+  if (!alreadyAdded) {
+    nodes.push(node);
+  }
+};
+
+
+/**
+ * Called when the active property of the this directive changes. Manage
+ * the activation/deactivation accordingly.
+ * @param {boolean} active Whether the directive is active or not.
+ * @private
+ */
+gmf.EditfeatureselectorController.prototype.handleActiveChange_ = function(
+  active
+) {
+  if (!active) {
+    this.selectedLayer = null;
+  }
+};
+
+
+gmf.module.controller(
+  'GmfEditfeatureselectorController', gmf.EditfeatureselectorController);

--- a/contribs/gmf/src/directives/partials/editfeature.html
+++ b/contribs/gmf/src/directives/partials/editfeature.html
@@ -1,0 +1,58 @@
+<div>
+  <div ng-switch="efCtrl.feature">
+    <a
+      ng-switch-when="null"
+      ng-if="efCtrl.geomType"
+      href
+      translate
+      ngeo-btn
+      ngeo-createfeature
+      ngeo-createfeature-active="efCtrl.createActive"
+      ngeo-createfeature-features="::efCtrl.features"
+      ngeo-createfeature-geom-type="::efCtrl.geomType"
+      ngeo-createfeature-map="::efCtrl.map"
+      class="btn btn-default"
+      ng-class="{active: efCtrl.createActive}"
+      ng-model="efCtrl.createActive">
+      <span ng-switch="::efCtrl.geomType">
+        <span ng-switch-when="Point">
+          <span class="gmf-icon gmf-icon-point"></span>
+          {{'Draw new point' | translate}}
+        </span>
+        <span ng-switch-when="LineString">
+          <span class="gmf-icon gmf-icon-line"></span>
+          {{'Draw new linestring' | translate}}
+        </span>
+        <span ng-switch-when="Polygon">
+          <span class="gmf-icon gmf-icon-polygon"></span>
+          {{'Draw new polygon' | translate}}
+        </span>
+      </span>
+    </a>
+    <div
+      ng-switch-default
+      ng-if="efCtrl.attributes">
+      <ngeo-attributes
+        ngeo-attributes-attributes="::efCtrl.attributes"
+        ngeo-attributes-feature="::efCtrl.feature">
+      </ngeo-attributes>
+      <a
+        class="btn btn-sm btn-default gmf-editfeature-btn-save"
+        ng-click="efCtrl.save()"
+        title="{{'Save modifications | translate'}}"
+        href>{{'Save' | translate}}</a>
+      <a
+        class="btn btn-sm btn-default gmf-editfeature-btn-cancel"
+        ng-click="efCtrl.cancel()"
+        title="{{'Cancel modifications | translate'}}"
+        href>{{'Cancel' | translate}}</a>
+      <button
+        class="btn btn-sm btn-link gmf-editfeature-btn-delete"
+        ng-click="efCtrl.delete()"
+        title="{{'Delete this feature | translate'}}">
+        <span class="fa fa-trash"></span>
+        {{'Delete' | translate}}
+      </button>
+    </div>
+  </div>
+</div>

--- a/contribs/gmf/src/directives/partials/editfeatureselector.html
+++ b/contribs/gmf/src/directives/partials/editfeatureselector.html
@@ -1,0 +1,30 @@
+<div
+    ng-switch="efsCtrl.selectedLayer">
+
+  <select
+      ng-switch-when="null"
+      ng-model="efsCtrl.getSetLayers"
+      ng-model-options="{getterSetter: true}"
+      ng-options="layer.name for layer in efsCtrl.layers">
+    <option value="">-- Choose a layer --</option>
+  </select>
+
+  <div ng-switch-default>
+    <button
+        ng-click="efsCtrl.selectedLayer = null;"
+        class="btn btn-link btn-xs gmf-editfeatureselector-stopediting">
+      <span class="fa fa-times"></span>
+      {{'Stop editing' | translate}}
+    </button>
+
+    <h3>{{ efsCtrl.selectedLayer.name }}</h3>
+
+    <gmf-editfeature
+        gmf-editfeature-layer="::efsCtrl.selectedLayer"
+        gmf-editfeature-map="::efsCtrl.map"
+        gmf-editfeature-vector="::efsCtrl.vectorLayer">
+    </gmf-editfeature>
+
+  </div>
+
+</div>


### PR DESCRIPTION
This is PR introduces the `gmf-editfeature` and `gmf-editfeatureselector` directives. There are still components and features that are missing from the SPECs, but I'm creating this early PR to be able to have the work in progress reviewed.

## Todo

 * [x] review

## Live example

 * https://adube.github.io/ngeo/gmf-editfeature-directive/examples/contribs/gmf/editfeatureselector.html

## Not included

This PR doesn't include the following features.  They will come in separate tickets:

 * refresh the WMS layer after a save has been made
 * measure while drawing
 * save button should be "gray" until modifications are maded
 * geometry modifications
 * validate required fields
 * have an option for the pixel buffer
 * confirm before delete

Also, there's currently a CORS error when deleting.