### PR TITLE
Handle one level of background groups

### DIFF
--- a/src/services/backgroundlayermgr.js
+++ b/src/services/backgroundlayermgr.js
@@ -170,8 +170,10 @@ ngeo.BackgroundLayerMgr.prototype.updateDimensions = function(map, dimensions) {
           var source = layer.getSource();
           if (source instanceof ol.source.WMTS) {
             source.updateDimensions(updatedDimensions);
+            source.refresh();
           } else if (source instanceof ol.source.TileWMS || source instanceof ol.source.ImageWMS) {
             source.updateParams(updatedDimensions);
+            source.refresh();
           }
         }
       }

--- a/src/services/backgroundlayermgr.js
+++ b/src/services/backgroundlayermgr.js
@@ -148,24 +148,34 @@ ngeo.BackgroundLayerMgr.prototype.set = function(map, layer) {
  * @export
  */
 ngeo.BackgroundLayerMgr.prototype.updateDimensions = function(map, dimensions) {
-  var layer = this.get(map);
-  goog.asserts.assertInstanceof(layer, ol.layer.Layer);
-  if (layer) {
-    var updatedDimensions = {};
-    for (var key in layer.get('dimensions')) {
-      var value = dimensions[key];
-      if (value !== undefined) {
-        updatedDimensions[key] = value;
-      }
+  var baseBgLayer = this.get(map);
+  if (baseBgLayer) {
+    var layers = [baseBgLayer];
+    if (baseBgLayer instanceof ol.layer.Group) {
+      // Handle the first level of layers of the base background layer.
+      layers = baseBgLayer.getLayers().getArray();
     }
-    if (!ol.object.isEmpty(dimensions)) {
-      var source = layer.getSource();
-      if (source instanceof ol.source.WMTS) {
-        source.updateDimensions(updatedDimensions);
-      } else if (source instanceof ol.source.TileWMS || source instanceof ol.source.ImageWMS) {
-        source.updateParams(updatedDimensions);
+
+    layers.forEach(function(layer) {
+      goog.asserts.assertInstanceof(layer, ol.layer.Layer);
+      if (layer) {
+        var updatedDimensions = {};
+        for (var key in layer.get('dimensions')) {
+          var value = dimensions[key];
+          if (value !== undefined) {
+            updatedDimensions[key] = value;
+          }
+        }
+        if (!ol.object.isEmpty(dimensions)) {
+          var source = layer.getSource();
+          if (source instanceof ol.source.WMTS) {
+            source.updateDimensions(updatedDimensions);
+          } else if (source instanceof ol.source.TileWMS || source instanceof ol.source.ImageWMS) {
+            source.updateParams(updatedDimensions);
+          }
+        }
       }
-    }
+    });
   }
 };
 


### PR DESCRIPTION
The group will appear in the background selector.
Selecting the group will activate child layers.

All children of a group are assumed to be plain layers.
Supported dimensions are read from the group.

In addition, trigger a source refresh on dimension change.