### PR TITLE
Show pencil icon in layer tree while editing

### DIFF
--- a/contribs/gmf/externs/gmf-themes.js
+++ b/contribs/gmf/externs/gmf-themes.js
@@ -30,6 +30,13 @@ GmfThemesNode.prototype.childLayers;
 
 
 /**
+ * Flag that is turned on when the node is currently being edited.
+ * @type {boolean|undefined}
+ */
+GmfThemesNode.prototype.editing;
+
+
+/**
  * @type {string}
  */
 GmfThemesNode.prototype.layers;

--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -457,6 +457,8 @@ gmf.EditfeatureController.prototype.toggle_ = function(active) {
 
     this.mapSelectActive = true;
     this.modify_.setActive(true);
+    this.layer['editing'] = true;
+
   } else {
 
     toolMgr.unregisterTool(createUid, this.createToolActivate);
@@ -469,6 +471,8 @@ gmf.EditfeatureController.prototype.toggle_ = function(active) {
     this.modify_.setActive(false);
     this.mapSelectActive = false;
     this.cancel();
+    this.layer['editing'] = false;
+
   }
 
 };

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -33,6 +33,11 @@
             gmf-time-slider-on-date-selected="gmfLayertreeCtrl.updateWMSTimeLayerState(layertreeCtrl, time)"/>
         </div>
     </span>
+    <span
+      class="fa fa-pencil"
+      title="{{'Currently editing this layer'|translate}}"
+      ng-if="layertreeCtrl.node.editing">
+    </span>
   </a>
   <span class="right-buttons">
     <a href="" ng-if="::layertreeCtrl.depth == 1" ng-click="gmfLayertreeCtrl.removeNode(layertreeCtrl.node)">


### PR DESCRIPTION
This PR introduces the following feature: show a small pencil icon in the layer tree while the `gmf-editfeature` directive is enabled.

There is no way of testing this without both a layer tree and the edit tools at the same time.  Instead of creating a new example or making either the layer tree or edit feature example more complex, I used the applications as test ground.

## Todo

 * [x] Wait for #1636 to be merged
 * [ ] Review

## Live example

 * https://adube.github.io/ngeo/gmf-editfeature-layertree-icon/examples/contribs/gmf/apps/desktop_alt/index.html?baselayer_ref=map&lang=fr&map_x=537500&map_y=152851&map_zoom=3&tree_groups=Edit&tree_group_layers_Edit=line%2Cpolygon%2Cpoint