### PR TITLE
Add pixelBuffer for gmf-editfeature directive

### DIFF
--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -33,12 +33,15 @@ goog.require('ol.format.GeoJSON');
  *     <gmf-editfeature
  *         gmf-editfeature-layer="::ctrl.layer">
  *         gmf-editfeature-map="::ctrl.map"
+ *         gmf-editfeature-pixelbuffer="::ctrl.pixelBuffer"
  *         gmf-editfeature-vector="::ctrl.vectorLayer">
  *     </gmf-editfeature>
  *
  * @htmlAttribute {GmfThemesNode} gmf-editfeature-layer The GMF node of the
  *     editable layer.
  * @htmlAttribute {ol.Map} gmf-editfeature-map The map.
+ * @htmlAttribute {number|undefined} gmf-editfeatureselector-pixelbuffer The
+ *     buffer in pixels to use when making queries to get the features.
  * @htmlAttribute {ol.layer.Vector} gmf-editfeature-vector The vector layer in
  *     which to draw the vector features.
  * @return {angular.Directive} The directive specs.
@@ -51,6 +54,7 @@ gmf.editfeatureDirective = function() {
     scope: {
       'layer': '=gmfEditfeatureLayer',
       'map': '<gmfEditfeatureMap',
+      'pixelBuffer': '<?gmfEditfeaturePixelbuffer',
       'vectorLayer': '<gmfEditfeatureVector'
     },
     bindToController: true,
@@ -91,6 +95,12 @@ gmf.EditfeatureController = function($scope, $timeout, gettextCatalog,
    * @export
    */
   this.map;
+
+  /**
+   * @type {number}
+   * @export
+   */
+  this.pixelBuffer = this.pixelBuffer !== undefined ? this.pixelBuffer : 10;
 
   /**
    * @type {ol.layer.Vector}
@@ -138,12 +148,6 @@ gmf.EditfeatureController = function($scope, $timeout, gettextCatalog,
    * @private
    */
   this.ngeoToolActivateMgr_ = ngeoToolActivateMgr;
-
-  /**
-   * @type {number}
-   * @private
-   */
-  this.pixelBuffer_ = 10;
 
   /**
    * @type {boolean}
@@ -418,7 +422,7 @@ gmf.EditfeatureController.prototype.handleMapClick_ = function(evt) {
   var map = this.map;
   var view = map.getView();
   var resolution = view.getResolution();
-  var buffer = resolution * this.pixelBuffer_;
+  var buffer = resolution * this.pixelBuffer;
   var extent = ol.extent.buffer(
     [coordinate[0], coordinate[1], coordinate[0], coordinate[1]],
     buffer

--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -33,14 +33,14 @@ goog.require('ol.format.GeoJSON');
  *     <gmf-editfeature
  *         gmf-editfeature-layer="::ctrl.layer">
  *         gmf-editfeature-map="::ctrl.map"
- *         gmf-editfeature-pixelbuffer="::ctrl.pixelBuffer"
+ *         gmf-editfeature-tolerance="::ctrl.tolerance"
  *         gmf-editfeature-vector="::ctrl.vectorLayer">
  *     </gmf-editfeature>
  *
  * @htmlAttribute {GmfThemesNode} gmf-editfeature-layer The GMF node of the
  *     editable layer.
  * @htmlAttribute {ol.Map} gmf-editfeature-map The map.
- * @htmlAttribute {number|undefined} gmf-editfeatureselector-pixelbuffer The
+ * @htmlAttribute {number|undefined} gmf-editfeatureselector-tolerance The
  *     buffer in pixels to use when making queries to get the features.
  * @htmlAttribute {ol.layer.Vector} gmf-editfeature-vector The vector layer in
  *     which to draw the vector features.
@@ -54,7 +54,7 @@ gmf.editfeatureDirective = function() {
     scope: {
       'layer': '=gmfEditfeatureLayer',
       'map': '<gmfEditfeatureMap',
-      'pixelBuffer': '<?gmfEditfeaturePixelbuffer',
+      'tolerance': '<?gmfEditfeatureTolerance',
       'vectorLayer': '<gmfEditfeatureVector'
     },
     bindToController: true,
@@ -100,7 +100,7 @@ gmf.EditfeatureController = function($scope, $timeout, gettextCatalog,
    * @type {number}
    * @export
    */
-  this.pixelBuffer = this.pixelBuffer !== undefined ? this.pixelBuffer : 10;
+  this.tolerance = this.tolerance !== undefined ? this.tolerance : 10;
 
   /**
    * @type {ol.layer.Vector}
@@ -422,7 +422,7 @@ gmf.EditfeatureController.prototype.handleMapClick_ = function(evt) {
   var map = this.map;
   var view = map.getView();
   var resolution = view.getResolution();
-  var buffer = resolution * this.pixelBuffer;
+  var buffer = resolution * this.tolerance;
   var extent = ol.extent.buffer(
     [coordinate[0], coordinate[1], coordinate[0], coordinate[1]],
     buffer

--- a/contribs/gmf/src/directives/editfeatureselector.js
+++ b/contribs/gmf/src/directives/editfeatureselector.js
@@ -18,14 +18,14 @@ goog.require('gmf.editfeatureDirective');
  *     <gmf-editfeatureselector
  *         gmf-editfeatureselector-active="ctrl.editFeatureSelectorActive"
  *         gmf-editfeatureselector-map="::ctrl.map"
- *         gmf-editfeatureselector-pixelbuffer="::ctrl.pixelBuffer"
+ *         gmf-editfeatureselector-tolerance="::ctrl.tolerance"
  *         gmf-editfeatureselector-vector="::ctrl.vectorLayer">
  *     </gmf-editfeatureselector>
  *
  * @htmlAttribute {boolean} gmf-editfeatureselector-active Whether the
  *     directive is active or not.
  * @htmlAttribute {ol.Map} gmf-editfeatureselector-map The map.
- * @htmlAttribute {number|undefined} gmf-editfeatureselector-pixelbuffer The
+ * @htmlAttribute {number|undefined} gmf-editfeatureselector-tolerance The
  *     buffer in pixels to use when making queries to get the features.
  * @htmlAttribute {ol.layer.Vector} gmf-editfeatureselector-vector The vector
  *     layer where the selected or created features are drawn.
@@ -39,7 +39,7 @@ gmf.editfeatureselectorDirective = function() {
     scope: {
       'active': '=gmfEditfeatureselectorActive',
       'map': '<gmfEditfeatureselectorMap',
-      'pixelBuffer': '<?gmfEditfeatureselectorPixelbuffer',
+      'tolerance': '<?gmfEditfeatureselectorTolerance',
       'vectorLayer': '<gmfEditfeatureselectorVector'
     },
     bindToController: true,
@@ -85,7 +85,7 @@ gmf.EditfeatureselectorController = function($scope, gmfThemes) {
    * @type {number|undefined}
    * @export
    */
-  this.pixelBuffer;
+  this.tolerance;
 
   /**
    * @type {ol.layer.Vector}

--- a/contribs/gmf/src/directives/editfeatureselector.js
+++ b/contribs/gmf/src/directives/editfeatureselector.js
@@ -18,12 +18,15 @@ goog.require('gmf.editfeatureDirective');
  *     <gmf-editfeatureselector
  *         gmf-editfeatureselector-active="ctrl.editFeatureSelectorActive"
  *         gmf-editfeatureselector-map="::ctrl.map"
+ *         gmf-editfeatureselector-pixelbuffer="::ctrl.pixelBuffer"
  *         gmf-editfeatureselector-vector="::ctrl.vectorLayer">
  *     </gmf-editfeatureselector>
  *
  * @htmlAttribute {boolean} gmf-editfeatureselector-active Whether the
  *     directive is active or not.
  * @htmlAttribute {ol.Map} gmf-editfeatureselector-map The map.
+ * @htmlAttribute {number|undefined} gmf-editfeatureselector-pixelbuffer The
+ *     buffer in pixels to use when making queries to get the features.
  * @htmlAttribute {ol.layer.Vector} gmf-editfeatureselector-vector The vector
  *     layer where the selected or created features are drawn.
  * @return {angular.Directive} The directive specs.
@@ -36,6 +39,7 @@ gmf.editfeatureselectorDirective = function() {
     scope: {
       'active': '=gmfEditfeatureselectorActive',
       'map': '<gmfEditfeatureselectorMap',
+      'pixelBuffer': '<?gmfEditfeatureselectorPixelbuffer',
       'vectorLayer': '<gmfEditfeatureselectorVector'
     },
     bindToController: true,
@@ -76,6 +80,12 @@ gmf.EditfeatureselectorController = function($scope, gmfThemes) {
    * @export
    */
   this.map;
+
+  /**
+   * @type {number|undefined}
+   * @export
+   */
+  this.pixelBuffer;
 
   /**
    * @type {ol.layer.Vector}

--- a/contribs/gmf/src/directives/partials/editfeatureselector.html
+++ b/contribs/gmf/src/directives/partials/editfeatureselector.html
@@ -22,7 +22,7 @@
     <gmf-editfeature
         gmf-editfeature-layer="::efsCtrl.selectedLayer"
         gmf-editfeature-map="::efsCtrl.map"
-        gmf-editfeature-pixelbuffer="::efsCtrl.pixelBuffer"
+        gmf-editfeature-tolerance="::efsCtrl.tolerance"
         gmf-editfeature-vector="::efsCtrl.vectorLayer">
     </gmf-editfeature>
 

--- a/contribs/gmf/src/directives/partials/editfeatureselector.html
+++ b/contribs/gmf/src/directives/partials/editfeatureselector.html
@@ -22,6 +22,7 @@
     <gmf-editfeature
         gmf-editfeature-layer="::efsCtrl.selectedLayer"
         gmf-editfeature-map="::efsCtrl.map"
+        gmf-editfeature-pixelbuffer="::efsCtrl.pixelBuffer"
         gmf-editfeature-vector="::efsCtrl.vectorLayer">
     </gmf-editfeature>
 


### PR DESCRIPTION
This PR is a follow-up of #1585.  It adds the `pixelBuffer` option to both `gmf-editfeature` and `gmf-editfeatureselector` directives.

## Todo

 * [x] Wait for #1585 to be merged
 * [x] Review

## Live example

 * https://adube.github.io/ngeo/gmf-editfeature-pixelbuffer/examples/contribs/gmf/editfeatureselector.html