### PR TITLE
Add support for url fragment parameters

### DIFF
--- a/src/services/location.js
+++ b/src/services/location.js
@@ -103,6 +103,17 @@ ngeo.Location.prototype.hasParam = function(key) {
 
 
 /**
+ * Check if a param exists in the fragment of the location's URI.
+ * @param {string} key Param key.
+ * @return {boolean} True if the param exists.
+ * @export
+ */
+ngeo.Location.prototype.hasFragmentParam = function(key) {
+  return this.getFragmentUri_().getQueryData().containsKey(key);
+};
+
+
+/**
  * Get a param in the location's URI.
  * @param {string} key Param key.
  * @return {string} Param value.
@@ -114,6 +125,17 @@ ngeo.Location.prototype.getParam = function(key) {
 
 
 /**
+ * Get a param from the fragment of the location's URI.
+ * @param {string} key Param key.
+ * @return {string} Param value.
+ * @export
+ */
+ngeo.Location.prototype.getFragmentParam = function(key) {
+  return /** @type {string} */ (this.getFragmentUri_().getQueryData().get(key));
+};
+
+
+/**
  * Get a param in the location's URI as integer. If the entry does not exist,
  * or if the value can not be parsed as integer, `undefined` is returned.
  * @param {string} key Param key.
@@ -121,10 +143,27 @@ ngeo.Location.prototype.getParam = function(key) {
  * @export
  */
 ngeo.Location.prototype.getParamAsInt = function(key) {
-  if (!this.hasParam(key)) {
+  var value = /** @type {string} */ (this.getParam(key));
+  if (value === undefined) {
     return undefined;
   }
-  var value = /** @type {string} */ (this.uri_.getQueryData().get(key));
+  var valueAsInt = parseInt(value, 10);
+  return (isNaN(valueAsInt)) ? undefined : valueAsInt;
+};
+
+
+/**
+ * Get a param from the fragment of the location's URI as integer. If the entry
+ * does not exist, or if the value can not be parsed as integer, `undefined` is returned.
+ * @param {string} key Param key.
+ * @return {number|undefined} Param value.
+ * @export
+ */
+ngeo.Location.prototype.getFragmentParamAsInt = function(key) {
+  var value = /** @type {string} */ (this.getFragmentParam(key));
+  if (value === undefined) {
+    return undefined;
+  }
   var valueAsInt = parseInt(value, 10);
   return (isNaN(valueAsInt)) ? undefined : valueAsInt;
 };
@@ -141,6 +180,16 @@ ngeo.Location.prototype.getParamKeys = function() {
 
 
 /**
+ * Get an array with all existing param's keys from the fragment of the location's URI.
+ * @return {Array.<string>} Param keys.
+ * @export
+ */
+ngeo.Location.prototype.getFragmentParamKeys = function() {
+  return this.getFragmentUri_().getQueryData().getKeys();
+};
+
+
+/**
  * Get an array with all existing param's keys in the location's URI that start
  * with the given prefix.
  * @param {string} prefix Key prefix.
@@ -148,7 +197,21 @@ ngeo.Location.prototype.getParamKeys = function() {
  * @export
  */
 ngeo.Location.prototype.getParamKeysWithPrefix = function(prefix) {
-  return this.uri_.getQueryData().getKeys().filter(function(key) {
+  return this.getParamKeys().filter(function(key) {
+    return key.indexOf(prefix) == 0;
+  });
+};
+
+
+/**
+ * Get an array with all existing param's keys from the fragment of the location's URI
+ * that start with the given prefix.
+ * @param {string} prefix Key prefix.
+ * @return {Array.<string>} Param keys.
+ * @export
+ */
+ngeo.Location.prototype.getFragmentParamKeysWithPrefix = function(prefix) {
+  return this.getFragmentParamKeys().filter(function(key) {
     return key.indexOf(prefix) == 0;
   });
 };
@@ -168,12 +231,39 @@ ngeo.Location.prototype.updateParams = function(params) {
 
 
 /**
+ * Set or create a param in the fragment of the location's URI.
+ * @param {Object.<string, string>} params Parameters.
+ * @export
+ */
+ngeo.Location.prototype.updateFragmentParams = function(params) {
+  var fragmentUri = this.getFragmentUri_();
+  var qd = fragmentUri.getQueryData();
+  goog.object.forEach(params, function(val, key) {
+    qd.set(key, val);
+  });
+  this.updateFragmentFromUri_(fragmentUri);
+};
+
+
+/**
  * Delete a param in the location's URI.
  * @param {string} key Param key.
  * @export
  */
 ngeo.Location.prototype.deleteParam = function(key) {
   this.uri_.getQueryData().remove(key);
+};
+
+
+/**
+ * Delete a param int the fragment of the location's URI.
+ * @param {string} key Param key.
+ * @export
+ */
+ngeo.Location.prototype.deleteFragmentParam = function(key) {
+  var fragmentUri = this.getFragmentUri_();
+  fragmentUri.getQueryData().remove(key);
+  this.updateFragmentFromUri_(fragmentUri);
 };
 
 
@@ -193,6 +283,32 @@ ngeo.Location.prototype.refresh = function() {
  */
 ngeo.Location.prototype.setPath = function(path) {
   this.uri_.setPath(path);
+};
+
+
+/**
+ * Return a {@link goog.Uri} instance where the fragment parameters are set
+ * as query parameters.
+ * @return {goog.Uri} An uri.
+ * @private
+ */
+ngeo.Location.prototype.getFragmentUri_ = function() {
+  var fragment = this.uri_.getFragment();
+  var uri = new goog.Uri(null);
+  uri.setQueryData(fragment);
+  return uri;
+};
+
+
+/**
+ * Update the fragment of the Uri with the given uri which contains
+ * fragment parameters as query params.
+ * @param {goog.Uri} fragmentUri An uri.
+ * @private
+ */
+ngeo.Location.prototype.updateFragmentFromUri_ = function(fragmentUri) {
+  var fragment = fragmentUri.getQueryData().toDecodedString();
+  this.uri_.setFragment(fragment);
 };
 
 

--- a/test/spec/services/location.spec.js
+++ b/test/spec/services/location.spec.js
@@ -45,10 +45,42 @@ describe('ngeo.Location', function() {
     });
   });
 
+  describe('#getParamAsInt', function() {
+    it('returns the param value as integer', function() {
+      ngeoLocation.updateParams({'key2': '2'});
+      var value = ngeoLocation.getParamAsInt('key2');
+      expect(value).toBe(2);
+    });
+
+    it('returns undefined if no integer', function() {
+      var value = ngeoLocation.getParamAsInt('key1');
+      expect(value).toBe(undefined);
+    });
+
+    it('returns undefined if no integer', function() {
+      var value = ngeoLocation.getParamAsInt('wrong-key');
+      expect(value).toBe(undefined);
+    });
+  });
+
   describe('#getParamKeys', function() {
     it('returns the param keys', function() {
       var keys = ngeoLocation.getParamKeys();
       expect(keys).toEqual(['some']);
+    });
+  });
+
+  describe('#updateParams', function() {
+    it('updates an existing param key', function() {
+      var keys = ngeoLocation.updateParams({'key1': 'new value'});
+      var value = ngeoLocation.getParam('key1');
+      expect(value).toBe('new value');
+    });
+
+    it('adds a new param key', function() {
+      var keys = ngeoLocation.updateParams({'key3': 'value3'});
+      var value = ngeoLocation.getParam('key3');
+      expect(value).toBe('value3');
     });
   });
 
@@ -65,6 +97,82 @@ describe('ngeo.Location', function() {
       ngeoLocation.refresh();
       expect(win.history.replaceState).toHaveBeenCalledWith(
         null, '', 'http://domain.com/some/path?some=param');
+    });
+  });
+
+  describe('fragment parameters', function() {
+    beforeEach(function() {
+      // change url to 'http://domain.com/some/path?some=param#key1=value1&key2=2'
+      ngeoLocation.uri_.setFragment('key1=value1&key2=2');
+    });
+
+    describe('#hasFragmentParam', function() {
+      it('returns true if the param exists', function() {
+        var value = ngeoLocation.hasFragmentParam('key1');
+        expect(value).toBe(true);
+        value = ngeoLocation.hasFragmentParam('missing');
+        expect(value).toBe(false);
+      });
+    });
+
+    describe('#getFragmentParam', function() {
+      it('returns the param value', function() {
+        var value = ngeoLocation.getFragmentParam('key1');
+        expect(value).toBe('value1');
+      });
+    });
+
+    describe('#getFragmentParamAsInt', function() {
+      it('returns the param value as integer', function() {
+        var value = ngeoLocation.getFragmentParamAsInt('key2');
+        expect(value).toBe(2);
+      });
+
+      it('returns undefined if no integer', function() {
+        var value = ngeoLocation.getFragmentParamAsInt('key1');
+        expect(value).toBe(undefined);
+      });
+
+      it('returns undefined if no integer', function() {
+        var value = ngeoLocation.getFragmentParamAsInt('wrong-key');
+        expect(value).toBe(undefined);
+      });
+    });
+
+    describe('#getFragmentParamKeys', function() {
+      it('returns the param keys', function() {
+        var keys = ngeoLocation.getFragmentParamKeys();
+        expect(keys).toEqual(['key1', 'key2']);
+      });
+    });
+
+    describe('#getFragmentParamKeysWithPrefix', function() {
+      it('returns the param keys', function() {
+        var keys = ngeoLocation.getFragmentParamKeysWithPrefix('key');
+        expect(keys).toEqual(['key1', 'key2']);
+      });
+    });
+
+    describe('#updateFragmentParams', function() {
+      it('updates an existing param key', function() {
+        var keys = ngeoLocation.updateFragmentParams({'key1': 'new value'});
+        var value = ngeoLocation.getFragmentParam('key1');
+        expect(value).toBe('new value');
+      });
+
+      it('adds a new param key', function() {
+        var keys = ngeoLocation.updateFragmentParams({'key3': 'value3'});
+        var value = ngeoLocation.getFragmentParam('key3');
+        expect(value).toBe('value3');
+      });
+    });
+
+    describe('#deleteFragmentParam', function() {
+      it('delete the params', function() {
+        ngeoLocation.deleteFragmentParam('key1');
+        var value = ngeoLocation.getFragmentParam('key1');
+        expect(value).toBe(undefined);
+      });
     });
   });
 });


### PR DESCRIPTION
Adds support for fragment parameters (`...#key1=val1&key2=val2`) to the `ngeo.Location` service.