### PR TITLE
Azimut modify

### DIFF
--- a/contribs/gmf/src/directives/drawfeature.js
+++ b/contribs/gmf/src/directives/drawfeature.js
@@ -312,9 +312,9 @@ gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
       return this.selectedFeature;
     }.bind(this),
     function(newFeature, previousFeature) {
+      this.selectedFeatures.clear();
       if (previousFeature) {
         this.featureHelper_.setStyle(previousFeature);
-        this.selectedFeatures.clear();
         this.unregisterInteractions_();
       }
       if (newFeature) {
@@ -609,8 +609,6 @@ gmf.DrawfeatureController.prototype.handleMapClick_ = function(evt) {
   if (feature === this.selectedFeature) {
     return;
   }
-
-  this.modify_.setActive(true);
 
   this.selectedFeature = feature;
 

--- a/src/ol-ext/interaction/modifycircle.js
+++ b/src/ol-ext/interaction/modifycircle.js
@@ -348,6 +348,10 @@ ngeo.interaction.ModifyCircle.handleDragEvent_ = function(evt) {
   var coordinates = ol.geom.Polygon.fromCircle(circle, 64).getCoordinates();
   this.setGeometryCoordinates_(geometry, coordinates);
 
+
+  var azimut = ngeo.interaction.MeasureAzimut.getAzimut(line);
+  this.features_.getArray()[0].set(ngeo.FeatureProperties.AZIMUT, azimut);
+
   this.createOrUpdateVertexFeature_(vertex);
 };
 

--- a/src/ol-ext/interaction/modifycircle.js
+++ b/src/ol-ext/interaction/modifycircle.js
@@ -142,8 +142,6 @@ ngeo.interaction.ModifyCircle.prototype.addFeature_ = function(feature) {
     if (map) {
       this.handlePointerAtPixel_(this.lastPixel_, map);
     }
-    ol.events.listen(feature, ol.events.EventType.CHANGE,
-        this.handleFeatureChange_, this);
   }
 };
 
@@ -173,8 +171,6 @@ ngeo.interaction.ModifyCircle.prototype.removeFeature_ = function(feature) {
     this.overlay_.getSource().removeFeature(this.vertexFeature_);
     this.vertexFeature_ = null;
   }
-  ol.events.unlisten(feature, ol.events.EventType.CHANGE,
-      this.handleFeatureChange_, this);
 };
 
 
@@ -218,19 +214,6 @@ ngeo.interaction.ModifyCircle.prototype.handleFeatureAdd_ = function(evt) {
   goog.asserts.assertInstanceof(feature, ol.Feature,
       'feature should be an ol.Feature');
   this.addFeature_(feature);
-};
-
-
-/**
- * @param {ol.events.Event} evt Event.
- * @private
- */
-ngeo.interaction.ModifyCircle.prototype.handleFeatureChange_ = function(evt) {
-  if (!this.changingFeature_) {
-    var feature = /** @type {ol.Feature} */ (evt.target);
-    this.removeFeature_(feature);
-    this.addFeature_(feature);
-  }
 };
 
 


### PR DESCRIPTION
With this pull request I cleaned the modify circle by removing some code that looks not necessary to me. I actually figured out that the number of features managed by the modify circle interaction was increasing where there should be only the currently selected feature.

But the main goal is to allow modification of the azimut when modifying the circle.

Demo:
https://pgiraud.github.io/ngeo/azimut_modify/examples/contribs/gmf/apps/desktop
https://pgiraud.github.io/ngeo/azimut_modify/examples/contribs/gmf/drawfeature.html

(Draw a circle, check the "Show radius and azimut", then modify the circle)