### PR TITLE
Fix too small disclaimer close button

### DIFF
--- a/contribs/gmf/less/map.less
+++ b/contribs/gmf/less/map.less
@@ -122,5 +122,6 @@ gmf-disclaimer {
   .alert-dismissable .close,
   .alert-dismissible .close {
     right: -0.5rem;
+    height: inherit;
   }
 }

--- a/src/services/disclaimer.js
+++ b/src/services/disclaimer.js
@@ -148,7 +148,7 @@ ngeo.Disclaimer.prototype.showMessage = function(message) {
     var button = angular.element(
       '<button type="button" class="close" data-dismiss="alert" aria-label="' +
         this.gettextCatalog_.getString('Close') +
-        '"><span aria-hidden="true">&times;</span></button>');
+        '"><span aria-hidden="true" class="fa fa-times"></span></button>');
     var msg = angular.element('<span />').html(message.msg);
     el.append(button).append(msg);
 


### PR DESCRIPTION
Fix https://github.com/camptocamp/ngeo/issues/1692

Example: https://ger-benjamin.github.io/ngeo/fixclose/examples/contribs/gmf/apps/mobile

Close disclaimer is easier on litlle device and no more cut (a in my opinion, the cross is (more) coherent now).