### PR TITLE
Add form-control to the layer <select> element

### DIFF
--- a/contribs/gmf/src/directives/partials/editfeatureselector.html
+++ b/contribs/gmf/src/directives/partials/editfeatureselector.html
@@ -2,6 +2,7 @@
     ng-switch="efsCtrl.selectedLayer">
 
   <select
+      class="form-control"
       ng-switch-when="null"
       ng-model="efsCtrl.getSetLayers"
       ng-model-options="{getterSetter: true}"


### PR DESCRIPTION
Adds the `form-control` to the select element of the `gmf-editfeatureselector` directive.

## Todo

 * [ ] There's a small "glitch" when selecting a layer.  The select element stays visible for a short while.  It didn't do that without `form-control`.  What should we do about that ? 

## Live demo

 * https://adube.github.io/ngeo/gmf-editfeature-select-form-control/examples/contribs/gmf/editfeatureselector.html