### PR TITLE
Order group layers in tree and map.

### DIFF
--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -354,7 +354,9 @@ gmf.LayertreeController.prototype.getLayer = function(node, parentCtrl, depth) {
       default:
         throw new Error('Node wrong type: ' + type);
     }
-    this.dataLayerGroup_.getLayers().insertAt(0, layer);
+    var position = this.gmfTreeManager_.tree.children.length -
+        this.gmfTreeManager_.layersToAddAtOnce | 0;
+    this.dataLayerGroup_.getLayers().insertAt(position, layer);
     return layer;
   }
 


### PR DESCRIPTION
Fix #1722 

Example: https://ger-benjamin.github.io/ngeo/layerGroupOrder/examples/contribs/gmf/apps/desktop_alt

The problem was far more complex than expected. Please read and understand before to comment.

To summarize (it's hard), try to understand this example:

 - If I add theme OSM, I add 4 first level groups at once.
  - The layer at the top of the layer tree will be added first in the map
  - then the second, etc.
 - Then I add the "edit" theme. So one another first level layer group.
  - I should add it at the top of the layertree but angular doesn't add all OSM theme again so it will be added alone.

The problem is that I can't just add layer in the map by a `insertAt(0, layer)` or a `push(layer)`.

 - With `insertAt(0, layer)`, the OSM layer will be ordered correctly on the map but the edit theme will be under all other layers.
 - With `push(layer)` the OSM theme will be in a wrong order, but edit will be right at the top.

So the only realistic solution that I found is to `insertAt(all existing first level group layers - number of layers to add at once, layer)`. But it's tricky and will perhaps complex to manage in the future.

Another solution it to add themes one by one. But that's not easy with angular and I don't find how to do that.

Perhaps I should add commentaries somewhere...

@pgiraud I guess you have worked on the layertree. Can you give me your opinion on theses changes ? Perhaps you have a better solution.