### PR TITLE
Fix editfeature selector example

### DIFF
--- a/contribs/gmf/examples/editfeatureselector.html
+++ b/contribs/gmf/examples/editfeatureselector.html
@@ -93,7 +93,7 @@
     </gmf-authentication>
 
     <div
-        ng-if="ctrl.gmfUser.username"
+        ng-show="ctrl.gmfUser.username"
         class="panel panel-default panel-body">
 
     <input type="checkbox"

--- a/contribs/gmf/examples/editfeatureselector.html
+++ b/contribs/gmf/examples/editfeatureselector.html
@@ -88,6 +88,8 @@
       the "Draw" button.
     </p>
 
+    <p><strong>Note:</strong> After logging it, you need to refresh the page</p>
+
     <gmf-authentication
         class="panel panel-default panel-body">
     </gmf-authentication>


### PR DESCRIPTION
This PR fixes the edit feature selector example.  The list of layers was empty due to the changes of theme loading using the event.

Also, after logging in, we would normally need to reload the themes, but that's out of scope of this example (in my opinion) and would bring more complexity to it. A simple note about reloading the page after logging in is enough (again, in my opinion).