### PR TITLE
#1680 - Fix CSS class names in gmf displayquerygrid

### DIFF
--- a/contribs/gmf/examples/displayquerygrid.html
+++ b/contribs/gmf/examples/displayquerygrid.html
@@ -24,7 +24,7 @@
       }
 
       /* DisplayQueryGrid */
-      .displayquerygrid {
+      .gmf-displayquerygrid {
         padding: .5rem;
         border-top: solid 1px black;
         background-color: white;

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -517,7 +517,7 @@ gmf-featurestyle {
   }
 }
 
-.displayquerywindow {
+.gmf-displayquerywindow {
   position: absolute;
   right: @app-margin;
 }

--- a/contribs/gmf/less/displayquerygrid.less
+++ b/contribs/gmf/less/displayquerygrid.less
@@ -3,7 +3,7 @@
 @grid-height: 25rem;
 @table-height: @grid-height - @app-margin - 2 * @map-tools-size;
 
-.displayquerygrid {
+.gmf-displayquerygrid {
   padding: @half-app-margin;
   border-top: solid 1px black;
   background-color: white;
@@ -60,7 +60,7 @@
     padding: 2px;
   }
 
-  .message {
+  .gmf-displayquerygrid-message {
     width: 300px;
     text-align: center;
     font-style: italic;
@@ -69,7 +69,7 @@
     margin-top: @app-margin;
   }
 
-  .pending {
+  .gmf-displayquerygrid-pending {
     font-size: 3em;
     margin-left: 50%;
     margin-right: 50%;

--- a/contribs/gmf/src/directives/partials/displayquerygrid.html
+++ b/contribs/gmf/src/directives/partials/displayquerygrid.html
@@ -1,10 +1,27 @@
-<div class="displayquerygrid panel">
-  <div class="close" ng-click="ctrl.clear()">&times;</div>
+<div class="gmf-displayquerygrid panel">
+  <div
+    class="close"
+    ng-click="ctrl.clear()">
+    &times;
+  </div>
 
-  <ul class="nav nav-pills small" role="tablist">
-    <li ng-repeat="gridSource in ctrl.getGridSources() track by gridSource.source.id" role="presentation"
-        ng-class="{'active' : ctrl.isSelected(gridSource)}" ng-click="ctrl.selectTab(gridSource)">
-      <a href="#{{gridSource.source.id}}" data-target="#{{gridSource.source.id}}" aria-controls="{{gridSource.source.id}}" role="tab" data-toggle="tab">
+  <ul
+    class="nav nav-pills small"
+    role="tablist">
+
+    <li
+      ng-repeat="gridSource in ctrl.getGridSources() track by gridSource.source.id"
+      role="presentation"
+      ng-class="{'active' : ctrl.isSelected(gridSource)}"
+      ng-click="ctrl.selectTab(gridSource)">
+
+      <a
+        href="#{{gridSource.source.id}}"
+        data-target="#{{gridSource.source.id}}"
+        aria-controls="{{gridSource.source.id}}"
+        role="tab"
+        data-toggle="tab">
+
         <span ng-if="gridSource.source.tooManyResults !== true">
           {{gridSource.source.label | translate}} ({{gridSource.source.features.length}})
         </span>
@@ -16,12 +33,20 @@
   </ul>
 
   <div class="tab-content">
-    <div ng-repeat="gridSource in ctrl.getGridSources() track by gridSource.source.id" role="tabpanel" class="tab-pane"
-         ng-class="{'active' : ctrl.isSelected(gridSource)}" id="{{gridSource.source.id}}">
-      <ngeo-grid ngeo-grid-configuration="gridSource.configuration" ng-if="gridSource.source.tooManyResults !== true">
+    <div
+      ng-repeat="gridSource in ctrl.getGridSources() track by gridSource.source.id"
+      role="tabpanel"
+      class="tab-pane"
+      ng-class="{'active' : ctrl.isSelected(gridSource)}"
+      id="{{gridSource.source.id}}">
+
+      <ngeo-grid
+        ngeo-grid-configuration="gridSource.configuration"
+        ng-if="gridSource.source.tooManyResults !== true">
       </ngeo-grid>
+
       <div ng-if="gridSource.source.tooManyResults === true">
-        <div class="message alert alert-warning">
+        <div class="gmf-displayquerygrid-message alert alert-warning">
           <p><span translate>The results can not be displayed because the maximum number has been reached</span> ({{ctrl.maxResults}}).</p>
           <p translate>Please refine your query.</p>
         </div>
@@ -29,38 +54,78 @@
     </div>
   </div>
 
-  <div class="navbar" ng-show="!ctrl.pending && ctrl.getActiveGridSource() && ctrl.getActiveGridSource().configuration !== null">
+  <div
+    class="navbar"
+    ng-show="!ctrl.pending && ctrl.getActiveGridSource() && ctrl.getActiveGridSource().configuration !== null">
+
     <ul class="nav navbar-nav navbar-right">
-      <li class="small ng-hide" ng-show="ctrl.isOneSelected()">
+
+      <li
+        class="small ng-hide"
+        ng-show="ctrl.isOneSelected()">
         <p class="navbar-text ng-binding">
           {{ctrl.getSelectedRowCount()}} <span translate>selected element(s)</span>
         </p>
       </li>
-      <li ng-show="ctrl.isOneSelected()" class="ng-hide">
-        <button class="btn btn-link btn-xs" title="{{'Zoom to selection' | translate}}" ng-click="ctrl.zoomToSelection()">
+
+      <li
+        ng-show="ctrl.isOneSelected()"
+        class="ng-hide">
+        <button
+          class="btn btn-link btn-xs"
+          title="{{'Zoom to selection' | translate}}"
+          ng-click="ctrl.zoomToSelection()">
           <i class="fa fa-search-plus"></i> <span translate>Zoom to</span>
         </button>
       </li>
-      <li ng-show="ctrl.isOneSelected()" class="ng-hide">
-        <button class="btn btn-link btn-xs" title="{{'Export selection as CSV' | translate}}" ng-click="ctrl.downloadCsv()">
+
+      <li
+        ng-show="ctrl.isOneSelected()"
+        class="ng-hide">
+        <button
+          class="btn btn-link btn-xs"
+          title="{{'Export selection as CSV' | translate}}"
+          ng-click="ctrl.downloadCsv()">
           <i class="fa fa-download"></i> <span translate>Export as CSV</span>
         </button>
       </li>
+
       <li class="dropdown navbar-link dropup">
-        <button type="button" class="dropup btn btn-default btn-xs" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <button
+          type="button"
+          class="dropup btn btn-default btn-xs"
+          data-toggle="dropdown"
+          aria-haspopup="true"
+          aria-expanded="false">
           <span translate>Select</span>
           <span class="caret"></span>
         </button>
-        <ul class="dropdown-menu" aria-labelledby="dLabel">
-          <li><a href="" ng-click="ctrl.selectAll()" translate>All</a></li>
-          <li><a href="" ng-click="ctrl.unselectAll()" translate>None</a></li>
-          <li><a href="" ng-click="ctrl.invertSelection()" translate>Reverse selection</a></li>
+        <ul
+          class="dropdown-menu"
+          aria-labelledby="dLabel">
+          <li>
+            <a
+              href=""
+              ng-click="ctrl.selectAll()" translate>All</a>
+          </li>
+          <li>
+            <a
+              href=""
+              ng-click="ctrl.unselectAll()" translate>None</a>
+          </li>
+          <li>
+            <a
+              href=""
+              ng-click="ctrl.invertSelection()" translate>Reverse selection</a>
+          </li>
         </ul>
       </li>
     </ul>
   </div>
 
-  <div ng-show="ctrl.pending" class="pending">
-      <span class="fa fa-spinner fa-spin"></span>
+  <div
+    ng-show="ctrl.pending"
+    class="gmf-displayquerygrid-pending">
+    <span class="fa fa-spinner fa-spin"></span>
   </div>
 </div>


### PR DESCRIPTION
This PR fixes the CSS class name for the gmf displayquerygrid directive.  Changes are made in the example, desktop application and template.  See #1680.  Note that this is one among many PR that will come to fix #1680.

I also made trivial changes to the template to make it more easilly readable.

## Todo

 * [ ] review

## Live examples

 * (example) https://adube.github.io/ngeo/1680-css-fix-displayquerygrid/examples/contribs/gmf/displayquerygrid.html
 * (desktop_alt app) https://adube.github.io/ngeo/1680-css-fix-displayquerygrid/examples/contribs/gmf/apps/desktop_alt/index.html