### PR TITLE
Fix #1781 - Configure WFS permalink in gmf apps

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -294,6 +294,16 @@
                 {action: 'add_layer', title: 'Add a layer'}
         ]);
         module.constant('gmfContextualdatacontentTemplateUrl', window.location.pathname + 'contextualdata.html');
+        module.value('ngeoWfsPermalinkOptions',
+            /** @type {ngeox.WfsPermalinkOptions} */ ({
+              url: 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy',
+              wfsTypes: [
+                {featureType: 'fuel', label: 'display_name'},
+                {featureType: 'osm_scale', label: 'display_name'}
+              ],
+              defaultFeatureNS: 'http://mapserver.gis.umn.edu/mapserver',
+              defaultFeaturePrefix: 'feature'
+            }));
       })();
     </script>
   </body>

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -298,6 +298,16 @@
         ]);
         module.constant('gmfTreeManagerModeFlush', false);
         module.value('gmfPermalinkOptions', {projectionCodes: ['EPSG:21781', 'EPSG:2056', 'EPSG:4326']});
+        module.value('ngeoWfsPermalinkOptions',
+            /** @type {ngeox.WfsPermalinkOptions} */ ({
+              url: 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy',
+              wfsTypes: [
+                {featureType: 'fuel', label: 'display_name'},
+                {featureType: 'osm_scale', label: 'display_name'}
+              ],
+              defaultFeatureNS: 'http://mapserver.gis.umn.edu/mapserver',
+              defaultFeaturePrefix: 'feature'
+            }));
       })();
     </script>
   </body>

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -190,6 +190,16 @@
         module.constant('gmfSearchGroups', []);
         // Requires that the gmfSearchGroups is specified
         module.constant('gmfSearchActions', []);
+        module.value('ngeoWfsPermalinkOptions',
+            /** @type {ngeox.WfsPermalinkOptions} */ ({
+              url: 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy',
+              wfsTypes: [
+                {featureType: 'fuel', label: 'display_name'},
+                {featureType: 'osm_scale', label: 'display_name'}
+              ],
+              defaultFeatureNS: 'http://mapserver.gis.umn.edu/mapserver',
+              defaultFeaturePrefix: 'feature'
+            }));
        })();
     </script>
   </body>


### PR DESCRIPTION
Fixes #1781.  This PR adds the required configuration of the wfs permalink service to work properly in the gmf applications.

## Todo

 * [x] @sbrunner Do we need to add more `wfsTypes`? - **update**: the answer is no.  Thanks, @sbrunner.
 * [ ] review

## Live example

 * https://adube.github.io/ngeo/1781-fix-apps-wfs-permalink/examples/contribs/gmf/apps/desktop_alt/index.html?wfs_layer=fuel&wfs_osm_id=1420918679&map_x=545278&map_y=148729&map_zoom=11&lang=fr&tree_groups=OSM%20functions%20mixed%2CLayers%2CGroup%2COSM%20functions%2CExternal&baselayer_ref=map