### PR TITLE
Refresh WMS layer after save in gmf-editfeature

### DIFF
--- a/contribs/gmf/examples/editfeatureselector.js
+++ b/contribs/gmf/examples/editfeatureselector.js
@@ -6,6 +6,7 @@ goog.require('gmf.authenticationDirective');
 goog.require('gmf.editfeatureselectorDirective');
 goog.require('gmf.mapDirective');
 goog.require('ngeo.FeatureHelper');
+goog.require('ngeo.LayerHelper');
 goog.require('ngeo.ToolActivate');
 goog.require('ngeo.ToolActivateMgr');
 goog.require('ngeo.proj.EPSG21781');
@@ -48,12 +49,13 @@ app.module.constant('gmfLayersUrl',
  * @param {gmf.Themes} gmfThemes The gmf themes service.
  * @param {gmfx.User} gmfUser User.
  * @param {ngeo.FeatureHelper} ngeoFeatureHelper Ngeo feature helper service.
+ * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
  * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
  *     service.
  * @constructor
  */
 app.MainController = function($scope, gmfThemes, gmfUser, ngeoFeatureHelper,
-    ngeoToolActivateMgr) {
+    ngeoLayerHelper, ngeoToolActivateMgr) {
 
   /**
    * @type {!angular.Scope}
@@ -78,58 +80,16 @@ app.MainController = function($scope, gmfThemes, gmfUser, ngeoFeatureHelper,
   var projection = ol.proj.get('EPSG:21781');
   projection.setExtent([485869.5728, 76443.1884, 837076.5648, 299941.7864]);
 
-  var proxyUrl =
-      'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy';
-
-  /**
-   * @type {ol.source.ImageWMS}
-   * @private
-   */
-  this.polygonWMSSource_ = new ol.source.ImageWMS({
-    url: proxyUrl,
-    params: {'LAYERS': 'polygon'}
-  });
-
   /**
    * @type {ol.layer.Image}
    * @private
    */
-  this.polygonWMSLayer_ = new ol.layer.Image({
-    source: this.polygonWMSSource_
-  });
-
-  /**
-   * @type {ol.source.ImageWMS}
-   * @private
-   */
-  this.lineWMSSource_ = new ol.source.ImageWMS({
-    url: proxyUrl,
-    params: {'LAYERS': 'line'}
-  });
-
-  /**
-   * @type {ol.layer.Image}
-   * @private
-   */
-  this.lineWMSLayer_ = new ol.layer.Image({
-    source: this.lineWMSSource_
-  });
-
-  /**
-   * @type {ol.source.ImageWMS}
-   * @private
-   */
-  this.pointWMSSource_ = new ol.source.ImageWMS({
-    url: proxyUrl,
-    params: {'LAYERS': 'point'}
-  });
-
-  /**
-   * @type {ol.layer.Image}
-   * @private
-   */
-  this.pointWMSLayer_ = new ol.layer.Image({
-    source: this.pointWMSSource_
+  var wmsLayer = new ol.layer.Image({
+    querySourceIds: [111, 112, 113],
+    source: new ol.source.ImageWMS({
+      url: 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy',
+      params: {'LAYERS': 'point,line,polygon'}
+    })
   });
 
   /**
@@ -212,11 +172,7 @@ app.MainController = function($scope, gmfThemes, gmfUser, ngeoFeatureHelper,
     layers: [
       new ol.layer.Tile({
         source: new ol.source.OSM()
-      }),
-      this.polygonWMSLayer_,
-      this.lineWMSLayer_,
-      this.pointWMSLayer_,
-      this.vectorLayer
+      })
     ],
     view: new ol.View({
       projection: projection,
@@ -225,6 +181,15 @@ app.MainController = function($scope, gmfThemes, gmfUser, ngeoFeatureHelper,
       zoom: 2
     })
   });
+
+  // Add the WMS layer to the 'data' group, which is what the layer tree
+  // would do
+  var dataLayerGroup = ngeoLayerHelper.getGroupFromMap(this.map,
+        gmf.DATALAYERGROUP_NAME);
+  dataLayerGroup.getLayers().push(wmsLayer);
+
+  // Add layer vector after
+  this.map.addLayer(this.vectorLayer);
 
  /**
    * @type {boolean}

--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -14,6 +14,7 @@ goog.require('ngeo.createfeatureDirective');
 goog.require('ngeo.DecorateInteraction');
 goog.require('ngeo.EventHelper');
 goog.require('ngeo.FeatureHelper');
+goog.require('ngeo.LayerHelper');
 goog.require('ngeo.ToolActivate');
 goog.require('ngeo.ToolActivateMgr');
 goog.require('ol.format.GeoJSON');
@@ -38,6 +39,7 @@ goog.require('ol.interaction.Modify');
  *         gmf-editfeature-map="::ctrl.map"
  *         gmf-editfeature-tolerance="::ctrl.tolerance"
  *         gmf-editfeature-vector="::ctrl.vectorLayer">
+ *         gmf-editfeature-wmslayer="::ctrl.selectedWMSLayer">
  *     </gmf-editfeature>
  *
  * @htmlAttribute {GmfThemesNode} gmf-editfeature-layer The GMF node of the
@@ -47,6 +49,8 @@ goog.require('ol.interaction.Modify');
  *     buffer in pixels to use when making queries to get the features.
  * @htmlAttribute {ol.layer.Vector} gmf-editfeature-vector The vector layer in
  *     which to draw the vector features.
+ * @htmlAttribute {ol.layer.Image|ol.layer.Tile} gmf-editfeature-wmslayer The
+ *     WMS layer to refresh after each saved modification.
  * @return {angular.Directive} The directive specs.
  * @ngdoc directive
  * @ngname gmfEditfeature
@@ -58,7 +62,8 @@ gmf.editfeatureDirective = function() {
       'layer': '=gmfEditfeatureLayer',
       'map': '<gmfEditfeatureMap',
       'tolerance': '<?gmfEditfeatureTolerance',
-      'vectorLayer': '<gmfEditfeatureVector'
+      'vectorLayer': '<gmfEditfeatureVector',
+      'wmsLayer': '<gmfEditfeatureWmslayer'
     },
     bindToController: true,
     controllerAs: 'efCtrl',
@@ -80,6 +85,7 @@ gmf.module.directive(
  *     interaction service.
  * @param {ngeo.EventHelper} ngeoEventHelper Ngeo Event Helper.
  * @param {ngeo.FeatureHelper} ngeoFeatureHelper Ngeo feature helper service.
+ * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
  * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
  *     service.
  * @constructor
@@ -89,7 +95,7 @@ gmf.module.directive(
  */
 gmf.EditfeatureController = function($scope, $timeout, gettextCatalog,
     gmfEditFeature, gmfXSDAttributes, ngeoDecorateInteraction, ngeoEventHelper,
-    ngeoFeatureHelper, ngeoToolActivateMgr) {
+    ngeoFeatureHelper, ngeoLayerHelper, ngeoToolActivateMgr) {
 
   /**
    * @type {GmfThemesNode}
@@ -114,6 +120,12 @@ gmf.EditfeatureController = function($scope, $timeout, gettextCatalog,
    * @export
    */
   this.vectorLayer;
+
+  /**
+   * @type {ol.layer.Image|ol.layer.Tile}
+   * @export
+   */
+  this.wmsLayer;
 
   /**
    * @type {!angular.Scope}
@@ -161,6 +173,12 @@ gmf.EditfeatureController = function($scope, $timeout, gettextCatalog,
    * @private
    */
   this.featureHelper_ = ngeoFeatureHelper;
+
+  /**
+   * @type {ngeo.LayerHelper}
+   * @private
+   */
+  this.layerHelper_ = ngeoLayerHelper;
 
   /**
    * @type {ngeo.ToolActivateMgr}
@@ -350,6 +368,7 @@ gmf.EditfeatureController.prototype.handleEditFeature_ = function(resp) {
   var features = new ol.format.GeoJSON().readFeatures(resp.data);
   if (features.length) {
     this.feature.setId(features[0].getId());
+    this.layerHelper_.refreshWMSLayer(this.wmsLayer);
   }
 };
 
@@ -360,7 +379,7 @@ gmf.EditfeatureController.prototype.handleEditFeature_ = function(resp) {
  * @private
  */
 gmf.EditfeatureController.prototype.handleDeleteFeature_ = function(resp) {
-  console.log('ok, deleted');
+  this.layerHelper_.refreshWMSLayer(this.wmsLayer);
 };
 
 

--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -35,10 +35,10 @@ goog.require('ol.interaction.Modify');
  * Example:
  *
  *     <gmf-editfeature
- *         gmf-editfeature-layer="::ctrl.layer">
+ *         gmf-editfeature-layer="::ctrl.layer"
  *         gmf-editfeature-map="::ctrl.map"
  *         gmf-editfeature-tolerance="::ctrl.tolerance"
- *         gmf-editfeature-vector="::ctrl.vectorLayer">
+ *         gmf-editfeature-vector="::ctrl.vectorLayer"
  *         gmf-editfeature-wmslayer="::ctrl.selectedWMSLayer">
  *     </gmf-editfeature>
  *

--- a/contribs/gmf/src/directives/partials/editfeatureselector.html
+++ b/contribs/gmf/src/directives/partials/editfeatureselector.html
@@ -5,7 +5,7 @@
       ng-switch-when="null"
       ng-model="efsCtrl.getSetLayers"
       ng-model-options="{getterSetter: true}"
-      ng-options="layer.name for layer in efsCtrl.layers">
+      ng-options="layer.name for layer in efsCtrl.availableLayers">
     <option value="">-- Choose a layer --</option>
   </select>
 
@@ -23,7 +23,8 @@
         gmf-editfeature-layer="::efsCtrl.selectedLayer"
         gmf-editfeature-map="::efsCtrl.map"
         gmf-editfeature-tolerance="::efsCtrl.tolerance"
-        gmf-editfeature-vector="::efsCtrl.vectorLayer">
+        gmf-editfeature-vector="::efsCtrl.vectorLayer"
+        gmf-editfeature-wmslayer="::efsCtrl.selectedWMSLayer">
     </gmf-editfeature>
 
   </div>

--- a/src/services/eventhelper.js
+++ b/src/services/eventhelper.js
@@ -17,7 +17,7 @@ goog.require('ngeo');
 ngeo.EventHelper = function() {
 
   /**
-   * @type {Object.<number, ngeo.EventHelper.ListenerKeys>}
+   * @type {Object.<number|string, ngeo.EventHelper.ListenerKeys>}
    * @private
    */
   this.listenerKeys_ = {};
@@ -28,7 +28,7 @@ ngeo.EventHelper = function() {
 /**
  * Utility method to add a listener key bound to a unique id. The key can
  * come from an `ol.events` (default) or `goog.events`.
- * @param {number} uid Unique id.
+ * @param {number|string} uid Unique id.
  * @param {ol.EventsKey|goog.events.Key} key Key.
  * @param {boolean=} opt_isol Whether it's an OpenLayers event or not. Defaults
  *     to true.
@@ -50,7 +50,7 @@ ngeo.EventHelper.prototype.addListenerKey = function(uid, key, opt_isol) {
 
 /**
  * Clear all listener keys from the given unique id.
- * @param {number} uid Unique id.
+ * @param {number|string} uid Unique id.
  * @export
  */
 ngeo.EventHelper.prototype.clearListenerKey = function(uid) {
@@ -64,7 +64,7 @@ ngeo.EventHelper.prototype.clearListenerKey = function(uid) {
  *   has not array set yet)
  * - unlisten any events if the array already exists for the given uid and
  *   empty the array.
- * @param {number} uid Unique id.
+ * @param {number|string} uid Unique id.
  * @private
  */
 ngeo.EventHelper.prototype.initListenerKey_ = function(uid) {

--- a/src/services/layerHelper.js
+++ b/src/services/layerHelper.js
@@ -43,6 +43,12 @@ ngeo.LayerHelper.GROUP_KEY = 'groupName';
 
 
 /**
+ * @const
+ */
+ngeo.LayerHelper.REFRESH_PARAM = 'random';
+
+
+/**
  * Create and return a basic WMS layer with only a source URL and a dot
  * separated layers names (see {@link ol.source.ImageWMS}).
  * @param {string} sourceURL The source URL.
@@ -295,6 +301,22 @@ ngeo.LayerHelper.prototype.isLayerVisible = function(layer, map) {
   var currentResolution = map.getView().getResolution();
   return currentResolution > layer.getMinResolution() &&
       currentResolution < layer.getMaxResolution();
+};
+
+
+/**
+ * Force a WMS layer to refresh using a random value.
+ * @param {ol.layer.Image|ol.layer.Tile} layer Layer to refresh.
+ */
+ngeo.LayerHelper.prototype.refreshWMSLayer = function(layer) {
+  var source = layer.getSource();
+  goog.asserts.assert(
+    source instanceof ol.source.ImageWMS ||
+    source instanceof ol.source.TileWMS
+  );
+  var params = source.getParams();
+  params[ngeo.LayerHelper.REFRESH_PARAM] = Math.random();
+  source.updateParams(params);
 };
 
 


### PR DESCRIPTION
This PR is a follow-up of #1585.  It features the refreshing of the WMS layer after a save action occurs in the `gmf-editfeature` directive.

## Todo

 * [x] Wait for #1585 to be merged
 * [ ] Review

## Live example

 * https://adube.github.io/ngeo/gmf-editfeature-refresh-wms/examples/contribs/gmf/editfeatureselector.html