### PR TITLE
I18n search actions

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -287,7 +287,11 @@
         module.constant('gmfShortenerCreateUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/short/create');
         module.constant('gmfSearchGroups', ['osm','district']);
         // Requires that the gmfSearchGroups is specified
-        module.constant('gmfSearchActions', ['add_theme', 'add_group', 'add_layer']);
+        module.constant('gmfSearchActions', [
+                {action: 'add_theme', title: 'Add a theme'},
+                {action: 'add_group', title: 'Add a sub theme'},
+                {action: 'add_layer', title: 'Add a layer'}
+        ]);
         module.constant('gmfContextualdatacontentTemplateUrl', window.location.pathname + 'contextualdata.html');
       })();
     </script>

--- a/contribs/gmf/apps/desktop/js/controller.js
+++ b/contribs/gmf/apps/desktop/js/controller.js
@@ -87,6 +87,13 @@ app.DesktopController = function($scope, $injector) {
     label: 'WGS84',
     filter: 'ngeoDMSCoordinates:2'
   }];
+
+  // Allow angular-gettext-tools to collect the strings to translate
+  /** @type {angularGettext.Catalog} */
+  var gettextCatalog = $injector.get('gettextCatalog');
+  gettextCatalog.getString('Add a theme');
+  gettextCatalog.getString('Add a sub theme');
+  gettextCatalog.getString('Add a layer');
 };
 ol.inherits(app.DesktopController, gmf.AbstractDesktopController);
 

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -290,7 +290,11 @@
         module.constant('gmfShortenerCreateUrl', '');
         module.constant('gmfSearchGroups', ['osm','district']);
         // Requires that the gmfSearchGroups is specified
-        module.constant('gmfSearchActions', ['add_theme', 'add_group', 'add_layer']);
+        module.constant('gmfSearchActions', [
+                {action: 'add_theme', title: 'Add a theme'},
+                {action: 'add_group', title: 'Add a sub theme'},
+                {action: 'add_layer', title: 'Add a layer'}
+        ]);
         module.constant('gmfTreeManagerModeFlush', false);
         module.value('gmfPermalinkOptions', {projectionCodes: ['EPSG:21781', 'EPSG:2056', 'EPSG:4326']});
       })();

--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -100,10 +100,13 @@ app.AlternativeDesktopController = function($scope, $injector) {
     'merged_osm_times': ['110', '126', '147']
   };
 
-  // mark 'merged_osm_times' as translatable
+  // Allow angular-gettext-tools to collect the strings to translate
   /** @type {angularGettext.Catalog} */
   var gettextCatalog = $injector.get('gettextCatalog');
   gettextCatalog.getString('merged_osm_times');
+  gettextCatalog.getString('Add a theme');
+  gettextCatalog.getString('Add a sub theme');
+  gettextCatalog.getString('Add a layer');
 
 };
 ol.inherits(app.AlternativeDesktopController, gmf.AbstractDesktopController);


### PR DESCRIPTION
Fix: #1764 

Example: https://ger-benjamin.github.io/ngeo/i18naddlayers/examples/contribs/gmf/apps/desktop_alt

Is that okay with this solution ?
I think it's good enough. We don't add new actions all day. If that become problematic with further dev, we can adapt the server part to add actions directly in english.