### PR TITLE
Deactivate query on print but keep query infos

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -49,7 +49,7 @@
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Login'|translate}}">
               <span class="fa fa-user"></span>
             </button>
-            <button ngeo-btn class="btn btn-default" ng-model="printActive"
+            <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.printPanelActive"
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Print'|translate}}">
               <span class="fa fa-print"></span>
             </button>
@@ -84,15 +84,15 @@
               <gmf-authentication></gmf-authentication>
             </div>
           </div>
-          <div ng-show="printActive" class="row">
+          <div ng-show="mainCtrl.printPanelActive" class="row">
             <div class="col-sm-12">
               <div class="tools-content-heading">
                 {{'Print' | translate}}
-                <a class="btn close" ng-click="printActive = false">&times;</a>
+                <a class="btn close" ng-click="mainCtrl.printPanelActive = false">&times;</a>
               </div>
               <gmf-print
                 gmf-print-map="mainCtrl.map"
-                gmf-print-active="printActive">
+                gmf-print-active="mainCtrl.printActive">
               </gmf-print>
             </div>
           </div>
@@ -187,9 +187,11 @@
           ngeo-map-query=""
           ngeo-map-query-map="::mainCtrl.map"
           ngeo-map-query-active="mainCtrl.queryActive"
+          ngeo-map-query-autoclear="mainCtrl.queryAutoClear"
           ngeo-bbox-query=""
           ngeo-bbox-query-map="::mainCtrl.map"
-          ngeo-bbox-query-active="mainCtrl.queryActive">
+          ngeo-bbox-query-active="mainCtrl.queryActive"
+          ngeo-bbox-query-autoclear="mainCtrl.queryAutoClear">
         </gmf-map>
 
         <!--infobar-->

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -47,7 +47,7 @@
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Login'|translate}}">
               <span class="fa fa-user"></span>
             </button>
-            <button ngeo-btn class="btn btn-default" ng-model="printActive"
+            <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.printPanelActive"
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Print'|translate}}">
               <span class="fa fa-print"></span>
             </button>
@@ -82,15 +82,15 @@
               <gmf-authentication></gmf-authentication>
             </div>
           </div>
-          <div ng-show="printActive" class="row">
+          <div ng-show="mainCtrl.printPanelActive" class="row">
             <div class="col-sm-12">
               <div class="tools-content-heading">
                 {{'Print' | translate}}
-                <a class="btn close" ng-click="printActive = false">&times;</a>
+                <a class="btn close" ng-click="mainCtrl.printPanelActive = false">&times;</a>
               </div>
               <gmf-print
                 gmf-print-map="mainCtrl.map"
-                gmf-print-active="printActive"
+                gmf-print-active="mainCtrl.printActive"
                 gmf-print-rotatemask="true">
               </gmf-print>
             </div>

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -31,6 +31,7 @@ goog.require('ngeo.filters');
 goog.require('ngeo.mapQueryDirective');
 goog.require('ngeo.FeatureOverlayMgr');
 goog.require('ngeo.GetBrowserLanguage');
+goog.require('ngeo.Query');
 goog.require('ngeo.StateManager');
 goog.require('ngeo.ToolActivate');
 goog.require('ngeo.ToolActivateMgr');
@@ -161,13 +162,6 @@ gmf.AbstractController = function(config, $scope, $injector) {
    */
   this.rightNavVisible = false;
 
-  /**
-   * The active state of the ngeo query directive.
-   * @type {boolean}
-   * @export
-   */
-  this.queryActive = true;
-
   // Not used in this file but the QueryManager must be injected to be watched.
   $injector.get('gmfQueryManager');
 
@@ -188,6 +182,51 @@ gmf.AbstractController = function(config, $scope, $injector) {
     }),
     stroke: queryStroke
   });
+
+  /**
+   * The active state of the ngeo query directive.
+   * @type {boolean}
+   * @export
+   */
+  this.queryActive = true;
+
+  /**
+   * Set the clearing of the ngeoQuery after the deactivation of the query
+   * @type {boolean}
+   * @export
+   */
+  this.queryAutoClear = true;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.printPanelActive = false;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.printActive = false;
+
+  /**
+   * @type {ngeo.Query}
+   * @private
+   */
+  this.ngeoQuery_ = $injector.get('ngeoQuery');
+
+  // Don't deactivate ngeoQuery on print activation
+  $scope.$watch(function() {
+    return this.printPanelActive;
+  }.bind(this), function(newVal) {
+    // Clear queries if another panel is open but not if user go back to the
+    // map form the print.
+    if (!newVal && !this.queryActive) {
+      this.ngeoQuery_.clear();
+    }
+    this.queryAutoClear = !newVal;
+    this.printActive = newVal;
+  }.bind(this));
 
   /**
    * The active state of the directive responsible of point measurements.
@@ -297,6 +336,9 @@ gmf.AbstractController = function(config, $scope, $injector) {
 
   var drawProfilePanelActivate = new ngeo.ToolActivate(this, 'drawProfilePanelActive');
   ngeoToolActivateMgr.registerTool('mapTools', drawProfilePanelActivate, false);
+
+  var printPanelActivate = new ngeo.ToolActivate(this, 'printPanelActive');
+  ngeoToolActivateMgr.registerTool('mapTools', printPanelActivate, false);
 
 
   $scope.$watch(function() {

--- a/src/directives/bboxquery.js
+++ b/src/directives/bboxquery.js
@@ -22,6 +22,7 @@ goog.require('ol.interaction.DragBox');
  *        ngeo-bbox-query=""
  *        ngeo-bbox-query-map="::ctrl.map"
  *        ngeo-bbox-query-active="ctrl.queryActive">
+ *        ngeo-bbox-query-autoclear="ctrl.queryAutoClear">
  *      </span>
  *
  * See the live example: {@link ../examples/bboxquery.html}
@@ -66,7 +67,9 @@ ngeo.bboxQueryDirective = function(ngeoQuery) {
             } else {
               // deactivate
               map.removeInteraction(interaction);
-              ngeoQuery.clear();
+              if (scope.$eval(attrs['ngeoBboxQueryAutoclear']) !== false) {
+                ngeoQuery.clear();
+              }
             }
           }
       );

--- a/src/directives/mapquery.js
+++ b/src/directives/mapquery.js
@@ -20,7 +20,8 @@ goog.require('ngeo.Query');
  *      <span
  *        ngeo-map-query=""
  *        ngeo-map-query-map="::ctrl.map"
- *        ngeo-map-query-active="ctrl.queryActive">
+ *        ngeo-map-query-active="ctrl.queryActive"
+ *        ngeo-map-query-autoclear="ctrl.queryAutoClear">
  *      </span>
  *
  * See our live example: {@link ../examples/mapquery.html}
@@ -65,7 +66,9 @@ ngeo.mapQueryDirective = function(ngeoQuery) {
           ol.events.unlistenByKey(clickEventKey_);
           clickEventKey_ = null;
         }
-        ngeoQuery.clear();
+        if (scope.$eval(attrs['ngeoMapQueryAutoclear']) !== false) {
+          ngeoQuery.clear();
+        }
       };
 
       // watch 'active' property -> activate/deactivate accordingly


### PR DESCRIPTION
Fix: #1527 

Demo: https://ger-benjamin.github.io/ngeo/printandqueries/examples/contribs/gmf/apps/desktop/

(No query tools in the desktop_alt)

I (already) don't remember, the query window should be effectively always visible ?