### PR TITLE
Add gmf-editfeature in desktop and desktop_alt apps

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -57,6 +57,10 @@
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Draw & Measure'|translate}}">
               <span class="fa fa-paint-brush"></span>
             </button>
+            <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.editFeatureActive"
+              data-toggle="tooltip" data-placement="left" data-original-title="{{'Editing'|translate}}">
+              <span class="fa fa-pencil"></span>
+            </button>
             <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.drawProfilePanelActive"
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Profile'|translate}}">
               <span class="fa fa-area-chart"></span>
@@ -103,6 +107,25 @@
                   gmf-drawfeature-layer="::mainCtrl.drawFeatureLayer"
                   gmf-drawfeature-map="::mainCtrl.map">
               </gmf-drawfeature>
+            </div>
+          </div>
+          <div ng-show="mainCtrl.editFeatureActive" class="row">
+            <div class="col-sm-12">
+              <div class="tools-content-heading">
+                {{'Editing'|translate}}
+                <a class="btn close" ng-click="mainCtrl.editFeatureActive = false">&times;</a>
+              </div>
+              <div ng-switch="mainCtrl.gmfUser.username">
+                <div ng-switch-when="null">
+                  {{'In order to use the editing tool, you must log in first.' | translate}}
+                </div>
+                <gmf-editfeatureselector
+                    ng-switch-default
+                    gmf-editfeatureselector-active="mainCtrl.editFeatureActive"
+                    gmf-editfeatureselector-map="::mainCtrl.map"
+                    gmf-editfeatureselector-vector="::mainCtrl.editFeatureVectorLayer">
+                </gmf-editfeatureselector>
+              </div>
             </div>
           </div>
           <div ng-show="mainCtrl.drawProfilePanelActive" class="row">
@@ -254,6 +277,7 @@
         module.constant('gmfPrintUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/printproxy');
         module.constant('gmfWmsUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy');
         module.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
+        module.constant('gmfLayersUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/layers/');
         module.constant('gmfShortenerCreateUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/short/create');
         module.constant('gmfSearchGroups', ['osm','district']);
         // Requires that the gmfSearchGroups is specified

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -55,6 +55,10 @@
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Draw & Measure'|translate}}">
               <span class="fa fa-paint-brush"></span>
             </button>
+            <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.editFeatureActive"
+              data-toggle="tooltip" data-placement="left" data-original-title="{{'Editing'|translate}}">
+              <span class="fa fa-pencil"></span>
+            </button>
             <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.drawProfilePanelActive"
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Profile'|translate}}">
               <span class="fa fa-area-chart"></span>
@@ -102,6 +106,25 @@
                   gmf-drawfeature-layer="::mainCtrl.drawFeatureLayer"
                   gmf-drawfeature-map="::mainCtrl.map">
               </gmf-drawfeature>
+            </div>
+          </div>
+          <div ng-show="mainCtrl.editFeatureActive" class="row">
+            <div class="col-sm-12">
+              <div class="tools-content-heading">
+                {{'Editing'|translate}}
+                <a class="btn close" ng-click="mainCtrl.editFeatureActive = false">&times;</a>
+              </div>
+              <div ng-switch="mainCtrl.gmfUser.username">
+                <div ng-switch-when="null">
+                  {{'In order to use the editing tool, you must log in first.' | translate}}
+                </div>
+                <gmf-editfeatureselector
+                    ng-switch-default
+                    gmf-editfeatureselector-active="mainCtrl.editFeatureActive"
+                    gmf-editfeatureselector-map="::mainCtrl.map"
+                    gmf-editfeatureselector-vector="::mainCtrl.editFeatureVectorLayer">
+                </gmf-editfeatureselector>
+              </div>
             </div>
           </div>
           <div ng-show="mainCtrl.drawProfilePanelActive" class="row">
@@ -243,6 +266,7 @@
         module.constant('gmfProfileJsonUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/profile.json');
         module.constant('gmfWmsUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy');
         module.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
+        module.constant('gmfLayersUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/layers/');
         module.constant('gmfShortenerCreateUrl', '');
         module.constant('gmfSearchGroups', ['osm','district']);
         // Requires that the gmfSearchGroups is specified

--- a/contribs/gmf/examples/editfeatureselector.js
+++ b/contribs/gmf/examples/editfeatureselector.js
@@ -17,10 +17,6 @@ goog.require('ol.layer.Tile');
 goog.require('ol.layer.Vector');
 goog.require('ol.source.OSM');
 goog.require('ol.source.Vector');
-goog.require('ol.style.Circle');
-goog.require('ol.style.Fill');
-goog.require('ol.style.Image');
-goog.require('ol.style.Stroke');
 
 
 /** @const **/
@@ -102,70 +98,8 @@ app.MainController = function($scope, gmfThemes, gmfUser, ngeoFeatureHelper,
       features: new ol.Collection()
     }),
     style: function(feature, resolution) {
-      // (1) Style definition depends on geometry type
-      var white = [255, 255, 255, 1];
-      var blue = [0, 153, 255, 1];
-      var width = 3;
-      var styles = [];
-
-      var geom = feature.getGeometry();
-      console.assert(geom);
-      var type = geom.getType();
-
-      if (type === 'Point') {
-        styles.push(
-          new ol.style.Style({
-            image: new ol.style.Circle({
-              radius: width * 2,
-              fill: new ol.style.Fill({
-                color: blue
-              }),
-              stroke: new ol.style.Stroke({
-                color: white,
-                width: width / 2
-              })
-            }),
-            zIndex: Infinity
-          })
-        );
-      } else {
-        if (type === 'LineString') {
-          styles.push(
-            new ol.style.Style({
-              stroke: new ol.style.Stroke({
-                color: white,
-                width: width + 2
-              })
-            })
-          );
-          styles.push(
-            new ol.style.Style({
-              stroke: new ol.style.Stroke({
-                color: blue,
-                width: width
-              })
-            })
-          );
-        } else {
-          styles.push(
-            new ol.style.Style({
-              stroke: new ol.style.Stroke({
-                color: blue,
-                width: width / 2
-              }),
-              fill: new ol.style.Fill({
-                color: [255, 255, 255, 0.5]
-              })
-            })
-          );
-        }
-
-        // (2) Anything else than 'Point' requires the vertex style as well
-        styles.push(ngeoFeatureHelper.getVertexStyle(true));
-      }
-
-      return styles;
-    }.bind(this)
+      return ngeoFeatureHelper.createEditingStyles(feature);
+    }
   });
 
   /**

--- a/contribs/gmf/examples/editfeatureselector.js
+++ b/contribs/gmf/examples/editfeatureselector.js
@@ -149,6 +149,10 @@ app.MainController = function($scope, gmfThemes, gmfUser, ngeoFeatureHelper,
         } else {
           styles.push(
             new ol.style.Style({
+              stroke: new ol.style.Stroke({
+                color: blue,
+                width: width / 2
+              }),
               fill: new ol.style.Fill({
                 color: [255, 255, 255, 0.5]
               })

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -525,3 +525,14 @@ gmf-disclaimer {
   vertical-align: bottom;
   left: ~"calc(2 * @{app-margin} + @{bgselector-image-size} + 2 * @{padding-small-vertical})";
 }
+
+
+/**
+ * GMF EditFeature directive
+ */
+.gmf-editfeatureselector-stopediting {
+  float: right;
+}
+.gmf-editfeature-btn-delete {
+  float: right;
+}

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -158,70 +158,9 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
       features: new ol.Collection()
     }),
     style: function(feature, resolution) {
-      // (1) Style definition depends on geometry type
-      var white = [255, 255, 255, 1];
-      var blue = [0, 153, 255, 1];
-      var width = 3;
-      var styles = [];
-
-      var geom = feature.getGeometry();
-      console.assert(geom);
-      var type = geom.getType();
-
-      if (type === ol.geom.GeometryType.POINT) {
-        styles.push(
-          new ol.style.Style({
-            image: new ol.style.Circle({
-              radius: width * 2,
-              fill: new ol.style.Fill({
-                color: blue
-              }),
-              stroke: new ol.style.Stroke({
-                color: white,
-                width: width / 2
-              })
-            }),
-            zIndex: Infinity
-          })
-        );
-      } else {
-        if (type === ol.geom.GeometryType.LINE_STRING) {
-          styles.push(
-            new ol.style.Style({
-              stroke: new ol.style.Stroke({
-                color: white,
-                width: width + 2
-              })
-            })
-          );
-          styles.push(
-            new ol.style.Style({
-              stroke: new ol.style.Stroke({
-                color: blue,
-                width: width
-              })
-            })
-          );
-        } else {
-          styles.push(
-            new ol.style.Style({
-              stroke: new ol.style.Stroke({
-                color: blue,
-                width: width / 2
-              }),
-              fill: new ol.style.Fill({
-                color: [255, 255, 255, 0.5]
-              })
-            })
-          );
-        }
-
-        // (2) Anything else than 'Point' requires the vertex style as well
-        styles.push(ngeoFeatureHelper.getVertexStyle(true));
-      }
-
-      return styles;
-    }.bind(this)
+      return ngeoFeatureHelper.createEditingStyles(feature);
+    }
+    // style: ngeoFeatureHelper.createEditingStyles.bind(ngeoFeatureHelper)
   });
   this.editFeatureVectorLayer.setMap(this.map);
 

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -40,6 +40,8 @@ goog.require('ngeo.FeatureOverlayMgr');
 goog.require('ngeo.ScaleselectorOptions');
 /** @suppress {extraRequire} */
 goog.require('ngeo.scaleselectorDirective');
+goog.require('ngeo.ToolActivate');
+goog.require('ngeo.ToolActivateMgr');
 goog.require('ol.Collection');
 goog.require('ol.Map');
 goog.require('ol.View');
@@ -222,6 +224,15 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
     }.bind(this)
   });
   this.editFeatureVectorLayer.setMap(this.map);
+
+  /**
+   * The ngeo ToolActivate manager service.
+   * @type {ngeo.ToolActivateMgr}
+   */
+  var ngeoToolActivateMgr = $injector.get('ngeoToolActivateMgr');
+
+  var editFeatureActivate = new ngeo.ToolActivate(this, 'editFeatureActive');
+  ngeoToolActivateMgr.registerTool('mapTools', editFeatureActivate, false);
 
   /**
    * @type {ngeo.ScaleselectorOptions}

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -7,6 +7,8 @@ goog.require('ngeo.bboxQueryDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.drawfeatureDirective');
 /** @suppress {extraRequire} */
+goog.require('gmf.editfeatureselectorDirective');
+/** @suppress {extraRequire} */
 goog.require('gmf.elevationDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.mousepositionDirective');
@@ -38,11 +40,18 @@ goog.require('ngeo.FeatureOverlayMgr');
 goog.require('ngeo.ScaleselectorOptions');
 /** @suppress {extraRequire} */
 goog.require('ngeo.scaleselectorDirective');
+goog.require('ol.Collection');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.control.ScaleLine');
 goog.require('ol.control.Zoom');
 goog.require('ol.interaction');
+goog.require('ol.layer.Vector');
+goog.require('ol.source.Vector');
+goog.require('ol.style.Circle');
+goog.require('ol.style.Fill');
+goog.require('ol.style.Stroke');
+goog.require('ol.style.Style');
 
 gmf.module.constant('isDesktop', true);
 
@@ -108,6 +117,12 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
    */
   this.modalShareShown = false;
 
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.editFeatureActive = false;
+
   // initialize tooltips
   $('body').tooltip({
     container: 'body',
@@ -128,6 +143,85 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
   this.drawFeatureLayer = $injector.get('ngeoFeatureOverlayMgr')
       .getFeatureOverlay();
   this.drawFeatureLayer.setFeatures(ngeoFeatures);
+
+  var ngeoFeatureHelper = $injector.get('ngeoFeatureHelper');
+
+  /**
+   * @type {ol.layer.Vector}
+   * @export
+   */
+  this.editFeatureVectorLayer = new ol.layer.Vector({
+    source: new ol.source.Vector({
+      wrapX: false,
+      features: new ol.Collection()
+    }),
+    style: function(feature, resolution) {
+      // (1) Style definition depends on geometry type
+      var white = [255, 255, 255, 1];
+      var blue = [0, 153, 255, 1];
+      var width = 3;
+      var styles = [];
+
+      var geom = feature.getGeometry();
+      console.assert(geom);
+      var type = geom.getType();
+
+      if (type === ol.geom.GeometryType.POINT) {
+        styles.push(
+          new ol.style.Style({
+            image: new ol.style.Circle({
+              radius: width * 2,
+              fill: new ol.style.Fill({
+                color: blue
+              }),
+              stroke: new ol.style.Stroke({
+                color: white,
+                width: width / 2
+              })
+            }),
+            zIndex: Infinity
+          })
+        );
+      } else {
+        if (type === ol.geom.GeometryType.LINE_STRING) {
+          styles.push(
+            new ol.style.Style({
+              stroke: new ol.style.Stroke({
+                color: white,
+                width: width + 2
+              })
+            })
+          );
+          styles.push(
+            new ol.style.Style({
+              stroke: new ol.style.Stroke({
+                color: blue,
+                width: width
+              })
+            })
+          );
+        } else {
+          styles.push(
+            new ol.style.Style({
+              stroke: new ol.style.Stroke({
+                color: blue,
+                width: width / 2
+              }),
+              fill: new ol.style.Fill({
+                color: [255, 255, 255, 0.5]
+              })
+            })
+          );
+        }
+
+        // (2) Anything else than 'Point' requires the vertex style as well
+        styles.push(ngeoFeatureHelper.getVertexStyle(true));
+      }
+
+      return styles;
+    }.bind(this)
+  });
+  this.editFeatureVectorLayer.setMap(this.map);
 
   /**
    * @type {ngeo.ScaleselectorOptions}

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -50,10 +50,6 @@ goog.require('ol.control.Zoom');
 goog.require('ol.interaction');
 goog.require('ol.layer.Vector');
 goog.require('ol.source.Vector');
-goog.require('ol.style.Circle');
-goog.require('ol.style.Fill');
-goog.require('ol.style.Stroke');
-goog.require('ol.style.Style');
 
 gmf.module.constant('isDesktop', true);
 

--- a/contribs/gmf/src/directives/partials/editfeatureselector.html
+++ b/contribs/gmf/src/directives/partials/editfeatureselector.html
@@ -5,8 +5,8 @@
       ng-switch-when="null"
       ng-model="efsCtrl.getSetLayers"
       ng-model-options="{getterSetter: true}"
-      ng-options="layer.name for layer in efsCtrl.availableLayers">
-    <option value="">-- Choose a layer --</option>
+      ng-options="layer.name | translate for layer in efsCtrl.availableLayers">
+    <option value="" translate>-- Choose a layer --</option>
   </select>
 
   <div ng-switch-default>

--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -319,6 +319,73 @@ ngeo.FeatureHelper.prototype.getTextStyle_ = function(feature) {
 };
 
 
+ngeo.FeatureHelper.prototype.createEditingStyles = function(feature) {
+  // (1) Style definition depends on geometry type
+  var white = [255, 255, 255, 1];
+  var blue = [0, 153, 255, 1];
+  var width = 3;
+  var styles = [];
+
+  var geom = feature.getGeometry();
+  console.assert(geom);
+  var type = geom.getType();
+
+  if (type === ol.geom.GeometryType.POINT) {
+    styles.push(
+      new ol.style.Style({
+        image: new ol.style.Circle({
+          radius: width * 2,
+          fill: new ol.style.Fill({
+            color: blue
+          }),
+          stroke: new ol.style.Stroke({
+            color: white,
+            width: width / 2
+          })
+        }),
+        zIndex: Infinity
+      })
+    );
+  } else {
+    if (type === ol.geom.GeometryType.LINE_STRING) {
+      styles.push(
+        new ol.style.Style({
+          stroke: new ol.style.Stroke({
+            color: white,
+            width: width + 2
+          })
+        })
+      );
+      styles.push(
+        new ol.style.Style({
+          stroke: new ol.style.Stroke({
+            color: blue,
+            width: width
+          })
+        })
+      );
+    } else {
+      styles.push(
+        new ol.style.Style({
+          stroke: new ol.style.Stroke({
+            color: blue,
+            width: width / 2
+          }),
+          fill: new ol.style.Fill({
+            color: [255, 255, 255, 0.5]
+          })
+        })
+      );
+    }
+
+    // (2) Anything else than 'Point' requires the vertex style as well
+    styles.push(this.getVertexStyle(true));
+  }
+
+  return styles;
+};
+
+
 /**
  * Create and return a style object to be used for vertex.
  * @param {boolean=} opt_incGeomFunc Whether to include the geometry function


### PR DESCRIPTION
This PR introduces the `gmf-editfeature` directive in the **dektop** and **desktop_alt** applications.

## Todo

 * [x] Issue - both the query and edit tools can be active at the same time. You can see this in action in the desktop app.
 * [x] review

## Live demo

You need to be logged in to see the editing tools.  Also, you need to have the "Editing" theme in order to have layers in the drop down list.

 * (Desktop Alternate) https://adube.github.io/ngeo/gmf-editfeature-app/examples/contribs/gmf/apps/desktop_alt/index.html?baselayer_ref=map&lang=fr&map_x=537500&map_y=152851&map_zoom=3&tree_groups=Edit&tree_group_layers_Edit=line%2Cpolygon%2Cpoint

 * (Desktop) https://adube.github.io/ngeo/gmf-editfeature-app/examples/contribs/gmf/apps/desktop/