### PR TITLE
Don't query if no childLayer is queryable

### DIFF
--- a/contribs/gmf/src/services/querymanager.js
+++ b/contribs/gmf/src/services/querymanager.js
@@ -137,6 +137,14 @@ gmf.QueryManager.prototype.createSources_ = function(node, ogcServers) {
       // This override makes sure that those layer names are used instead of
       // the original one.
       if (node.childLayers && node.childLayers.length) {
+        // skip layers with no queryable childLayer
+        var isQueryable = function(item) {
+          return item.queryable;
+        };
+        if (!node.childLayers.some(isQueryable)) {
+          return;
+        }
+
         var childLayerNames = [];
         node.childLayers.forEach(function(childLayer) {
           if (childLayer.queryable) {


### PR DESCRIPTION
This pull request fixes the case where queries were issued even for not queryable layers.
This is a partial fix for #1659.

In the "OSM Functions", the nodes "srtm" & "aster" are generating requests even if they're not queryable.

Please review.
Ping @adube 

You can compare the results in the following examples. In the current version, you'll see that aster and srtm are available in the filter.
https://camptocamp.github.io/ngeo/master/examples/contribs/gmf/apps/desktop/?baselayer_ref=map&lang=en&map_x=610038&map_y=190238&map_zoom=3&rl_features&tree_group_layers_OSM%20functions=osm_time&tree_groups=OSM%20functions

https://pgiraud.github.io/ngeo/fix_query_two_layers/examples/contribs/gmf/apps/desktop/?baselayer_ref=map&lang=en&map_x=610038&map_y=190238&map_zoom=3&rl_features&tree_group_layers_OSM%20functions=osm_time&tree_groups=OSM%20functions