### PR TITLE
Validate attributes of gmf-editfeature before saving

### DIFF
--- a/contribs/gmf/src/directives/partials/editfeature.html
+++ b/contribs/gmf/src/directives/partials/editfeature.html
@@ -59,6 +59,7 @@
         <span class="fa fa-trash"></span>
         {{'Delete' | translate}}
       </button>
+      <div class="gmf-editfeature-error"></div>
     </div>
   </div>
 </div>

--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -25,21 +25,29 @@ goog.require('ol.style.Text');
  *  - style setting / getting
  *  - measurement
  *  - export
+ *  - validation (using attributes)
  *
  * @constructor
  * @param {angular.$injector} $injector Main injector.
  * @param {angular.$filter} $filter Angular filter
+ * @param {angularGettext.Catalog} gettextCatalog Gettext service.
  * @ngdoc service
  * @ngname ngeoFeatureHelper
  * @ngInject
  */
-ngeo.FeatureHelper = function($injector, $filter) {
+ngeo.FeatureHelper = function($injector, $filter, gettextCatalog) {
 
   /**
    * @type {angular.$filter}
    * @private
    */
   this.$filter_ = $filter;
+
+  /**
+   * @type {angularGettext.Catalog}
+   * @private
+   */
+  this.gettextCatalog_ = gettextCatalog;
 
   /**
    * @type {?number}
@@ -724,6 +732,50 @@ ngeo.FeatureHelper.prototype.export_ = function(features, format, fileName,
     ].join(''),
     'mimeType': mimeType
   })[0].click();
+};
+
+
+// === VALIDATION ===
+
+
+/**
+ * Check if the feature properties validate against a list of attributes.
+ * Return any error bound ot the attribute.
+ *
+ * @param {ol.Feature} feature Feature to validate.
+ * @param {Array.<ngeox.Attribute>} attributes List of attributes to use to
+ *     validate the feature with.
+ * @return {Array.<ngeox.Message>} List of error messages.
+ */
+ngeo.FeatureHelper.prototype.validateAttributes = function(
+  feature, attributes
+) {
+  var errors = [];
+  var attribute;
+
+  for (var i = 0, ii = attributes.length; i < ii; i++) {
+    attribute = attributes[i];
+
+    // (1) Skip any geometry attribute
+    if (attribute.type === ngeo.format.XSDAttributeType.GEOMETRY) {
+      continue;
+    }
+
+    // (2) Check if attribute is required
+    var value = feature.get(attribute.name);
+    if (attribute.required &&
+        (value === undefined || value === null || value === '')
+    ) {
+      errors.push({
+        msg: this.gettextCatalog_.getString(
+            'This field is required: '
+          ) + attribute.name,
+        type: ngeo.MessageType.ERROR
+      });
+    }
+  }
+
+  return errors;
 };
 
 


### PR DESCRIPTION
This PR is a follow-up of #1585.  It introduces the validation of the attributes of a feature before saving its modifications. For now, there's only one type of thing to validate: whether it's required or not.

## Todo

 * [x] Wait for #1585 to be merged
 * [ ] Review

## Live example

 * https://adube.github.io/ngeo/gmf-editfeature-validation/examples/contribs/gmf/editfeatureselector.html