### PR TITLE
Add confirmation before deleting a feature in gmf-editfeature

### DIFF
--- a/contribs/gmf/src/directives/partials/editfeature.html
+++ b/contribs/gmf/src/directives/partials/editfeature.html
@@ -49,6 +49,7 @@
       <button
         class="btn btn-sm btn-link gmf-editfeature-btn-delete"
         ng-click="efCtrl.delete()"
+        ng-show="efCtrl.featureId"
         title="{{'Delete this feature | translate'}}">
         <span class="fa fa-trash"></span>
         {{'Delete' | translate}}


### PR DESCRIPTION
This PR is a follow-up of #1585.  It features the addition of a confirmation message before deleting a feature. The "Delete" button is also only shown when an existing feature is selected, i.e. it's not shown when a feature is being created.

## Todo

 * [x] Wait for #1585 to be merged
 * [ ] Review

## Live example

 * https://adube.github.io/ngeo/gmf-editfeature-confirm-delete/examples/contribs/gmf/editfeatureselector.html