### PR TITLE
#1680 - Fix CSS in gmf layertree

### DIFF
--- a/contribs/gmf/examples/displayquerygrid.html
+++ b/contribs/gmf/examples/displayquerygrid.html
@@ -87,63 +87,63 @@
       ul {
         list-style-type: none;
       }
-      .treenode a{
+      gmf-layertree a{
         color: black;
         text-decoration: none;
         padding-right: 5px;
       }
-      .treenode .metadata a:before {
+      gmf-layertree .gmf-layertree-metadata a:before {
         font-family: FontAwesome;
         content: "\f129";
       }
-      .treenode .layerIcon {
+      gmf-layertree .gmf-layertree-layer-icon {
         display: inline-flex;
         width: 20px;
         height: 10px;
       }
-      .treenode .zoom {
+      gmf-layertree .gmf-layertree-zoom {
         display: none;
       }
-      .treenode .zoom:hover {
+      gmf-layertree .gmf-layertree-zoom:hover {
         cursor: pointer;
       }
-      .treenode .zoom:before {
+      gmf-layertree .gmf-layertree-zoom:before {
         font-family: FontAwesome;
         content: "\f18e";
       }
-      .treenode .outOfResolution .legend {
+      gmf-layertree .outOfResolution .gmf-layertree-legend {
         display: none;
       }
-      .treenode .legendButton a:after {
+      gmf-layertree .gmf-layertree-legend-button a:after {
         font-family: FontAwesome;
         content: "\f036";
       }
-      .treenode .legend img {
+      gmf-layertree .gmf-layertree-legend img {
         padding-left: 15px;
       }
-      .treenode .noSource {
+      gmf-layertree .noSource {
         opacity: 0.3;
       }
-      .treenode .noSource:after {
+      gmf-layertree .noSource:after {
         content: "(source not available)";
       }
-      .treenode .outOfResolution {
+      gmf-layertree .outOfResolution {
         opacity: 0.6;
       }
-      .treenode .outOfResolution .zoom {
+      gmf-layertree .outOfResolution .gmf-layertree-zoom {
         display: inline;
       }
-      .treenode .state {
+      gmf-layertree .gmf-layertree-state {
         font-family: FontAwesome;
         font-weight: lighter;
       }
-      .treenode .on .state:before {
+      gmf-layertree .on .gmf-layertree-state:before {
         content: "\f14a";
       }
-      .treenode .off .state:before {
+      gmf-layertree .off .gmf-layertree-state:before {
         content: "\f096";
       }
-      .treenode .indeterminate .state:before {
+      gmf-layertree .indeterminate .gmf-layertree-state:before {
         content: "\f147";
       }
       [ngeo-popup] {

--- a/contribs/gmf/examples/displayquerywindow.html
+++ b/contribs/gmf/examples/displayquerywindow.html
@@ -172,63 +172,63 @@
       ul {
         list-style-type: none;
       }
-      .treenode a{
+      gmf-layertree a{
         color: black;
         text-decoration: none;
         padding-right: 5px;
       }
-      .treenode .metadata a:before {
+      gmf-layertree .gmf-layertree-metadata a:before {
         font-family: FontAwesome;
         content: "\f129";
       }
-      .treenode .layerIcon {
+      gmf-layertree .gmf-layertree-layer-icon {
         display: inline-flex;
         width: 20px;
         height: 10px;
       }
-      .treenode .zoom {
+      gmf-layertree .gmf-layertree-zoom {
         display: none;
       }
-      .treenode .zoom:hover {
+      gmf-layertree .gmf-layertree-zoom:hover {
         cursor: pointer;
       }
-      .treenode .zoom:before {
+      gmf-layertree .gmf-layertree-zoom:before {
         font-family: FontAwesome;
         content: "\f18e";
       }
-      .treenode .outOfResolution .legend {
+      gmf-layertree .outOfResolution .gmf-layertree-legend {
         display: none;
       }
-      .treenode .legendButton a:after {
+      gmf-layertree .gmf-layertree-legend-button a:after {
         font-family: FontAwesome;
         content: "\f036";
       }
-      .treenode .legend img {
+      gmf-layertree .gmf-layertree-legend img {
         padding-left: 15px;
       }
-      .treenode .noSource {
+      gmf-layertree .noSource {
         opacity: 0.3;
       }
-      .treenode .noSource:after {
+      gmf-layertree .noSource:after {
         content: "(source not available)";
       }
-      .treenode .outOfResolution {
+      gmf-layertree .outOfResolution {
         opacity: 0.6;
       }
-      .treenode .outOfResolution .zoom {
+      gmf-layertree .outOfResolution .gmf-layertree-zoom {
         display: inline;
       }
-      .treenode .state {
+      gmf-layertree .gmf-layertree-state {
         font-family: FontAwesome;
         font-weight: lighter;
       }
-      .treenode .on .state:before {
+      gmf-layertree .on .gmf-layertree-state:before {
         content: "\f14a";
       }
-      .treenode .off .state:before {
+      gmf-layertree .off .gmf-layertree-state:before {
         content: "\f096";
       }
-      .treenode .indeterminate .state:before {
+      gmf-layertree .indeterminate .gmf-layertree-state:before {
         content: "\f147";
       }
       [ngeo-popup] {

--- a/contribs/gmf/examples/layertree.html
+++ b/contribs/gmf/examples/layertree.html
@@ -18,63 +18,63 @@
       ul {
         list-style-type: none;
       }
-      .treenode a{
+      gmf-layertree a{
         color: black;
         text-decoration: none;
         padding-right: 5px;
       }
-      .treenode .metadata a:before {
+      gmf-layertree .gmf-layertree-metadata a:before {
         font-family: FontAwesome;
         content: "\f129";
       }
-      .treenode .layerIcon {
+      gmf-layertree .gmf-layertree-layer-icon {
         display: inline-flex;
         width: 20px;
         height: 10px;
       }
-      .treenode .zoom {
+      gmf-layertree .gmf-layertree-zoom {
         display: none;
       }
-      .treenode .zoom:hover {
+      gmf-layertree .gmf-layertree-zoom:hover {
         cursor: pointer;
       }
-      .treenode .zoom:before {
+      gmf-layertree .gmf-layertree-zoom:before {
         font-family: FontAwesome;
         content: "\f18e";
       }
-      .treenode .outOfResolution .legend {
+      gmf-layertree .outOfResolution .gmf-layertree-legend {
         display: none;
       }
-      .treenode .legendButton a:after {
+      gmf-layertree .gmf-layertree-legend-button a:after {
         font-family: FontAwesome;
         content: "\f036";
       }
-      .treenode .legend img {
+      gmf-layertree .gmf-layertree-legend img {
         padding-left: 15px;
       }
-      .treenode .noSource {
+      gmf-layertree .noSource {
         opacity: 0.3;
       }
-      .treenode .noSource:after {
+      gmf-layertree .noSource:after {
         content: "(source not available)";
       }
-      .treenode .outOfResolution {
+      gmf-layertree .outOfResolution {
         opacity: 0.6;
       }
-      .treenode .outOfResolution .zoom {
+      gmf-layertree .outOfResolution .gmf-layertree-zoom {
         display: inline;
       }
-      .treenode .state {
+      gmf-layertree .gmf-layertree-state {
         font-family: FontAwesome;
         font-weight: lighter;
       }
-      .treenode .on .state:before {
+      gmf-layertree .on .gmf-layertree-state:before {
         content: "\f14a";
       }
-      .treenode .off .state:before {
+      gmf-layertree .off .gmf-layertree-state:before {
         content: "\f096";
       }
-      .treenode .indeterminate .state:before {
+      gmf-layertree .indeterminate .gmf-layertree-state:before {
         content: "\f147";
       }
       [ngeo-popup] {
@@ -125,13 +125,13 @@
       #desc, #selections {
         margin-bottom: 20px;
       }
-      .treenode a.expand-node.fa {
+      gmf-layertree a.gmf-layertree-expand-node.fa {
         display: inline-block;
       }
-      .treenode a.expand-node.fa::before {
+      gmf-layertree a.gmf-layertree-expand-node.fa::before {
           content: "\f054";
       }
-      .treenode a.expand-node.fa[aria-expanded="true"]::before {
+      gmf-layertree a.gmf-layertree-expand-node.fa[aria-expanded="true"]::before {
           content: "\f078";
       }
 

--- a/contribs/gmf/examples/print.html
+++ b/contribs/gmf/examples/print.html
@@ -88,63 +88,63 @@
       ul {
         list-style-type: none;
       }
-      .treenode a{
+      gmf-layertree a{
         color: black;
         text-decoration: none;
         padding-right: 5px;
       }
-      .treenode .metadata a:before {
+      gmf-layertree .gmf-layertree-metadata a:before {
         font-family: FontAwesome;
         content: "\f129";
       }
-      .treenode .layerIcon {
+      gmf-layertree .gmf-layertree-layer-icon {
         display: inline-flex;
         width: 20px;
         height: 10px;
       }
-      .treenode .zoom {
+      gmf-layertree .gmf-layertree-zoom {
         display: none;
       }
-      .treenode .zoom:hover {
+      gmf-layertree .gmf-layertree-zoom:hover {
         cursor: pointer;
       }
-      .treenode .zoom:before {
+      gmf-layertree .gmf-layertree-zoom:before {
         font-family: FontAwesome;
         content: "\f18e";
       }
-      .treenode .outOfResolution .legend {
+      gmf-layertree .outOfResolution .gmf-layertree-legend {
         display: none;
       }
-      .treenode .legendButton a:after {
+      gmf-layertree .gmf-layertree-legend-button a:after {
         font-family: FontAwesome;
         content: "\f036";
       }
-      .treenode .legend img {
+      gmf-layertree .gmf-layertree-legend img {
         padding-left: 15px;
       }
-      .treenode .noSource {
+      gmf-layertree .noSource {
         opacity: 0.3;
       }
-      .treenode .noSource:after {
+      gmf-layertree .noSource:after {
         content: "(source not available)";
       }
-      .treenode .outOfResolution {
+      gmf-layertree .outOfResolution {
         opacity: 0.6;
       }
-      .treenode .outOfResolution .zoom {
+      gmf-layertree .outOfResolution .gmf-layertree-zoom {
         display: inline;
       }
-      .treenode .state {
+      gmf-layertree .gmf-layertree-state {
         font-family: FontAwesome;
         font-weight: lighter;
       }
-      .treenode .on .state:before {
+      gmf-layertree .on .gmf-layertree-state:before {
         content: "\f14a";
       }
-      .treenode .off .state:before {
+      gmf-layertree .off .gmf-layertree-state:before {
         content: "\f096";
       }
-      .treenode .indeterminate .state:before {
+      gmf-layertree .indeterminate .gmf-layertree-state:before {
         content: "\f147";
       }
 

--- a/contribs/gmf/less/desktoplayertree.less
+++ b/contribs/gmf/less/desktoplayertree.less
@@ -20,12 +20,12 @@ gmf-layertree {
 
 .gmf-layertree-node {
 
-  .right-buttons {
+  .gmf-layertree-right-buttons {
     display: none;
     cursor: pointer;
   }
 
-  &.depth-1 {
+  &.gmf-layertree-depth-1 {
     //styling first level node for desktop app
     background-color: @nav-bg;
     box-shadow: 0 0 4px 1px @input-border-focus;
@@ -45,7 +45,7 @@ gmf-layertree {
     }
   }
 
-  &.dragger {
+  &.gmf-layertree-dragger {
     * {
       cursor: url(../cursors/grabbing.cur), default;
       cursor: -webkit-grabbing;
@@ -55,7 +55,7 @@ gmf-layertree {
       display: none;
     }
   }
-  &.curr-drag-item {
+  &.gmf-layertree-curr-drag-item {
     * {
       visibility: hidden;
     }
@@ -66,39 +66,39 @@ gmf-layertree {
     }
   }
 
-  .group.depth-1 {
+  .gmf-layertree-group.gmf-layertree-depth-1 {
     background-color: @main-bg-color;
     padding: @half-app-margin;
   }
 
-  .group:hover,
-  .leaf:hover {
-    .right-buttons {
+  .gmf-layertree-group:hover,
+  .gmf-layertree-leaf:hover {
+    .gmf-layertree-right-buttons {
       display: block;
     }
   }
 
-  .leaf {
+  .gmf-layertree-leaf {
     padding-right: @half-app-margin;
   }
 
-  .legend:hover {
+  .gmf-layertree-legend:hover {
     a {
       cursor: pointer;
       display: inline-block;
     }
   }
 
-  .legend-button {
+  .gmf-layertree-legend-button {
     display: none;
   }
 
-  .name {
+  .gmf-layertree-name {
     white-space: nowrap;
   }
 
   // leave space for the drag handle
-  .depth-1 a.expand-node.fa {
+  .gmf-layertree-depth-1 a.gmf-layertree-expand-node.fa {
     margin-left: @half-app-margin;
   }
 

--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -6,7 +6,7 @@
    */
   margin-left: @app-margin; // left shifting (indentation)
 
-  &.depth-1 {
+  &.gmf-layertree-depth-1 {
     margin: 0 @micro-app-margin @app-margin @micro-app-margin;
   }
 
@@ -27,7 +27,7 @@
     padding-left: 0;
     text-decoration: none;
 
-    &.expand-node.fa {
+    &.gmf-layertree-expand-node.fa {
       color : @color-light;
       display: inline-block;
       &::before {
@@ -39,18 +39,18 @@
     }
   }
 
-  .state {
+  .gmf-layertree-state {
     font-family: gmf-icons;
     color: @color;
   }
 
   .off,
-  .off .legend img {
+  .off .gmf-layertree-legend img {
     opacity: 0.5;
   }
 
-  .leaf,
-  .group {
+  .gmf-layertree-leaf,
+  .gmf-layertree-group {
     position: relative;
     padding: @micro-app-margin;
     display: flex;
@@ -61,32 +61,32 @@
     }
   }
 
-  .leaf .state::after {
+  .gmf-layertree-leaf .gmf-layertree-state::after {
     content: "\e603";
   }
 
-  .group {
-    .state::after {
+  .gmf-layertree-group {
+    .gmf-layertree-state::after {
       content: "\e600";
     }
-    .layer-icon {
+    .gmf-layertree-layer-icon {
       display: none;
     }
 
-    &.depth-1 {
-      .name {
+    &.gmf-layertree-depth-1 {
+      .gmf-layertree-name {
         font-weight: bold;
         color: black;
       }
     }
 
-    &.indeterminate .state::after {
+    &.indeterminate .gmf-layertree-state::after {
       content: "\e900";
     }
   }
 
-  .layer-icon {
-    &.no-layer-icon::after {
+  .gmf-layertree-layer-icon {
+    &.gmf-layertree-no-layer-icon::after {
       font-family: gmf-icons;
       content: "\e907";
       width: 100%;
@@ -108,7 +108,7 @@
     }
   }
 
-  .name {
+  .gmf-layertree-name {
     overflow: hidden;
     text-overflow: ellipsis;
     flex: 2;
@@ -116,7 +116,7 @@
     padding-right: @half-app-margin;
   }
 
-  .metadata {
+  .gmf-layertree-metadata {
     a {
       padding: 0;
       &::after {
@@ -127,7 +127,7 @@
     }
   }
 
-  .zoom {
+  .gmf-layertree-zoom {
     display: none;
     // leave space after text label
     padding-left: 4px;
@@ -137,23 +137,23 @@
   }
 
   .out-of-resolution {
-    .name {
+    .gmf-layertree-name {
       font-style: italic;
     }
-    .zoom {
+    .gmf-layertree-zoom {
       display: inline;
     }
-    .right-buttons {
-      .legend-button {
+    .gmf-layertree-right-buttons {
+      .gmf-layertree-legend-button {
         display: none;
       }
     }
-    &.leaf .state::after {
+    &.gmf-layertree-leaf .gmf-layertree-state::after {
       content: "\e604";
     }
   }
 
-  .legend {
+  .gmf-layertree-legend {
     margin: 0 @app-margin;
     position: relative;
     border: 1px solid @main-bg-color;

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -1,7 +1,7 @@
 <div
   ng-if="::!layertreeCtrl.isRoot"
-  id="node-{{::layertreeCtrl.uid}}"
-  ng-class="[layertreeCtrl.node.children ? 'group' : 'leaf', 'depth-' + layertreeCtrl.depth, gmfLayertreeCtrl.getResolutionStyle(layertreeCtrl.node), gmfLayertreeCtrl.getNodeState(layertreeCtrl)]">
+  id="gmf-layertree-node-{{::layertreeCtrl.uid}}"
+  ng-class="[layertreeCtrl.node.children ? 'gmf-layertree-group' : 'gmf-layertree-leaf', 'gmf-layertree-depth-' + layertreeCtrl.depth, gmfLayertreeCtrl.getResolutionStyle(layertreeCtrl.node), gmfLayertreeCtrl.getNodeState(layertreeCtrl)]">
 
   <div
     class="ngeo-sortable-handle"
@@ -12,16 +12,16 @@
   <a
     ng-if="::layertreeCtrl.node.children"
     data-toggle="collapse"
-    href="#layer-group-{{::layertreeCtrl.uid}}"
+    href="#gmf-layertree-layer-group-{{::layertreeCtrl.uid}}"
     aria-expanded="{{::layertreeCtrl.node.metadata.isExpanded}}"
-    class="fa expand-node fa-fw">
+    class="fa gmf-layertree-expand-node fa-fw">
   </a>
 
   <a
     href
     ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)"
-    ng-if="::!layertreeCtrl.node.children" ng-class="::{'no-layer-icon' : !gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl)}"
-    class="layer-icon">
+    ng-if="::!layertreeCtrl.node.children" ng-class="::{'gmf-layertree-no-layer-icon' : !gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl)}"
+    class="gmf-layertree-layer-icon">
 
     <img
       ng-if="::(legendIconUrl=gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl))"
@@ -32,19 +32,20 @@
   <a
     href
     ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)"
-    ng-if="::layertreeCtrl.node.children" ng-class="['fa fa-fw', layertreeCtrl.node.children && !layertreeCtrl.layer.loading ? 'state' : 'fa-refresh fa-spin']">
+    ng-if="::layertreeCtrl.node.children"
+    ng-class="['fa fa-fw', layertreeCtrl.node.children && !layertreeCtrl.layer.loading ? 'gmf-layertree-state' : 'fa-refresh fa-spin']">
   </a>
 
   <a
     href
     ng-click="::gmfLayertreeCtrl.toggleActive(layertreeCtrl)"
-    class="name"
+    class="gmf-layertree-name"
     title="{{layertreeCtrl.node.name | translate}}">
 
     {{layertreeCtrl.node.name | translate}}
 
     <i
-      class="gmf-icon gmf-icon-search-go zoom"
+      class="gmf-icon gmf-icon-search-go gmf-layertree-zoom"
       data-toggle="tooltip"
       data-title="{{'Not visible at current scale. Click to zoom.'|translate}}"
       ng-click="::gmfLayertreeCtrl.zoomToResolution(layertreeCtrl); $event.preventDefault(); $event.stopPropagation();"
@@ -84,7 +85,7 @@
     </span>
   </a>
 
-  <span class="right-buttons">
+  <span class="gmf-layertree-right-buttons">
     <a
       href=""
       ng-if="::layertreeCtrl.depth == 1"
@@ -119,7 +120,7 @@
             <i class="fa fa-th-list fa-fw"></i>
             <a
               title="{{'Show/hide legend'|translate}}"
-              ng-click="::gmfLayertreeCtrl.toggleNodeLegend('#node-' + layertreeCtrl.uid + '-legend'); popoverCtrl.dismissPopover()"
+              ng-click="::gmfLayertreeCtrl.toggleNodeLegend('#gmf-layertree-node-' + layertreeCtrl.uid + '-legend'); popoverCtrl.dismissPopover()"
               data-toggle="collapse"
               href="">
               {{'Show/hide legend'|translate}}
@@ -130,7 +131,7 @@
     </span>
 
     <span
-      class="metadata"
+      class="gmf-layertree-metadata"
       ng-if="::layertreeCtrl.node.metadata.metadataUrl">
 
       <span ng-if="::gmfLayertreeCtrl.openLinksInNewWindow === true">
@@ -150,24 +151,24 @@
     </span>
 
     <a
-      class="fa fa-align-left legend-button"
+      class="fa fa-align-left gmf-layertree-legend-button"
       ng-if="::gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend"
       title="{{'Show/hide legend'|translate}}"
       data-toggle="collapse"
-      href="#node-{{::layertreeCtrl.uid}}-legend">
+      href="#gmf-layertree-node-{{::layertreeCtrl.uid}}-legend">
     </a>
   </span>
 </div>
 
 <div
-  ng-if="::!layertreeCtrl.isRoot && gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend" id="node-{{::layertreeCtrl.uid}}-legend"
-  class="collapse legend"
+  ng-if="::!layertreeCtrl.isRoot && gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend" id="gmf-layertree-node-{{::layertreeCtrl.uid}}-legend"
+  class="collapse gmf-layertree-legend"
   ng-class="::[layertreeCtrl.node.metadata.isLegendExpanded ? 'in' : '']">
 
   <a
     title="{{'Hide legend'|translate}}"
     data-toggle="collapse"
-    ng-click="::gmfLayertreeCtrl.toggleNodeLegend('#node-' + layertreeCtrl.uid + '-legend')"
+    ng-click="::gmfLayertreeCtrl.toggleNodeLegend('#gmf-layertree-node-' + layertreeCtrl.uid + '-legend')"
     href="">
     {{'Hide legend'|translate}}
   </a>
@@ -176,16 +177,16 @@
 </div>
 
 <ul
-  id="layer-group-{{::layertreeCtrl.uid}}"
+  id="gmf-layertree-layer-group-{{::layertreeCtrl.uid}}"
   ng-if="::layertreeCtrl.node.children"
   ng-class="{collapse: !layertreeCtrl.isRoot, in : layertreeCtrl.node.metadata.isExpanded}"
   ngeo-sortable="::layertreeCtrl.isRoot && gmfLayertreeCtrl.layers"
-  ngeo-sortable-options="{handleClassName: 'ngeo-sortable-handle', draggerClassName: 'dragger', currDragItemClassName : 'curr-drag-item'}">
+  ngeo-sortable-options="{handleClassName: 'ngeo-sortable-handle', draggerClassName: 'gmf-layertree-dragger', currDragItemClassName : 'gmf-layertree-curr-drag-item'}">
 
   <li
     class="gmf-layertree-node"
     ng-repeat="node in layertreeCtrl.node.children"
-    ng-class="'depth-' + layertreeCtrl.depth"
+    ng-class="'gmf-layertree-depth-' + layertreeCtrl.depth"
     ngeo-layertree="node"
     ngeo-layertree-notroot
     ngeo-layertree-map="layertreeCtrl.map"


### PR DESCRIPTION
This PR fixes the CSS class names for the gmf layertree directive.  Changes are made in every examples and applications figuring it and the html template itself.  **Important**: no changes were made to the JavaScript, i.e. to the controller itself because the layer tree is currently being refactored, as told by @ger-benjamin.  The other modifications were fine.

See #1680.  Note that this is one among many PR that will come to fix #1680.

Here's the list of class names that were **not changed** due to the fact that they are defined in the controller (i.e. in the .js file):

* `on`
* `off`
* `out-of-resolution`
* `indeterminate`

Those are all related to the 'state' of a node, which is controlled in the controller.  These can be changed **after** the refactoring is completed.  See #1814.


## Todo

 * [ ] review

## Live examples

 * (example) https://adube.github.io/ngeo/1680-css-fix-layertree/examples/contribs/gmf/layertree.html
 * (desktop_alt app) https://adube.github.io/ngeo/1680-css-fix-layertree/examples/contribs/gmf/apps/desktop_alt/index.html
 * (desktop app) https://adube.github.io/ngeo/1680-css-fix-layertree/examples/contribs/gmf/apps/desktop/index.html