### PR TITLE
#1680 - Fix CSS class names in apps <body>

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -6,7 +6,7 @@
     <link rel="shortcut icon" href="image/favicon.ico"/>
     <link rel="stylesheet" href="../../build/desktop.css">
   </head>
-  <body ng-class="{'profile-chart-active': !!profileChartActive}">
+  <body ng-class="{'gmf-profile-chart-active': !!profileChartActive}">
     <header>
       <div>
         <img src="image/logo.png" />

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -6,7 +6,7 @@
     <link rel="shortcut icon" href="image/favicon.ico"/>
     <link rel="stylesheet" href="../../build/desktop_alt.css">
   </head>
-  <body ng-class="{'profile-chart-active': !!profileChartActive, 'query-grid-active': !!queryGridActive}">
+  <body ng-class="{'gmf-profile-chart-active': !!profileChartActive, 'gmf-query-grid-active': !!queryGridActive}">
     <header>
       <div>
         <img src="image/logo.png" />

--- a/contribs/gmf/less/displayquerygrid.less
+++ b/contribs/gmf/less/displayquerygrid.less
@@ -76,6 +76,6 @@
   }
 }
 
-.query-grid-active main {
+.gmf-query-grid-active main {
   height: calc(~'100%' - @grid-height);
 }

--- a/contribs/gmf/less/profile.less
+++ b/contribs/gmf/less/profile.less
@@ -35,6 +35,6 @@
   }
 }
 
-.profile-chart-active main {
+.gmf-profile-chart-active main {
   height: calc(~'100%' - @profile-height);
 }


### PR DESCRIPTION
This PR fixes the CSS class name used in the `<body>` element of the desktop applications.  See #1680.  Note that this is one among many PR that will come to fix #1680.

## Todo

 * [ ] review

## Live examples

No live updated required.