### PR TITLE
#1680 - Fix CSS names of ngeo colorpicker

### DIFF
--- a/contribs/gmf/examples/drawfeature.html
+++ b/contribs/gmf/examples/drawfeature.html
@@ -126,14 +126,14 @@
       gmf-featurestyle input[type=range] {
         padding: 6px 12px;
       }
-      .palette {
+      .ngeo-colorpicker-palette {
         border-collapse: separate;
         border-spacing: 0px;
       }
-      .palette tr {
+      .ngeo-colorpicker-palette tr {
         cursor: default;
       }
-      .palette td {
+      .ngeo-colorpicker-palette td {
         position: relative;
         padding: 0px;
         text-align: center;
@@ -141,14 +141,14 @@
         font-size: 1px;
         cursor: pointer;
       }
-      .palette td > div {
+      .ngeo-colorpicker-palette td > div {
         position: relative;
         height: 12px;
         width: 12px;
         border: 1px solid #fff;
         box-sizing: content-box;
       }
-      .palette td:hover > div::after {
+      .ngeo-colorpicker-palette td:hover > div::after {
         display: block;
         content: '';
         background: inherit;
@@ -163,7 +163,7 @@
         box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
         z-index: 11;
       }
-      .palette td.selected > div::after {
+      .ngeo-colorpicker-palette td.ngeo-colorpicker-selected > div::after {
         border: 2px solid #444;
         margin: 0;
         content: '';

--- a/contribs/gmf/examples/featurestyle.html
+++ b/contribs/gmf/examples/featurestyle.html
@@ -36,14 +36,14 @@
       gmf-featurestyle input[type=range] {
         padding: 6px 12px;
       }
-      .palette {
+      .ngeo-colorpicker-palette {
         border-collapse: separate;
         border-spacing: 0px;
       }
-      .palette tr {
+      .ngeo-colorpicker-palette tr {
         cursor: default;
       }
-      .palette td {
+      .ngeo-colorpicker-palette td {
         position: relative;
         padding: 0px;
         text-align: center;
@@ -51,14 +51,14 @@
         font-size: 1px;
         cursor: pointer;
       }
-      .palette td > div {
+      .ngeo-colorpicker-palette td > div {
         position: relative;
         height: 12px;
         width: 12px;
         border: 1px solid #fff;
         box-sizing: content-box;
       }
-      .palette td:hover > div::after {
+      .ngeo-colorpicker-palette td:hover > div::after {
         display: block;
         content: '';
         background: inherit;
@@ -73,7 +73,7 @@
         box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
         z-index: 11;
       }
-      .palette td.selected > div::after {
+      .ngeo-colorpicker-palette td.ngeo-colorpicker-selected > div::after {
         border: 2px solid #444;
         margin: 0;
         content: '';

--- a/contribs/gmf/examples/search.html
+++ b/contribs/gmf/examples/search.html
@@ -11,25 +11,25 @@
     <link rel="stylesheet" href="../../../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
     <link rel="stylesheet" href="../../../third-party/jquery-ui/jquery-ui.min.css">
     <style>
-      .palette {
+      .ngeo-colorpicker-palette {
         border-collapse: separate;
         border-spacing: 0;
       }
-      .palette td {
+      .ngeo-colorpicker-palette td {
         position: relative;
         padding: 0;
         text-align: center;
         vertical-align: middle;
         font-size: 1px;
       }
-      .palette td > div {
+      .ngeo-colorpicker-palette td > div {
         position: relative;
         height: 12px;
         width: 12px;
         border: 1px solid #fff;
         box-sizing: content-box;
       }
-      .palette td:hover > div::after {
+      .ngeo-colorpicker-palette td:hover > div::after {
         display: block;
         content: '';
         background: inherit;
@@ -43,7 +43,7 @@
         box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
         z-index: 11;
       }
-      .palette td.selected > div::after {
+      .ngeo-colorpicker-palette td.ngeo-colorpicker-selected > div::after {
         border: 2px solid #444;
         margin: 0;
         content: '';

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -416,7 +416,7 @@ gmf-featurestyle {
 /**
  * Color palette within GMF FeatureStyle directive
  */
-.palette {
+.ngeo-colorpicker-palette {
   border-collapse: separate;
   border-spacing: 0px;
 
@@ -456,7 +456,7 @@ gmf-featurestyle {
       }
     }
 
-    &.selected > div::after {
+    &.ngeo-colorpicker-selected > div::after {
       border: 2px solid #444;
       margin: 0;
       content: '';

--- a/examples/colorpicker.html
+++ b/examples/colorpicker.html
@@ -12,15 +12,15 @@
       body {
         padding: 10px;
       }
-      .palette {
+      .ngeo-colorpicker-palette {
         padding-left: 20px;
         border-collapse: separate;
         border-spacing: 0px;
       }
-      .palette tr {
+      .ngeo-colorpicker-palette tr {
         cursor: default;
       }
-      .palette td {
+      .ngeo-colorpicker-palette td {
         position: relative;
         padding: 0px;
         text-align: center;
@@ -28,14 +28,14 @@
         font-size: 1px;
         cursor: pointer;
       }
-      .palette td > div {
+      .ngeo-colorpicker-palette td > div {
         position: relative;
         height: 12px;
         width: 12px;
         border: 1px solid #fff;
         box-sizing: content-box;
       }
-      .palette td:hover > div::after {
+      .ngeo-colorpicker-palette td:hover > div::after {
         display: block;
         content: '';
         background: inherit;
@@ -50,7 +50,7 @@
         box-shadow: rgba(0,0,0,0.3) 0 1px 3px 0;
         z-index: 11;
       }
-      .palette td.selected > div::after {
+      .ngeo-colorpicker-palette td.ngeo-colorpicker-selected > div::after {
         border: 2px solid #444;
         margin: 0;
         content: '';

--- a/src/directives/partials/colorpicker.html
+++ b/src/directives/partials/colorpicker.html
@@ -1,6 +1,9 @@
-<table class="palette">
+<table class="ngeo-colorpicker-palette">
   <tr ng-repeat="colors in ::ctrl.colors">
-    <td ng-repeat="color in ::colors" ng-click="ctrl.setColor(color)" ng-class="{'selected': color == ctrl.color}">
+    <td
+      ng-repeat="color in ::colors"
+      ng-click="ctrl.setColor(color)"
+      ng-class="{'ngeo-colorpicker-selected': color == ctrl.color}">
       <div ng-style="::{'background-color': color}"></div>
     </td>
   </tr>


### PR DESCRIPTION
This PR fixes the CSS class name for the ngeo colorpicker directive.  Changes are made in the examples, directives, templates and applications.  See #1680.  Note that this is one among many PR that will come to fix #1680.

## Todo

 * [ ] review

## Live examples

 *  https://adube.github.io/ngeo/1680-css-fix-colorpicker/examples/colorpicker.html
 *  https://adube.github.io/ngeo/1680-css-fix-colorpicker/examples/contribs/gmf/drawfeature.html
