### PR TITLE
Manage layer removal while active in gmf-editfeatureselector

### DIFF
--- a/contribs/gmf/src/directives/editfeatureselector.js
+++ b/contribs/gmf/src/directives/editfeatureselector.js
@@ -312,11 +312,15 @@ gmf.EditfeatureselectorController.prototype.unregisterLayer_ = function(layer) {
     if (ids) {
       for (var i = 0, ii = ids.length; i < ii; i++) {
         delete this.wmsLayers_[ids[i]];
+        var removedLayer;
         for (var j = 0, jj = this.availableLayers.length; j < jj; j++) {
           if (this.availableLayers[j].id == ids[i]) {
-            this.availableLayers.splice(j, 1);
+            removedLayer = this.availableLayers.splice(j, 1)[0];
             break;
           }
+        }
+        if (removedLayer && removedLayer === this.selectedLayer) {
+          this.selectedLayer = null;
         }
       }
     }


### PR DESCRIPTION
This PR makes sure that if a layer gets removed while it's active in the `gmf-editfeatureselector`, the selected layer gets reseted.

It's easier to see this in action with the application.

## Todo

 * [x] ~~Not working in 'minized' version... fix this~~
 * [x] Wait for ￼ #1636 to be merged first
 * [ ] Review

## Live example

 * https://adube.github.io/ngeo/gmf-editfeature-layer-remove-reset/examples/contribs/gmf/apps/desktop_alt/index.html?baselayer_ref=map&lang=fr&map_x=537500&map_y=152851&map_zoom=3&tree_groups=Edit&tree_group_layers_Edit=line%2Cpolygon%2Cpoint