### PR TITLE
Use 'editable' theme node property as configuration

### DIFF
--- a/contribs/gmf/examples/editfeatureselector.js
+++ b/contribs/gmf/examples/editfeatureselector.js
@@ -81,7 +81,7 @@ app.MainController = function($scope, gmfThemes, gmfUser, ngeoFeatureHelper,
    * @private
    */
   var wmsLayer = new ol.layer.Image({
-    querySourceIds: [111, 112, 113],
+    editableIds: [111, 112, 113],
     source: new ol.source.ImageWMS({
       url: 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy',
       params: {'LAYERS': 'point,line,polygon'}

--- a/contribs/gmf/externs/gmf-themes.js
+++ b/contribs/gmf/externs/gmf-themes.js
@@ -37,6 +37,12 @@ GmfThemesNode.prototype.editing;
 
 
 /**
+ * @type {boolean|undefined}
+ */
+GmfThemesNode.prototype.editable;
+
+
+/**
  * @type {string}
  */
 GmfThemesNode.prototype.layers;

--- a/contribs/gmf/src/directives/editfeatureselector.js
+++ b/contribs/gmf/src/directives/editfeatureselector.js
@@ -269,9 +269,7 @@ gmf.EditfeatureselectorController.prototype.registerLayer_ = function(layer) {
     }, this);
 
   } else {
-    // FIXME - We should use the 'edit' metadata to detect if the layer is
-    //         is editable instead.
-    var ids = layer.get('querySourceIds');
+    var ids = layer.get('editableIds');
     if (ids &&
         (layer instanceof ol.layer.Image || layer instanceof ol.layer.Tile)
     ) {
@@ -306,9 +304,7 @@ gmf.EditfeatureselectorController.prototype.unregisterLayer_ = function(layer) {
     layer.getLayers().forEach(this.unregisterLayer_, this);
 
   } else {
-    // FIXME - We should use the 'edit' metadata to detect if the layer is
-    //         is editable instead.
-    var ids = layer.get('querySourceIds');
+    var ids = layer.get('editableIds');
     if (ids) {
       for (var i = 0, ii = ids.length; i < ii; i++) {
         delete this.wmsLayers_[ids[i]];

--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -987,7 +987,9 @@ gmf.LayertreeController.getLayerNodeIds = function(node, opt_editable) {
   var children = node.children || node;
   if (children && children.length) {
     children.forEach(function(childNode) {
-      ids = ids.concat(gmf.LayertreeController.getLayerNodeIds(childNode));
+      ids = ids.concat(
+        gmf.LayertreeController.getLayerNodeIds(childNode, editable)
+      );
     });
   } else if (node.id !== undefined && (!editable || node.editable)) {
     ids.push(node.id);

--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -280,8 +280,10 @@ gmf.LayertreeController.prototype.updateLayerDimensions_ = function(layer, node)
 gmf.LayertreeController.prototype.prepareLayer_ = function(node, layer) {
   var type = gmf.Themes.getNodeType(node);
   var ids =  gmf.LayertreeController.getLayerNodeIds(node);
+  var editableIds = gmf.LayertreeController.getLayerNodeIds(node, true);
   var childNodes = [], allChildNodesUnchecked;
   layer.set('querySourceIds', ids);
+  layer.set('editableIds', editableIds);
   layer.set('layerName', node.name);
   layer.set('disclaimers', this.getNodeDisclaimers_(node));
 
@@ -975,16 +977,19 @@ gmf.LayertreeController.prototype.zoomToResolution = function(treeCtrl) {
 /**
  * Collect and return all ids of this layer node and all child nodes as well.
  * @param {GmfThemesNode} node Layer tree node.
+ * @param {boolean=} opt_editable Whether the node needs to be editable to
+ *     have its id returned.
  * @return {Array.<number|string>} Layer names.
  */
-gmf.LayertreeController.getLayerNodeIds = function(node) {
+gmf.LayertreeController.getLayerNodeIds = function(node, opt_editable) {
+  var editable = opt_editable === true;
   var ids = [];
   var children = node.children || node;
   if (children && children.length) {
     children.forEach(function(childNode) {
       ids = ids.concat(gmf.LayertreeController.getLayerNodeIds(childNode));
     });
-  } else if (node.id !== undefined) {
+  } else if (node.id !== undefined && (!editable || node.editable)) {
     ids.push(node.id);
   }
   return ids;

--- a/contribs/gmf/src/services/themesservice.js
+++ b/contribs/gmf/src/services/themesservice.js
@@ -223,6 +223,7 @@ gmf.Themes.prototype.getBgLayers = function() {
         layer.set('metadata', item['metadata']);
         var ids = gmf.LayertreeController.getLayerNodeIds(item);
         layer.set('querySourceIds', ids);
+        layer.set('editableIds', []);
         return layer;
       };
 


### PR DESCRIPTION
This PR uses the `editable` theme node property as configuration for the `gmf-editfeatureselector` directive to determine which layers are editable. Adjust the other examples as well.

In order to see it in action, we need the layer tree.  This requires #1636 to be merged first.

## Todo

 * [x] Wait for #1636 to be merged first
 * [x] Review

## Live example

 * https://adube.github.io/ngeo/gmf-editfeature-editable/examples/contribs/gmf/apps/desktop_alt/index.html?baselayer_ref=map&lang=fr&map_x=537500&map_y=152851&map_zoom=3&tree_groups=Edit&tree_group_layers_Edit=line%2Cpolygon%2Cpoint