### PR TITLE
#1680 - Fix CSS names of ngeo grid

### DIFF
--- a/contribs/gmf/examples/displayquerygrid.html
+++ b/contribs/gmf/examples/displayquerygrid.html
@@ -31,7 +31,7 @@
         height: 25rem;
       }
 
-      .table-container {
+      .ngeo-grid-table-container {
         height: 18rem;
         overflow: auto;
       }

--- a/contribs/gmf/less/displayquerygrid.less
+++ b/contribs/gmf/less/displayquerygrid.less
@@ -9,7 +9,7 @@
   background-color: white;
   height: @grid-height;
 
-  .table-container {
+  .ngeo-grid-table-container {
     height: @table-height;
     overflow: auto;
   }

--- a/examples/grid.html
+++ b/examples/grid.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
     <link rel="stylesheet" href="../third-party/jquery-ui/jquery-ui.min.css">
     <style>
-      .table-container {
+      .ngeo-grid-table-container {
         height: 154px;
         overflow: auto;
       }
@@ -24,7 +24,7 @@
         cursor: pointer;
       }
 
-      .table-container > .table-hover > tbody > tr:hover {
+      .ngeo-grid-table-container > .table-hover > tbody > tr:hover {
           background-color: #f5f5f5;
       }
 

--- a/src/directives/grid.js
+++ b/src/directives/grid.js
@@ -232,7 +232,7 @@ ngeo.GridController = function($scope) {
    */
   this.floatTheadConfig = {
     'scrollContainer': function($table) {
-      return $table.closest('.table-container');
+      return $table.closest('.ngeo-grid-table-container');
     }
   };
 

--- a/src/directives/partials/grid.html
+++ b/src/directives/partials/grid.html
@@ -1,4 +1,4 @@
-<div class="table-container">
+<div class="ngeo-grid-table-container">
   <table float-thead="ctrl.floatTheadConfig" ng-model="ctrl.configuration.data"
          class="table table-bordered table-striped table-hover">
     <thead class="table-header">


### PR DESCRIPTION
This PR fixes the CSS class name for the ngeo grid directive.  Changes are made in the examples, directives, templates and applications.  See #1680.  Note that this is one among many PR that will come to fix #1680.

## Todo

 * [ ] review

## Live examples

 * https://adube.github.io/ngeo/1680-css-fix-grid/examples/grid.html
