### PR TITLE
Fix node with several layer names not correctly removed or added

### DIFF
--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -659,13 +659,21 @@ gmf.LayertreeController.prototype.toggleActive = function(treeCtrl) {
           source.getParams()['LAYERS'].split(','))  || [];
       if (isActive) {
         for (i = 0; i < layersNames.length; i++) {
-          ol.array.remove(layers, layersNames[i]);
+          // layersNames may be "foo,bar". Each should be removed from the
+          // LAYERS param
+          layersNames[i].split(',').forEach(function(name) {
+            ol.array.remove(layers, name);
+          });
         }
       } else {
         for (i = 0; i < layersNames.length; i++) {
-          if (!ol.array.includes(layers, layersNames[i])) {
-            layers.push(layersNames[i]);
-          }
+          // layersNames may be "foo,bar". Each should be checked for presence
+          // in the LAYERS param
+          layersNames[i].split(',').forEach(function(name) {
+            if (!ol.array.includes(layers, name)) {
+              layers.push(name);
+            }
+          });
         }
       }
       firstParentTreeLayer = /** @type {ol.layer.Image} */


### PR DESCRIPTION
The purpose of this pull request is to fix an issue related to node corresponding to several LAYERS params (ie. several mapfile layers).

Currently in the "OSM Functions" group, there's a node called "two_layers" which actually displays "sustenance" and "entertainment" features on the map.

Steps to reproduce bug:
 - Clic on URL below
 - Expand the OSM Function group,
 - Deactivate the group -> the node "two_layers" is not deactivated.

Current:
https://camptocamp.github.io/ngeo/master/examples/contribs/gmf/apps/desktop_alt/?baselayer_ref=map&lang=en&map_x=601000&map_y=207500&map_zoom=4&rl_features&tree_groups=OSM%20functions&tree_group_layers_OSM%20functions=sustenance%2Centertainment%2Cosm_time%2Cosm_time2%2Cosm_scale%2Cosm_open%2Cbank%2Csustenance%2Centertainment%2Chalf_query%2Csrtm%2Caster
After fix:
https://pgiraud.github.io/ngeo/fix_two_layers/examples/contribs/gmf/apps/desktop_alt?baselayer_ref=map&lang=en&map_x=601000&map_y=207500&map_zoom=4&rl_features&tree_groups=OSM%20functions&tree_group_layers_OSM%20functions=sustenance%2Centertainment%2Cosm_time%2Cosm_time2%2Cosm_scale%2Cosm_open%2Cbank%2Csustenance%2Centertainment%2Chalf_query%2Csrtm%2Caster


The problem comes from the fact that we try to remove "foo,bar" from ["foo", "bar", "dude"] and eventually nothing is removed.

Please review.