### PR TITLE
#1680 - Fix CSS names of search tool

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -157,7 +157,6 @@
       </div>
       <div class="map-container" ng-class="{'infobar-active': mainCtrl.showInfobar}">
         <gmf-search gmf-search-map="mainCtrl.map"
-          class="search"
           gmf-search-datasources="mainCtrl.searchDatasources"
           gmf-search-coordinatesprojections="mainCtrl.searchCoordinatesProjections"
           gmf-search-colorchooser="false"

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -157,7 +157,6 @@
       </div>
       <div class="map-container" ng-class="{'infobar-active': mainCtrl.showInfobar}">
         <gmf-search gmf-search-map="mainCtrl.map"
-          class="search"
           gmf-search-datasources="mainCtrl.searchDatasources"
           gmf-search-coordinatesprojections="mainCtrl.searchCoordinatesProjections"
           gmf-search-colorchooser="true"

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -11,7 +11,7 @@
   <body ng-class="{'nav-is-visible': mainCtrl.navIsVisible(),
                    'nav-left-is-visible': mainCtrl.leftNavIsVisible(),
                    'nav-right-is-visible': mainCtrl.rightNavIsVisible()}">
-    <main ng-class="{'search-is-active': mainCtrl.searchOverlayVisible}">
+    <main ng-class="{'gmf-search-is-active': mainCtrl.searchOverlayVisible}">
       <gmf-map gmf-map-map="mainCtrl.map"
         ngeo-map-query=""
         ngeo-map-query-map="::mainCtrl.map"
@@ -40,7 +40,6 @@
         <span class="gmf-icon gmf-icon-layers"></span>
       </button>
       <gmf-search gmf-search-map="mainCtrl.map"
-        class="search"
         gmf-search-datasources="mainCtrl.searchDatasources"
         gmf-search-clearbutton="true"
         gmf-search-coordinatesprojections="mainCtrl.searchCoordinatesProjections"
@@ -51,7 +50,10 @@
         <i class="fa fa-wrench"></i>
       </button>
       <div class="overlay" ng-click="mainCtrl.hideNav()"></div>
-      <div class="search-overlay" ng-click="mainCtrl.hideSearchOverlay()"></div>
+      <div
+        class="gmf-search-overlay"
+        ng-click="mainCtrl.hideSearchOverlay()">
+      </div>
       <button ngeo-mobile-geolocation=""
         ngeo-mobile-geolocation-map="::mainCtrl.map"
         ngeo-mobile-geolocation-options="::mainCtrl.mobileGeolocationOptions">

--- a/contribs/gmf/examples/search.html
+++ b/contribs/gmf/examples/search.html
@@ -67,15 +67,15 @@
       .gmf-search > * {
         float: left;
       }
-      .gmf-search > .clear-button{
+      .gmf-search > .gmf-clear-button{
         margin-left: -15px;
         padding: 3px 0 2px;
         position: relative;
       }
-      .gmf-search > .clear-button:hover{
+      .gmf-search > .gmf-clear-button:hover{
         cursor: pointer;
       }
-      .gmf-search > .clear-button:after{
+      .gmf-search > .gmf-clear-button:after{
         content: 'x';
       }
       /* CSS stolen from https://github.com/bassjobsen/typeahead.js-bootstrap-css/ */

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -146,10 +146,10 @@ main {
   }
 }
 
-.search {
+gmf-search {
   position: absolute;
 
-  .clear-button {
+  .gmf-clear-button {
     top: 0;
   }
 
@@ -166,7 +166,7 @@ main {
       border: 1px solid @color;
       border-radius: @border-radius-base;
 
-      .search-header {
+      .gmf-search-header {
         padding: @app-margin;
         padding-left: @app-margin + 2rem + @app-margin;
         display:block;
@@ -176,7 +176,7 @@ main {
         color: #666;
       }
 
-      .search-group {
+      .gmf-search-group {
         display: none;
       }
     }

--- a/contribs/gmf/less/mobile-nav.less
+++ b/contribs/gmf/less/mobile-nav.less
@@ -54,7 +54,7 @@ main {
   }
 }
 
-.search-overlay {
+.gmf-search-overlay {
   /* shadow layer visible when search is active */
   position: absolute;
   z-index: @above-menus-index;
@@ -71,7 +71,7 @@ main {
   .backface-visibility(hidden);
 
   @media (max-width: @screen-xs-max) {
-    .search-is-active & {
+    .gmf-search-is-active & {
       visibility: visible;
       opacity: 1;
     }

--- a/contribs/gmf/less/search.less
+++ b/contribs/gmf/less/search.less
@@ -1,6 +1,6 @@
 @import "../../../node_modules/font-awesome/less/variables.less";
 
-.search {
+gmf-search {
   top: @app-margin;
   z-index: @content-index;
 
@@ -25,7 +25,7 @@
   input::-ms-clear {
     display: none;
   }
-  .clear-button {
+  .gmf-clear-button {
     position: absolute;
     top: @half-app-margin;
     right: @app-margin;
@@ -44,7 +44,7 @@
       cursor: pointer;
     }
   }
-  .color-button {
+  .gmf-color-button {
     width: @map-tools-size;
     height: @map-tools-size;
     background-color: @map-tools-bg-color;
@@ -68,7 +68,7 @@
     }
   }
 
-  .search-is-active & {
+  .gmf-search-is-active & {
     z-index: @search-index;
   }
 
@@ -87,10 +87,10 @@
     overflow-y: auto;
     background-color: @map-tools-bg-color;
     border: solid 1px @border-color;
-    .search-header {
+    .gmf-search-header {
       display: none;
     }
-    .search-datum {
+    .gmf-search-datum {
       border-bottom: solid 1px @border-color;
       padding: @app-margin;
       padding-left: @app-margin + 2rem + @app-margin;
@@ -102,10 +102,10 @@
       p {
         margin: 0;
       }
-      .search-label {
+      .gmf-search-label {
         color: @color;
       }
-      .search-group {
+      .gmf-search-group {
         color: @color-light;
         font-size: 80%;
       }
@@ -115,7 +115,7 @@
 
 // Overrides for small browser widths
 @media (max-width: @screen-sm-min) {
-  .search {
+  gmf-search {
     margin: 0;
     left: 2 * @app-margin + @map-tools-size;
     .gmf-search {
@@ -128,13 +128,13 @@
 
 // Overrides for tablet devices
 @media (min-width: @screen-sm-min) {
-  .search {
+  gmf-search {
     margin: 0;
     left: 2 * @app-margin + @map-tools-size;
     .gmf-search {
       width: @search-width;
     }
-    .clear-button {
+    .gmf-clear-button {
       margin-right: @app-margin;
       right: 0;
     }

--- a/contribs/gmf/less/searchmobile.less
+++ b/contribs/gmf/less/searchmobile.less
@@ -2,7 +2,7 @@
 
 // Overrides for phone devices
 @media (max-width: @screen-sm-min) {
-  .search {
+  gmf-search {
     left: 0;
     right: 0;
     margin: 0 @app-margin + @map-tools-size;

--- a/contribs/gmf/src/directives/partials/search.html
+++ b/contribs/gmf/src/directives/partials/search.html
@@ -5,13 +5,13 @@
     ngeo-search="ctrl.options"
     ngeo-search-datasets="ctrl.datasets"
     ngeo-search-listeners="ctrl.listeners">
-  <span class="clear-button ng-hide"
+  <span class="gmf-clear-button ng-hide"
     ng-hide="!ctrl.clearButton || ctrl.inputValue == ''"
     ng-click="ctrl.onClearButton()">
   </span>
 </div>
 <span ng-show="ctrl.colorchooser && ctrl.displayColorPicker" ngeo-popover ngeo-popover-placement="bottom">
-  <button class="color-button fa fa-tint" ngeo-popover-anchor
+  <button class="gmf-color-button fa fa-tint" ngeo-popover-anchor
     data-original-title="{{'Change the color of the search result'|translate}}"
     ></button>
   <div ngeo-popover-content>

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -365,13 +365,13 @@ gmf.SearchController = function($scope, $compile, $timeout, gettextCatalog,
     name: 'coordinates',
     display: 'label',
     templates: {
-      header: '<div class="search-header">' + gettextCatalog.getString('Recenter to') + '</div>',
+      header: '<div class="gmf-search-header">' + gettextCatalog.getString('Recenter to') + '</div>',
       suggestion: function(suggestion) {
         var coordinates = suggestion['label'];
 
-        var html = '<p class="search-label">' + coordinates + '</p>';
-        html += '<p class="search-group">' + gettextCatalog.getString('Recenter to') + '</p>';
-        html = '<div class="search-datum">' + html + '</div>';
+        var html = '<p class="gmf-search-label">' + coordinates + '</p>';
+        html += '<p class="gmf-search-group">' + gettextCatalog.getString('Recenter to') + '</p>';
+        html = '<div class="gmf-search-datum">' + html + '</div>';
         return html;
       }
     }
@@ -469,7 +469,7 @@ gmf.SearchController.prototype.createDataset_ = function(config, opt_filter) {
           return '';
         } else {
           var header = gettextCatalog.getString(config.datasetTitle);
-          return '<div class="search-header">' + header + '</div>';
+          return '<div class="gmf-search-header">' + header + '</div>';
         }
       },
       suggestion: function(suggestion) {
@@ -478,11 +478,11 @@ gmf.SearchController.prototype.createDataset_ = function(config, opt_filter) {
         var scope = directiveScope.$new(true);
         scope['feature'] = feature;
 
-        var html = '<p class="search-label">' + feature.get(config.labelKey) +
-                   '</p>';
-        html += '<p class="search-group">' + (feature.get('layer_name') ||
+        var html = '<p class="gmf-search-label">' +
+                   feature.get(config.labelKey) + '</p>';
+        html += '<p class="gmf-search-group">' + (feature.get('layer_name') ||
                 config.datasetTitle) + '</p>';
-        html = '<div class="search-datum">' + html + '</div>';
+        html = '<div class="gmf-search-datum">' + html + '</div>';
         return compile(html)(scope);
       }
     })

--- a/examples/search.js
+++ b/examples/search.js
@@ -106,7 +106,7 @@ app.SearchController = function($rootScope, $compile,
     },
     templates: {
       header: function() {
-        return '<div class="header">Addresses</div>';
+        return '<div class="ngeo-header">Addresses</div>';
       },
       suggestion: function(suggestion) {
         var feature = /** @type {ol.Feature} */ (suggestion);


### PR DESCRIPTION
This PR fixes the CSS class name for the search tool.  Changes are made in the examples, directives, templates and applications.  See #1680.  Note that this is one among many PR that will come to fix #1680.

## Todo

 * [ ] review

## Live examples

 * https://adube.github.io/ngeo/1680-css-fix-search/examples/contribs/gmf/search.html
 * https://adube.github.io/ngeo/1680-css-fix-search/examples/contribs/gmf/apps/desktop/
 * https://adube.github.io/ngeo/1680-css-fix-search/examples/contribs/gmf/apps/desktop_alt/
 * https://adube.github.io/ngeo/1680-css-fix-search/examples/contribs/gmf/apps/mobile/

