### PR TITLE
Add options in csvdownload service

### DIFF
--- a/contribs/gmf/src/directives/displayquerygrid.js
+++ b/contribs/gmf/src/directives/displayquerygrid.js
@@ -810,7 +810,7 @@ gmf.DisplayquerygridController.prototype.downloadCsv = function() {
     var selectedRows = source.configuration.getSelectedRows();
 
     this.ngeoCsvDownload_.startDownload(
-        selectedRows, columnDefs, 'query-results.csv');
+        selectedRows, columnDefs, 'query-results');
   }
 };
 

--- a/src/services/csvdownload.js
+++ b/src/services/csvdownload.js
@@ -7,13 +7,14 @@ goog.require('ngeo');
  * Service to generate and download a CSV file from tabular data.
  * Column headers are translated using {@link angularGettext.Catalog}.
  *
+ * @param {angular.$injector} $injector Main injector.
  * @param {angularGettext.Catalog} gettextCatalog Gettext service.
  * @constructor
  * @ngdoc service
  * @ngname ngeoCsvDownload
  * @ngInject
  */
-ngeo.CsvDownload = function(gettextCatalog) {
+ngeo.CsvDownload = function($injector, gettextCatalog) {
 
   /**
    * @type {angularGettext.Catalog}
@@ -22,18 +23,44 @@ ngeo.CsvDownload = function(gettextCatalog) {
   this.gettextCatalog_ = gettextCatalog;
 
   /**
-   * Separator character.
+   * File extension of the CSV file.
    * @type {string}
    * @private
    */
-  this.separator_ = ',';
+  this.encoding_ = $injector.has('ngeoCsvEncoding') ?
+    $injector.get('ngeoCsvEncoding') : 'utf-8';
+
+  /**
+   * File extension of the CSV file.
+   * @type {string}
+   * @private
+   */
+  this.extension_ = $injector.has('ngeoCsvExtension') ?
+    $injector.get('ngeoCsvExtension') : '.csv';
+
+  /**
+   * Whether to include the header in the exported file or not.
+   * @type {boolean}
+   * @private
+   */
+  this.includeHeader_ = $injector.has('ngeoCsvIncludeHeader') ?
+    $injector.get('ngeoCsvIncludeHeader') : true;
 
   /**
    * Quote character.
    * @type {string}
    * @private
    */
-  this.quote_ = '"';
+  this.quote_ = $injector.has('ngeoCsvQuote') ?
+    $injector.get('ngeoCsvQuote') : '"';
+
+  /**
+   * Separator character.
+   * @type {string}
+   * @private
+   */
+  this.separator_ = $injector.has('ngeoCsvSeparator') ?
+    $injector.get('ngeoCsvSeparator') : ',';
 };
 
 
@@ -62,7 +89,7 @@ ngeo.CsvDownload.prototype.generateCsv = function(data, columnDefs) {
     return this.getRow_(rowValues);
   }.bind(this));
 
-  return header + dataRows.join('');
+  return this.includeHeader_ ? header + dataRows.join('') : dataRows.join('');
 };
 
 
@@ -94,7 +121,7 @@ ngeo.CsvDownload.prototype.getRow_ = function(values) {
  *
  * @param {Array.<Object>} data Entries/objects to include in the CSV.
  * @param {Array.<ngeox.GridColumnDef>} columnDefs Column definitions.
- * @param {string} fileName The CSV file name.
+ * @param {string} fileName The CSV file name, without the extension.
  * @export
  */
 ngeo.CsvDownload.prototype.startDownload = function(data, columnDefs, fileName) {
@@ -103,9 +130,10 @@ ngeo.CsvDownload.prototype.startDownload = function(data, columnDefs, fileName) 
   var hiddenElement = document.createElement('a');
   // FF requires the link to be in the body
   document.body.appendChild(hiddenElement);
-  hiddenElement.href = 'data:attachment/csv,' + encodeURI(fileContent);
+  hiddenElement.href = 'data:attachment/csv;charset=' + this.encoding_ +
+    ',' + encodeURI(fileContent);
   hiddenElement.target = '_blank';
-  hiddenElement.download = fileName;
+  hiddenElement.download = fileName + this.extension_;
   hiddenElement.click();
   document.body.removeChild(hiddenElement);
 };


### PR DESCRIPTION
This PR adds options in the `csvdownload` service:

 * ngeoCsvEncoding
 * ngeoCsvExtension
 * ngeoCsvIncludeHeader
 * ngeoCsvQuote
 * ngeoCsvSeparator

See specs for description: https://github.com/camptocamp/c2cgeoportal/wiki/Spec-%231672-Querying-results-CSV-export-plugin#configuration

The `csvExportLikeCurrentGrid` as not beed added. It's already possible to export only a sub-section of selected rows and in the proper order.

## Todo

 * [ ] review