### PR TITLE
Make draw/edit context menu take precedence over contextual data

### DIFF
--- a/contribs/gmf/src/directives/drawfeature.js
+++ b/contribs/gmf/src/directives/drawfeature.js
@@ -531,7 +531,7 @@ gmf.DrawfeatureController.prototype.handleFeaturesRemove_ = function(evt) {
 gmf.DrawfeatureController.prototype.handleMapSelectActiveChange_ = function(
     active) {
 
-  var mapDiv = this.map.getTargetElement();
+  var mapDiv = this.map.getViewport();
   goog.asserts.assertElement(mapDiv);
 
   if (active) {
@@ -658,6 +658,7 @@ gmf.DrawfeatureController.prototype.handleMapContextMenu_ = function(evt) {
     }
 
     evt.preventDefault();
+    evt.stopPropagation();
   }
 
   // do not do any further action if feature is null or already selected

--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -695,7 +695,7 @@ gmf.EditfeatureController.prototype.toggle_ = function(active) {
 gmf.EditfeatureController.prototype.handleMapSelectActiveChange_ = function(
     active) {
 
-  var mapDiv = this.map.getTargetElement();
+  var mapDiv = this.map.getViewport();
   goog.asserts.assertElement(mapDiv);
 
   if (active) {
@@ -810,6 +810,7 @@ gmf.EditfeatureController.prototype.handleMapContextMenu_ = function(evt) {
       this.menu_.open(coordinate);
     }
     evt.preventDefault();
+    evt.stopPropagation();
   }
 };
 


### PR DESCRIPTION
Fixes #1725.

With this pull request a right-click (or long press) on a feature when using the drawing or editing tools the propagation of the event is stopped. This helps preventing the contextual menu (with coordinates, elevation, etc...) to show up when a feature is right clicked.

In order to do that I had to use a different target for the event listener because it's not possible to stop propagation on the same element easily. Using `stopImmediatePropagation` is not possible here since we cannot make sure of the order in which the listeners are added.

Please review.