### PR TITLE
Fix #1791 - Background layer selector directive must use dimensions

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -170,6 +170,7 @@
               <img src="image/background-layer-button.png" alt="" />
             </button>
             <gmf-backgroundlayerselector
+              gmf-backgroundlayerselector-dimensions="::mainCtrl.dimensions"
               gmf-backgroundlayerselector-map="::mainCtrl.map"
               class="dropdown-menu">
             </gmf-backgroundlayerselector>

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -170,6 +170,7 @@
               <img src="image/background-layer-button.png" alt="" />
             </button>
             <gmf-backgroundlayerselector
+              gmf-backgroundlayerselector-dimensions="::mainCtrl.dimensions"
               gmf-backgroundlayerselector-map="::mainCtrl.map"
               class="dropdown-menu">
             </gmf-backgroundlayerselector>

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -88,6 +88,7 @@
         id="background"
         class="slide"
         data-header-title="{{'Background' | translate}}"
+        gmf-backgroundlayerselector-dimensions="::mainCtrl.dimensions"
         gmf-backgroundlayerselector-map="::mainCtrl.map"
         gmf-backgroundlayerselector-select="mainCtrl.hideNav()">
       </gmf-backgroundlayerselector>

--- a/contribs/gmf/examples/backgroundlayerselector.html
+++ b/contribs/gmf/examples/backgroundlayerselector.html
@@ -41,6 +41,7 @@
     <div>
         <span>Select base layer:</span>
         <gmf-backgroundlayerselector
+          gmf-backgroundlayerselector-dimensions="::ctrl.dimensions"
           gmf-backgroundlayerselector-map="::ctrl.map">
         </gmf-backgroundlayerselector>
     </div>

--- a/contribs/gmf/examples/backgroundlayerselector.js
+++ b/contribs/gmf/examples/backgroundlayerselector.js
@@ -35,6 +35,12 @@ app.MainController = function(gmfThemes) {
   gmfThemes.loadThemes();
 
   /**
+   * @type {Object.<string, string>}
+   * @export
+   */
+  this.dimensions = {};
+
+  /**
    * @type {ol.Map}
    * @export
    */

--- a/contribs/gmf/src/directives/backgroundlayerselector.js
+++ b/contribs/gmf/src/directives/backgroundlayerselector.js
@@ -27,7 +27,8 @@ gmf.module.value('gmfBackgroundlayerselectorTemplateUrl',
  * Example:
  *
  *      <gmf-backgroundlayerselector
- *        gmf-backgroundlayerselector-map="::ctrl.map">
+ *        gmf-backgroundlayerselector-dimensions="::ctrl.dimensions"
+ *        gmf-backgroundlayerselector-map="::ctrl.map"
  *        gmf-backgroundlayerselector-select="onBackgroundSelected()">
  *      </gmf-backgroundlayerselector>
  *
@@ -35,6 +36,8 @@ gmf.module.value('gmfBackgroundlayerselectorTemplateUrl',
  *
  *  * thumbnail: The URL used for the icon.
  *
+ * @htmlAttribute {Object.<string, string>} gmf-backgroundlayerselector-dimensions
+ *     The dimensions.
  * @htmlAttribute {ol.Map=} gmf-backgroundlayerselector-map The map.
  * @htmlAttribute {Function} gmf-backgroundlayerselector-select Function called
  *     when a layer was selected by the user.
@@ -50,8 +53,8 @@ gmf.backgroundlayerselectorDirective = function(
   return {
     restrict: 'E',
     scope: {
-      'map': '=gmfBackgroundlayerselectorMap',
       'dimensions': '=gmfBackgroundlayerselectorDimensions',
+      'map': '=gmfBackgroundlayerselectorMap',
       'select': '&?gmfBackgroundlayerselectorSelect'
     },
     bindToController: true,
@@ -79,6 +82,14 @@ gmf.module.directive('gmfBackgroundlayerselector',
  */
 gmf.BackgroundlayerselectorController = function($scope, ngeoBackgroundLayerMgr,
     gmfThemes) {
+
+  /**
+   * @type {Object.<string, string>}
+   * @export
+   */
+  this.dimensions;
+
+  goog.asserts.assert(this.dimensions, 'The dimensions object is required');
 
   /**
    * @type {ol.Map}
@@ -119,14 +130,6 @@ gmf.BackgroundlayerselectorController = function($scope, ngeoBackgroundLayerMgr,
 
   this.listenerKeys_.push(ol.events.listen(gmfThemes,
     gmf.ThemesEventType.CHANGE, this.handleThemesChange_, this));
-
-  /**
-   * @type {Object.<string, string>}
-   * @export
-   */
-  this.dimensions;
-
-  goog.asserts.assert(this.dimensions, 'The dimensions object is required');
 
   gmfThemes.getBgLayers(this.dimensions).then(function(layers) {
     this.bgLayers = layers;


### PR DESCRIPTION
Fixes #1791.  The `gmf-backgroundlayerselector` directive must use the `dimensions` options.  This PR fixes this in all 3 applications and in the example.

## Todo

 * [ ] review

## Live examples

 * (example) https://adube.github.io/ngeo/1791-fix-apps-bls/examples/contribs/gmf/backgroundlayerselector.html
 * (app) https://adube.github.io/ngeo/1791-fix-apps-bls/examples/contribs/gmf/apps/desktop_alt/index.html