### PR TITLE
Allow query on nodes that have several layer names

### DIFF
--- a/contribs/gmf/src/services/querymanager.js
+++ b/contribs/gmf/src/services/querymanager.js
@@ -152,9 +152,7 @@ gmf.QueryManager.prototype.createSources_ = function(node, ogcServers) {
           }
         }, this);
         layers = childLayerNames.join(',');
-        if (node.type === 'WMS' && childLayerNames.length == 1) {
-          validateLayerParams = true;
-        }
+        validateLayerParams = node.type === 'WMS';
       }
 
       var source = {

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -520,15 +520,12 @@ ngeox.QuerySource.prototype.url;
  * to a layer that also has an ol3 WMS source object, then the latter may
  * contain more than one layer name within the LAYERS param. In that case,
  * this `validateLayerParams` property, when enabled, will make the query
- * service check if the layer name within its LAYERS params is currently inside
- * the layer source LAYERS params. If it's not there, then the source should
- * not be queried.
+ * service check if the layer name(s) within its LAYERS params is currently
+ * inside the layer source LAYERS params. If it's not there, then the source
+ * should not be queried.
  *
  * When setting this option, you must not set the wmsSource or layer if
  * it has an inner ol3 wms source object.
- *
- * Also, when using this option, your config `params` must also only have
- * one layer name set in the LAYERS property.
  * @type {boolean|undefined}
  */
 ngeox.QuerySource.prototype.validateLayerParams;

--- a/src/services/query.js
+++ b/src/services/query.js
@@ -423,10 +423,12 @@ ngeo.Query.prototype.getQueryableSources_ = function(map, wfsOnly) {
             'validateLayerParams option.'
         );
         var layerLayers = layerSource.getParams()['LAYERS'].split(',');
-        var cfgLayer = item.source.wmsSource.getParams()['LAYERS'];
-        goog.asserts.assert(cfgLayer.indexOf(',') === -1,
-            'The LAYERS param contains more than one item');
-        if (layerLayers.indexOf(cfgLayer) === -1) {
+        var cfgLayer = item.source.wmsSource.getParams()['LAYERS'].split(',');
+
+        var every = cfgLayer.every(function(layer) {
+          return layerLayers.indexOf(layer) != -1;
+        });
+        if (!every) {
           continue;
         }
       }


### PR DESCRIPTION
Fixes #1659 

With this pull request nodes with layer names (for example "sustenance,entertainment") are correctly checked (ie. compared with the OL3 layer source LAYERS param) before the query request are sent.

Démo:
https://pgiraud.github.io/ngeo/too_much_queries/examples/contribs/gmf/apps/desktop_alt/?baselayer_ref=map&lang=fr&map_x=554380&map_y=145380&map_zoom=3&rl_features=Fa(57v1-3bcEgC8w*9t!hH90s6*~n*Polygon%25201%27c*%2523DB4436%27a*0%27o*0.2%27m*false%27s*10%27k*1)&tree_groups=OSM%20functions&tree_group_layers_OSM%20functions=osm_time

To be compared with:
https://camptocamp.github.io/ngeo/master/examples/contribs/gmf/apps/desktop_alt/?baselayer_ref=map&lang=fr&map_x=554380&map_y=145380&map_zoom=3&rl_features=Fa(57v1-3bcEgC8w*9t!hH90s6*~n*Polygon%25201%27c*%2523DB4436%27a*0%27o*0.2%27m*false%27s*10%27k*1)&tree_groups=OSM%20functions&tree_group_layers_OSM%20functions=osm_time

In the first example, no query is sent for sustenance. In the second one, user may receive results for "two_layers".