### PR TITLE
Fix #1652 - Fix gmf-editfeature dirty state with new features

### DIFF
--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -783,11 +783,14 @@ gmf.EditfeatureController.prototype.handleFeatureChange_ = function(
 
     // The `ui-date` triggers an unwanted change, i.e. it converts the text
     // to Date, which makes the directive dirty when it shouldn't... to
-    // bypass this, we reset the dirty state here
-    this.timeout_(function() {
-      this.dirty = false;
-      this.scope_.$apply();
-    }.bind(this), 0);
+    // bypass this, we reset the dirty state here. We do so only if we're
+    // editing an existing feature
+    if (this.featureId) {
+      this.timeout_(function() {
+        this.dirty = false;
+        this.scope_.$apply();
+      }.bind(this), 0);
+    }
   } else {
     this.featureId = null;
   }


### PR DESCRIPTION
This PR fixes #1652.  The dirty state is not reseted for newly created features.

## Live demo

 * https://adube.github.io/ngeo/gmf-editfeature-fix-insert/examples/contribs/gmf/editfeatureselector.html