### PR TITLE
Fix layer order in layertree

### DIFF
--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -294,7 +294,7 @@ gmf.LayertreeController.prototype.prepareLayer_ = function(node, layer) {
   var metadata = node.metadata;
   if (isMerged) {
     //Case Non Mixed group -> Hide the layer if all child nodes have isChecked set to false
-    this.getFlatNodes_(node, childNodes);
+    gmf.LayertreeController.getFlatNodes(node, childNodes);
     allChildNodesUnchecked = childNodes.every(function(childNode) {
       return !childNode.metadata || !childNode.metadata['isChecked'];
     });
@@ -421,7 +421,7 @@ gmf.LayertreeController.prototype.getLayerCaseNotMixedGroup_ = function(node) {
   var childNodes = [];
   var timeParam, timeValues;
 
-  this.getFlatNodes_(node, childNodes);
+  gmf.LayertreeController.getFlatNodes(node, childNodes);
   // layersNames come from the json theme nodes and will become the wms
   // LAYERS. It must be reversed to get the correct layer order on the map.
   var layersNames = childNodes.map(function(node) {
@@ -480,14 +480,14 @@ gmf.LayertreeController.prototype.getLayerCaseWMTS_ = function(node) {
  * given node itself.
  * @param {GmfThemesNode} node Layertree node.
  * @param {Array.<GmfThemesNode>} nodes An array.
- * @private
+ * @export
  */
-gmf.LayertreeController.prototype.getFlatNodes_ = function(node, nodes) {
+gmf.LayertreeController.getFlatNodes = function(node, nodes) {
   var i;
   var children = node.children;
   if (children !== undefined) {
     for (i = 0; i < children.length; i++) {
-      this.getFlatNodes_(children[i], nodes);
+      gmf.LayertreeController.getFlatNodes(children[i], nodes);
     }
   } else {
     nodes.push(node);
@@ -506,7 +506,7 @@ gmf.LayertreeController.prototype.retrieveNodeNames_ = function(node,
     opt_onlyChecked) {
   var names = [];
   var nodes = [];
-  this.getFlatNodes_(node, nodes);
+  gmf.LayertreeController.getFlatNodes(node, nodes);
   var metadata, n, i;
   for (i = 0; i < nodes.length; i++) {
     n = nodes[i];
@@ -608,7 +608,7 @@ gmf.LayertreeController.prototype.toggleActive = function(treeCtrl) {
         var currentLayersNames = (firstParentTreeLayer.getVisible()) ?
             firstParentTreeSource.getParams()['LAYERS'] : '';
         var newLayersNames = [];
-        this.getFlatNodes_(firstParentTreeNode, childNodes);
+        gmf.LayertreeController.getFlatNodes(firstParentTreeNode, childNodes);
         // Add/remove layer and keep order of layers in layergroup.
         for (i = 0; i < childNodes.length; i++) {
           layersNames = this.getLayersNames_(childNodes[i]);
@@ -630,7 +630,7 @@ gmf.LayertreeController.prototype.toggleActive = function(treeCtrl) {
     case gmf.Themes.NodeType.MIXED_GROUP:
       var nodeLayers = [];
       var l, source;
-      this.getFlatNodes_(node, childNodes);
+      gmf.LayertreeController.getFlatNodes(node, childNodes);
       layersNames = childNodes.map(this.getLayersNames_).join(',');
       layers = this.layerHelper_.getFlatLayers(firstParentTreeLayer);
       for (i = 0; i < layers.length; i++) {
@@ -657,7 +657,7 @@ gmf.LayertreeController.prototype.toggleActive = function(treeCtrl) {
       if (isActive) {
         this.layerHelper_.updateWMSLayerState(firstParentTreeLayer, '');
       } else {
-        this.getFlatNodes_(node, childNodes);
+        gmf.LayertreeController.getFlatNodes(node, childNodes);
         layersNames = childNodes.map(this.getLayersNames_);
         // layersNames come from the json theme nodes and replace the wms
         // LAYERS. It must be reversed to get the correct layer order on the map.

--- a/contribs/gmf/test/spec/directives/layertree.spec.js
+++ b/contribs/gmf/test/spec/directives/layertree.spec.js
@@ -7,7 +7,7 @@ var fakeParentController = {
 };
 fakeParentController['node'].children = []
 fakeParentController['node'].mixed = true
-fakeParentController['layer'].getLayers = function() { return [] };
+fakeParentController['layer'].getLayers = function() { return new ol.Collection() };
 
 describe('gmf.LayertreeController', function() {
   var layertreeController;


### PR DESCRIPTION
Fix: #1570

Demo: https://ger-benjamin.github.io/ngeo/gmfLayerOrder/examples/contribs/gmf/apps/desktop

Please, try around functions of the layertree (search layers, queries) as well.

I've:
 
- Removed redounded call of the "prepareLayer_" function (line 372 was redound with 395)
- "insertAt 0" inseatead of "push" of the wms/wmts layers (mixed groups). (line 394)
- Simplified the toggle function (part "not mixed groups", lines 653~681).
- Reorder wms LAYERS names in not mixed groups (every times read in order, must be added to the map in reverse order. (others changes)

Second commit is for the add layer action (order was wrong with wms layers).

(Create a function that update wms, keep server order AND works in all cases was a headache. I've gave up.)