### PR TITLE
Enable search layer

### DIFF
--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -618,7 +618,7 @@ gmf.LayertreeController.prototype.toggleActive = function(treeCtrl) {
           }
         }
         goog.asserts.assertInstanceof(firstParentTreeLayer, ol.layer.Image);
-        this.updateWMSLayerState_(firstParentTreeLayer, newLayersNames.join(','));
+        this.layerHelper_.updateWMSLayerState(firstParentTreeLayer, newLayersNames.join(','));
       }
       break;
 
@@ -668,7 +668,7 @@ gmf.LayertreeController.prototype.toggleActive = function(treeCtrl) {
       }
       firstParentTreeLayer = /** @type {ol.layer.Image} */
           (firstParentTreeLayer);
-      this.updateWMSLayerState_(firstParentTreeLayer, layers.join(','));
+      this.layerHelper_.updateWMSLayerState(firstParentTreeLayer, layers.join(','));
       break;
     // no default
   }
@@ -804,34 +804,7 @@ gmf.LayertreeController.prototype.updateWMSTimeLayerState = function(layertreeCt
     if (layer) {
       var source = /** @type {ol.source.ImageWMS} */ (layer.getSource());
       var timeParam = this.gmfWMSTime_.formatWMSTimeParam(wmsTime, time);
-      this.updateWMSLayerState_(layer, source.getParams()['LAYERS'], timeParam);
-    }
-  }
-};
-
-
-/**
- * Update the LAYERS parameter of the source of the given WMS layer.
- * @param {ol.layer.Image} layer The WMS layer.
- * @param {string} names The names that will be used to set
- * the LAYERS parameter.
- * @param {string=} opt_time The start
- * and optionally the end datetime (for time range selection) selected by user
- * in a ISO-8601 string datetime or time interval format
- * @private
- */
-gmf.LayertreeController.prototype.updateWMSLayerState_ = function(layer,
-    names, opt_time) {
-  // Don't send layer without parameters, hide layer instead;
-  if (names.length <= 0) {
-    layer.setVisible(false);
-  } else {
-    layer.setVisible(true);
-    var source = /** @type {ol.source.ImageWMS} */ (layer.getSource());
-    if (opt_time) {
-      source.updateParams({'LAYERS': names, 'TIME': opt_time});
-    } else {
-      source.updateParams({'LAYERS': names});
+      this.layerHelper_.updateWMSLayerState(layer, source.getParams()['LAYERS'], timeParam);
     }
   }
 };

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -792,9 +792,7 @@ gmf.SearchController.prototype.selectFromGMF_ = function(event, feature, dataset
         this.gmfTreeManager_.addGroupByName(actionData, true);
       } else if (actionName == 'add_layer' &&
             groupActions.indexOf('add_layer') >= 0) {
-        // FIXME: Set the layer visible again (Issue also in the
-        // treemanager service).
-        this.gmfTreeManager_.addGroupByLayerName(actionData, true, goog.isDefAndNotNull(featureGeometry));
+        this.gmfTreeManager_.addGroupByLayerName(actionData, true, goog.isDefAndNotNull(featureGeometry), this.map_);
       }
     }
   }

--- a/contribs/gmf/src/services/themesservice.js
+++ b/contribs/gmf/src/services/themesservice.js
@@ -125,7 +125,7 @@ gmf.Themes.findGroupByLayerName = function(themes, name) {
       var group = theme.children[j];
       for (var k = 0, kk = group.children.length; k < kk; k++) {
         var layer = group.children[k];
-        if (layer.layers == name) {
+        if (layer.name == name) {
           return group;
         }
       }

--- a/contribs/gmf/src/services/treemanager.js
+++ b/contribs/gmf/src/services/treemanager.js
@@ -329,10 +329,10 @@ gmf.TreeManager.prototype.addGroupByLayerName = function(layerName, opt_add, opt
 
 /**
  * Make the layer of a group visible if the group is already in the layertree.
- * If the group has jus been added set only the layer layerName visible.
+ * If the group has just been added set only the layer layerName visible.
  * @param{string} layerName Name of the layer to set visible.
- * @param{Object} group Group containg the layer to activate.
- * @param{boolean} groupAdded True if the croup has been newly added. False otherwise
+ * @param{Object} group Group containing the layer to activate.
+ * @param{boolean} groupAdded True if the group has been newly added. False otherwise
  * @param{ol.Map} map Map obkect.
  * @private
  */
@@ -354,7 +354,7 @@ gmf.TreeManager.prototype.setLayerVisible_ = function(layerName, group, groupAdd
       activeLayers += activeLayers.includes(layerName) ? '' : ',' + layerName;
     }
 
-    ngeo.LayerHelper.prototype.updateWMSLayerState(layerGroup, activeLayers);
+    this.layerHelper_.updateWMSLayerState(layerGroup, activeLayers);
 
   } else {
     var layer;

--- a/src/services/layerHelper.js
+++ b/src/services/layerHelper.js
@@ -320,4 +320,31 @@ ngeo.LayerHelper.prototype.refreshWMSLayer = function(layer) {
 };
 
 
+/**
+ * Update the LAYERS parameter of the source of the given WMS layer.
+ * @param {ol.layer.Image} layer The WMS layer.
+ * @param {string} names The names that will be used to set
+ * the LAYERS parameter.
+ * @param {string=} opt_time The start
+ * and optionally the end datetime (for time range selection) selected by user
+ * in a ISO-8601 string datetime or time interval format
+ * @export
+ */
+ngeo.LayerHelper.prototype.updateWMSLayerState = function(layer,
+    names, opt_time) {
+  // Don't send layer without parameters, hide layer instead;
+  if (names.length <= 0) {
+    layer.setVisible(false);
+  } else {
+    layer.setVisible(true);
+    var source = /** @type {ol.source.ImageWMS} */ (layer.getSource());
+    if (opt_time) {
+      source.updateParams({'LAYERS': names, 'TIME': opt_time});
+    } else {
+      source.updateParams({'LAYERS': names});
+    }
+  }
+};
+
+
 ngeo.module.service('ngeoLayerHelper', ngeo.LayerHelper);


### PR DESCRIPTION
Fixes #1220 

Note: In  [themesservice.js](https://github.com/marionb/ngeo/blob/d677bebe1a8b2d2e29b2cf1163dddf14d8077533/contribs/gmf/src/services/themesservice.js#L128) I changed the use of `layer.layers` to `layer.name` to be able to also use this for WMTS layers. Is there a particular reason that we should continue using `layer.layers`?