### PR TITLE
Displaying interaction overlay on top of all features drawn (redlining)

### DIFF
--- a/contribs/gmf/src/directives/drawfeature.js
+++ b/contribs/gmf/src/directives/drawfeature.js
@@ -178,6 +178,13 @@ gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
    */
   this.selectedFeatures = new ol.Collection();
 
+
+  /**
+   * @type {ol.Collection}
+   * @private
+   */
+  this.interactions_ = new ol.Collection();
+
   /**
    * @type {ngeo.interaction.Modify}
    * @private
@@ -186,7 +193,7 @@ gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
     features: this.selectedFeatures,
     style: ngeoFeatureHelper.getVertexStyle(false)
   });
-  this.registerInteraction_(this.modify_);
+  this.interactions_.push(this.modify_);
 
   /**
    * @type {ngeo.Menu}
@@ -232,7 +239,7 @@ gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
       })
     })
   });
-  this.registerInteraction_(this.translate_);
+  this.interactions_.push(this.translate_);
 
   /**
    * @type {ngeo.interaction.Rotate}
@@ -251,7 +258,9 @@ gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
       })
     })
   });
-  this.registerInteraction_(this.rotate_);
+  this.interactions_.push(this.rotate_);
+
+  this.initializeInteractions_();
 
   /**
    * @type {ngeo.ToolActivate}
@@ -306,10 +315,12 @@ gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
       if (previousFeature) {
         this.featureHelper_.setStyle(previousFeature);
         this.selectedFeatures.clear();
+        this.unregisterInteractions_();
       }
       if (newFeature) {
         this.featureHelper_.setStyle(newFeature, true);
         this.selectedFeatures.push(newFeature);
+        this.registerInteractions_();
         if (this.listSelectionInProgress_) {
           this.featureHelper_.panMapToFeature(newFeature, this.map);
           this.listSelectionInProgress_ = false;
@@ -351,16 +362,36 @@ gmf.DrawfeatureController.MenuActionType = {
 
 
 /**
- * Register an interaction by setting it inactive, decorating it and adding it
- * to the map
- * @param {ol.interaction.Interaction} interaction Interaction to register.
+ * Initialize interactions by setting them inactive and decorating them
  * @private
  */
-gmf.DrawfeatureController.prototype.registerInteraction_ = function(
-    interaction) {
-  interaction.setActive(false);
-  this.ngeoDecorateInteraction_(interaction);
-  this.map.addInteraction(interaction);
+gmf.DrawfeatureController.prototype.initializeInteractions_ = function() {
+  this.interactions_.forEach(function(interaction) {
+    interaction.setActive(false);
+    this.ngeoDecorateInteraction_(interaction);
+  },this);
+};
+
+
+/**
+ * Register interactions by adding them to the map
+ * @private
+ */
+gmf.DrawfeatureController.prototype.registerInteractions_ = function() {
+  this.interactions_.forEach(function(interaction) {
+    this.map.addInteraction(interaction);
+  },this);
+};
+
+
+/**
+ * Register interactions by removing them to the map
+ * @private
+ */
+gmf.DrawfeatureController.prototype.unregisterInteractions_ = function() {
+  this.interactions_.forEach(function(interaction) {
+    this.map.removeInteraction(interaction);
+  },this);
 };
 
 


### PR DESCRIPTION
Close #1580

**demo:**

[Here](https://oliviersemet.github.io/ngeo/display-interaction-cursor-on-top-of-features/examples/contribs/gmf/apps/desktop_alt/?baselayer_ref=map&lang=fr&map_x=521000&map_y=120250&map_zoom=0&rl_features=Fa(dhz2-9b9Fj_dn-rCym-rHwk-pMfj-eRfg-xV1e-807b-84-w7-v7-94-6b-90zd-yVeg-fRej-qMvk-sHxm-sCcn-k_en-j_xm-rCvk-rHej-pMeg-eRzd-xV6b-80v7-84-84-v7-806b-xVzd-eReg-pMej-rHvk-rCxm-j_cn-k_en-sCxm-sHvk-qMej-fReg-yVzd-906b-94-v7-w7-84-7b-801e-xVfg-eRfj-pMwk-rHym-rCfn-j_dn-k_ym-sCwk-sHfj-qMfg-fR1e-yV7b-90w7-94-94-w7-907b-yV1e-fRfg-qMfj-sHwk-sCym-~l*true%27n*Circle%25201%27c*%2523DB4436%27a*0%27o*0.2%27m*false%27s*10%27k*1)a(k6z3-18cEg!u7_cF77_8Mu5_vSu3_cZ51_e5-ww-ab-1t-mg-kn-jn-ng-zs-bb-vw-f5-41_dZt3_wSt5_9M67_dFt7_h!v7_g!67_cFt5_8Mt3_vS41_cZvw-e5-zs-ab-jn-mg-mg-jn-ab-zs-e5-vw-cZ41_vSt3_8Mt5_cF67_g!t7_h!v7_dF67_9Mt5_wSt3_dZ41_f5-vw-bb-zs-ng-jn-kn-mg-1t-ab-ww-e5-51_cZu3_vSu5_8M77_cFw7_g!u7_h!77_dFu5_9Mu3_wS51_dZww-f5-1t-bb-kn-ng-ng-kn-bb-1t-f5-ww-dZ51_wSu3_9Mu5_dF77_~l*true%27n*Circle%25202%27c*%2523DB4436%27a*0%27o*0.2%27m*false%27s*10%27k*1)a(5hh4-hr8Fg_3m-gCnk-eHnj-8M5h-vQ9f-8Vwc-gZ5a-c3-w6-v6-d3-4a-hZvc-9V8f-wQ4h-9Mmj-fHmk-hC2m-h_4m-g_mk-gCmj-eH4h-8M8f-vQvc-8V4a-gZv6-c3-c3-v6-gZ4a-8Vvc-vQ8f-8M4h-eHmj-gCmk-g_2m-h_4m-hCmk-fHmj-9M4h-wQ8f-9Vvc-hZ4a-d3-v6-w6-c3-5a-gZwc-8V9f-vQ5h-8Mnj-eHnk-gC5m-g_3m-h_nk-hCnj-fH5h-9M9f-wQwc-9V5a-hZw6-d3-d3-w6-hZ5a-9Vwc-wQ9f-9M5h-fHnj-hCnk-~l*true%27n*Circle%25203%27c*%2523DB4436%27a*0%27o*0.2%27m*false%27s*10%27k*1)l(dfx2-9qzD90gr_1c_gy-seK9B1c_hr_sN9j_~n*LineString%25204%27c*%2523DB4436%27a*0%27o*0.2%27m*false%27s*10%27k*1)a(3n33-sdnEOkHt-fH2!7H8*wGcAdGeBsFgC5FgDbEaEhD4FhCrFfBcGdAvG9*6H3!eHu-jHPmHOeHt-6H2!vG8*cGcArFeB4FgCaEgDgDaEgC4FeBrFcAcG8*vG2!6Ht-eHOjHPmHu-eH3!6H9*vGdAcGfBrFhC4FhDaEbEgD5FgCsFeBdGcAwG8*7H2!fHt-nHOkHPfHu-7H3!wG9*dGdAsFfB5FhCbEhDhDbEhC5FfBsFdAdG9*wG3!7Hu-fH~l*true%27n*Circle%25205%27c*%2523DB4436%27a*0%27o*0.2%27m*false%27s*10%27k*1)a(kmn3-1mnEOkHv-hH2!9H8*wGeAfGeBuFjC7FeDdEcEfD6FkCtFfBeGfAvG9*8H3!gHw-jHPmHOgHv-8H2!vG8*eGeAtFeB6FjCcEeDeDcEjC6FeBtFeAeG8*vG2!8Hv-gHOjHPmHw-gH3!8H9*vGfAeGfBtFkC6FfDcEdEeD7FjCuFeBfGeAwG8*9H2!hHv-nHOkHPhHw-9H3!wG9*fGfAuFfB7FkCdEfDfDdEkC7FfBuFfAfG9*wG3!9Hw-hH~l*true%27n*Circle%25206%27c*%2523DB4436%27a*0%27o*0.2%27m*false%27s*10%27k*1)l(n3p3-harDsx_z6Mh2SsN1x!zw!9s-8fB~n*LineString%25207%27c*%2523DB4436%27a*0%27o*0.2%27m*false%27s*10%27k*1)l(dxn4-1cwC8B8zU~n*LineString%25208%27c*%2523DB4436%27a*0%27o*0.2%27m*false%27s*10%27k*1)l(5r33-1knDrc-reKrwPhHrg*zw!gr_ga*rN8sV~n*LineString%25209%27c*%2523DB4436%27a*0%27o*0.2%27m*false%27s*10%27k*1)&tree_groups)

**Note:** The interaction cursor appeared under the redline features because its overlay was set to the map before features were drawn. The solution take care of adding interactions only when the user select a feature.  

@pgiraud @sbrunner this PR is ready for review.