### PR TITLE
Manage dirty and pending in gmf-editfeature

### DIFF
--- a/contribs/gmf/examples/editfeatureselector.html
+++ b/contribs/gmf/examples/editfeatureselector.html
@@ -34,15 +34,6 @@
       .gmf-editfeatureselector-stopediting {
         float: right;
       }
-      .gmf-editfeature-attributes-container {
-        position: relative;
-      }
-      .gmf-editfeature-pending-panel {
-        background-color: rgba(230, 230, 230, 0.3);
-        height: 100%;
-        position: absolute;
-        width: 100%;
-      }
       ngeo-attributes {
         border-top: 0.1rem solid black;
         display: block;

--- a/contribs/gmf/examples/editfeatureselector.html
+++ b/contribs/gmf/examples/editfeatureselector.html
@@ -28,8 +28,20 @@
         display: block;
         width: 30rem;
       }
+      gmf-editfeature {
+        display: block;
+      }
       .gmf-editfeatureselector-stopediting {
         float: right;
+      }
+      .gmf-editfeature-attributes-container {
+        position: relative;
+      }
+      .gmf-editfeature-pending-panel {
+        background-color: rgba(230, 230, 230, 0.3);
+        height: 100%;
+        position: absolute;
+        width: 100%;
       }
       ngeo-attributes {
         border-top: 0.1rem solid black;

--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -187,12 +187,6 @@ gmf.EditfeatureController = function($scope, $timeout, gettextCatalog,
   this.ngeoToolActivateMgr_ = ngeoToolActivateMgr;
 
   /**
-   * @type {number}
-   * @private
-   */
-  this.pixelBuffer_ = 10;
-
-  /**
    * Flag that is toggled as soon as the feature changes, i.e. if any of its
    * properties change, which includes the geometry.
    * @type {boolean}
@@ -581,11 +575,20 @@ gmf.EditfeatureController.prototype.handleFeatureChange_ = function(
   newFeature, oldFeature
 ) {
 
+  var geom;
   if (oldFeature) {
     ol.events.unlisten(
       oldFeature,
       ol.ObjectEventType.PROPERTYCHANGE,
       this.handleFeaturePropertyChange_,
+      this
+    );
+    geom = oldFeature.getGeometry();
+    goog.asserts.assert(geom);
+    ol.events.unlisten(
+      geom,
+      ol.events.EventType.CHANGE,
+      this.handleFeatureGeometryChange_,
       this
     );
   }
@@ -598,6 +601,14 @@ gmf.EditfeatureController.prototype.handleFeatureChange_ = function(
       this.handleFeaturePropertyChange_,
       this
     );
+    geom = newFeature.getGeometry();
+    goog.asserts.assert(geom);
+    ol.events.listen(
+      geom,
+      ol.events.EventType.CHANGE,
+      this.handleFeatureGeometryChange_,
+      this
+    );
   } else {
     this.featureId = null;
   }
@@ -606,13 +617,19 @@ gmf.EditfeatureController.prototype.handleFeatureChange_ = function(
 
 
 /**
- * @param {ol.ObjectEvent} evt Event.
  * @private
  */
-gmf.EditfeatureController.prototype.handleFeaturePropertyChange_ = function(
-  evt
-) {
+gmf.EditfeatureController.prototype.handleFeaturePropertyChange_ = function() {
   this.dirty = true;
+};
+
+
+/**
+ * @private
+ */
+gmf.EditfeatureController.prototype.handleFeatureGeometryChange_ = function() {
+  this.dirty = true;
+  this.scope_.$apply();
 };
 
 

--- a/contribs/gmf/src/directives/partials/editfeature.html
+++ b/contribs/gmf/src/directives/partials/editfeature.html
@@ -33,28 +33,27 @@
       class="gmf-editfeature-attributes-container"
       ng-switch-default
       ng-if="efCtrl.attributes">
-      <div
-          class="gmf-editfeature-pending-panel"
-          ng-if="efCtrl.pending">
-      </div>
       <ngeo-attributes
         ngeo-attributes-attributes="::efCtrl.attributes"
+        ngeo-attributes-disabled="efCtrl.pending"
         ngeo-attributes-feature="::efCtrl.feature">
       </ngeo-attributes>
       <a
         class="btn btn-sm btn-default gmf-editfeature-btn-save"
-        ng-class="{'disabled': !efCtrl.dirty}"
         ng-click="efCtrl.save()"
+        ng-disabled="!efCtrl.dirty"
         title="{{'Save modifications | translate'}}"
         href>{{'Save' | translate}}</a>
       <a
         class="btn btn-sm btn-default gmf-editfeature-btn-cancel"
         ng-click="efCtrl.cancel()"
+        ng-disabled="efCtrl.pending"
         title="{{'Cancel modifications | translate'}}"
         href>{{'Cancel' | translate}}</a>
       <button
         class="btn btn-sm btn-link gmf-editfeature-btn-delete"
         ng-click="efCtrl.delete()"
+        ng-disabled="efCtrl.pending"
         ng-show="efCtrl.featureId"
         title="{{'Delete this feature | translate'}}">
         <span class="fa fa-trash"></span>

--- a/contribs/gmf/src/directives/partials/editfeature.html
+++ b/contribs/gmf/src/directives/partials/editfeature.html
@@ -30,14 +30,20 @@
       </span>
     </a>
     <div
+      class="gmf-editfeature-attributes-container"
       ng-switch-default
       ng-if="efCtrl.attributes">
+      <div
+          class="gmf-editfeature-pending-panel"
+          ng-if="efCtrl.pending">
+      </div>
       <ngeo-attributes
         ngeo-attributes-attributes="::efCtrl.attributes"
         ngeo-attributes-feature="::efCtrl.feature">
       </ngeo-attributes>
       <a
         class="btn btn-sm btn-default gmf-editfeature-btn-save"
+        ng-class="{'disabled': !efCtrl.dirty}"
         ng-click="efCtrl.save()"
         title="{{'Save modifications | translate'}}"
         href>{{'Save' | translate}}</a>

--- a/examples/attributes.html
+++ b/examples/attributes.html
@@ -25,13 +25,16 @@
                 ng-click="ctrl.updateName()"
                 value="Change name" >
             </input>
-            to change the name.
+            to change the name. You can also
+            <label for="disable">Disable the form</label>
+            <input id="disable" type="checkbox" ng-model="ctrl.disabled" />.
           </p>
         </div>
         <div class="col-sm-6">
           <ngeo-attributes
             ng-if="ctrl.attributes"
             ngeo-attributes-attributes="::ctrl.attributes"
+            ngeo-attributes-disabled="ctrl.disabled"
             ngeo-attributes-feature="::ctrl.feature">
           </ngeo-attributes>
         </div>

--- a/examples/attributes.js
+++ b/examples/attributes.js
@@ -33,6 +33,12 @@ app.MainController = function($http, $timeout) {
   this.attributes = null;
 
   /**
+   * @type {boolean}
+   * @export
+   */
+  this.disabled = false;
+
+  /**
    * @type {ol.Feature}
    * @export
    */

--- a/src/directives/attributes.js
+++ b/src/directives/attributes.js
@@ -11,11 +11,14 @@ goog.require('ngeo.EventHelper');
  *
  *     <ngeo-attributes
  *       ngeo-attributes-attributes="::ctrl.attributes"
+ *       ngeo-attributes-disabled="ctrl.attributesDisabled"
  *       ngeo-attributes-feature="::ctrl.feature">
  *     </ngeo-attributes>
  *
  * @htmlAttribute {Array.<ngeox.Attribute>} ngeo-attributes-attributes The
  *     list of attributes to use.
+ * @htmlAttribute {boolean} ngeo-attributes-disabled Whether the fieldset should
+ *     be disabled or not.
  * @htmlAttribute {ol.Feature} ngeo-attributes-feature The feature.
  * @return {angular.Directive} The directive specs.
  * @ngInject
@@ -28,6 +31,7 @@ ngeo.attributesDirective = function() {
     scope: true,
     bindToController: {
       'attributes': '=ngeoAttributesAttributes',
+      'disabled': '<ngeoAttributesDisabled',
       'feature': '=ngeoAttributesFeature'
     },
     controllerAs: 'attrCtrl',
@@ -54,6 +58,13 @@ ngeo.AttributesController = function($scope, ngeoEventHelper) {
    * @export
    */
   this.attributes;
+
+  /**
+   * Whether the fieldset should be disabled or not.
+   * @type {boolean}
+   * @export
+   */
+  this.disabled = this.disabled === true;
 
   /**
    * The feature containing the values.

--- a/src/directives/partials/attributes.html
+++ b/src/directives/partials/attributes.html
@@ -1,4 +1,5 @@
 <form class="form">
+  <fieldset ng-disabled="attrCtrl.disabled">
   <div
       class="form-group"
       ng-repeat="attribute in ::attrCtrl.attributes">
@@ -27,4 +28,5 @@
       </div>
     </div>
   </div>
+  </fieldset>
 </form>


### PR DESCRIPTION
This PR is a follow-up of #1585.  It introduces `dirty` and `pending` properties in the `gmf-editfeature` directive :

 * the directive is marked `dirty` when a feature is modified, i.e. its geometry or its properties. Only when dirty does the "Save" button is enabled
 * the directive is marked `pending` while a save request or a get request is in progress. While so, the form and buttons are prevented from being used.

## Todo

 * [x] Wait for #1585 to be merged
 * [x] Review

## Live example

 * https://adube.github.io/ngeo/gmf-editfeature-dirty-management/examples/contribs/gmf/editfeatureselector.html