### PR TITLE
Enhance readability of layertree html templates

### DIFF
--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -9,7 +9,7 @@
     <i class="gmf-layertree-sortable-handle-icon fa fa-ellipsis-v"></i>
   </div>
 
-  <a 
+  <a
     ng-if="::layertreeCtrl.node.children"
     data-toggle="collapse"
     href="#layer-group-{{::layertreeCtrl.uid}}"

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -1,94 +1,195 @@
-<div ng-if="::!layertreeCtrl.isRoot" id="node-{{::layertreeCtrl.uid}}" ng-class="[layertreeCtrl.node.children ? 'group' : 'leaf', 'depth-' + layertreeCtrl.depth, gmfLayertreeCtrl.getResolutionStyle(layertreeCtrl.node), gmfLayertreeCtrl.getNodeState(layertreeCtrl)]">
-  <div class="ngeo-sortable-handle" ng-show="layertreeCtrl.depth === 1 && gmfLayertreeCtrl.layers.length > 1">
+<div
+  ng-if="::!layertreeCtrl.isRoot"
+  id="node-{{::layertreeCtrl.uid}}"
+  ng-class="[layertreeCtrl.node.children ? 'group' : 'leaf', 'depth-' + layertreeCtrl.depth, gmfLayertreeCtrl.getResolutionStyle(layertreeCtrl.node), gmfLayertreeCtrl.getNodeState(layertreeCtrl)]">
+
+  <div
+    class="ngeo-sortable-handle"
+    ng-show="layertreeCtrl.depth === 1 && gmfLayertreeCtrl.layers.length > 1">
     <i class="gmf-layertree-sortable-handle-icon fa fa-ellipsis-v"></i>
   </div>
 
-    <a  ng-if="::layertreeCtrl.node.children"
-        data-toggle="collapse"
-        href="#layer-group-{{::layertreeCtrl.uid}}"
-        aria-expanded="{{::layertreeCtrl.node.metadata.isExpanded}}"
-        class="fa expand-node fa-fw">
-    </a>
-  <a href ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)"
-     ng-if="::!layertreeCtrl.node.children" ng-class="::{'no-layer-icon' : !gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl)}"
-     class="layer-icon">
-    <img ng-if="::(legendIconUrl=gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl))" ng-src="{{::legendIconUrl}}"></img>
+  <a 
+    ng-if="::layertreeCtrl.node.children"
+    data-toggle="collapse"
+    href="#layer-group-{{::layertreeCtrl.uid}}"
+    aria-expanded="{{::layertreeCtrl.node.metadata.isExpanded}}"
+    class="fa expand-node fa-fw">
   </a>
-  <a href ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)"
-     ng-if="::layertreeCtrl.node.children" ng-class="['fa fa-fw', layertreeCtrl.node.children && !layertreeCtrl.layer.loading ? 'state' : 'fa-refresh fa-spin']"></a>
-  <a href ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)"
-     class="name" title="{{layertreeCtrl.node.name | translate}}">
+
+  <a
+    href
+    ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)"
+    ng-if="::!layertreeCtrl.node.children" ng-class="::{'no-layer-icon' : !gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl)}"
+    class="layer-icon">
+
+    <img
+      ng-if="::(legendIconUrl=gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl))"
+      ng-src="{{::legendIconUrl}}">
+    </img>
+  </a>
+
+  <a
+    href
+    ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)"
+    ng-if="::layertreeCtrl.node.children" ng-class="['fa fa-fw', layertreeCtrl.node.children && !layertreeCtrl.layer.loading ? 'state' : 'fa-refresh fa-spin']">
+  </a>
+
+  <a
+    href
+    ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)"
+    class="name"
+    title="{{layertreeCtrl.node.name | translate}}">
+
     {{layertreeCtrl.node.name | translate}}
-    <i class="gmf-icon gmf-icon-search-go zoom"
-       data-toggle="tooltip"
-       data-title="{{'Not visible at current scale. Click to zoom.'|translate}}"
-       ng-click="::gmfLayertreeCtrl.zoomToResolution(layertreeCtrl); $event.preventDefault(); $event.stopPropagation();"
-       ng-if="gmfLayertreeCtrl.getNodeState(layertreeCtrl) == 'on'"></i>
-    <span ngeo-popover ngeo-popover-dismiss=".content" ng-if="gmfLayertreeCtrl.getNodeState(layertreeCtrl) !== 'off' && layertreeCtrl.node.time && layertreeCtrl.node.time.mode !== 'disabled'">
-      <span ngeo-popover-anchor class="fa fa-clock-o" ng-click="$event.preventDefault(); $event.stopPropagation()"></span>
-        <div ngeo-popover-content>
-          <ngeo-date-picker ng-if="::layertreeCtrl.node.time.widget === 'datepicker'" time="layertreeCtrl.node.time" on-date-selected="gmfLayertreeCtrl.updateWMSTimeLayerState(layertreeCtrl, time)"></ngeo-date-picker>
-          <gmf-time-slider ng-if="::layertreeCtrl.node.time.widget === 'slider'"
-            gmf-time-slider-time="layertreeCtrl.node.time"
-            gmf-time-slider-on-date-selected="gmfLayertreeCtrl.updateWMSTimeLayerState(layertreeCtrl, time)"/>
-        </div>
+
+    <i
+      class="gmf-icon gmf-icon-search-go zoom"
+      data-toggle="tooltip"
+      data-title="{{'Not visible at current scale. Click to zoom.'|translate}}"
+      ng-click="::gmfLayertreeCtrl.zoomToResolution(layertreeCtrl); $event.preventDefault(); $event.stopPropagation();"
+      ng-if="gmfLayertreeCtrl.getNodeState(layertreeCtrl) == 'on'">
+    </i>
+
+    <span
+      ngeo-popover
+      ngeo-popover-dismiss=".content"
+      ng-if="gmfLayertreeCtrl.getNodeState(layertreeCtrl) !== 'off' && layertreeCtrl.node.time && layertreeCtrl.node.time.mode !== 'disabled'">
+
+      <span
+        ngeo-popover-anchor
+        class="fa fa-clock-o"
+        ng-click="$event.preventDefault(); $event.stopPropagation()">
+      </span>
+
+      <div ngeo-popover-content>
+        <ngeo-date-picker
+          ng-if="::layertreeCtrl.node.time.widget === 'datepicker'"
+          time="layertreeCtrl.node.time"
+          on-date-selected="gmfLayertreeCtrl.updateWMSTimeLayerState(layertreeCtrl, time)">
+        </ngeo-date-picker>
+
+        <gmf-time-slider
+          ng-if="::layertreeCtrl.node.time.widget === 'slider'"
+          gmf-time-slider-time="layertreeCtrl.node.time"
+          gmf-time-slider-on-date-selected="gmfLayertreeCtrl.updateWMSTimeLayerState(layertreeCtrl, time)">
+        </gmf-time-slider>
+      </div>
     </span>
+
     <span
       class="fa fa-pencil"
       title="{{'Currently editing this layer'|translate}}"
       ng-if="layertreeCtrl.node.editing">
     </span>
   </a>
+
   <span class="right-buttons">
-    <a href="" ng-if="::layertreeCtrl.depth == 1" ng-click="gmfLayertreeCtrl.removeNode(layertreeCtrl.node)">
+    <a
+      href=""
+      ng-if="::layertreeCtrl.depth == 1"
+      ng-click="gmfLayertreeCtrl.removeNode(layertreeCtrl.node)">
       <span class="fa fa-trash"></span>
     </a>
-    <span ngeo-popover ng-if="::(layertreeCtrl.depth === 1 && !layertreeCtrl.node.mixed) || (layertreeCtrl.depth > 1 && layertreeCtrl.parent.node.mixed && !layertreeCtrl.node.children) || (gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend)" ngeo-popover-dismiss=".content">
-      <span ngeo-popover-anchor class="extra-actions fa fa-cog"></span>
+
+    <span
+      ngeo-popover
+      ng-if="::(layertreeCtrl.depth === 1 && !layertreeCtrl.node.mixed) || (layertreeCtrl.depth > 1 && layertreeCtrl.parent.node.mixed && !layertreeCtrl.node.children) || (gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend)" ngeo-popover-dismiss=".content">
+
+      <span
+        ngeo-popover-anchor
+        class="extra-actions fa fa-cog">
+      </span>
+
       <div ngeo-popover-content>
         <ul>
           <li ng-if="::(layertreeCtrl.depth === 1 && !layertreeCtrl.node.mixed) || (layertreeCtrl.depth > 1 && layertreeCtrl.parent.node.mixed)">
             <i class="fa fa-tint fa-fw"></i>
             <span for="layer-opactity">{{'Opacity'|translate}}</span>
-            <input class="input-action" name="layer-opactity" type="range" min="0" max="1" step="0.01" ng-model="layertreeCtrl.layer.opacity">
+            <input
+              class="input-action"
+              name="layer-opactity"
+              type="range"
+              min="0"
+              max="1"
+              step="0.01"
+              ng-model="layertreeCtrl.layer.opacity" />
           </li>
           <li ng-if="::gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend">
             <i class="fa fa-th-list fa-fw"></i>
-            <a title="{{'Show/hide legend'|translate}}" ng-click="::gmfLayertreeCtrl.toggleNodeLegend('#node-' + layertreeCtrl.uid + '-legend'); popoverCtrl.dismissPopover()" data-toggle="collapse" href="">{{'Show/hide legend'|translate}}</a>
+            <a
+              title="{{'Show/hide legend'|translate}}"
+              ng-click="::gmfLayertreeCtrl.toggleNodeLegend('#node-' + layertreeCtrl.uid + '-legend'); popoverCtrl.dismissPopover()"
+              data-toggle="collapse"
+              href="">
+              {{'Show/hide legend'|translate}}
+            </a>
           </li>
         </ul>
       </div>
     </span>
-    <span class="metadata" ng-if="::layertreeCtrl.node.metadata.metadataUrl">
+
+    <span
+      class="metadata"
+      ng-if="::layertreeCtrl.node.metadata.metadataUrl">
+
       <span ng-if="::gmfLayertreeCtrl.openLinksInNewWindow === true">
-        <a title="{{'More informations'|translate}}" href="{{::layertreeCtrl.node.metadata.metadataUrl}}" target="blank_"></a>
+        <a
+          title="{{'More informations'|translate}}"
+          href="{{::layertreeCtrl.node.metadata.metadataUrl}}"
+          target="blank_">
+        </a>
       </span>
+
       <span ng-if="::gmfLayertreeCtrl.openLinksInNewWindow !== true">
-        <a title="{{'More informations'|translate}}" href="" ng-click="gmfLayertreeCtrl.displayMetadata(layertreeCtrl)"></a>
+        <a
+          title="{{'More informations'|translate}}"
+          href="" ng-click="gmfLayertreeCtrl.displayMetadata(layertreeCtrl)">
+        </a>
       </span>
     </span>
-    <a class="fa fa-align-left legend-button"
-       ng-if="::gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend"
-       title="{{'Show/hide legend'|translate}}"
-       data-toggle="collapse"
-       href="#node-{{::layertreeCtrl.uid}}-legend"></a>
+
+    <a
+      class="fa fa-align-left legend-button"
+      ng-if="::gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend"
+      title="{{'Show/hide legend'|translate}}"
+      data-toggle="collapse"
+      href="#node-{{::layertreeCtrl.uid}}-legend">
+    </a>
   </span>
 </div>
-<div ng-if="::!layertreeCtrl.isRoot && gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend" id="node-{{::layertreeCtrl.uid}}-legend" class="collapse legend" ng-class="::[layertreeCtrl.node.metadata.isLegendExpanded ? 'in' : '']">
-  <a title="{{'Hide legend'|translate}}" data-toggle="collapse" ng-click="::gmfLayertreeCtrl.toggleNodeLegend('#node-' + layertreeCtrl.uid + '-legend')" href="">{{'Hide legend'|translate}}</a>
+
+<div
+  ng-if="::!layertreeCtrl.isRoot && gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend" id="node-{{::layertreeCtrl.uid}}-legend"
+  class="collapse legend"
+  ng-class="::[layertreeCtrl.node.metadata.isLegendExpanded ? 'in' : '']">
+
+  <a
+    title="{{'Hide legend'|translate}}"
+    data-toggle="collapse"
+    ng-click="::gmfLayertreeCtrl.toggleNodeLegend('#node-' + layertreeCtrl.uid + '-legend')"
+    href="">
+    {{'Hide legend'|translate}}
+  </a>
+
   <img ng-src="{{gmfLayertreeCtrl.getLegendURL(layertreeCtrl)}}"></img>
 </div>
-<ul id="layer-group-{{::layertreeCtrl.uid}}"
-    ng-if="::layertreeCtrl.node.children"
-    ng-class="{collapse: !layertreeCtrl.isRoot, in : layertreeCtrl.node.metadata.isExpanded}"
-    ngeo-sortable="::layertreeCtrl.isRoot && gmfLayertreeCtrl.layers"
-    ngeo-sortable-options="{handleClassName: 'ngeo-sortable-handle', draggerClassName: 'dragger', currDragItemClassName : 'curr-drag-item'}">
-  <li class="gmf-layertree-node" ng-repeat="node in layertreeCtrl.node.children"
-      ng-class="'depth-' + layertreeCtrl.depth"
-      ngeo-layertree="node"
-      ngeo-layertree-notroot
-      ngeo-layertree-map="layertreeCtrl.map"
-      ngeo-layertree-nodelayerexpr="layertreeCtrl.nodelayerExpr"
-      ngeo-layertree-listenersexpr="layertreeCtrl.listenersExpr">
+
+<ul
+  id="layer-group-{{::layertreeCtrl.uid}}"
+  ng-if="::layertreeCtrl.node.children"
+  ng-class="{collapse: !layertreeCtrl.isRoot, in : layertreeCtrl.node.metadata.isExpanded}"
+  ngeo-sortable="::layertreeCtrl.isRoot && gmfLayertreeCtrl.layers"
+  ngeo-sortable-options="{handleClassName: 'ngeo-sortable-handle', draggerClassName: 'dragger', currDragItemClassName : 'curr-drag-item'}">
+
+  <li
+    class="gmf-layertree-node"
+    ng-repeat="node in layertreeCtrl.node.children"
+    ng-class="'depth-' + layertreeCtrl.depth"
+    ngeo-layertree="node"
+    ngeo-layertree-notroot
+    ngeo-layertree-map="layertreeCtrl.map"
+    ngeo-layertree-nodelayerexpr="layertreeCtrl.nodelayerExpr"
+    ngeo-layertree-listenersexpr="layertreeCtrl.listenersExpr">
   </li>
 </ul>

--- a/src/directives/partials/layertree.html
+++ b/src/directives/partials/layertree.html
@@ -1,12 +1,16 @@
 <span ng-if="::!layertreeCtrl.isRoot">{{::layertreeCtrl.node.name}}</span>
-<input type="checkbox" ng-if="::layertreeCtrl.node && !layertreeCtrl.node.children"
-    ng-model="layertreeCtrl.getSetActive" ng-model-options="{getterSetter: true}"/>
+<input
+  type="checkbox"
+  ng-if="::layertreeCtrl.node && !layertreeCtrl.node.children"
+  ng-model="layertreeCtrl.getSetActive"
+  ng-model-options="{getterSetter: true}"/>
 <ul ng-if="::layertreeCtrl.node.children">
-  <li ng-repeat="node in ::layertreeCtrl.node.children"
-      ngeo-layertree="::node"
-      ngeo-layertree-notroot
-      ngeo-layertree-map="layertreeCtrl.map"
-      ngeo-layertree-nodelayerexpr="layertreeCtrl.nodelayerExpr"
-      ngeo-layertree-listenersexpr="layertreeCtrl.listenersExpr">
+  <li
+    ng-repeat="node in ::layertreeCtrl.node.children"
+    ngeo-layertree="::node"
+    ngeo-layertree-notroot
+    ngeo-layertree-map="layertreeCtrl.map"
+    ngeo-layertree-nodelayerexpr="layertreeCtrl.nodelayerExpr"
+    ngeo-layertree-listenersexpr="layertreeCtrl.listenersExpr">
   </li>
 </ul>


### PR DESCRIPTION
This PR makes the layer tree html templates easier to read by breaking very long lines into one per attribute within a node, if there's more than one.  Some space are also added above child nodes if the parent node has many children, again to improve readability.

Having more lines makes the files heavier, but that shouldn't matter since the templates get compiled in the end, on production.