### PR TITLE
Set layer property 'layerName' to 'layerNodeName'

### DIFF
--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -284,7 +284,7 @@ gmf.LayertreeController.prototype.prepareLayer_ = function(node, layer) {
   var childNodes = [], allChildNodesUnchecked;
   layer.set('querySourceIds', ids);
   layer.set('editableIds', editableIds);
-  layer.set('layerName', node.name);
+  layer.set('layerNodeName', node.name);
   layer.set('disclaimers', this.getNodeDisclaimers_(node));
 
   var isMerged = type === gmf.Themes.NodeType.NOT_MIXED_GROUP;

--- a/contribs/gmf/src/directives/print.js
+++ b/contribs/gmf/src/directives/print.js
@@ -861,7 +861,7 @@ gmf.PrintController.prototype.getLegend_ = function(scale) {
     if (layer.getVisible() && source !== undefined) {
       // For WMTS layers.
       if (layer instanceof ol.layer.Tile) {
-        layerName = layer.get('layerName');
+        layerName = layer.get('layerNodeName');
         icons = this.ngeoLayerHelper_.getWMTSLegendURL(layer);
         // Don't add classes without legend url.
         if (icons !== null) {

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -936,7 +936,7 @@ gmf.Permalink.prototype.handleLayerOpacityChange_ = function(evt) {
   goog.asserts.assertInstanceof(layer, ol.layer.Base);
   var state = {};
   var isMerged = /** @type {boolean} */ (layer.get('isMerged'));
-  var layerName = /** @type {string} */ (layer.get('layerName'));
+  var layerName = /** @type {string} */ (layer.get('layerNodeName'));
   var param = this.getLayerStateParam_(layerName, isMerged, gmf.PermalinkOpenLayersLayerProperties.OPACITY);
   state[param] = layer.getOpacity();
   this.ngeoStateManager_.updateState(state);
@@ -975,7 +975,7 @@ gmf.Permalink.prototype.updateLayerStateByVisibility_ = function(layer) {
  * @private
  */
 gmf.Permalink.prototype.updateLayerFromState_ = function(layer) {
-  var layerName = /** @type {string} */ (layer.get('layerName'));
+  var layerName = /** @type {string} */ (layer.get('layerNodeName'));
   var isMerged = /** @type {boolean} */ (layer.get('isMerged'));
   var param, stateValue;
   Object.keys(gmf.PermalinkOpenLayersLayerProperties).forEach(function(layerProp) {
@@ -1007,7 +1007,7 @@ gmf.Permalink.prototype.updateLayerFromState_ = function(layer) {
  * @private
  */
 gmf.Permalink.prototype.deleteStateParams_ = function(layer) {
-  var layerName = /** @type {string} */ (layer.get('layerName'));
+  var layerName = /** @type {string} */ (layer.get('layerNodeName'));
   var isMerged = /** @type {boolean} */ (layer.get('isMerged'));
   var param;
   Object.keys(gmf.PermalinkOpenLayersLayerProperties).forEach(function(layerProp) {
@@ -1029,7 +1029,7 @@ gmf.Permalink.prototype.handleWMSSourceChange_ = function(layer, source) {
   if (Array.isArray(layers)) {
     layers = layers.join(',');
   }
-  var layerName = layer.get('layerName');
+  var layerName = layer.get('layerNodeName');
   var param = gmf.PermalinkParamPrefix.TREE_GROUP_LAYERS + layerName;
   var object = {};
   object[param] = layers;
@@ -1043,7 +1043,7 @@ gmf.Permalink.prototype.handleWMSSourceChange_ = function(layer, source) {
  * @private
  */
 gmf.Permalink.prototype.getLayerStateParamFromLayer_ = function(layer) {
-  var layerName = /** @type {string} */ (layer.get('layerName'));
+  var layerName = /** @type {string} */ (layer.get('layerNodeName'));
   var isMerged = /** @type {boolean} */ (layer.get('isMerged'));
   return this.getLayerStateParam_(layerName, isMerged);
 };

--- a/src/services/layerHelper.js
+++ b/src/services/layerHelper.js
@@ -228,7 +228,7 @@ ngeo.LayerHelper.prototype.getLayerByName = function(layerName, layers) {
     if (layer instanceof ol.layer.Group) {
       var sublayers = layer.getLayers().getArray();
       found = this.getLayerByName(layerName, sublayers);
-    } else if (layer.get('layerName') === layerName) {
+    } else if (layer.get('layerNodeName') === layerName) {
       found = layer;
     }
     return !!found;


### PR DESCRIPTION
Fix: #1436 

Example: https://ger-benjamin.github.io/ngeo/layerNodeName/examples/contribs/gmf/apps/desktop