### PR TITLE
Display azimuth of circles in the redlining tools

### DIFF
--- a/contribs/gmf/src/directives/partials/featurestyle.html
+++ b/contribs/gmf/src/directives/partials/featurestyle.html
@@ -119,7 +119,7 @@
           for="gmf-featurestyle-showmeasure"
           class="control-label">
         <span ng-switch-when="Circle">
-          {{'Display surface' | translate}}
+          {{'Display azimuth and radius' | translate}}
         </span>
         <span ng-switch-when="Polygon">
           {{'Display surface' | translate}}

--- a/src/directives/drawfeature.js
+++ b/src/directives/drawfeature.js
@@ -266,6 +266,9 @@ ngeo.DrawfeatureController.prototype.handleDrawEnd = function(type, event) {
   switch (type) {
     case ngeo.GeometryType.CIRCLE:
       feature.set(prop.IS_CIRCLE, true);
+      if (event.feature.get('azimut') !== undefined) {
+        feature.set(prop.AZIMUT, event.feature.get('azimut'));
+      }
       break;
     case ngeo.GeometryType.TEXT:
       feature.set(prop.IS_TEXT, true);

--- a/src/directives/measureazimut.js
+++ b/src/directives/measureazimut.js
@@ -59,6 +59,11 @@ ngeo.measureazimutDirective = function($compile, gettext, $filter) {
                 geometry.getGeometries()[1]);
             var polygon = ol.geom.Polygon.fromCircle(circle, 64);
             event.feature = new ol.Feature(polygon);
+            var azimut = ngeo.interaction.MeasureAzimut.getAzimut(
+              /** @type {ol.geom.LineString} */ (geometry.getGeometries()[0])
+            );
+            event.feature.set('azimut', azimut);
+
             drawFeatureCtrl.handleDrawEnd(ngeo.GeometryType.CIRCLE, event);
           },
           drawFeatureCtrl

--- a/src/ngeo.js
+++ b/src/ngeo.js
@@ -56,6 +56,11 @@ ngeo.FeatureProperties = {
    */
   OPACITY: 'o',
   /**
+   * @type {number}
+   * @export
+   */
+  AZIMUT: 'z',
+  /**
    * @type {string}
    * @export
    */


### PR DESCRIPTION
Supersedes #1573

I reworked @jlap 's pull request to make it simpler (well I hope).
Instead of storing the radius line geometry, only the azimut is kept as a property of the feature.
Also, the placement of the azimut value on the map is computed using the point which is on the circle instead of a complex computation with an offset from the center.
Also the radius value and the position of the azimut update correctly if the circle is modified.
Finally, the radius length displays along the line (ie. oriented).

Demo:
http://pgiraud.github.io/ngeo/azimuth/examples/contribs/gmf/drawfeature.html
https://pgiraud.github.io/ngeo/azimuth/examples/contribs/gmf/apps/desktop

Still missing: update of the azimut value when modifying the circle.