### PR TITLE
#1680 - Fix CSS names of ngeo sortable

### DIFF
--- a/contribs/gmf/less/desktoplayertree.less
+++ b/contribs/gmf/less/desktoplayertree.less
@@ -39,7 +39,7 @@ gmf-layertree {
     }
 
     &:hover {
-      .sortable-handle-icon {
+      .gmf-layertree-sortable-handle-icon {
         visibility: visible;
       }
     }
@@ -102,7 +102,7 @@ gmf-layertree {
     margin-left: @half-app-margin;
   }
 
-  .sortable-handle {
+  .ngeo-sortable-handle {
     cursor: url(../cursors/grab.cur), default;
     cursor: -webkit-grab;
     cursor: grab;
@@ -114,7 +114,7 @@ gmf-layertree {
     margin: 0;
   }
 
-  .sortable-handle-icon {
+  .gmf-layertree-sortable-handle-icon {
     color:#555;
     visibility: hidden;
     position: absolute;

--- a/contribs/gmf/less/mobilelayertree.less
+++ b/contribs/gmf/less/mobilelayertree.less
@@ -10,7 +10,7 @@ nav.nav-left .gmf-layertree-node a[data-toggle] {
 }
 
 .gmf-layertree-node {
-  .sortable-handle {
+  .ngeo-sortable-handle {
     display: none;
   }
   .extra-actions {

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -1,6 +1,6 @@
 <div ng-if="::!layertreeCtrl.isRoot" id="node-{{::layertreeCtrl.uid}}" ng-class="[layertreeCtrl.node.children ? 'group' : 'leaf', 'depth-' + layertreeCtrl.depth, gmfLayertreeCtrl.getResolutionStyle(layertreeCtrl.node), gmfLayertreeCtrl.getNodeState(layertreeCtrl)]">
-  <div class="sortable-handle" ng-show="layertreeCtrl.depth === 1 && gmfLayertreeCtrl.layers.length > 1">
-    <i class="sortable-handle-icon fa fa-ellipsis-v"></i>
+  <div class="ngeo-sortable-handle" ng-show="layertreeCtrl.depth === 1 && gmfLayertreeCtrl.layers.length > 1">
+    <i class="gmf-layertree-sortable-handle-icon fa fa-ellipsis-v"></i>
   </div>
 
     <a  ng-if="::layertreeCtrl.node.children"
@@ -82,7 +82,7 @@
     ng-if="::layertreeCtrl.node.children"
     ng-class="{collapse: !layertreeCtrl.isRoot, in : layertreeCtrl.node.metadata.isExpanded}"
     ngeo-sortable="::layertreeCtrl.isRoot && gmfLayertreeCtrl.layers"
-    ngeo-sortable-options="{handleClassName: 'sortable-handle', draggerClassName: 'dragger', currDragItemClassName : 'curr-drag-item'}">
+    ngeo-sortable-options="{handleClassName: 'ngeo-sortable-handle', draggerClassName: 'dragger', currDragItemClassName : 'curr-drag-item'}">
   <li class="gmf-layertree-node" ng-repeat="node in layertreeCtrl.node.children"
       ng-class="'depth-' + layertreeCtrl.depth"
       ngeo-layertree="node"

--- a/src/directives/sortable.js
+++ b/src/directives/sortable.js
@@ -26,9 +26,9 @@ ngeo.SortableOptions;
  * Example:
  *
  *     <ul ngeo-sortable="ctrl.layers"
- *         ngeo-sortable-options="{handleClassName: 'sortable-handle'}">
+ *         ngeo-sortable-options="{handleClassName: 'ngeo-sortable-handle'}">
  *       <li ng-repeat="layer in ctrl.layers">
- *         <span class="sortable-handle">handle</span>{{layer.get('name')}}
+ *         <span class="ngeo-sortable-handle">handle</span>{{layer.get('name')}}
  *       </li>
  *     </ul>
  *
@@ -36,8 +36,8 @@ ngeo.SortableOptions;
  * to an array (an array of layers in the above example). This is the array
  * that is re-ordered after a drag-and-drop.
  *
- * The element with the class "sortable-handle" is the "drag handle". It is
- * required.
+ * The element with the class "ngeo-sortable-handle" is the "drag handle".
+ * It is required.
  *
  * This directives uses `$watchCollection` to watch the "sortable" array. So
  * if some outside code adds/removes elements to/from the "sortable" array,
@@ -173,11 +173,12 @@ ngeo.sortableDirective = function($timeout) {
            */
           function getOptions(options) {
             var ret;
+            var defaultHandleClassName = 'ngeo-sortable-handle';
             if (options === undefined) {
-              ret = {'handleClassName': 'handle'};
+              ret = {'handleClassName': defaultHandleClassName};
             } else {
               if (options['handleClassName'] === undefined) {
-                options['handleClassName'] = 'handle';
+                options['handleClassName'] = defaultHandleClassName;
               }
               ret = /** @type {ngeo.SortableOptions} */ (options);
             }


### PR DESCRIPTION
This PR fixes the CSS class name for the ngeo sortable directive.  Changes are made in the examples, directives, templates and applications.  See #1680.  Note that this is one among many PR that will come to fix #1680.

## Todo

 * [ ] review

## Live examples

 * https://adube.github.io/ngeo/1680-css-fix-sortable/examples/contribs/gmf/apps/desktop_alt/index.html