### PR TITLE
Make tool panel scrollable in sidebar

### DIFF
--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -249,6 +249,8 @@ gmf-backgroundlayerselector {
     margin-right: -@right-panel-width;
     transition: margin-right 0.2s ease;
     float: right;
+    height: 100%;
+    overflow: auto;
 
     &.active {
       margin-right: 0;


### PR DESCRIPTION
This makes the tool panel in the right panel scrollable. At first I tried to keep the panel title fixed, and only make the panel content area scrollable. But this caused several layouting issues, which would require more profound changes. Considering that *usually* the vertical space is sufficient, I would propose to go with this simple but effective solution. If wanted we can still improve it later.

![ngeo-scrollable-tool-panel](https://cloud.githubusercontent.com/assets/266474/18202165/99960d06-710e-11e6-9947-b09ca1622465.png)


Closes https://github.com/camptocamp/ngeo/issues/1738