### PR TITLE
Add on-the-fly validation in attributes directive

### DIFF
--- a/contribs/gmf/src/directives/partials/editfeature.html
+++ b/contribs/gmf/src/directives/partials/editfeature.html
@@ -29,8 +29,10 @@
         </span>
       </span>
     </a>
-    <div
-      class="gmf-editfeature-attributes-container"
+    <form
+      novalidate
+      name="form"
+      class="form gmf-editfeature-attributes-container"
       ng-switch-default
       ng-if="efCtrl.attributes">
       <ngeo-attributes
@@ -38,12 +40,13 @@
         ngeo-attributes-disabled="efCtrl.pending"
         ngeo-attributes-feature="::efCtrl.feature">
       </ngeo-attributes>
-      <a
+      <input
+        type="submit"
+        value="{{'Save' | translate}}"
         class="btn btn-sm btn-default gmf-editfeature-btn-save"
-        ng-click="efCtrl.save()"
+        ng-click="form.$valid && efCtrl.save()"
         ng-disabled="!efCtrl.dirty"
-        title="{{'Save modifications | translate'}}"
-        href>{{'Save' | translate}}</a>
+        title="{{'Save modifications | translate'}}"></input>
       <a
         class="btn btn-sm btn-default gmf-editfeature-btn-cancel"
         ng-click="efCtrl.cancel()"
@@ -59,6 +62,6 @@
         <span class="fa fa-trash"></span>
         {{'Delete' | translate}}
       </button>
-    </div>
+    </form>
   </div>
 </div>

--- a/src/directives/partials/attributes.html
+++ b/src/directives/partials/attributes.html
@@ -1,12 +1,13 @@
-<form class="form">
-  <fieldset ng-disabled="attrCtrl.disabled">
+<fieldset ng-disabled="attrCtrl.disabled">
   <div
       class="form-group"
       ng-repeat="attribute in ::attrCtrl.attributes">
     <div ng-if="attribute.type !== 'geometry'">
-      <label>{{ attribute.name }}:</label>
+      <label>{{::attribute.required ? "* " : ""}}{{ ::attribute.name }}:</label>
       <div ng-switch="attribute.type">
         <select
+            name="{{::attribute.name}}"
+            ng-required="attribute.required"
             ng-switch-when="select"
             ng-model="attrCtrl.properties[attribute.name]"
             ng-change="attrCtrl.handleInputChange(attribute.name);"
@@ -20,6 +21,8 @@
         </select>
 
         <input
+            name="{{::attribute.name}}"
+            ng-required="attribute.required"
             ng-switch-when="date"
             ui-date="attrCtrl.dateOptions"
             ng-model="attrCtrl.properties[attribute.name]"
@@ -29,6 +32,8 @@
         </input>
 
         <input
+            name="{{::attribute.name}}"
+            ng-required="attribute.required"
             ng-switch-when="datetime"
             ui-date="attrCtrl.dateOptions"
             ng-model="attrCtrl.properties[attribute.name]"
@@ -38,14 +43,22 @@
         </input>
 
         <input
+            name="{{::attribute.name}}"
+            ng-required="attribute.required"
             ng-switch-default
             ng-model="attrCtrl.properties[attribute.name]"
             ng-change="attrCtrl.handleInputChange(attribute.name);"
             class="form-control"
             type="text">
         </input>
+
+        <div ng-show="form.$submitted || form[attribute.name].$touched">
+          <p class="text-danger"
+             ng-show="form[attribute.name].$error.required">
+            {{'This field is required' | translate}}
+          </p>
+        </div>
       </div>
     </div>
   </div>
-  </fieldset>
-</form>
+</fieldset>


### PR DESCRIPTION
Work in progress.

This PR implements "on-the-fly" validation in the attributes directive.

## Live example

 * https://adube.github.io/ngeo/gmf-editfeature-live-validation/examples/contribs/gmf/editfeatureselector.html