### PR TITLE
Handle WMS background layers dimensions + fixes

### DIFF
--- a/contribs/gmf/externs/gmf-themes.js
+++ b/contribs/gmf/externs/gmf-themes.js
@@ -15,7 +15,8 @@ var GmfOgcServers;
  * @typedef {{
  *     themes: Array.<GmfThemesNode>,
  *     background_layers: Array.<GmfThemesNode>,
- *     ogcServers: GmfOgcServers
+ *     ogcServers: GmfOgcServers,
+ *     errors: Array.<string>
  * }}
  */
 var GmfThemesResponse;
@@ -95,6 +96,18 @@ GmfThemesNode.prototype.name;
 
 
 /**
+ * @type {Object.<string, string>|undefined}
+ */
+GmfThemesNode.prototype.dimensions;
+
+
+/**
+ * @type {string}
+ */
+GmfThemesNode.prototype.serverType;
+
+
+/**
  * @type {string}
  */
 GmfThemesNode.prototype.type;
@@ -110,6 +123,7 @@ GmfThemesNode.prototype.url;
  * @type {ngeox.TimeProperty|undefined}
  */
 GmfThemesNode.prototype.time;
+
 
 /**
  * @type {string|undefined}

--- a/contribs/gmf/externs/gmf-themes.js
+++ b/contribs/gmf/externs/gmf-themes.js
@@ -6,6 +6,22 @@
 
 
 /**
+ * @typedef {Object<string, GmfOgcServer>}
+ */
+var GmfOgcServers;
+
+
+/**
+ * @typedef {{
+ *     themes: Array.<GmfThemesNode>,
+ *     background_layers: Array.<GmfThemesNode>,
+ *     ogcServers: GmfOgcServers
+ * }}
+ */
+var GmfThemesResponse;
+
+
+/**
  * @constructor
  */
 var GmfThemesNode = function() {};

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -145,6 +145,16 @@ gmf.AbstractController = function(config, $scope, $injector) {
   // watch any change on dimensions object to refresh the url
   permalink.setDimensions(this.dimensions);
 
+  if ($injector.has('gmfDefaultDimensions')) {
+    // Set defaults
+    var defaultDimensions = $injector.get('gmfDefaultDimensions');
+    for (var dim in defaultDimensions) {
+      if (this.dimensions[dim] === undefined) {
+        this.dimensions[dim] = defaultDimensions[dim];
+      }
+    }
+  }
+
   var backgroundLayerMgr = $injector.get('ngeoBackgroundLayerMgr');
 
   // watch any change on dimensions object to refresh the background layer
@@ -354,7 +364,7 @@ gmf.AbstractController = function(config, $scope, $injector) {
         var backgrounds = theme['functionalities']['default_basemap'];
         if (backgrounds && backgrounds.length > 0) {
           var background = backgrounds[0];
-          gmfThemes.getBgLayers().then(function(layers) {
+          gmfThemes.getBgLayers(this.dimensions).then(function(layers) {
             var layer = ol.array.find(layers, function(layer) {
               return layer.get('label') === background;
             });
@@ -373,7 +383,7 @@ gmf.AbstractController = function(config, $scope, $injector) {
    * @private
    */
   this.updateCurrentBackgroundLayer_ = function(skipPermalink) {
-    gmfThemes.getBgLayers().then(function(layers) {
+    gmfThemes.getBgLayers(this.dimensions).then(function(layers) {
       var background;
       if (!skipPermalink) {
         // get the background from the permalink

--- a/contribs/gmf/src/directives/backgroundlayerselector.js
+++ b/contribs/gmf/src/directives/backgroundlayerselector.js
@@ -1,6 +1,7 @@
 goog.provide('gmf.BackgroundlayerselectorController');
 goog.provide('gmf.backgroundlayerselectorDirective');
 
+goog.require('goog.asserts');
 goog.require('gmf');
 goog.require('gmf.Themes');
 goog.require('ngeo.BackgroundEventType');
@@ -50,6 +51,7 @@ gmf.backgroundlayerselectorDirective = function(
     restrict: 'E',
     scope: {
       'map': '=gmfBackgroundlayerselectorMap',
+      'dimensions': '=gmfBackgroundlayerselectorDimensions',
       'select': '&?gmfBackgroundlayerselectorSelect'
     },
     bindToController: true,
@@ -119,6 +121,18 @@ gmf.BackgroundlayerselectorController = function($scope, ngeoBackgroundLayerMgr,
     gmf.ThemesEventType.CHANGE, this.handleThemesChange_, this));
 
   /**
+   * @type {Object.<string, string>}
+   * @export
+   */
+  this.dimensions;
+
+  goog.asserts.assert(this.dimensions, "The dimensions object is required");
+
+  gmfThemes.getBgLayers(this.dimensions).then(function(layers) {
+    this.bgLayers = layers;
+  }.bind(this));
+
+  /**
    * @type {ngeo.BackgroundLayerMgr}
    * @private
    */
@@ -145,7 +159,7 @@ gmf.module.controller('GmfBackgroundlayerselectorController',
  * @private
  */
 gmf.BackgroundlayerselectorController.prototype.handleThemesChange_ = function() {
-  this.gmfThemes_.getBgLayers().then(function(layers) {
+  this.gmfThemes_.getBgLayers(this.dimensions).then(function(layers) {
     this.bgLayers = layers;
   }.bind(this));
 };

--- a/contribs/gmf/src/directives/backgroundlayerselector.js
+++ b/contribs/gmf/src/directives/backgroundlayerselector.js
@@ -126,7 +126,7 @@ gmf.BackgroundlayerselectorController = function($scope, ngeoBackgroundLayerMgr,
    */
   this.dimensions;
 
-  goog.asserts.assert(this.dimensions, "The dimensions object is required");
+  goog.asserts.assert(this.dimensions, 'The dimensions object is required');
 
   gmfThemes.getBgLayers(this.dimensions).then(function(layers) {
     this.bgLayers = layers;

--- a/contribs/gmf/src/services/querymanager.js
+++ b/contribs/gmf/src/services/querymanager.js
@@ -108,7 +108,7 @@ gmf.QueryManager.prototype.handleThemesChange_ = function() {
  * it has no children, otherwise create the sources for each child node if
  * it has any.
  * @param {GmfThemesNode} node Theme layer node.
- * @param {gmf.OgcServers} ogcServers OGC servers.
+ * @param {GmfOgcServers} ogcServers OGC servers.
  * @private
  */
 gmf.QueryManager.prototype.createSources_ = function(node, ogcServers) {

--- a/contribs/gmf/src/services/themesservice.js
+++ b/contribs/gmf/src/services/themesservice.js
@@ -173,9 +173,10 @@ gmf.Themes.findGroupByName = function(themes, name) {
 
 /**
  * Find an object by its name. Return null if not found.
- * @param {Array.<Object>} objects Array of objects.
+ * @param {Array.<T>} objects Array of objects.
  * @param {string} objectName The object name.
- * @return {Object} The object.
+ * @return {T} The object.
+ * @template T
  * @private
  */
 gmf.Themes.findObjectByName_ = function(objects, objectName) {
@@ -192,8 +193,7 @@ gmf.Themes.findObjectByName_ = function(objects, objectName) {
  * @return {GmfThemesNode} The theme object.
  */
 gmf.Themes.findThemeByName = function(themes, themeName) {
-  var theme = gmf.Themes.findObjectByName_(themes, themeName);
-  return /** @type {GmfThemesNode} */ (theme);
+  return gmf.Themes.findObjectByName_(themes, themeName);
 };
 
 
@@ -241,7 +241,7 @@ gmf.Themes.getFlatNodes = function(node, nodes) {
 /**
  * Get background layers.
  * @param {Object.<string, string>} appDimensions Dimensions.
- * @return {angular.$q.Promise} Promise.
+ * @return {angular.$q.Promise.<Array.<GmfThemesNode>>} Promise.
  */
 gmf.Themes.prototype.getBgLayers = function(appDimensions) {
   if (this.bgLayerPromise_) {
@@ -250,6 +250,11 @@ gmf.Themes.prototype.getBgLayers = function(appDimensions) {
   var $q = this.$q_;
   var layerHelper = this.layerHelper_;
 
+  /**
+   * @param {GmfThemesNode} item The item.
+   * @param {ol.layer.Base} layer The layer.
+   * @return {ol.layer.Base} the provided layer.
+   */
   var callback = function(item, layer) {
     layer.set('label', item['name']);
     layer.set('metadata', item['metadata']);
@@ -260,6 +265,10 @@ gmf.Themes.prototype.getBgLayers = function(appDimensions) {
     return layer;
   };
 
+  /**
+   * @param {GmfThemesNode} item The item.
+   * @return {angular.$q.Promise.<ol.layer.Base>|ol.layer.Base} the created layer.
+   */
   var layerLayerCreationFn = function(item) {
     // Overwrite conflicting server dimensions with application ones
     for (var dimkey in item['dimensions']) {
@@ -287,8 +296,13 @@ gmf.Themes.prototype.getBgLayers = function(appDimensions) {
           item['dimensions']
       ));
     }
+    goog.asserts.fail('Unsupported type: ' + item['type']);
   };
 
+  /**
+   * @param {GmfThemesNode} item The item.
+   * @return {angular.$q.Promise.<ol.layer.Group>} the created layer.
+   */
   var layerGroupCreationFn = function(item) {
     // We assume no child is a layer group.
     var promises = item['children'].map(layerLayerCreationFn);
@@ -301,8 +315,8 @@ gmf.Themes.prototype.getBgLayers = function(appDimensions) {
   };
 
   /**
-   * @param {gmf.ThemesResponse} data The "themes" web service response.
-   * @return {angular.$q.Promise} Promise.
+   * @param {GmfThemesResponse} data The "themes" web service response.
+   * @return {angular.$q.Promise.<Array.<ol.layer.Base>>} Promise.
    */
   var promiseSuccessFn = function(data) {
     var promises = data['background_layers'].map(function(item) {
@@ -344,50 +358,48 @@ gmf.Themes.prototype.getBgLayers = function(appDimensions) {
 /**
  * Get a theme object by its name.
  * @param {string} themeName Theme name.
- * @return {angular.$q.Promise} Promise.
+ * @return {angular.$q.Promise.<GmfThemesNode>} Promise.
  * @export
  */
 gmf.Themes.prototype.getThemeObject = function(themeName) {
   return this.promise_.then(
       /**
-       * @param {gmf.ThemesResponse} data The "themes" web service response.
-       * @return {Object} The theme object for themeName, or null if not found.
+       * @param {GmfThemesResponse} data The "themes" web service response.
+       * @return {GmfThemesNode} The theme object for themeName, or null if not found.
        */
       function(data) {
-        var themes = data['themes'];
-        return gmf.Themes.findThemeByName(themes, themeName);
+        return gmf.Themes.findThemeByName(data['themes'], themeName);
       });
 };
 
 
 /**
  * Get an array of theme objects.
- * @return {angular.$q.Promise} Promise.
+ * @return {angular.$q.Promise.<Array.<GmfThemesNode>>} Promise.
  * @export
  */
 gmf.Themes.prototype.getThemesObject = function() {
   return this.promise_.then(
       /**
-       * @param {gmf.ThemesResponse} data The "themes" web service response.
-       * @return {Array.<Object>} The themes object.
+       * @param {GmfThemesResponse} data The "themes" web service response.
+       * @return {Array.<GmfThemesNode>} The themes object.
        */
       function(data) {
-        var themes = data['themes'];
-        return themes;
+        return data['themes'];
       });
 };
 
 
 /**
  * Get an array of background layer objects.
- * @return {angular.$q.Promise} Promise.
+ * @return {angular.$q.Promise.<Array.<GmfThemesNode>>} Promise.
  */
 gmf.Themes.prototype.getBackgroundLayersObject = function() {
   goog.asserts.assert(this.promise_ !== null);
   return this.promise_.then(
       /**
-       * @param {gmf.ThemesResponse} data The "themes" web service response.
-       * @return {Array.<Object>} The background layers object.
+       * @param {GmfThemesResponse} data The "themes" web service response.
+       * @return {Array.<GmfThemesNode>} The background layers object.
        */
       function(data) {
         var backgroundLayers = data['background_layers'];
@@ -398,18 +410,17 @@ gmf.Themes.prototype.getBackgroundLayersObject = function() {
 
 /**
  * Get the `ogcServers` object.
- * @return {angular.$q.Promise} Promise.
+ * @return {angular.$q.Promise.<GmfOgcServers>} Promise.
  */
 gmf.Themes.prototype.getOgcServersObject = function() {
   goog.asserts.assert(this.promise_ !== null);
   return this.promise_.then(
       /**
-       * @param {gmf.ThemesResponse} data The "themes" web service response.
-       * @return {gmf.OgcServers} The `ogcServers` object.
+       * @param {GmfThemesResponse} data The "themes" web service response.
+       * @return {GmfOgcServers} The `ogcServers` object.
        */
       function(data) {
-        var ogcServers = data['ogcServers'];
-        return ogcServers;
+        return data['ogcServers'];
       });
 };
 

--- a/contribs/gmf/test/spec/services/themesservice.spec.js
+++ b/contribs/gmf/test/spec/services/themesservice.spec.js
@@ -22,7 +22,7 @@ describe('gmf.Themes', function() {
 
   it('Get background layers', function() {
     var spy = jasmine.createSpy();
-    gmfThemes.getBgLayers().then(spy);
+    gmfThemes.getBgLayers({}).then(spy);
 
     $httpBackend.expectGET(treeUrl);
     themes.background_layers.forEach(function(bgLayer) {

--- a/src/ol-ext/interaction/measureazimut.js
+++ b/src/ol-ext/interaction/measureazimut.js
@@ -2,6 +2,7 @@ goog.provide('ngeo.interaction.DrawAzimut');
 goog.provide('ngeo.interaction.MeasureAzimut');
 
 goog.require('goog.asserts');
+goog.require('goog.functions');
 goog.require('ngeo.interaction.Measure');
 goog.require('ol.Feature');
 goog.require('ol.MapBrowserEvent');

--- a/src/services/backgroundlayermgr.js
+++ b/src/services/backgroundlayermgr.js
@@ -4,7 +4,6 @@ goog.provide('ngeo.BackgroundLayerMgr');
 
 goog.require('goog.asserts');
 goog.require('ngeo');
-goog.require('ol.obj');
 goog.require('ol.Observable');
 goog.require('ol.events');
 goog.require('ol.source.ImageWMS');
@@ -159,14 +158,16 @@ ngeo.BackgroundLayerMgr.prototype.updateDimensions = function(map, dimensions) {
     layers.forEach(function(layer) {
       goog.asserts.assertInstanceof(layer, ol.layer.Layer);
       if (layer) {
+        var hasUpdates = false;
         var updatedDimensions = {};
         for (var key in layer.get('dimensions')) {
           var value = dimensions[key];
           if (value !== undefined) {
             updatedDimensions[key] = value;
+            hasUpdates = true;
           }
         }
-        if (!ol.obj.isEmpty(dimensions)) {
+        if (hasUpdates) {
           var source = layer.getSource();
           if (source instanceof ol.source.WMTS) {
             source.updateDimensions(updatedDimensions);

--- a/src/services/layerHelper.js
+++ b/src/services/layerHelper.js
@@ -49,18 +49,19 @@ ngeo.LayerHelper.REFRESH_PARAM = 'random';
 
 
 /**
- * Create and return a basic WMS layer with only a source URL and a dot
+ * Create and return a basic WMS layer with only a source URL and a cmoma
  * separated layers names (see {@link ol.source.ImageWMS}).
  * @param {string} sourceURL The source URL.
- * @param {string} sourceLayersName A dot separated names string.
+ * @param {string} sourceLayersName A comma separated names string.
  * @param {string=} opt_serverType Type of the server ("mapserver",
  *     "geoserver", "qgisserver", …).
  * @param {string=} opt_time time parameter for layer queryable by time/periode
+ * @param {Object.<string, string>=} opt_params WMS parameters.
  * @return {ol.layer.Image} WMS Layer.
  * @export
  */
 ngeo.LayerHelper.prototype.createBasicWMSLayer = function(sourceURL,
-    sourceLayersName, opt_serverType, opt_time) {
+    sourceLayersName, opt_serverType, opt_time, opt_params) {
   var params = {'LAYERS': sourceLayersName};
   var olServerType;
   if (opt_time) {
@@ -71,14 +72,16 @@ ngeo.LayerHelper.prototype.createBasicWMSLayer = function(sourceURL,
     // OpenLayers expects 'qgis' insteads of 'qgisserver'
     olServerType = opt_serverType.replace('qgisserver', 'qgis');
   }
-  var layer = new ol.layer.Image({
-    source: new ol.source.ImageWMS({
-      url: sourceURL,
-      params: params,
-      serverType: olServerType
-    })
+  var source = new ol.source.ImageWMS({
+    url: sourceURL,
+    params: params,
+    serverType: olServerType
   });
-  return layer;
+  if (opt_params) {
+    source.updateParams(opt_params);
+  }
+
+  return new ol.layer.Image({source: source});
 };
 
 

--- a/src/services/layerHelper.js
+++ b/src/services/layerHelper.js
@@ -49,7 +49,7 @@ ngeo.LayerHelper.REFRESH_PARAM = 'random';
 
 
 /**
- * Create and return a basic WMS layer with only a source URL and a cmoma
+ * Create and return a basic WMS layer with only a source URL and a comma
  * separated layers names (see {@link ol.source.ImageWMS}).
  * @param {string} sourceURL The source URL.
  * @param {string} sourceLayersName A comma separated names string.
@@ -95,7 +95,7 @@ ngeo.LayerHelper.prototype.createBasicWMSLayer = function(sourceURL,
  * @param {string} capabilitiesURL The getCapabilities url.
  * @param {string} layerName The name of the layer.
  * @param {Object.<string, string>=} opt_dimensions WMTS dimensions.
- * @return {angular.$q.Promise} A Promise with a layer (with source) on success,
+ * @return {angular.$q.Promise.<ol.layer.Tile>} A Promise with a layer (with source) on success,
  *     no layer else.
  * @export
  */


### PR DESCRIPTION
Properly initialize background layers dimensions by passing the abstract
controller dimensions object.

Allow provisionning default dimensions with Angular gmfDefaultDimensions.
The dimensions should now be passed to the background selector.

Handle WMS layers in addition to WMTS layers.