### PR TITLE
OpenLayers optimizations

### DIFF
--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -94,7 +94,9 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
     interactions: config.mapInteractions || ol.interaction.defaults({
       pinchRotate: false,
       altShiftDragRotate: false
-    })
+    }),
+    loadTilesWhileAnimating: true,
+    loadTilesWhileInteracting: true
   });
 
   /**

--- a/src/services/layerHelper.js
+++ b/src/services/layerHelper.js
@@ -98,7 +98,9 @@ ngeo.LayerHelper.prototype.createBasicWMSLayer = function(sourceURL,
  */
 ngeo.LayerHelper.prototype.createWMTSLayerFromCapabilitites = function(capabilitiesURL, layerName, opt_dimensions) {
   var parser = new ol.format.WMTSCapabilities();
-  var layer = new ol.layer.Tile();
+  var layer = new ol.layer.Tile({
+    preload: Infinity
+  });
   var $q = this.$q_;
 
   return this.$http_.get(capabilitiesURL).then(function(response) {


### PR DESCRIPTION
see #1544 

Notes:
 - The Infinity preloading applies to all WMTS layers, not only to the background layers.
 - All the tiles are loaded while animating and interacting (but only form the desktop interface) 