### PR TITLE
Fix feature selection

### DIFF
--- a/contribs/gmf/examples/drawfeature.html
+++ b/contribs/gmf/examples/drawfeature.html
@@ -197,7 +197,6 @@
     <gmf-drawfeature
       ng-show="ctrl.drawFeatureActive === true"
       gmf-drawfeature-active="ctrl.drawFeatureActive"
-      gmf-drawfeature-layer="::ctrl.vectorLayer"
       gmf-drawfeature-map="::ctrl.map">
     </gmf-drawfeature>
 

--- a/contribs/gmf/examples/drawfeature.js
+++ b/contribs/gmf/examples/drawfeature.js
@@ -32,10 +32,12 @@ app.module.constant('ngeoExportFeatureFormats', [
  * @param {ol.Collection.<ol.Feature>} ngeoFeatures Collection of features.
  * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
  *     service.
+ * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr Ngeo FeatureOverlay
+ *     manager
  * @constructor
  */
 app.MainController = function($scope, ngeoFeatureHelper, ngeoFeatures,
-    ngeoToolActivateMgr) {
+    ngeoToolActivateMgr, ngeoFeatureOverlayMgr) {
 
   /**
    * @type {!angular.Scope}
@@ -50,16 +52,8 @@ app.MainController = function($scope, ngeoFeatureHelper, ngeoFeatures,
 
   ngeoFeatureHelper.setProjection(view.getProjection());
 
-  /**
-   * @type {ol.layer.Vector}
-   * @export
-   */
-  this.vectorLayer = new ol.layer.Vector({
-    source: new ol.source.Vector({
-      wrapX: false,
-      features: ngeoFeatures
-    })
-  });
+  var featureOverlay = ngeoFeatureOverlayMgr.getFeatureOverlay();
+  featureOverlay.setFeatures(ngeoFeatures);
 
   /**
    * @type {ol.Map}
@@ -69,8 +63,7 @@ app.MainController = function($scope, ngeoFeatureHelper, ngeoFeatures,
     layers: [
       new ol.layer.Tile({
         source: new ol.source.OSM()
-      }),
-      this.vectorLayer
+      })
     ],
     view: view
   });

--- a/contribs/gmf/src/directives/drawfeature.js
+++ b/contribs/gmf/src/directives/drawfeature.js
@@ -29,13 +29,11 @@ goog.require('ol.style.Text');
  *
  *     <gmf-drawfeature
  *         gmf-drawfeature-active="ctrl.drawFeatureActive"
- *         gmf-drawfeature-layer="::ctrl.vectorLayer"
  *         gmf-drawfeature-map="::ctrl.map">
  *     </gmf-drawfeature>
  *
  * @htmlAttribute {boolean} gmf-drawfeature-active Whether the directive is
  *     active or not.
- * @htmlAttribute {ol.layer.Vector} gmf-drawfeature-layer The vector layer.
  * @htmlAttribute {ol.Map} gmf-drawfeature-map The map.
  * @return {angular.Directive} The directive specs.
  * @ngInject
@@ -47,7 +45,6 @@ gmf.drawfeatureDirective = function() {
     controller: 'GmfDrawfeatureController',
     scope: {
       'active': '=gmfDrawfeatureActive',
-      'layer': '<gmfDrawfeatureLayer',
       'map': '<gmfDrawfeatureMap'
     },
     bindToController: true,
@@ -77,12 +74,6 @@ gmf.module.directive('gmfDrawfeature', gmf.drawfeatureDirective);
 gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
     ngeoDecorateInteraction, ngeoFeatureHelper, ngeoFeatures,
     ngeoToolActivateMgr) {
-
-  /**
-   * @type {ol.layer.Vector}
-   * @export
-   */
-  this.layer;
 
   /**
    * @type {ol.Map}
@@ -228,7 +219,6 @@ gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
    */
   this.translate_ = new ngeo.interaction.Translate({
     features: this.selectedFeatures,
-    layers: [this.layer],
     style: new ol.style.Style({
       text: new ol.style.Text({
         text: '\uf047',
@@ -247,7 +237,6 @@ gmf.DrawfeatureController = function($scope, $timeout, gettextCatalog,
    */
   this.rotate_ = new ngeo.interaction.Rotate({
     features: this.selectedFeatures,
-    layers: [this.layer],
     style: new ol.style.Style({
       text: new ol.style.Text({
         text: '\uf01e',
@@ -597,10 +586,7 @@ gmf.DrawfeatureController.prototype.handleMapClick_ = function(evt) {
       }
       return ret;
     }.bind(this),
-    null,
-    function(layer) {
-      return layer === this.layer;
-    }.bind(this)
+    null
   );
 
   feature = feature ? feature : null;
@@ -655,10 +641,7 @@ gmf.DrawfeatureController.prototype.handleMapContextMenu_ = function(evt) {
       }
       return ret;
     }.bind(this),
-    null,
-    function(layer) {
-      return layer === this.layer;
-    }.bind(this)
+    null
   );
 
   feature = feature ? feature : null;


### PR DESCRIPTION
Supersedes #1603.

Fixes #1471 & #1579.

It looks like the filtering using "layer" in `forEachFeatureAtPixel` is not really required since we already ensure that the feature is the from the correct collection.
This means that we don't need to give the `drawFeature` directive a layer. The `ngeoFeature` service is already doing the job.
In summary, we were doing too much. Code has been simplified and it continues to work.

Demo
https://pgiraud.github.io/ngeo/fix_feature_selection/examples/contribs/gmf/apps/desktop
https://pgiraud.github.io/ngeo/fix_feature_selection/examples/contribs/gmf/drawfeature.html