### PR TITLE
#1680 - Fix CSS class name in gmf-contextualdata directive

### DIFF
--- a/contribs/gmf/examples/contextualdata.html
+++ b/contribs/gmf/examples/contextualdata.html
@@ -15,11 +15,11 @@
         height: 400px;
       }
 
-      .contextualdata {
+      .gmf-contextualdata {
         font-size: 0.8em;
         width: 300px;
       }
-      .contextualdata table {
+      .gmf-contextualdata table {
         width: 100%;
       }
     </style>

--- a/contribs/gmf/less/contextualdata.less
+++ b/contribs/gmf/less/contextualdata.less
@@ -1,4 +1,4 @@
-.contextualdata {
+.gmf-contextualdata {
   width: 40rem;
   font-size: @font-size-small;
 

--- a/contribs/gmf/src/directives/contextualdata.js
+++ b/contribs/gmf/src/directives/contextualdata.js
@@ -188,7 +188,7 @@ gmf.ContextualdataController.prototype.setContent_ = function(coordinate) {
 gmf.ContextualdataController.prototype.preparePopover_ = function() {
 
   var container = goog.dom.createElement('DIV');
-  container.classList.add('popover', 'bottom', 'contextualdata');
+  container.classList.add('popover', 'bottom', 'gmf-contextualdata');
   angular.element(container).css('position', 'relative');
   var arrow = goog.dom.createElement('DIV');
   arrow.classList.add('arrow');


### PR DESCRIPTION
This PR fixes the CSS class name for the gmf contextualdata directive.  Changes are made in the example and and desktop application.  See #1680.  Note that this is one among many PR that will come to fix #1680.

## Todo

 * [ ] review

## Live examples

 * (example) https://adube.github.io/ngeo/1680-css-fix-contextualdata/examples/contribs/gmf/contextualdata.html
 * (desktop app) https://adube.github.io/ngeo/1680-css-fix-contextualdata/examples/contribs/gmf/apps/desktop/index.html