### PR TITLE
Fix dirty state in gmf-editfeature

### DIFF
--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -609,6 +609,14 @@ gmf.EditfeatureController.prototype.handleFeatureChange_ = function(
       this.handleFeatureGeometryChange_,
       this
     );
+
+    // The `ui-date` triggers an unwanted change, i.e. it converts the text
+    // to Date, which makes the directive dirty when it shouldn't... to
+    // bypass this, we reset the dirty state here
+    this.timeout_(function() {
+      this.dirty = false;
+      this.scope_.$apply();
+    }.bind(this), 0);
   } else {
     this.featureId = null;
   }


### PR DESCRIPTION
This PR fixes an issue in the `gmf-editfeature` directive.

When clicking on a feature that has a date set, the value is read by the `ui-date` directive. Upon initialization, it converts it from a string to a `Date` object.  This is set in the feature, which triggers a change, which sets the dirty state to true.  Long story short: when clicking on a feature that has a date set, the save button is enabled, because the dirty is set.

This fix is simple: set a timeout to set the dirty state to `false` upon setting a new feature.  This leaves enough time for the feature to be set with a date upon initialization.

## Todo

 * [ ] Review

## Live example

 * https://adube.github.io/ngeo/gmf-fix-date-dirty/examples/contribs/gmf/editfeatureselector.html