### PR TITLE
Skip undefined layers

### DIFF
--- a/contribs/gmf/src/services/themesservice.js
+++ b/contribs/gmf/src/services/themesservice.js
@@ -277,7 +277,13 @@ gmf.Themes.prototype.getBgLayers = function() {
     // We assume no child is a layer group.
     var promises = item['children'].map(layerLayerCreationFn);
     return $q.all(promises).then(function(layers) {
-      var collection = layers ? new ol.Collection(layers) : undefined;
+      var collection;
+      if (layers) {
+        layers = layers.filter(function(l) {
+          return l;
+        });
+        collection = new ol.Collection(layers);
+      }
       var group = layerHelper.createBasicGroup(collection);
       callback(item, group);
       return group;

--- a/src/ol-ext/interaction/measureazimut.js
+++ b/src/ol-ext/interaction/measureazimut.js
@@ -2,6 +2,7 @@ goog.provide('ngeo.interaction.DrawAzimut');
 goog.provide('ngeo.interaction.MeasureAzimut');
 
 goog.require('goog.asserts');
+goog.require('goog.functions');
 goog.require('ngeo.interaction.Measure');
 goog.require('ol.Feature');
 goog.require('ol.MapBrowserEvent');


### PR DESCRIPTION
This is necessary to avoid bad access farther in OpenLayers 3 code.