### PR TITLE
Displaying features label after the locale has been loaded successfully

### DIFF
--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -88,6 +88,7 @@ gmf.module.constant('gmfPermalinkOptions',
  *     the gmf permalink service with.
  * @param {ngeo.Location} ngeoLocation ngeo location service.
  * @param {ngeo.WfsPermalink} ngeoWfsPermalink ngeo WFS query service.
+ * @param {angular.Scope} $rootScope Angular rootScope.
  * @ngInject
  * @ngdoc service
  * @ngname gmfPermalink
@@ -95,7 +96,7 @@ gmf.module.constant('gmfPermalinkOptions',
 gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
     ngeoFeatureOverlayMgr, ngeoFeatureHelper, ngeoFeatures, ngeoLayerHelper,
     ngeoStateManager, gmfThemes, gmfTreeManager, gmfPermalinkOptions,
-    ngeoLocation, ngeoWfsPermalink) {
+    ngeoLocation, ngeoWfsPermalink, $rootScope) {
 
   // == listener keys ==
 
@@ -280,7 +281,6 @@ gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
   //   (2) listen for further features added/removed
   var features = this.getFeatures();
   features.forEach(function(feature) {
-    this.featureHelper_.setStyle(feature);
     this.addNgeoFeature_(feature);
   }, this);
   this.ngeoFeatures_.extend(features);
@@ -289,6 +289,11 @@ gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
   ol.events.listen(this.ngeoFeatures_, ol.CollectionEventType.REMOVE,
     this.handleNgeoFeaturesRemove_, this);
 
+  $rootScope.$on('$localeChangeSuccess', function() {
+    features.forEach(function(feature) {
+      this.featureHelper_.setStyle(feature);
+    }, this);
+  }.bind(this));
 };
 
 


### PR DESCRIPTION
**Demo**:

https://oliviersemet.github.io/ngeo/fixing-feature-wrong-area-value-after-reload/examples/contribs/gmf/apps/desktop_alt/?baselayer_ref=map&lang=fr&map_x=583100&map_y=130100&map_zoom=0&tree_groups&rl_features=Fa(qf83-57uF.rmt-1e3_..smt-~r*true%27n*Rectangle%25201%27c*%2523DB4436%27a*0%27o*0.2%27m*true%27s*10%27k*1)a(ye93-d5aD.z4f_wav_..15f_~r*true%27n*Rectangle%25202%27c*%2523DB4436%27a*0%27o*0.2%27m*true%27s*10%27k*1)


Close #1576 

@pgiraud @sbrunner PR ready for review. 