### PR TITLE
#1680 - Fix CSS class name in gmf-mouseposition directive

### DIFF
--- a/contribs/gmf/examples/mouseposition.html
+++ b/contribs/gmf/examples/mouseposition.html
@@ -20,7 +20,7 @@
       .dropdown-menu {
         min-width: 260px;
       }
-      #mouse-position {
+      .gmf-mouseposition-control {
         display: inline-block;
         min-width: 200px;
       }

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -133,7 +133,7 @@ main {
   gmf-mouseposition {
     display: inline-block;
   }
-  #mouse-position {
+  .gmf-mouseposition-control {
     display: inline-block;
     min-width: 18rem;
   }

--- a/contribs/gmf/src/directives/mouseposition.js
+++ b/contribs/gmf/src/directives/mouseposition.js
@@ -81,9 +81,9 @@ gmf.MousepositionController = function($filter, gettext) {
   };
 
   this.control = new ol.control.MousePosition({
-    className: 'custom-mouse-position',
+    className: 'gmf-mouseposition-control',
     coordinateFormat: formatFn.bind(this),
-    target: document.getElementById('mouse-position'),
+    target: document.getElementById('gmf-mouseposition-control-target'),
     undefinedHTML: gettext('Coordinates')
   });
 

--- a/contribs/gmf/src/directives/partials/mouseposition.html
+++ b/contribs/gmf/src/directives/partials/mouseposition.html
@@ -1,6 +1,7 @@
 <div class="btn-group dropup">
   <a type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-    <span id="mouse-position"></span><span class="caret"></span>
+    <span id="gmf-mouseposition-control-target"></span>
+    <span class="caret"></span>
   </a>
   <ul class="dropdown-menu dropdown-menu-right" role="menu">
     <li class="dropdown-header" translate>Coordinate systems</li>


### PR DESCRIPTION
This PR fixes the CSS class name for the gmf mouseposition directive.  Changes are made in the example and and desktop application.  See #1680.  Note that this is one among many PR that will come to fix #1680.

The use of an `id` within the directive is not a good practice.  If one wanted to have 2 maps with each their own mouse positions directive, then it wouldn't work because the directive appends the created control using the id of the element defined within the template.  That's not an issue for now, but this could be changed.

Instead of using the id in the CSS, the class name of the control itself is used.

## Todo

 * [ ] review

## Live examples

 * (example) https://adube.github.io/ngeo/1680-css-fix-mouseposition/examples/contribs/gmf/mouseposition.html
 * (desktop app) https://adube.github.io/ngeo/1680-css-fix-mouseposition/examples/contribs/gmf/apps/desktop/index.html