### PR TITLE
#1680 - Fix CSS names of datepicker

### DIFF
--- a/contribs/gmf/examples/datepicker.html
+++ b/contribs/gmf/examples/datepicker.html
@@ -12,10 +12,10 @@
         margin: 20px;
         list-style: none;
       }
-      .end-date {
+      .ngeo-datepicker-end-date {
         display: inline-block;
       }
-      .start-date {
+      .ngeo-datepicker-start-date {
         display: inline-block;
       }
       pre {

--- a/contribs/gmf/less/datepicker.less
+++ b/contribs/gmf/less/datepicker.less
@@ -11,9 +11,9 @@
 
 .ngeo-datepicker {
   font-size: @datepicker-font-size;
-  .datepicker-form {
-    .start-date,
-    .end-date {
+  .ngeo-datepicker-form {
+    .ngeo-datepicker-start-date,
+    .ngeo-datepicker-end-date {
       display: inline-block;
       input {
         max-width: 7rem;

--- a/contribs/gmf/src/services/wmstime.js
+++ b/contribs/gmf/src/services/wmstime.js
@@ -2,6 +2,7 @@ goog.provide('gmf.WMSTime');
 
 goog.require('gmf');
 goog.require('ngeo.Time');
+goog.require('ol');
 
 /**
  * gmf - WMS time service

--- a/examples/datepicker.html
+++ b/examples/datepicker.html
@@ -12,10 +12,10 @@
         margin: 20px;
         list-style: none;
       }
-      .end-date {
+      .ngeo-datepicker-end-date {
         display: inline-block;
       }
-      .start-date {
+      .ngeo-datepicker-start-date {
         display: inline-block;
       }
       pre {

--- a/src/directives/partials/datepicker.html
+++ b/src/directives/partials/datepicker.html
@@ -1,12 +1,14 @@
 <div class="ngeo-datepicker">
-  <form name="dateForm" class="datepicker-form" novalidate>
+  <form name="dateForm" class="ngeo-datepicker-form" novalidate>
     <div ng-if="::datepickerCtrl.time.widget === 'datepicker'">
-      <div class="start-date">
+      <div class="ngeo-datepicker-start-date">
         <span ng-if="::datepickerCtrl.time.mode === 'range'" translate>From:</span>
         <span ng-if="::datepickerCtrl.time.mode !== 'range'"translate>Date:</span>
         <input name="sdate" ui-date="datepickerCtrl.sdateOptions" ng-model="datepickerCtrl.sdate" required=""/>
       </div>
-      <div class="end-date" ng-if="::datepickerCtrl.time.mode === 'range'">
+      <div
+        class="ngeo-datepicker-end-date"
+        ng-if="::datepickerCtrl.time.mode === 'range'">
         <span translate>To:</span>
         <input name="edate" ui-date="datepickerCtrl.edateOptions" ng-model="datepickerCtrl.edate" required=""/>
       </div>


### PR DESCRIPTION
This PR fixes the CSS class name for the ngeo datepicker directive.  Changes are made in the examples, directives, templates and applications.  See #1680.  Note that this is one among many PR that will come to fix #1680.

## Todo

 * [ ] review

## Live examples

 * (ngeo example) https://adube.github.io/ngeo/1680-css-fix-datepicker/examples/datepicker.html
 * (gmf example) https://adube.github.io/ngeo/1680-css-fix-datepicker/examples/contribs/gmf/datepicker.html

