### PR TITLE
Mark merged layer label as translatable

### DIFF
--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -99,6 +99,12 @@ app.AlternativeDesktopController = function($scope, $injector) {
   this.gridMergeTabs = {
     'merged_osm_times': ['110', '126', '147']
   };
+
+  // mark 'merged_osm_times' as translatable
+  /** @type {angularGettext.Catalog} */
+  var gettextCatalog = $injector.get('gettextCatalog');
+  gettextCatalog.getString('merged_osm_times');
+
 };
 ol.inherits(app.AlternativeDesktopController, gmf.AbstractDesktopController);
 


### PR DESCRIPTION
Closes https://github.com/camptocamp/ngeo/issues/1765

Note that this string is no extracted together with the GMF translation strings, like all other i18n strings in `contribs/gmf/apps`.