### PR TITLE
Support measure while drawing in gmf-editfeature

### DIFF
--- a/contribs/gmf/examples/editfeatureselector.html
+++ b/contribs/gmf/examples/editfeatureselector.html
@@ -39,6 +39,38 @@
       .gmf-editfeature-btn-delete {
         float: right;
       }
+
+      /* measure tooltips  */
+      .tooltip {
+        position: relative;
+        background: rgba(0, 0, 0, 0.5);
+        border-radius: 4px;
+        color: white;
+        padding: 4px 8px;
+        opacity: 0.7;
+        white-space: nowrap;
+      }
+      .tooltip-measure {
+        opacity: 1;
+        font-weight: bold;
+      }
+      .tooltip-static {
+        display: none;
+      }
+      .tooltip-measure:before,
+      .tooltip-static:before {
+        border-top: 6px solid rgba(0, 0, 0, 0.5);
+        border-right: 6px solid transparent;
+        border-left: 6px solid transparent;
+        content: "";
+        position: absolute;
+        bottom: -6px;
+        margin-left: -7px;
+        left: 50%;
+      }
+      .tooltip-static:before {
+        border-top-color: #ffcc33;
+      }
     </style>
   </head>
   <body ng-controller="MainController as ctrl">

--- a/src/directives/createfeature.js
+++ b/src/directives/createfeature.js
@@ -238,6 +238,7 @@ ngeo.CreatefeatureController.prototype.handleDestroy_ = function() {
   this.timeout_(function() {
     var uid = goog.getUid(this);
     this.ngeoEventHelper_.clearListenerKey(uid);
+    this.interaction_.setActive(false);
     this.map.removeInteraction(this.interaction_);
   }.bind(this), 0);
 };


### PR DESCRIPTION
This PR is a follow-up of #1585.  It adds the measurements of lines and polygons while drawing

## Todo

 * [x] Wait for #1585 to be merged
 * [ ] Review

## Live example

 * https://adube.github.io/ngeo/gmf-editfeature-measure-while-drawing/examples/contribs/gmf/editfeatureselector.html