### PR TITLE
Remove goog.base from ol-ext files

### DIFF
--- a/src/ol-ext/format/featurehash.js
+++ b/src/ol-ext/format/featurehash.js
@@ -82,7 +82,8 @@ ngeo.format.FeatureHashLegacyProperties_ = {};
  * @export
  */
 ngeo.format.FeatureHash = function(opt_options) {
-  goog.base(this);
+
+  ol.format.TextFeature.call(this);
 
   var options = opt_options !== undefined ? opt_options : {};
 
@@ -132,7 +133,7 @@ ngeo.format.FeatureHash = function(opt_options) {
   ngeo.format.FeatureHashLegacyProperties_ = (options.propertiesType !== undefined) &&  options.propertiesType;
 
 };
-goog.inherits(ngeo.format.FeatureHash, ol.format.TextFeature);
+ol.inherits(ngeo.format.FeatureHash, ol.format.TextFeature);
 
 
 /**

--- a/src/ol-ext/format/xsdattribute.js
+++ b/src/ol-ext/format/xsdattribute.js
@@ -12,9 +12,9 @@ goog.require('ol.format.XML');
  * @export
  */
 ngeo.format.XSDAttribute = function() {
-  goog.base(this);
+  ol.format.XML.call(this);
 };
-goog.inherits(ngeo.format.XSDAttribute, ol.format.XML);
+ol.inherits(ngeo.format.XSDAttribute, ol.format.XML);
 
 
 /**
@@ -23,7 +23,7 @@ goog.inherits(ngeo.format.XSDAttribute, ol.format.XML);
  */
 ngeo.format.XSDAttribute.prototype.read = function(source) {
   return /** @type {Array.<ngeox.Attribute>} */ (
-    goog.base(this, 'read', source)
+    ol.format.XML.prototype.read.call(this, source)
   );
 };
 

--- a/src/ol-ext/interaction/measure.js
+++ b/src/ol-ext/interaction/measure.js
@@ -58,7 +58,7 @@ ngeo.MeasureEventType = {
  */
 ngeo.MeasureEvent = function(type, feature) {
 
-  goog.base(this, type);
+  ol.events.Event.call(this, type);
 
   /**
    * The feature being drawn.
@@ -68,7 +68,7 @@ ngeo.MeasureEvent = function(type, feature) {
   this.feature = feature;
 
 };
-goog.inherits(ngeo.MeasureEvent, ol.events.Event);
+ol.inherits(ngeo.MeasureEvent, ol.events.Event);
 
 
 /**
@@ -82,7 +82,7 @@ ngeo.interaction.Measure = function(opt_options) {
 
   var options = opt_options !== undefined ? opt_options : {};
 
-  goog.base(this, {
+  ol.interaction.Interaction.call(this, {
     handleEvent: ngeo.interaction.Measure.handleEvent_
   });
 
@@ -217,7 +217,7 @@ ngeo.interaction.Measure = function(opt_options) {
       ol.Object.getChangeEventType(ol.interaction.InteractionProperty.ACTIVE),
       this.updateState_, this);
 };
-goog.inherits(ngeo.interaction.Measure, ol.interaction.Interaction);
+ol.inherits(ngeo.interaction.Measure, ol.interaction.Interaction);
 
 /**
  * Calculate the area of the passed polygon and return a formatted string
@@ -349,7 +349,8 @@ ngeo.interaction.Measure.prototype.createDrawInteraction = goog.abstractMethod;
  * @inheritDoc
  */
 ngeo.interaction.Measure.prototype.setMap = function(map) {
-  goog.base(this, 'setMap', map);
+
+  ol.interaction.Interaction.prototype.setMap.call(this, map);
 
   this.vectorLayer_.setMap(map);
 

--- a/src/ol-ext/interaction/measurearea.js
+++ b/src/ol-ext/interaction/measurearea.js
@@ -21,7 +21,7 @@ ngeo.interaction.MeasureArea = function(format, opt_options) {
 
   var options = opt_options !== undefined ? opt_options : {};
 
-  goog.base(this, options);
+  ngeo.interaction.Measure.call(this, options);
 
 
   /**
@@ -41,7 +41,7 @@ ngeo.interaction.MeasureArea = function(format, opt_options) {
   this.format = format;
 
 };
-goog.inherits(ngeo.interaction.MeasureArea, ngeo.interaction.Measure);
+ol.inherits(ngeo.interaction.MeasureArea, ngeo.interaction.Measure);
 
 
 /**

--- a/src/ol-ext/interaction/measureazimut.js
+++ b/src/ol-ext/interaction/measureazimut.js
@@ -36,7 +36,7 @@ ngeo.interaction.MeasureAzimut = function(format, opt_options) {
 
   var options = opt_options !== undefined ? opt_options : {};
 
-  goog.base(this, options);
+  ngeo.interaction.Measure.call(this, options);
 
 
   /**
@@ -53,7 +53,7 @@ ngeo.interaction.MeasureAzimut = function(format, opt_options) {
   this.format = format;
 
 };
-goog.inherits(ngeo.interaction.MeasureAzimut, ngeo.interaction.Measure);
+ol.inherits(ngeo.interaction.MeasureAzimut, ngeo.interaction.Measure);
 
 
 /**
@@ -140,7 +140,7 @@ ngeo.interaction.MeasureAzimut.getAzimut = function(line) {
  */
 ngeo.interaction.DrawAzimut = function(options) {
 
-  goog.base(this, {
+  ol.interaction.Pointer.call(this, {
     handleDownEvent: ngeo.interaction.DrawAzimut.handleDownEvent_,
     handleEvent: ngeo.interaction.DrawAzimut.handleEvent_,
     handleUpEvent: ngeo.interaction.DrawAzimut.handleUpEvent_
@@ -210,7 +210,7 @@ ngeo.interaction.DrawAzimut = function(options) {
       ol.Object.getChangeEventType(ol.interaction.InteractionProperty.ACTIVE),
       this.updateState_, this);
 };
-goog.inherits(ngeo.interaction.DrawAzimut, ol.interaction.Pointer);
+ol.inherits(ngeo.interaction.DrawAzimut, ol.interaction.Pointer);
 
 
 /**
@@ -424,6 +424,6 @@ ngeo.interaction.DrawAzimut.prototype.finishDrawing_ = function() {
  * @inheritDoc
  */
 ngeo.interaction.DrawAzimut.prototype.setMap = function(map) {
-  goog.base(this, 'setMap', map);
+  ol.interaction.Pointer.prototype.setMap.call(this, map);
   this.updateState_();
 };

--- a/src/ol-ext/interaction/measurelength.js
+++ b/src/ol-ext/interaction/measurelength.js
@@ -21,7 +21,7 @@ ngeo.interaction.MeasureLength = function(format, opt_options) {
 
   var options = opt_options !== undefined ? opt_options : {};
 
-  goog.base(this, options);
+  ngeo.interaction.Measure.call(this, options);
 
 
   /**
@@ -41,7 +41,7 @@ ngeo.interaction.MeasureLength = function(format, opt_options) {
   this.format = format;
 
 };
-goog.inherits(ngeo.interaction.MeasureLength, ngeo.interaction.Measure);
+ol.inherits(ngeo.interaction.MeasureLength, ngeo.interaction.Measure);
 
 
 /**

--- a/src/ol-ext/interaction/measurelengthmobile.js
+++ b/src/ol-ext/interaction/measurelengthmobile.js
@@ -20,11 +20,11 @@ ngeo.interaction.MeasureLengthMobile = function(format, opt_options) {
 
   goog.object.extend(options, {displayHelpTooltip: false});
 
-  goog.base(this, format, options);
+  ngeo.interaction.MeasureLength.call(this, format, options);
 
 };
-goog.inherits(ngeo.interaction.MeasureLengthMobile,
-              ngeo.interaction.MeasureLength);
+ol.inherits(
+  ngeo.interaction.MeasureLengthMobile, ngeo.interaction.MeasureLength);
 
 
 /**

--- a/src/ol-ext/interaction/measurepointmobile.js
+++ b/src/ol-ext/interaction/measurepointmobile.js
@@ -20,10 +20,10 @@ ngeo.interaction.MeasurePointMobile = function(opt_options) {
 
   goog.object.extend(options, {displayHelpTooltip: false});
 
-  goog.base(this, options);
+  ngeo.interaction.Measure.call(this, options);
 
 };
-goog.inherits(ngeo.interaction.MeasurePointMobile, ngeo.interaction.Measure);
+ol.inherits(ngeo.interaction.MeasurePointMobile, ngeo.interaction.Measure);
 
 
 /**

--- a/src/ol-ext/interaction/mobiledraw.js
+++ b/src/ol-ext/interaction/mobiledraw.js
@@ -37,7 +37,7 @@ ngeo.interaction.MobileDrawProperty = {
  */
 ngeo.interaction.MobileDraw = function(options) {
 
-  goog.base(this, {
+  ol.interaction.Interaction.call(this, {
     handleEvent: goog.functions.TRUE
   });
 
@@ -112,7 +112,7 @@ ngeo.interaction.MobileDraw = function(options) {
   this.set(ngeo.interaction.MobileDrawProperty.VALID, false);
 
 };
-goog.inherits(ngeo.interaction.MobileDraw, ol.interaction.Interaction);
+ol.inherits(ngeo.interaction.MobileDraw, ol.interaction.Interaction);
 
 
 /**
@@ -127,7 +127,7 @@ ngeo.interaction.MobileDraw.prototype.setMap = function(map) {
     }
   }
 
-  goog.base(this, 'setMap', map);
+  ol.interaction.Interaction.prototype.setMap.call(this, map);
 
   if (map) {
     this.changeEventKey_ = ol.events.listen(map.getView(),

--- a/src/ol-ext/interaction/modify.js
+++ b/src/ol-ext/interaction/modify.js
@@ -88,12 +88,12 @@ ngeo.interaction.Modify = function(options) {
   }));
 
 
-  goog.base(this, {
+  ol.interaction.Interaction.call(this, {
     handleEvent: goog.functions.TRUE
   });
 
 };
-goog.inherits(ngeo.interaction.Modify, ol.interaction.Interaction);
+ol.inherits(ngeo.interaction.Modify, ol.interaction.Interaction);
 
 
 /**
@@ -102,7 +102,7 @@ goog.inherits(ngeo.interaction.Modify, ol.interaction.Interaction);
  * @export
  */
 ngeo.interaction.Modify.prototype.setActive = function(active) {
-  goog.base(this, 'setActive', active);
+  ol.interaction.Interaction.prototype.setActive.call(this, active);
   this.setState_();
 };
 
@@ -124,7 +124,7 @@ ngeo.interaction.Modify.prototype.setMap = function(map) {
     }, this);
   }
 
-  goog.base(this, 'setMap', map);
+  ol.interaction.Interaction.prototype.setMap.call(this, map);
 
   if (map) {
     interactions.forEach(function(interaction) {

--- a/src/ol-ext/interaction/modifycircle.js
+++ b/src/ol-ext/interaction/modifycircle.js
@@ -36,7 +36,7 @@ goog.require('ol.structs.RBush');
  */
 ngeo.interaction.ModifyCircle = function(options) {
 
-  goog.base(this, {
+  ol.interaction.Pointer.call(this, {
     handleDownEvent: ngeo.interaction.ModifyCircle.handleDownEvent_,
     handleDragEvent: ngeo.interaction.ModifyCircle.handleDragEvent_,
     handleEvent: ngeo.interaction.ModifyCircle.handleEvent,
@@ -125,7 +125,7 @@ ngeo.interaction.ModifyCircle = function(options) {
       this.handleFeatureRemove_, this);
 
 };
-goog.inherits(ngeo.interaction.ModifyCircle, ol.interaction.Pointer);
+ol.inherits(ngeo.interaction.ModifyCircle, ol.interaction.Pointer);
 
 
 /**
@@ -201,7 +201,7 @@ ngeo.interaction.ModifyCircle.prototype.removeFeatureSegmentData_ = function(fea
  */
 ngeo.interaction.ModifyCircle.prototype.setMap = function(map) {
   this.overlay_.setMap(map);
-  goog.base(this, 'setMap', map);
+  ol.interaction.Pointer.prototype.setMap.call(this, map);
 };
 
 

--- a/src/ol-ext/interaction/modifyrectangle.js
+++ b/src/ol-ext/interaction/modifyrectangle.js
@@ -28,7 +28,7 @@ goog.require('ol.source.Vector');
  */
 ngeo.interaction.ModifyRectangle = function(options) {
 
-  goog.base(this, {
+  ol.interaction.Pointer.call(this, {
     handleDownEvent: this.handleDown_,
     handleMoveEvent: this.handleMove_,
     handleDragEvent: this.handleDrag_,
@@ -105,7 +105,7 @@ ngeo.interaction.ModifyRectangle = function(options) {
   this.features_.forEach(this.addFeature_, this);
 
 };
-goog.inherits(ngeo.interaction.ModifyRectangle, ol.interaction.Pointer);
+ol.inherits(ngeo.interaction.ModifyRectangle, ol.interaction.Pointer);
 
 
 /**
@@ -221,7 +221,7 @@ ngeo.interaction.ModifyRectangle.prototype.removeFeature_ = function(feature) {
 ngeo.interaction.ModifyRectangle.prototype.setMap = function(map) {
   this.vectorPoints_.setMap(map);
   this.vectorPoints_.setVisible(false);
-  goog.base(this, 'setMap', map);
+  ol.interaction.Pointer.prototype.setMap.call(this, map);
 };
 
 

--- a/src/ol-ext/interaction/rotate.js
+++ b/src/ol-ext/interaction/rotate.js
@@ -44,7 +44,7 @@ ngeo.RotateEventType = {
  */
 ngeo.RotateEvent = function(type, feature) {
 
-  goog.base(this, type);
+  ol.events.Event.call(this, type);
 
   /**
    * The feature being rotated.
@@ -54,7 +54,7 @@ ngeo.RotateEvent = function(type, feature) {
   this.feature = feature;
 
 };
-goog.inherits(ngeo.RotateEvent, ol.events.Event);
+ol.inherits(ngeo.RotateEvent, ol.events.Event);
 
 
 /**
@@ -151,14 +151,14 @@ ngeo.interaction.Rotate = function(options) {
    */
   this.centerFeatures_ = {};
 
-  goog.base(this, {
+  ol.interaction.Pointer.call(this, {
     handleDownEvent: this.handleDown_,
     handleDragEvent: this.handleDrag_,
     handleUpEvent: this.handleUp_
   });
 
 };
-goog.inherits(ngeo.interaction.Rotate, ol.interaction.Pointer);
+ol.inherits(ngeo.interaction.Rotate, ol.interaction.Pointer);
 
 
 /**
@@ -173,7 +173,7 @@ ngeo.interaction.Rotate.prototype.setActive = function(active) {
     this.keyPressListenerKey_ = null;
   }
 
-  goog.base(this, 'setActive', active);
+  ol.interaction.Pointer.prototype.setActive.call(this, active);
 
   if (active) {
     this.keyPressListenerKey_ = goog.events.listen(
@@ -255,7 +255,7 @@ ngeo.interaction.Rotate.prototype.removeFeature_ = function(feature) {
  */
 ngeo.interaction.Rotate.prototype.setMap = function(map) {
   this.overlay_.setMap(map);
-  goog.base(this, 'setMap', map);
+  ol.interaction.Pointer.prototype.setMap.call(this, map);
 };
 
 

--- a/src/ol-ext/interaction/translate.js
+++ b/src/ol-ext/interaction/translate.js
@@ -74,9 +74,10 @@ ngeo.interaction.Translate = function(options) {
    */
   this.centerFeatures_ = {};
 
-  goog.base(this, /** @type {olx.interaction.TranslateOptions} */ (options));
+  ol.interaction.Translate.call(
+    this, /** @type {olx.interaction.TranslateOptions} */ (options));
 };
-goog.inherits(ngeo.interaction.Translate, ol.interaction.Translate);
+ol.inherits(ngeo.interaction.Translate, ol.interaction.Translate);
 
 
 /**
@@ -91,7 +92,7 @@ ngeo.interaction.Translate.prototype.setActive = function(active) {
     this.keyPressListenerKey_ = null;
   }
 
-  goog.base(this, 'setActive', active);
+  ol.interaction.Translate.prototype.setActive.call(this, active);
 
   if (active) {
     this.keyPressListenerKey_ = goog.events.listen(
@@ -120,7 +121,7 @@ ngeo.interaction.Translate.prototype.setMap = function(map) {
     this.vectorLayer_.setMap(null);
   }
 
-  goog.base(this, 'setMap', map);
+  ol.interaction.Translate.prototype.setMap.call(this, map);
 
   if (map) {
     this.vectorLayer_.setMap(map);

--- a/src/ol-ext/menu.js
+++ b/src/ol-ext/menu.js
@@ -30,7 +30,7 @@ ngeo.MenuEventType = {
  */
 ngeo.MenuEvent = function(type, action) {
 
-  goog.base(this, type);
+  ol.events.Event.call(this, type);
 
   /**
    * The action name that was clicked.
@@ -40,7 +40,7 @@ ngeo.MenuEvent = function(type, action) {
   this.action = action;
 
 };
-goog.inherits(ngeo.MenuEvent, ol.events.Event);
+ol.inherits(ngeo.MenuEvent, ol.events.Event);
 
 
 /**
@@ -130,10 +130,10 @@ ngeo.Menu = function(menuOptions, opt_overlayOptions) {
 
   options.element = contentEl[0];
 
-  goog.base(this, options);
+  ol.Overlay.call(this, options);
 
 };
-goog.inherits(ngeo.Menu, ol.Overlay);
+ol.inherits(ngeo.Menu, ol.Overlay);
 
 
 /**
@@ -157,7 +157,7 @@ ngeo.Menu.prototype.setMap = function(map) {
     olKeys.length = 0;
   }
 
-  goog.base(this, 'setMap', map);
+  ol.Overlay.prototype.setMap.call(this, map);
 
   if (map) {
     this.actions_.forEach(function(action) {

--- a/src/ol-ext/popover.js
+++ b/src/ol-ext/popover.js
@@ -51,10 +51,10 @@ ngeo.Popover = function(opt_options) {
 
   options.element = $('<div />')[0];
 
-  goog.base(this, options);
+  ol.Overlay.call(this, options);
 
 };
-goog.inherits(ngeo.Popover, ol.Overlay);
+ol.inherits(ngeo.Popover, ol.Overlay);
 
 
 /**
@@ -74,7 +74,7 @@ ngeo.Popover.prototype.setMap = function(map) {
     $(element).popover('destroy');
   }
 
-  goog.base(this, 'setMap', map);
+  ol.Overlay.prototype.setMap.call(this, map);
 
   if (map) {
     var contentEl = this.contentEl_;


### PR DESCRIPTION
This PR removes the `goog.base` methods from the files that are in `src/ol-ext`, i.e. from files that inherits from OpenLayers classes.

This allow those classes to be built with Closure-Util in which the `useOfGoogBase` configuration is not used.