### PR TITLE
Fix #1720 - Show modal on feature unsaved changes - gmf-editfeature

### DIFF
--- a/contribs/gmf/src/directives/partials/editfeature.html
+++ b/contribs/gmf/src/directives/partials/editfeature.html
@@ -29,39 +29,80 @@
         </span>
       </span>
     </a>
-    <form
-      novalidate
-      name="form"
-      class="form gmf-editfeature-attributes-container"
-      ng-switch-default
-      ng-if="efCtrl.attributes">
-      <ngeo-attributes
-        ngeo-attributes-attributes="::efCtrl.attributes"
-        ngeo-attributes-disabled="efCtrl.pending"
-        ngeo-attributes-feature="::efCtrl.feature">
-      </ngeo-attributes>
-      <input
-        type="submit"
-        value="{{'Save' | translate}}"
-        class="btn btn-sm btn-default gmf-editfeature-btn-save"
-        ng-click="form.$valid && efCtrl.save()"
-        ng-disabled="!efCtrl.dirty"
-        title="{{'Save modifications | translate'}}"></input>
-      <a
-        class="btn btn-sm btn-default gmf-editfeature-btn-cancel"
-        ng-click="efCtrl.cancel()"
-        ng-disabled="efCtrl.pending"
-        title="{{'Cancel modifications | translate'}}"
-        href>{{'Cancel' | translate}}</a>
-      <button
-        class="btn btn-sm btn-link gmf-editfeature-btn-delete"
-        ng-click="efCtrl.delete()"
-        ng-disabled="efCtrl.pending"
-        ng-show="efCtrl.featureId"
-        title="{{'Delete this feature | translate'}}">
-        <span class="fa fa-trash"></span>
-        {{'Delete' | translate}}
-      </button>
-    </form>
+    <div ng-switch-default>
+      <ngeo-modal ng-model="efCtrl.unsavedModificationsModalShown">
+        <div class="modal-header">
+          <button
+              type="button"
+              class="close"
+              data-dismiss="modal"
+              aria-label="{{'Close' | translate}}">
+            <span aria-hidden="true">&times;</span>
+          </button>
+          <h4 class="modal-title">
+            {{'Unsaved modifications!' | translate}}
+          </h4>
+        </div>
+        <div class="modal-body">
+          {{'There are unsaved changes.' | translate}}
+        </div>
+        <div class="modal-footer">
+          <button
+              type="button"
+              class="btn btn-default"
+              data-dismiss="modal"
+              ng-click="efCtrl.cancel()">
+            {{'Continue without saving' | translate}}
+          </button>
+          <button
+              type="button"
+              class="btn btn-primary"
+              data-dismiss="modal">
+            {{'Cancel' | translate}}
+          </button>
+          <button
+              type="button"
+              class="btn btn-default"
+              data-dismiss="modal"
+              ng-click="efCtrl.submit()">
+            {{'Save' | translate}}
+          </button>
+        </div>
+      </ngeo-modal>
+
+      <form
+        novalidate
+        name="form"
+        class="form gmf-editfeature-attributes-container"
+        ng-if="efCtrl.attributes">
+        <ngeo-attributes
+          ngeo-attributes-attributes="::efCtrl.attributes"
+          ngeo-attributes-disabled="efCtrl.pending"
+          ngeo-attributes-feature="::efCtrl.feature">
+        </ngeo-attributes>
+        <input
+          type="submit"
+          value="{{'Save' | translate}}"
+          class="btn btn-sm btn-default gmf-editfeature-btn-save"
+          ng-click="form.$valid && efCtrl.save()"
+          ng-disabled="!efCtrl.dirty"
+          title="{{'Save modifications | translate'}}"></input>
+        <a
+          class="btn btn-sm btn-default gmf-editfeature-btn-cancel"
+          ng-click="efCtrl.cancel()"
+          ng-disabled="efCtrl.pending"
+          title="{{'Cancel modifications | translate'}}"
+          href>{{'Cancel' | translate}}</a>
+        <button
+          class="btn btn-sm btn-link gmf-editfeature-btn-delete"
+          ng-click="efCtrl.delete()"
+          ng-disabled="efCtrl.pending"
+          ng-show="efCtrl.featureId"
+          title="{{'Delete this feature | translate'}}">
+          <span class="fa fa-trash"></span>
+          {{'Delete' | translate}}
+        </button>
+      </form>
+    </div>
   </div>
 </div>

--- a/contribs/gmf/src/directives/partials/editfeature.html
+++ b/contribs/gmf/src/directives/partials/editfeature.html
@@ -51,7 +51,7 @@
               type="button"
               class="btn btn-default"
               data-dismiss="modal"
-              ng-click="efCtrl.cancel()">
+              ng-click="efCtrl.continueWithoutSaving()">
             {{'Continue without saving' | translate}}
           </button>
           <button
@@ -89,7 +89,7 @@
           title="{{'Save modifications | translate'}}"></input>
         <a
           class="btn btn-sm btn-default gmf-editfeature-btn-cancel"
-          ng-click="efCtrl.cancel()"
+          ng-click="efCtrl.confirmCancel()"
           ng-disabled="efCtrl.pending"
           title="{{'Cancel modifications | translate'}}"
           href>{{'Cancel' | translate}}</a>


### PR DESCRIPTION
This PR fixes #1720.  When a feature is being edited in the `gmf-editfeature` directive, if there are unsaved modifications and the user clicks out of the feature, a confirmation modal is shown to ask him or her what to do.

The above behavior also happens when the "cancel" button of the form is clicked.

Finally, when the "continue without saving" or "save" of the confirm modal is clicked, the previously clicked location is managed, i.e. after the modal is closed the location where the click occured will be managed. If an other feature had been clicked, it will be selected.

## Todo

 * [x] review

## Will be done in an other task

* The "stop editing" management
* The selection of an other tool

I'll create 2 separate issues for those.

## Live example

 * https://adube.github.io/ngeo/1720-unsaved-modifications/examples/contribs/gmf/editfeatureselector.html