### PR TITLE
Rework of UI for editing panel

### DIFF
--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -532,9 +532,8 @@ gmf-disclaimer {
 /**
  * GMF EditFeature directive
  */
-.gmf-editfeatureselector-stopediting {
-  float: right;
-}
-.gmf-editfeature-btn-delete {
-  float: right;
+gmf-editfeature > div {
+  border-top: 1px solid #333;
+  margin-top: 1rem;
+  padding-top: 1rem;
 }

--- a/contribs/gmf/src/directives/partials/editfeature.html
+++ b/contribs/gmf/src/directives/partials/editfeature.html
@@ -35,6 +35,16 @@
       class="form gmf-editfeature-attributes-container"
       ng-switch-default
       ng-if="efCtrl.attributes">
+      <div class="row">
+        <div class="col-sm-12">
+          <a
+            class="close"
+            ng-click="efCtrl.cancel()"
+            ng-disabled="efCtrl.pending"
+            title="{{'Cancel modifications | translate'}}"
+            href>&times;</a>
+        </div>
+      </div>
       <ngeo-attributes
         ngeo-attributes-attributes="::efCtrl.attributes"
         ngeo-attributes-disabled="efCtrl.pending"
@@ -43,18 +53,18 @@
       <input
         type="submit"
         value="{{'Save' | translate}}"
-        class="btn btn-sm btn-default gmf-editfeature-btn-save"
+        class="btn btn-sm btn-default btn-primary"
         ng-click="form.$valid && efCtrl.save()"
         ng-disabled="!efCtrl.dirty"
         title="{{'Save modifications | translate'}}"></input>
       <a
-        class="btn btn-sm btn-default gmf-editfeature-btn-cancel"
+        class="btn btn-sm btn-default"
         ng-click="efCtrl.cancel()"
         ng-disabled="efCtrl.pending"
         title="{{'Cancel modifications | translate'}}"
         href>{{'Cancel' | translate}}</a>
       <button
-        class="btn btn-sm btn-link gmf-editfeature-btn-delete"
+        class="btn btn-sm btn-link pull-right"
         ng-click="efCtrl.delete()"
         ng-disabled="efCtrl.pending"
         ng-show="efCtrl.featureId"

--- a/contribs/gmf/src/directives/partials/editfeatureselector.html
+++ b/contribs/gmf/src/directives/partials/editfeatureselector.html
@@ -11,14 +11,21 @@
   </div>
 
   <div ng-switch-default>
-    <button
-        ng-click="efsCtrl.selectedLayer = null;"
-        class="btn btn-link btn-xs gmf-editfeatureselector-stopediting">
-      <span class="fa fa-times"></span>
-      {{'Stop editing' | translate}}
-    </button>
 
-    <h3>{{ efsCtrl.selectedLayer.name | translate }}</h3>
+    <div class="row">
+      <div class="col-sm-12">
+        <span translate>Currently editing: </span>
+        <b>{{ efsCtrl.selectedLayer.name | translate }}</b>
+        <span class="fa fa-pencil"></span>
+        <br>
+        <button
+            ng-click="efsCtrl.selectedLayer = null;"
+            class="btn btn-link btn-xs pull-right">
+          <span class="fa fa-times"></span>
+          {{'Stop editing' | translate}}
+        </button>
+      </div>
+    </div>
 
     <gmf-editfeature
         gmf-editfeature-layer="::efsCtrl.selectedLayer"

--- a/src/directives/partials/attributes.html
+++ b/src/directives/partials/attributes.html
@@ -3,7 +3,7 @@
       class="form-group"
       ng-repeat="attribute in ::attrCtrl.attributes">
     <div ng-if="attribute.type !== 'geometry'">
-      <label>{{::attribute.required ? "* " : ""}}{{ ::attribute.name | translate }}:</label>
+      <label class="control-label">{{ ::attribute.name | translate }} <span class="text-muted">{{::attribute.required ? "*" : ""}}</span></label>
       <div ng-switch="attribute.type">
         <select
             name="{{::attribute.name}}"


### PR DESCRIPTION
Fixes #1724 

 - Removed the ":" after the label. The spaces before and after are not the same in the different languages. Also, it's not really required. So I removed them for simplicity.
 - Changed the "chosen" editing layer title look and feel to make it a bit more clear.
 - Added a more clear separation between the chosen editing layer title and the editing attributes section.
 - Used primary color for the "save" button.
 - Added a cross (close) button to deselect the current feature. It has the same behavior as the cancel button actually.

Please review.

After / Before
![screenshot from 2016-08-23 14 01 41](https://cloud.githubusercontent.com/assets/319774/17891695/bb323364-693d-11e6-864a-f7c0595bac35.png)

Demo:
https://pgiraud.github.io/ngeo/editing_ui/examples/contribs/gmf/apps/desktop?baselayer_ref=map&lang=fr&map_x=561294&map_y=204601&map_zoom=7&rl_features=Fa(57v1-3bcEgC8w*9t!hH90s6*~n*Polygon%25201%27c*%2523DB4436%27a*0%27o*0.2%27m*false%27s*10%27k*1)&tree_groups=Edit

