### PR TITLE
Fix error in gmf-editfeatureselector example

### DIFF
--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -319,6 +319,11 @@ ngeo.FeatureHelper.prototype.getTextStyle_ = function(feature) {
 };
 
 
+/**
+ * @param {ol.Feature} feature Feature to create the editing styles with.
+ * @return {Array.<ol.style.Style>} List of style.
+ * @export
+ */
 ngeo.FeatureHelper.prototype.createEditingStyles = function(feature) {
   // (1) Style definition depends on geometry type
   var white = [255, 255, 255, 1];


### PR DESCRIPTION
This PR fixes the gmf-editfeatureselector example because of a missing comment block.

## Live example

 * https://adube.github.io/ngeo/gmf-editfeature-fix-example/examples/contribs/gmf/editfeatureselector.html