### PR TITLE
Simplify createTextStyle by shortening the list of args

### DIFF
--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -1261,3 +1261,25 @@ ngeox.number;
  * @typedef {function(number, string=, string=, number=): string}
  */
 ngeox.unitPrefix;
+
+
+/**
+ * Namespace.
+ * @type {Object}
+ */
+ngeox.style;
+
+
+/**
+ * The options for creating a text style.
+ * @typedef {{
+ *     text: (string),
+ *     size: (number|undefined),
+ *     angle: (number|undefined),
+ *     color: (ol.Color|undefined),
+ *     width: (number|undefined),
+ *     offsetX: (number|undefined),
+ *     offsetY: (number|undefined)
+ * }}
+ */
+ngeox.style.TextOptions;


### PR DESCRIPTION
With this pull request I tried to simplify the helper to create a text style.
Currently this method can take 7 arguments (5 are optional).

This drives us to some code looking like this:
https://github.com/camptocamp/ngeo/blob/master/src/services/featurehelper.js#L211-L219

This is ugly in my opinion.
I propose instead to use only on object argument.

Please review.