### PR TITLE
#1680 - Fix CSS names of gmf mobile nav

### DIFF
--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -8,9 +8,9 @@
     <link rel="shortcut icon" href="image/favicon.ico"/>
     <link rel="stylesheet" href="../../build/mobile.css">
   </head>
-  <body ng-class="{'nav-is-visible': mainCtrl.navIsVisible(),
-                   'nav-left-is-visible': mainCtrl.leftNavIsVisible(),
-                   'nav-right-is-visible': mainCtrl.rightNavIsVisible()}">
+  <body ng-class="{'gmf-mobile-nav-is-visible': mainCtrl.navIsVisible(),
+                   'gmf-mobile-nav-left-is-visible': mainCtrl.leftNavIsVisible(),
+                   'gmf-mobile-nav-right-is-visible': mainCtrl.rightNavIsVisible()}">
     <main ng-class="{'gmf-search-is-active': mainCtrl.searchOverlayVisible}">
       <gmf-map gmf-map-map="mainCtrl.map"
         ngeo-map-query=""
@@ -35,7 +35,7 @@
         gmf-mobile-measurepoint-layers="::mainCtrl.elevationLayers"
         gmf-mobile-measurepoint-map="::mainCtrl.map">
       </div>
-      <button class="nav-trigger nav-left-trigger"
+      <button class="gmf-mobile-nav-trigger gmf-mobile-nav-left-trigger"
         ng-click="mainCtrl.toggleLeftNavVisibility()">
         <span class="gmf-icon gmf-icon-layers"></span>
       </button>
@@ -45,7 +45,7 @@
         gmf-search-coordinatesprojections="mainCtrl.searchCoordinatesProjections"
         gmf-search-listeners="::mainCtrl.searchListeners">
       </gmf-search>
-      <button class="nav-trigger nav-right-trigger"
+      <button class="gmf-mobile-nav-trigger gmf-mobile-nav-right-trigger"
         ng-click="mainCtrl.toggleRightNavVisibility()">
         <i class="fa fa-wrench"></i>
       </button>
@@ -63,18 +63,18 @@
         gmf-disclaimer-map="::mainCtrl.map">
       </gmf-disclaimer>
     </main>
-    <nav class="nav-left" gmf-mobile-nav>
+    <nav class="gmf-mobile-nav-left" gmf-mobile-nav>
       <header>
-        <a class="go-back" href>{{'Back' | translate}}</a>
+        <a class="gmf-mobile-nav-go-back" href>{{'Back' | translate}}</a>
       </header>
       <!-- main menu -->
-      <div class="active slide">
+      <div class="gmf-mobile-nav-active gmf-mobile-nav-slide">
         <ul>
           <li>
-            <a href data-target="#background" data-toggle="slide-in" class="nav-button">{{'Background' | translate}}</a>
+            <a href data-target="#background" data-toggle="slide-in" class="gmf-mobile-nav-button">{{'Background' | translate}}</a>
           </li>
           <li>
-            <a href data-target="#themes" data-toggle="slide-in" class="nav-button">{{'Themes' | translate}}</a>
+            <a href data-target="#themes" data-toggle="slide-in" class="gmf-mobile-nav-button">{{'Themes' | translate}}</a>
           </li>
         </ul>
         <gmf-layertree
@@ -86,14 +86,14 @@
       </div>
       <gmf-backgroundlayerselector
         id="background"
-        class="slide"
+        class="gmf-mobile-nav-slide"
         data-header-title="{{'Background' | translate}}"
         gmf-backgroundlayerselector-map="::mainCtrl.map"
         gmf-backgroundlayerselector-select="mainCtrl.hideNav()">
       </gmf-backgroundlayerselector>
       <gmf-themeselector
         id="themes"
-        class="slide"
+        class="gmf-mobile-nav-slide"
         data-header-title="{{'Themes' | translate}}"
         gmf-themeselector-defaulttheme="OSM"
         gmf-themeselector-currenttheme="mainCtrl.theme"
@@ -101,25 +101,25 @@
         gmf-mobile-nav-back-on-click>
       </gmf-themeselector>
     </nav>
-    <nav class="nav-right" gmf-mobile-nav>
+    <nav class="gmf-mobile-nav-right" gmf-mobile-nav>
       <header>
-        <a class="go-back" href>{{'Back' | translate}}</a>
+        <a class="gmf-mobile-nav-go-back" href>{{'Back' | translate}}</a>
       </header>
       <!-- main menu -->
-      <div class="active slide">
+      <div class="gmf-mobile-nav-active gmf-mobile-nav-slide">
         <ul>
           <li>
-            <a href data-target="#measure-tools" data-toggle="slide-in" class="nav-button">{{'Measure tools' | translate}}</a>
-            <a href data-target="#login" data-toggle="slide-in" class="nav-button">{{'Login' | translate}}</a>
+            <a href data-target="#measure-tools" data-toggle="slide-in" class="gmf-mobile-nav-button">{{'Measure tools' | translate}}</a>
+            <a href data-target="#login" data-toggle="slide-in" class="gmf-mobile-nav-button">{{'Login' | translate}}</a>
           </li>
         </ul>
       </div>
-      <div id="measure-tools" class="slide" data-header-title="{{'Measure tools' | translate}}">
+      <div id="measure-tools" class="gmf-mobile-nav-slide" data-header-title="{{'Measure tools' | translate}}">
         <ul>
           <li>
             <a ngeo-btn
               ng-click="mainCtrl.hideNav()"
-              class="nav-button"
+              class="gmf-mobile-nav-button"
               ng-model="mainCtrl.measurePointActive">
               <span class="fa fa-fw" ng-class="{'fa-check': mainCtrl.measurePointActive}"></span>
               {{'Coordinate' | translate}}
@@ -128,7 +128,7 @@
           <li>
             <a ngeo-btn
               ng-click="mainCtrl.hideNav()"
-              class="nav-button"
+              class="gmf-mobile-nav-button"
               ng-model="mainCtrl.measureLengthActive">
               <span class="fa fa-fw" ng-class="{'fa-check': mainCtrl.measureLengthActive}"></span>
               {{'Length' | translate}}
@@ -136,7 +136,7 @@
           </li>
         </ul>
       </div>
-      <gmf-authentication id="login" class="slide" data-header-title="{{'Login' | translate}}"
+      <gmf-authentication id="login" class="gmf-mobile-nav-slide" data-header-title="{{'Login' | translate}}"
         gmf-mobile-nav-back="authCtrl.gmfUser.username !== null">
       </gmf-authentication>
     </nav>

--- a/contribs/gmf/less/mobile-nav.less
+++ b/contribs/gmf/less/mobile-nav.less
@@ -20,10 +20,10 @@ main {
   transform: translateZ(0);
   transition: transform @duration;
   will-change: transform;
-  .nav-left-is-visible & {
+  .gmf-mobile-nav-left-is-visible & {
     transform: translateX(@nav-width);
   }
-  .nav-right-is-visible & {
+  .gmf-mobile-nav-right-is-visible & {
     transform: translateX(-@nav-width);
   }
 
@@ -47,7 +47,7 @@ main {
     .transition(opacity @duration, visibility @duration;);
     .backface-visibility(hidden);
 
-    .nav-is-visible & {
+    .gmf-mobile-nav-is-visible & {
       visibility: visible;
       opacity: 1;
     }
@@ -80,18 +80,18 @@ main {
 
 @nav-bar-height: 50px;
 
-.nav-left-is-visible nav.nav-right,
-.nav-right-is-visible nav.nav-left  {
+.gmf-mobile-nav-left-is-visible nav.gmf-mobile-nav-right,
+.gmf-mobile-nav-right-is-visible nav.gmf-mobile-nav-left  {
   display: none;
 }
 
-.nav-left-is-visible nav.nav-left,
-.nav-right-is-visible nav.nav-right  {
+.gmf-mobile-nav-left-is-visible nav.gmf-mobile-nav-left,
+.gmf-mobile-nav-right-is-visible nav.gmf-mobile-nav-right  {
   visibility: visible;
 }
 
-nav.nav-left,
-nav.nav-right {
+nav.gmf-mobile-nav-left,
+nav.gmf-mobile-nav-right {
   position: fixed;
   top: 0;
   width: @nav-width;
@@ -109,7 +109,7 @@ nav.nav-right {
     line-height: @nav-bar-height;
     background-color: @nav-header-bg;
 
-    .go-back {
+    .gmf-mobile-nav-go-back {
       position: absolute;
       left: 0;
       z-index: 2;
@@ -122,7 +122,7 @@ nav.nav-right {
       padding-left: 24px;
       color: @back-color;
 
-      &.active {
+      &.gmf-mobile-nav-active {
         opacity: 1;
         visibility: visible;
       }
@@ -145,24 +145,24 @@ nav.nav-right {
       text-align: center;
 
 
-      &.active {
+      &.gmf-mobile-nav-active {
         transform: translateX(-100%);
         opacity: 1;
       }
-      &.slide-out {
+      &.gmf-mobile-nav-slide-out {
         transform: translateX(-120%);
         opacity: 0;
       }
     }
 
-    &.back {
+    &.gmf-mobile-nav-back {
       > nav {
         transform: translate(-120%);
       }
-      > nav.active {
+      > nav.gmf-mobile-nav-active {
         transform: translateX(-100%);
       }
-      > nav.slide-out {
+      > nav.gmf-mobile-nav-slide-out {
         transform: translateX(0);
       }
     }
@@ -179,7 +179,7 @@ nav.nav-right {
     }
   }
 
-  .go-back,
+  .gmf-mobile-nav-go-back,
   a[data-toggle=slide-in] {
     &::before, &::after {
       /* arrow icon in CSS - for element with nested unordered lists */
@@ -202,7 +202,7 @@ nav.nav-right {
     }
   }
 
-  .slide {
+  .gmf-mobile-nav-slide {
     position: fixed;
     height: ~"calc(100% - @{nav-bar-height})";
     width: @nav-width;
@@ -219,11 +219,11 @@ nav.nav-right {
       display: block;
     }
 
-    &.active {
+    &.gmf-mobile-nav-active {
       transform: translateX(0%);
       opacity: 1;
     }
-    &.slide-out {
+    &.gmf-mobile-nav-slide-out {
       transform: translateX(-20%);
       opacity: 0;
     }
@@ -234,17 +234,17 @@ nav.nav-right {
 // 90% of the viewport width
 @media (max-width: @screen-xs) {
   main {
-    .nav-left-is-visible & {
+    .gmf-mobile-nav-left-is-visible & {
       transform: translateX(90vw);
     }
-    .nav-right-is-visible & {
+    .gmf-mobile-nav-right-is-visible & {
       transform: translateX(-90vw);
     }
   }
-  nav.nav-left,
-  nav.nav-right {
+  nav.gmf-mobile-nav-left,
+  nav.gmf-mobile-nav-right {
     width: 90vw;
-    .slide {
+    .gmf-mobile-nav-slide {
       width: 90vw;
     }
 
@@ -255,19 +255,19 @@ nav.nav-right {
   }
 }
 
-.nav-left {
+.gmf-mobile-nav-left {
   left: 0;
   right: auto;
 }
 
-.nav-right {
+.gmf-mobile-nav-right {
   right: 0;
 }
 
 /**
  * Buttons to open right and left navigation menus
  */
-.nav-trigger {
+.gmf-mobile-nav-trigger {
   top: @app-margin;
   background-color: @map-tools-bg-color;
   color: @map-tools-color;
@@ -279,13 +279,13 @@ nav.nav-right {
   }
 }
 
-.nav-left-trigger {
+.gmf-mobile-nav-left-trigger {
   left: @app-margin;
   border-right: none;
   box-shadow: 3px 0 5px -2px #bbb;
 }
 
-.nav-right-trigger {
+.gmf-mobile-nav-right-trigger {
   right: @app-margin;
   border-left: none;
   box-shadow: -3px 0 5px -2px #bbb;
@@ -294,7 +294,7 @@ nav.nav-right {
 /**
  * Buttons for tool buttons (for example measure tools)
  */
-.nav-button {
+.gmf-mobile-nav-button {
   display: block;
   padding: @app-margin 0;
   overflow: hidden;
@@ -312,13 +312,13 @@ nav.nav-right {
     background-color: @onhover-color;
   }
 
-  .nav-trigger {
+  .gmf-mobile-nav-trigger {
     margin: 0;
     border: solid 1px @border-color;
     box-shadow: none;
   }
 
-  .nav-right-trigger {
+  .gmf-mobile-nav-right-trigger {
     left: auto;
   }
 }

--- a/contribs/gmf/less/mobilelayertree.less
+++ b/contribs/gmf/less/mobilelayertree.less
@@ -4,8 +4,8 @@ gmf-layertree {
   border-top: 1px solid @back-color;
 }
 
-nav.nav-left .gmf-layertree-node a[data-toggle] {
-  //override rule: nav.nav-left a[data-toggle] padding-right: 4rem
+nav.gmf-mobile-nav-left .gmf-layertree-node a[data-toggle] {
+  //override rule: nav.gmf-mobile-nav-left a[data-toggle] padding-right: 4rem
   padding-right: 0;
 }
 

--- a/contribs/gmf/src/controllers/abstractmobile.js
+++ b/contribs/gmf/src/controllers/abstractmobile.js
@@ -151,7 +151,8 @@ gmf.AbstractMobileController = function(config, $scope, $injector) {
    * @type {number}
    * @private
    */
-  this.navWidth_ = angular.element(document.querySelector('.nav-left')).width();
+  this.navWidth_ = angular.element(document.querySelector(
+    '.gmf-mobile-nav-left')).width();
 
   goog.events.listen(this.dragger_, 'end', (function(e) {
     angular.element(dragEl).removeClass('dragging');

--- a/contribs/gmf/src/directives/mobilenav.js
+++ b/contribs/gmf/src/directives/mobilenav.js
@@ -12,9 +12,9 @@ goog.require('gmf');
  * structure:
  * <nav gmf-mobile-nav>
  *   <header>
- *     <a class="go-back" href="#"></a>
+ *     <a class="gmf-mobile-nav-go-back" href="#"></a>
  *   </header>
- *   <div class="active slide">
+ *   <div class="gmf-mobile-nav-active gmf-mobile-nav-slide">
  *     <ul>
  *       <li>
  *         <a href data-target="#devices">Devices</a>
@@ -24,13 +24,13 @@ goog.require('gmf');
  *       </li>
  *     </ul>
  *   </div>
- *   <div id="devices" class="slide" data-header-title="Devices">
+ *   <div id="devices" class="gmf-mobile-nav-slide" data-header-title="Devices">
  *     <ul>
  *       <li>Mobile Phones</li>
  *       <li>Televisions</li>
  *     </ul>
  *   </div>
- *   <div id="vehicles" class="slide" data-header-title="Vehicles">
+ *   <div id="vehicles" class="gmf-mobile-nav-slide" data-header-title="Vehicles">
  *     <ul>
  *       <li>Cars</li>
  *       <li>Planes</li>
@@ -120,29 +120,32 @@ gmf.module.controller('gmfMobileNavController', gmf.MobileNavController);
  * @param {angular.JQLite} element Element.
  */
 gmf.MobileNavController.prototype.init = function(element) {
-  this.active_ = $(element.find('.active.slide'));
+  var cls = gmf.MobileNavController.ClassName_;
+  this.active_ = $(element.find('.' + cls.ACTIVE + '.' + cls.SLIDE));
   this.header_ = $(element.find('> header'));
-  this.backButton_ = $(element.find('header > .go-back'));
+  this.backButton_ = $(element.find('header > .' + cls.GO_BACK));
 
   // watch for clicks on "slide-in" elements
   element.find('[data-toggle=slide-in]').on('click', function(evt) {
 
+    var cls = gmf.MobileNavController.ClassName_;
+
     // the element to slide out is the div.slide parent
-    var slideOut = $(evt.currentTarget).parents('.slide');
+    var slideOut = $(evt.currentTarget).parents('.' + cls.SLIDE);
     goog.asserts.assert(slideOut.length === 1);
 
     // push the item to the selected stack
     this.slid_.push(slideOut);
 
     // slide the "old" element out
-    slideOut.addClass('slide-out').removeClass('active');
+    slideOut.addClass(cls.SLIDE_OUT).removeClass(cls.ACTIVE);
 
     // element to slide in
     var slideIn = $($(evt.currentTarget).attr('data-target'));
     goog.asserts.assert(slideIn.length === 1);
 
     // slide the "new" element in
-    slideIn.addClass('active');
+    slideIn.addClass(cls.ACTIVE);
 
     // update the navigation header
     this.updateNavigationHeader_(slideIn, false);
@@ -162,17 +165,18 @@ gmf.MobileNavController.prototype.init = function(element) {
  */
 gmf.MobileNavController.prototype.updateNavigationHeader_ = function(
     active, back) {
-  this.header_.toggleClass('back', back);
+  var cls = gmf.MobileNavController.ClassName_;
+  this.header_.toggleClass(cls.BACK, back);
 
   // remove any inactive nav
-  this.header_.find('nav:not(.active)').remove();
+  this.header_.find('nav:not(.' + cls.ACTIVE + ' +)').remove();
 
   // deactivate the currently active nav
-  this.header_.find('nav.active').removeClass('active')
-      .addClass('slide-out');
+  this.header_.find('nav.' + cls.ACTIVE).removeClass(cls.ACTIVE)
+      .addClass(cls.SLIDE_OUT);
 
   // show the back button when relevant
-  this.backButton_.toggleClass('active', this.slid_.length > 0);
+  this.backButton_.toggleClass(cls.ACTIVE, this.slid_.length > 0);
 
   // create a new nav
   var nav = $('<nav>');
@@ -196,7 +200,7 @@ gmf.MobileNavController.prototype.updateNavigationHeader_ = function(
       // fix: calling `position()` makes sure that the animation
       // is always run
       nav.position();
-      nav.addClass('active');
+      nav.addClass(gmf.MobileNavController.ClassName_.ACTIVE);
     }, 0);
   }, 0);
 };
@@ -213,14 +217,16 @@ gmf.MobileNavController.prototype.back_ = function() {
     return;
   }
 
+  var cls = gmf.MobileNavController.ClassName_;
+
   // slide active item to the right
-  this.active_.removeClass('active');
+  this.active_.removeClass(cls.ACTIVE);
 
   // get the previously active item
   var slideBack = this.slid_.pop();
 
   // slide previous item to the right
-  slideBack.addClass('active').removeClass('slide-out');
+  slideBack.addClass(cls.ACTIVE).removeClass(cls.SLIDE_OUT);
 
   // update the navigation header
   this.updateNavigationHeader_(slideBack, true);
@@ -242,6 +248,21 @@ gmf.MobileNavController.prototype.backIfActive = function(element) {
 
 
 /**
+ * CSS class names toggled by the controller.
+ * @enum {string}
+ * @private
+ */
+
+gmf.MobileNavController.ClassName_ = {
+  ACTIVE: 'gmf-mobile-nav-active',
+  BACK: 'gmf-mobile-nav-go-back',
+  GO_BACK: 'gmf-mobile-nav-go-back',
+  SLIDE: 'gmf-mobile-nav-slide',
+  SLIDE_OUT: 'gmf-mobile-nav-slide-out'
+};
+
+
+/**
  * A directive to be used in conjunction with {@link gmf.mobileNavDirective}.
  * The directive can be set on a slide element of {@link gmf.mobileNavDirective}
  * with an expression. When the value of the expression changes and becomes
@@ -250,9 +271,9 @@ gmf.MobileNavController.prototype.backIfActive = function(element) {
  *
  * Example:
  *
- *    <nav class="nav-left" gmf-mobile-nav>
+ *    <nav class="gmf-mobile-nav-left" gmf-mobile-nav>
  *      ...
- *      <gmf-authentication class="slide"
+ *      <gmf-authentication class="gmf-mobile-nav-slide"
  *         gmf-mobile-nav-back="authCtrl.gmfUser.username !== null">
  *      </gmf-authentication>
  *
@@ -295,7 +316,7 @@ gmf.module.directive('gmfMobileNavBack', gmf.mobileNavBackDirective);
  *
  * Example:
  *
- *    <nav class="nav-left" gmf-mobile-nav>
+ *    <nav class="gmf-mobile-nav-left" gmf-mobile-nav>
  *      ...
  *      <gmf-themeselector
  *         gmf-mobile-nav-back-on-click

--- a/contribs/gmf/src/directives/themeselector.js
+++ b/contribs/gmf/src/directives/themeselector.js
@@ -15,7 +15,6 @@ goog.require('ngeo.Location');
  *
  *     <gmf-themeselector
  *         id="themes"
- *         class="slide"
  *         data-header-title="Themes"
  *         gmf-themeselector-filter="::mainCtrl.filter">
  *     </gmf-themeselector>


### PR DESCRIPTION
This PR fixes the CSS class name for the gmf mobilenav directive and the navigation in general in the mobile application.  See #1680.

Just to clarify, here's the list of class names that are changed in this PR.

```
go-back              -->  gmf-mobile-nav-go-back
active               -->  gmf-mobile-nav-active
slide                -->  gmf-mobile-nav-slide
slide-out            -->  gmf-mobile-nav-slide-out
back                 -->  gmf-mobile-nav-back
nav-left             -->  gmf-mobile-nav-left
nav-right            -->  gmf-mobile-nav-right
nav-left-is-visible  -->  gmf-mobile-nav-left-is-visible
nav-right-is-visible -->  gmf-mobile-nav-right-is-visible
nav-trigger          -->  gmf-mobile-nav-trigger
nav-left-trigger     -->  gmf-mobile-nav-left-trigger
nav-right-trigger    -->  gmf-mobile-nav-right-trigger
nav-button           -->  gmf-mobile-nav-button
```

To clarify even more, the `.nav` and `.nav-pills` are defined in Bootstrap, but none of the others that were begining with `nav` were part of Bootstrap (see above).

The `active` class name is something defined in Boostrap, but it is only used on buttons and anchor elements. Here, it is used on divs, which is unique to gmf.

The `slide-in` and `slide-out` values are used by Bootsrap, but never as class names.  That's also unique to gmf.


## Todo

 * [ ] review

## Live examples

 *  https://adube.github.io/ngeo/1680-css-fix-mobile-nav/examples/contribs/gmf/apps/mobile/index.html