### PR TITLE
FindGroupByLayerName search now in sub groups

### DIFF
--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -294,7 +294,7 @@ gmf.LayertreeController.prototype.prepareLayer_ = function(node, layer) {
   var metadata = node.metadata;
   if (isMerged) {
     //Case Non Mixed group -> Hide the layer if all child nodes have isChecked set to false
-    gmf.LayertreeController.getFlatNodes(node, childNodes);
+    gmf.Themes.getFlatNodes(node, childNodes);
     allChildNodesUnchecked = childNodes.every(function(childNode) {
       return !childNode.metadata || !childNode.metadata['isChecked'];
     });
@@ -421,7 +421,7 @@ gmf.LayertreeController.prototype.getLayerCaseNotMixedGroup_ = function(node) {
   var childNodes = [];
   var timeParam, timeValues;
 
-  gmf.LayertreeController.getFlatNodes(node, childNodes);
+  gmf.Themes.getFlatNodes(node, childNodes);
   // layersNames come from the json theme nodes and will become the wms
   // LAYERS. It must be reversed to get the correct layer order on the map.
   var layersNames = childNodes.map(function(node) {
@@ -476,26 +476,6 @@ gmf.LayertreeController.prototype.getLayerCaseWMTS_ = function(node) {
 
 
 /**
- * Fill the given "nodes" array with all node in the given node including the
- * given node itself.
- * @param {GmfThemesNode} node Layertree node.
- * @param {Array.<GmfThemesNode>} nodes An array.
- * @export
- */
-gmf.LayertreeController.getFlatNodes = function(node, nodes) {
-  var i;
-  var children = node.children;
-  if (children !== undefined) {
-    for (i = 0; i < children.length; i++) {
-      gmf.LayertreeController.getFlatNodes(children[i], nodes);
-    }
-  } else {
-    nodes.push(node);
-  }
-};
-
-
-/**
  * Return all names existing in a node and in its children.
  * @param {GmfThemesNode} node Layer tree node.
  * @param {boolean=} opt_onlyChecked return only 'isChecked' node names.
@@ -506,7 +486,7 @@ gmf.LayertreeController.prototype.retrieveNodeNames_ = function(node,
     opt_onlyChecked) {
   var names = [];
   var nodes = [];
-  gmf.LayertreeController.getFlatNodes(node, nodes);
+  gmf.Themes.getFlatNodes(node, nodes);
   var metadata, n, i;
   for (i = 0; i < nodes.length; i++) {
     n = nodes[i];
@@ -608,7 +588,7 @@ gmf.LayertreeController.prototype.toggleActive = function(treeCtrl) {
         var currentLayersNames = (firstParentTreeLayer.getVisible()) ?
             firstParentTreeSource.getParams()['LAYERS'] : '';
         var newLayersNames = [];
-        gmf.LayertreeController.getFlatNodes(firstParentTreeNode, childNodes);
+        gmf.Themes.getFlatNodes(firstParentTreeNode, childNodes);
         // Add/remove layer and keep order of layers in layergroup.
         for (i = 0; i < childNodes.length; i++) {
           layersNames = this.getLayersNames_(childNodes[i]);
@@ -630,7 +610,7 @@ gmf.LayertreeController.prototype.toggleActive = function(treeCtrl) {
     case gmf.Themes.NodeType.MIXED_GROUP:
       var nodeLayers = [];
       var l, source;
-      gmf.LayertreeController.getFlatNodes(node, childNodes);
+      gmf.Themes.getFlatNodes(node, childNodes);
       layersNames = childNodes.map(this.getLayersNames_).join(',');
       layers = this.layerHelper_.getFlatLayers(firstParentTreeLayer);
       for (i = 0; i < layers.length; i++) {
@@ -657,7 +637,7 @@ gmf.LayertreeController.prototype.toggleActive = function(treeCtrl) {
       if (isActive) {
         this.layerHelper_.updateWMSLayerState(firstParentTreeLayer, '');
       } else {
-        gmf.LayertreeController.getFlatNodes(node, childNodes);
+        gmf.Themes.getFlatNodes(node, childNodes);
         layersNames = childNodes.map(this.getLayersNames_);
         // layersNames come from the json theme nodes and replace the wms
         // LAYERS. It must be reversed to get the correct layer order on the map.

--- a/contribs/gmf/src/services/themesservice.js
+++ b/contribs/gmf/src/services/themesservice.js
@@ -103,7 +103,6 @@ gmf.Themes = function($http, $injector, $q, ngeoLayerHelper, gettextCatalog) {
    */
   this.promise_ = this.deferred_.promise;
 
-
   /**
    * @type {angular.$q.Promise}
    * @private
@@ -119,13 +118,15 @@ goog.inherits(gmf.Themes, ol.events.EventTarget);
  * @param {string} name The layer name.
  * @return {GmfThemesNode} The group.
  */
-gmf.Themes.findGroupByLayerName = function(themes, name) {
+gmf.Themes.findGroupByLayerNodeName = function(themes, name) {
   for (var i = 0, ii = themes.length; i < ii; i++) {
     var theme = themes[i];
     for (var j = 0, jj = theme.children.length; j < jj; j++) {
       var group = theme.children[j];
-      for (var k = 0, kk = group.children.length; k < kk; k++) {
-        var layer = group.children[k];
+      var childNodes = [];
+      gmf.Themes.getFlatNodes(group, childNodes);
+      for (var k = 0, kk = childNodes.length; k < kk; k++) {
+        var layer = childNodes[k];
         if (layer.name == name) {
           return group;
         }
@@ -199,6 +200,26 @@ gmf.Themes.getNodeType = function(node) {
     return gmf.Themes.NodeType.WMTS;
   }
   return gmf.Themes.NodeType.WMS;
+};
+
+
+/**
+ * Fill the given "nodes" array with all node in the given node including the
+ * given node itself.
+ * @param {GmfThemesNode} node Layertree node.
+ * @param {Array.<GmfThemesNode>} nodes An array.
+ * @export
+ */
+gmf.Themes.getFlatNodes = function(node, nodes) {
+  var i;
+  var children = node.children;
+  if (children !== undefined) {
+    for (i = 0; i < children.length; i++) {
+      gmf.Themes.getFlatNodes(children[i], nodes);
+    }
+  } else {
+    nodes.push(node);
+  }
 };
 
 

--- a/contribs/gmf/src/services/treemanager.js
+++ b/contribs/gmf/src/services/treemanager.js
@@ -314,7 +314,7 @@ gmf.TreeManager.prototype.addGroupByName = function(groupName, opt_add) {
  */
 gmf.TreeManager.prototype.addGroupByLayerName = function(layerName, opt_add, opt_silent, opt_map) {
   this.gmfThemes_.getThemesObject().then(function(themes) {
-    var group = gmf.Themes.findGroupByLayerName(themes, layerName);
+    var group = gmf.Themes.findGroupByLayerNodeName(themes, layerName);
     if (group) {
       var groupAdded = this.addGroups([group], opt_add, opt_silent);
       if (opt_map) {
@@ -354,7 +354,7 @@ gmf.TreeManager.prototype.setLayerVisible_ = function(layerName, group, groupAdd
       activeLayers = layerGroup.getVisible() ? source.getParams()['LAYERS'] : '';
       // Get all possible LAYERS values in this group.
       var childNodes = [];
-      gmf.LayertreeController.getFlatNodes(group, childNodes);
+      gmf.Themes.getFlatNodes(group, childNodes);
       var allLayersNames = childNodes.map(function(node) {
         return node['layers'];
       });


### PR DESCRIPTION
Fix: #1614

Demo: https://ger-benjamin.github.io/ngeo/1614/examples/contribs/gmf/apps/desktop/

I hope it's correct, I don't really know how I can test in the current demo. But now, this method search the group in all `children`.