### PR TITLE
Fix #1780 - Do not change bg layer on login READY

### DIFF
--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -113,7 +113,9 @@ gmf.AbstractController = function(config, $scope, $injector) {
   var userChange = function(evt) {
     var roleId = (evt.user.username !== null) ? evt.user.role_id : undefined;
     // Reload background layer when login status changes.
-    this.updateCurrentBackgroundLayer_(true);
+    if (evt.type !== gmf.AuthenticationEventType.READY) {
+      this.updateCurrentBackgroundLayer_(true);
+    }
     // Reload themes when login status changes.
     gmfThemes.loadThemes(roleId);
     this.updateHasEditableLayers_();


### PR DESCRIPTION
Fixes #1780.  Before this fix, the abstract controller of the gmf applications was calling the loading of the background layer twice: first time upon initialization (with the reading of permalink), and a second (unwanted) time when the themes service triggers an event.  We do want to reload the bg layer on LOGIN or LOGOUT, but not on READY, which was the 2nd unwanted call that was overriding the first call that managed the permalink.

This PR doesn't currently have a live example yet due to #1807.

## Todo

 * [x] Wait for #1807 to be fixed
 * [x] Create a live example
 * [ ] Review

## Live example

 * https://adube.github.io/ngeo/1780-fix-permalink-bgmap/examples/contribs/gmf/apps/desktop_alt/index.html?baselayer_ref=asitvd.fond_couleur&lang=fr