### PR TITLE
Take device pixel ratio when displaying print mask

### DIFF
--- a/src/services/printutils.js
+++ b/src/services/printutils.js
@@ -62,18 +62,20 @@ ngeo.PrintUtils.prototype.createPrintMaskPostcompose = function(getSize,
         var center = [viewportWidth / 2, viewportHeight / 2];
 
         var size = getSize();
+        var height = size[1] * ol.has.DEVICE_PIXEL_RATIO;
+        var width = size[0] * ol.has.DEVICE_PIXEL_RATIO;
         var scale = getScale(frameState);
 
         var ppi = ngeo.PrintUtils.DOTS_PER_INCH_;
         var ipm = ngeo.PrintUtils.INCHES_PER_METER_;
 
         var extentHalfWidth =
-            (((size[0] / ppi) / ipm) * scale / resolution) / 2;
+            (((width / ppi) / ipm) * scale / resolution) / 2;
         self.extentHalfHorizontalDistance_ =
             (((size[0] / ppi) / ipm) * scale) / 2;
 
         var extentHalfHeight =
-            (((size[1] / ppi) / ipm) * scale / resolution) / 2;
+            (((height / ppi) / ipm) * scale / resolution) / 2;
         self.extentHalfVerticalDistance_ =
             (((size[1] / ppi) / ipm) * scale) / 2;
 


### PR DESCRIPTION
Fixes #1533
Please review

Demo:
https://pgiraud.github.io/ngeo/print_mask_retina/examples/contribs/gmf/print.html?baselayer_ref=map&lang=en&map_x=552200&map_y=193800&map_zoom=0&tree_enable_osm_open=false&tree_enable_osm_scale=true&tree_groups=OSM%20functions%20mixed%2CLayers%2CGroup%2COSM%20functions
(to be compared with https://camptocamp.github.io/ngeo/master/examples/contribs/gmf/print.html?baselayer_ref=map&lang=en&map_x=552200&map_y=193800&map_zoom=0&tree_enable_osm_open=false&tree_enable_osm_scale=true&tree_groups=OSM%20functions%20mixed%2CLayers%2CGroup%2COSM%20functions)