### PR TITLE
Add ui-date in ngeo-attributes

### DIFF
--- a/contribs/gmf/examples/editfeatureselector.html
+++ b/contribs/gmf/examples/editfeatureselector.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="../../../node_modules/openlayers/css/ol.css" type="text/css">
     <link rel="stylesheet" href="../../../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
     <link rel="stylesheet" href="../../../node_modules/font-awesome/css/font-awesome.css" type="text/css">
-    <link rel="stylesheet" href="../third-party/jquery-ui/jquery-ui.min.css">
+    <link rel="stylesheet" href="../../../third-party/jquery-ui/jquery-ui.min.css">
     <style>
       body {
         padding: 1rem;
@@ -113,7 +113,7 @@
     </div>
 
     <script src="../../../node_modules/jquery/dist/jquery.js"></script>
-    <script src="../third-party/jquery-ui/jquery-ui.min.js"></script>
+    <script src="../../../third-party/jquery-ui/jquery-ui.min.js"></script>
     <script src="../../../node_modules/angular/angular.js"></script>
     <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
     <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>

--- a/src/directives/attributes.js
+++ b/src/directives/attributes.js
@@ -4,7 +4,6 @@ goog.provide('ngeo.attributesDirective');
 goog.require('ngeo');
 goog.require('ngeo.EventHelper');
 
-
 /**
  * Directive used to render the attributes of a feature into a form.
  * Example:
@@ -81,6 +80,16 @@ ngeo.AttributesController = function($scope, ngeoEventHelper) {
    * @private
    */
   this.ngeoEventHelper_ = ngeoEventHelper;
+
+  /**
+   * Datepicker options
+   * @type {Object}
+   * @export
+   */
+  this.dateOptions = {
+    'changeMonth': true,
+    'changeYear': true
+  };
 
   // Listen to the feature inner properties change and apply them to the form
   var uid = goog.getUid(this);

--- a/src/directives/datepicker.js
+++ b/src/directives/datepicker.js
@@ -19,7 +19,9 @@ ngeo.module.value('ngeoDatePickerTemplateUrl',
 
 
 /**
- * Provide a directive to select a signle date or a range of dates
+ * Provide a directive to select a signle date or a range of dates. Requires
+ * jQuery UI for the 'datepicker' widget.
+ *
  * @param {string|function(!angular.JQLite=, !angular.Attributes=)}
  * ngeoDatePickerTemplateUrl Template for the directive.
  * @param  {angular.$timeout} $timeout angular timeout service

--- a/src/directives/partials/attributes.html
+++ b/src/directives/partials/attributes.html
@@ -17,6 +17,25 @@
             {{ ::attribute }}
           </option>
         </select>
+
+        <input
+            ng-switch-when="date"
+            ui-date="attrCtrl.dateOptions"
+            ng-model="attrCtrl.properties[attribute.name]"
+            ng-change="attrCtrl.handleInputChange(attribute.name);"
+            class="form-control"
+            type="text">
+        </input>
+
+        <input
+            ng-switch-when="datetime"
+            ui-date="attrCtrl.dateOptions"
+            ng-model="attrCtrl.properties[attribute.name]"
+            ng-change="attrCtrl.handleInputChange(attribute.name);"
+            class="form-control"
+            type="text">
+        </input>
+
         <input
             ng-switch-default
             ng-model="attrCtrl.properties[attribute.name]"


### PR DESCRIPTION
This PR introduces the use of the `ui-date` directive in the `ngeo-attributes` directive for both `date` and `datetime` attribute types. Note that we should definitively use something else for `datetime`, but this should come in an other PR.

## Todo

 * [ ] review

## Live demo

 * https://adube.github.io/ngeo/xsd-datetime/examples/contribs/gmf/editfeatureselector.html