### PR TITLE
Manage 'stop editing' with unsaved changes in gmf-editfeature

### DIFF
--- a/contribs/gmf/examples/editfeatureselector.html
+++ b/contribs/gmf/examples/editfeatureselector.html
@@ -93,7 +93,7 @@
     </gmf-authentication>
 
     <div
-        ng-if="ctrl.gmfUser.username"
+        ng-show="ctrl.gmfUser.username"
         class="panel panel-default panel-body">
 
     <input type="checkbox"

--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -46,6 +46,7 @@ goog.require('ol.style.Text');
  *     <gmf-editfeature
  *         gmf-editfeature-layer="::ctrl.layer"
  *         gmf-editfeature-map="::ctrl.map"
+ *         gmf-editfeature-state="efsCtrl.state"
  *         gmf-editfeature-tolerance="::ctrl.tolerance"
  *         gmf-editfeature-vector="::ctrl.vectorLayer"
  *         gmf-editfeature-wmslayer="::ctrl.selectedWMSLayer">
@@ -54,6 +55,8 @@ goog.require('ol.style.Text');
  * @htmlAttribute {GmfThemesNode} gmf-editfeature-layer The GMF node of the
  *     editable layer.
  * @htmlAttribute {ol.Map} gmf-editfeature-map The map.
+ * @htmlAttribute {string} gmf-editfeature-stopeditingrequest Stop editing
+ *     state.
  * @htmlAttribute {number|undefined} gmf-editfeatureselector-tolerance The
  *     buffer in pixels to use when making queries to get the features.
  * @htmlAttribute {ol.layer.Vector} gmf-editfeature-vector The vector layer in
@@ -70,6 +73,7 @@ gmf.editfeatureDirective = function() {
     scope: {
       'layer': '=gmfEditfeatureLayer',
       'map': '<gmfEditfeatureMap',
+      'state': '=gmfEditfeatureState',
       'tolerance': '<?gmfEditfeatureTolerance',
       'vectorLayer': '<gmfEditfeatureVector',
       'wmsLayer': '<gmfEditfeatureWmslayer'
@@ -119,6 +123,28 @@ gmf.EditfeatureController = function($element, $scope, $timeout, $q,
    * @export
    */
   this.map;
+
+  /**
+   * The state property shared with the `gmf-editfeatureselector` directive.
+   * For more info, see in that directive.
+   * @type {string}
+   * @export
+   */
+  this.state;
+
+  $scope.$watch(
+    function() {
+      return this.state;
+    }.bind(this),
+    function(newValue, oldValue) {
+      if (newValue === gmf.EditfeatureController.State.STOP_EDITING_PENDING) {
+        this.confirmCancel().then(function() {
+          this.state =
+            gmf.EditfeatureController.State.STOP_EDITING_EXECUTE;
+        }.bind(this));
+      }
+    }.bind(this)
+  );
 
   /**
    * @type {number}
@@ -224,6 +250,18 @@ gmf.EditfeatureController = function($element, $scope, $timeout, $q,
    * @export
    */
   this.unsavedModificationsModalShown = false;
+
+  // Reset stop request when closing the confirmation modal
+  $scope.$watch(
+    function() {
+      return this.unsavedModificationsModalShown;
+    }.bind(this),
+    function(newValue, oldValue) {
+      if (oldValue && !newValue) {
+        this.state = gmf.EditfeatureController.State.IDLE;
+      }
+    }.bind(this)
+  );
 
   /**
    * Flag that is toggled as soon as the feature changes, i.e. if any of its
@@ -482,10 +520,12 @@ gmf.EditfeatureController.prototype.cancel = function() {
 /**
  * Check if there are unsaved modifications. If there aren't, then cancel.
  * Used by the 'cancel' button in the template.
+ * @return {angular.$q.Promise} The promise attached to the confirm deferred
+ *     object.
  * @export
  */
 gmf.EditfeatureController.prototype.confirmCancel = function() {
-  this.checkForModifications_().then(function() {
+  return this.checkForModifications_().then(function() {
     this.cancel();
   }.bind(this));
 };
@@ -1004,3 +1044,29 @@ gmf.EditfeatureController.prototype.handleDestroy_ = function() {
 
 gmf.module.controller(
   'GmfEditfeatureController', gmf.EditfeatureController);
+
+
+/**
+ * The different possible values of the `state` inner property.
+ * @enum {string}
+ */
+gmf.EditfeatureController.State = {
+  /**
+   * The default state. While idle, nothing happens.
+   * @type {string}
+   */
+  IDLE: 'idle',
+  /**
+   * Final state set after the "stop editing" button has been clicked while
+   * no unsaved modifications were made or if the user saved them or confirmed
+   * to continue without saving.
+   * @type {string}
+   */
+  STOP_EDITING_EXECUTE: 'execute',
+  /**
+   * The state that is active while when the "stop editing" button has been
+   * clicked but before any confirmation has been made to continue.
+   * @type {string}
+   */
+  STOP_EDITING_PENDING: 'pending'
+};

--- a/contribs/gmf/src/directives/editfeatureselector.js
+++ b/contribs/gmf/src/directives/editfeatureselector.js
@@ -147,12 +147,48 @@ gmf.EditfeatureselectorController = function($scope, gmfThemes,
    */
   this.selectedLayer = null;
 
+  $scope.$watch(
+    function() {
+      return this.selectedLayer;
+    }.bind(this),
+    function(newValue, oldValue) {
+      if (newValue) {
+        this.selectedWMSLayer = newValue ? this.wmsLayers_[newValue.id] : null;
+      } else {
+        this.selectedWMSLayer = null;
+        this.state = gmf.EditfeatureController.State.IDLE;
+      }
+    }.bind(this)
+  );
+
   /**
    * The currently selected OpenLayers layer object.
    * @type {?ol.layer.Image|ol.layer.Tile}
    * @export
    */
   this.selectedWMSLayer = null;
+
+  /**
+   * The state of this directive shared with the `gmf-editfeature` directive.
+   * This property allows the proper management of the "stop editing" button.
+   * When clicked, the according state is set and the `gmf-editfeature`
+   * directive checks if it has unsaved changes and allow this directive to
+   * continue the action that was made or not.
+   * @type {string}
+   * @export
+   */
+  this.state = gmf.EditfeatureController.State.IDLE;
+
+  $scope.$watch(
+    function() {
+      return this.state;
+    }.bind(this),
+    function(newValue, oldValue) {
+      if (newValue === gmf.EditfeatureController.State.STOP_EDITING_EXECUTE) {
+        this.selectedLayer = null;
+      }
+    }.bind(this)
+  );
 
   this.themesChangeListenerKey = ol.events.listen(this.gmfThemes_,
       gmf.ThemesEventType.CHANGE, this.setLayersFromThemes_, this);
@@ -161,15 +197,17 @@ gmf.EditfeatureselectorController = function($scope, gmfThemes,
 
   $scope.$on('$destroy', this.handleDestroy_.bind(this));
 
-  $scope.$watch(
-    function() {
-      return this.selectedLayer;
-    }.bind(this),
-    function(newValue, oldValue) {
-      this.selectedWMSLayer = newValue ? this.wmsLayers_[newValue.id] : null;
-    }.bind(this)
-  );
+};
 
+
+/**
+ * Called when the 'stop editing' button is clicked. Set the 'state'
+ * variable to 'pending' allow the editfeature directive to check if it can
+ * stop or if it requires confirmation due to unsaved modifications.
+ * @export
+ */
+gmf.EditfeatureselectorController.prototype.stopEditing = function() {
+  this.state = gmf.EditfeatureController.State.STOP_EDITING_PENDING;
 };
 
 

--- a/contribs/gmf/src/directives/partials/editfeatureselector.html
+++ b/contribs/gmf/src/directives/partials/editfeatureselector.html
@@ -11,7 +11,6 @@
   </div>
 
   <div ng-switch-default>
-
     <div class="row">
       <div class="col-sm-12">
         <span translate>Currently editing: </span>
@@ -19,7 +18,7 @@
         <span class="fa fa-pencil"></span>
         <br>
         <button
-            ng-click="efsCtrl.selectedLayer = null;"
+            ng-click="efsCtrl.stopEditing()"
             class="btn btn-link btn-xs pull-right">
           <span class="fa fa-times"></span>
           {{'Stop editing' | translate}}
@@ -30,6 +29,7 @@
     <gmf-editfeature
         gmf-editfeature-layer="::efsCtrl.selectedLayer"
         gmf-editfeature-map="::efsCtrl.map"
+        gmf-editfeature-state="efsCtrl.state"
         gmf-editfeature-tolerance="::efsCtrl.tolerance"
         gmf-editfeature-vector="::efsCtrl.vectorLayer"
         gmf-editfeature-wmslayer="::efsCtrl.selectedWMSLayer">


### PR DESCRIPTION
Fixes https://github.com/camptocamp/ngeo/issues/1740

In the `gmf-editfeatureselector` directive, when the "stop editing" button is click, if there are unsaved modifications then the `gmf-editfeature` directive takes care of showing the confirm modal.

## Todo

 * [ ] review

## Live demo

 * https://adube.github.io/ngeo/1740-unsaved-modifications-stop-editing/examples/contribs/gmf/editfeatureselector.html