### PR TITLE
#1680 - Fix CSS class names in gmf displayquerywindow

### DIFF
--- a/contribs/gmf/examples/displayquerywindow.html
+++ b/contribs/gmf/examples/displayquerywindow.html
@@ -24,7 +24,7 @@
       }
 
       /* Display queries */
-      .displayquerywindow {
+      .gmf-displayquerywindow {
         max-height: 400px;
         width: 350px;
         max-width: 350px;
@@ -34,7 +34,16 @@
         left: 50%;
         right: 50%;
       }
-      .displayquerywindow .collapse-button {
+      .gmf-displayquerywindow button {
+        background: none;
+        border: none;
+        font-family: FontAwesome;
+        width: 32px;
+      }
+      .gmf-displayquerywindow button.close {
+        padding: 5px 5px 0 0;
+      }
+      .gmf-displayquerywindow .gmf-displayquerywindow-collapse-button {
         background-color: white;
         border: solid 1px black;
         border-bottom-width: 0;
@@ -44,27 +53,27 @@
         width: 48px;
         margin-left: calc(50% - 24px);
       }
-      .displayquerywindow .collapse-button.up:after {
+      .gmf-displayquerywindow-collapse-button-up:after {
         content: "\f077";
       }
-      .displayquerywindow .collapse-button.down:after {
+      .gmf-displayquerywindow-collapse-button-down:after {
         content: "\f078";
       }
-      .displayquerywindow .displayquerywindow-container {
+      .gmf-displayquerywindow-container {
         background-color: white;
         border: solid 1px black;
       }
-      .displayquerywindow .animation-container {
+      .gmf-displayquerywindow-animation-container {
         position: relative;
         overflow: hidden;
         height: 60px;
         margin: 0 15px;
         transition: 0.3s ease-in all;
       }
-      .displayquerywindow .animation-container.detailed {
+      .gmf-displayquerywindow-animation-container-detailed {
         height: 160px;
       }
-      .displayquerywindow .animation-container .slide-animation {
+      .gmf-displayquerywindow-animation-container .gmf-displayquerywindow-slide-animation {
         height: 100%;
         padding: 5px 5px 0;
         text-align: left;
@@ -75,91 +84,79 @@
         left: 0;
         right: 0;
       }
-      .displayquerywindow .slide-animation.ng-enter, .slide-animation.ng-leave {
+      .gmf-displayquerywindow-slide-animation.ng-enter, .gmf-displayquerywindow-slide-animation.ng-leave {
         transition: 0.3s ease-in all;
       }
       /* Left to right animation */
-      .displayquerywindow .next .slide-animation.ng-enter {
+      .gmf-displayquerywindow-next .gmf-displayquerywindow-slide-animation.ng-enter {
         left: 100%;
       }
-      .displayquerywindow .next .slide-animation.ng-enter-active {
+      .gmf-displayquerywindow-next .gmf-displayquerywindow-slide-animation.ng-enter-active {
         left: 0;
       }
-      .displayquerywindow .next .slide-animation.ng-leave {
+      .gmf-displayquerywindow-next .gmf-displayquerywindow-slide-animation.ng-leave {
         left: 0;
       }
-      .displayquerywindow .next .slide-animation.ng-leave-active {
+      .gmf-displayquerywindow-next .gmf-displayquerywindow-slide-animation.ng-leave-active {
         left: -100%;
       }
       /* Right to left animation */
-      .displayquerywindow .previous .slide-animation.ng-enter {
+      .gmf-displayquerywindow-previous .gmf-displayquerywindow-slide-animation.ng-enter {
         left: -100%;
       }
-      .displayquerywindow .previous .slide-animation.ng-enter-active {
+      .gmf-displayquerywindow-previous .gmf-displayquerywindow-slide-animation.ng-enter-active {
         left: 0;
       }
-      .displayquerywindow .previous .slide-animation.ng-leave {
+      .gmf-displayquerywindow-previous .gmf-displayquerywindow-slide-animation.ng-leave {
         left: 0;
       }
-      .displayquerywindow .previous .slide-animation.ng-leave-active {
+      .gmf-displayquerywindow-previous .gmf-displayquerywindow-slide-animation.ng-leave-active {
         left: 100%;
       }
-      .displayquerywindow .header .title {
+      .gmf-displayquerywindow-title {
         font-weight: bold;
       }
-      .displayquerywindow .header .subtitle {
+      .gmf-displayquerywindow-subtitle {
         margin-left: 10px;
         height: 2ex;
       }
-      .displayquerywindow .details {
+      .gmf-displayquerywindow-details {
         height: 65%;
         overflow-x: hidden;
         overflow-y: auto;
         margin-left: 10px;
         padding-bottom: 10px
       }
-      .displayquerywindow .details table {
+      .gmf-displayquerywindow-details table {
         font-size: 0.9em;
       }
-      .displayquerywindow .details .key {
+      .gmf-displayquerywindow-details-key {
         padding-right: 25px;
       }
-      .displayquerywindow .slide-animation.ng-enter-active .details .value {
+      .gmf-displayquerywindow-slide-animation.ng-enter-active .gmf-displayquerywindow-details-value {
         white-space: nowrap;
       }
-      .displayquerywindow .navigate {
+      .gmf-displayquerywindow-navigate {
         border-top: solid 1px black;
         text-align: center;
         margin-top: 10px;
         padding-top: 5px;
         height: 32px;
       }
-      .displayquerywindow button {
-        background: none;
-        border: none;
-        font-family: FontAwesome;
-        width: 32px;
-      }
-      .displayquerywindow button.close {
-        padding: 5px 5px 0 0;
-      }
-      .displayquerywindow button.close:after {
-        content: "\f00d";
-      }
-      .displayquerywindow .navigate .previous {
+      .gmf-displayquerywindow-navigate .gmf-displayquerywindow-previous {
         float: left;
       }
-      .displayquerywindow .navigate .previous:after {
+      .gmf-displayquerywindow-navigate .gmf-displayquerywindow-previous:after {
         content: "\f053";
       }
-      .displayquerywindow .navigate .next {
+      .gmf-displayquerywindow-navigate .gmf-displayquerywindow-next {
         float: right;
       }
-      .displayquerywindow .navigate .next:after {
+      .gmf-displayquerywindow-navigate .gmf-displayquerywindow-next:after {
         content: "\f054";
       }
       @media (max-width: 768px) {
-        .displayquerywindow {
+        .gmf-displayquerywindow {
           width: 100%;
           max-width: 100%;
           margin-left: -50%;

--- a/contribs/gmf/examples/wfs-permalink.html
+++ b/contribs/gmf/examples/wfs-permalink.html
@@ -17,7 +17,7 @@
       }
 
       /* Display queries */
-      .displayquerywindow {
+      .gmf-displayquerywindow {
         max-height: 400px;
         width: 350px;
         max-width: 350px;
@@ -26,7 +26,16 @@
         top: 20px;
         right: 0px;
       }
-      .displayquerywindow .collapse-button {
+      .gmf-displayquerywindow button {
+        background: none;
+        border: none;
+        font-family: FontAwesome;
+        width: 32px;
+      }
+      .gmf-displayquerywindow button.close {
+        padding: 5px 5px 0 0;
+      }
+      .gmf-displayquerywindow .gmf-displayquerywindow-collapse-button {
         background-color: white;
         border: solid 1px black;
         border-bottom-width: 0;
@@ -36,27 +45,27 @@
         width: 48px;
         margin-left: calc(50% - 24px);
       }
-      .displayquerywindow .collapse-button.up:after {
+      .gmf-displayquerywindow-collapse-button-up:after {
         content: "\f077";
       }
-      .displayquerywindow .collapse-button.down:after {
+      .gmf-displayquerywindow-collapse-button-down:after {
         content: "\f078";
       }
-      .displayquerywindow .displayquerywindow-container {
+      .gmf-displayquerywindow-container {
         background-color: white;
         border: solid 1px black;
       }
-      .displayquerywindow .animation-container {
+      .gmf-displayquerywindow-animation-container {
         position: relative;
         overflow: hidden;
         height: 60px;
         margin: 0 15px;
         transition: 0.3s ease-in all;
       }
-      .displayquerywindow .animation-container.detailed {
+      .gmf-displayquerywindow-animation-container-detailed {
         height: 160px;
       }
-      .displayquerywindow .animation-container .slide-animation {
+      .gmf-displayquerywindow-animation-container .gmf-displayquerywindow-slide-animation {
         height: 100%;
         padding: 5px 5px 0;
         text-align: left;
@@ -67,91 +76,79 @@
         left: 0;
         right: 0;
       }
-      .displayquerywindow .slide-animation.ng-enter, .slide-animation.ng-leave {
+      .gmf-displayquerywindow-slide-animation.ng-enter, .gmf-displayquerywindow-slide-animation.ng-leave {
         transition: 0.3s ease-in all;
       }
       /* Left to right animation */
-      .displayquerywindow .next .slide-animation.ng-enter {
+      .gmf-displayquerywindow-next .gmf-displayquerywindow-slide-animation.ng-enter {
         left: 100%;
       }
-      .displayquerywindow .next .slide-animation.ng-enter-active {
+      .gmf-displayquerywindow-next .gmf-displayquerywindow-slide-animation.ng-enter-active {
         left: 0;
       }
-      .displayquerywindow .next .slide-animation.ng-leave {
+      .gmf-displayquerywindow-next .gmf-displayquerywindow-slide-animation.ng-leave {
         left: 0;
       }
-      .displayquerywindow .next .slide-animation.ng-leave-active {
+      .gmf-displayquerywindow-next .gmf-displayquerywindow-slide-animation.ng-leave-active {
         left: -100%;
       }
       /* Right to left animation */
-      .displayquerywindow .previous .slide-animation.ng-enter {
+      .gmf-displayquerywindow-previous .gmf-displayquerywindow-slide-animation.ng-enter {
         left: -100%;
       }
-      .displayquerywindow .previous .slide-animation.ng-enter-active {
+      .gmf-displayquerywindow-previous .gmf-displayquerywindow-slide-animation.ng-enter-active {
         left: 0;
       }
-      .displayquerywindow .previous .slide-animation.ng-leave {
+      .gmf-displayquerywindow-previous .gmf-displayquerywindow-slide-animation.ng-leave {
         left: 0;
       }
-      .displayquerywindow .previous .slide-animation.ng-leave-active {
+      .gmf-displayquerywindow-previous .gmf-displayquerywindow-slide-animation.ng-leave-active {
         left: 100%;
       }
-      .displayquerywindow .header .title {
+      .gmf-displayquerywindow-title {
         font-weight: bold;
       }
-      .displayquerywindow .header .subtitle {
+      .gmf-displayquerywindow-subtitle {
         margin-left: 10px;
         height: 2ex;
       }
-      .displayquerywindow .details {
+      .gmf-displayquerywindow-details {
         height: 65%;
         overflow-x: hidden;
         overflow-y: auto;
         margin-left: 10px;
         padding-bottom: 10px
       }
-      .displayquerywindow .details table {
+      .gmf-displayquerywindow-details table {
         font-size: 0.9em;
       }
-      .displayquerywindow .details .key {
+      .gmf-displayquerywindow-details-key {
         padding-right: 25px;
       }
-      .displayquerywindow .slide-animation.ng-enter-active .details .value {
+      .gmf-displayquerywindow-slide-animation.ng-enter-active .gmf-displayquerywindow-details-value {
         white-space: nowrap;
       }
-      .displayquerywindow .navigate {
+      .gmf-displayquerywindow-navigate {
         border-top: solid 1px black;
         text-align: center;
         margin-top: 10px;
         padding-top: 5px;
         height: 32px;
       }
-      .displayquerywindow button {
-        background: none;
-        border: none;
-        font-family: FontAwesome;
-        width: 32px;
-      }
-      .displayquerywindow button.close {
-        padding: 5px 5px 0 0;
-      }
-      .displayquerywindow button.close:after {
-        content: "\f00d";
-      }
-      .displayquerywindow .navigate .previous {
+      .gmf-displayquerywindow-navigate .gmf-displayquerywindow-previous {
         float: left;
       }
-      .displayquerywindow .navigate .previous:after {
+      .gmf-displayquerywindow-navigate .gmf-displayquerywindow-previous:after {
         content: "\f053";
       }
-      .displayquerywindow .navigate .next {
+      .gmf-displayquerywindow-navigate .gmf-displayquerywindow-next {
         float: right;
       }
-      .displayquerywindow .navigate .next:after {
+      .gmf-displayquerywindow-navigate .gmf-displayquerywindow-next:after {
         content: "\f054";
       }
       @media (max-width: 768px) {
-        .displayquerywindow {
+        .gmf-displayquerywindow {
           width: 100%;
           max-width: 100%;
           margin-left: -50%;

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -517,7 +517,7 @@ gmf-featurestyle {
   }
 }
 
-.displayquerywindow {
+.gmf-displayquerywindow {
   position: absolute;
   right: @app-margin;
 }

--- a/contribs/gmf/less/displayquerywindow.less
+++ b/contribs/gmf/less/displayquerywindow.less
@@ -4,7 +4,7 @@
 @displayquerywindow-detailed-header-height: 5rem;
 @displayquerywindow-detailed-details-line-height: 2rem;
 @displayquerywindow-detailed-details-height: 8 * @displayquerywindow-detailed-details-line-height;
-.displayquerywindow {
+.gmf-displayquerywindow {
   width: @displayquerywindow-tablet-width;
   max-width: @displayquerywindow-tablet-width;
   margin-left: -@displayquerywindow-tablet-width / 2;
@@ -14,7 +14,7 @@
   max-height: 10 * @map-tools-size;
   position: fixed;
   z-index: @above-menus-index;
-  .collapse-button {
+  .gmf-displayquerywindow-collapse-button {
     background-color: @nav-bg;
     border: solid 1px @border-color;
     border-bottom-width: 0;
@@ -22,19 +22,19 @@
     line-height: 0.5;
     height: @map-tools-size;
     width: @map-tools-size + @map-tools-size * 2/3;
-    &.up::after {
-      content: @fa-var-chevron-up;
-    }
-    &.down::after {
-      content: @fa-var-chevron-down;
-    }
   }
-  .displayquerywindow-container {
+  .gmf-displayquerywindow-collapse-button-up::after {
+    content: @fa-var-chevron-up;
+  }
+  .gmf-displayquerywindow-collapse-button-down::after {
+    content: @fa-var-chevron-down;
+  }
+  .gmf-displayquerywindow-container {
     background-color: @nav-bg;
     border: solid 1px @border-color;
     position: relative;
   }
-  .animation-container {
+  .gmf-displayquerywindow-animation-container {
     position: relative;
     overflow: hidden;
     // height with 2em: 1em per text (title, subtitle)
@@ -42,10 +42,7 @@
     max-height: 10 * @map-tools-size;
     margin: 0;
     transition: 0.3s ease-in all;
-    &.detailed {
-      height: @displayquerywindow-detailed-header-height + @displayquerywindow-detailed-details-height + @app-margin * 3;
-    }
-    .slide-animation {
+    .gmf-displayquerywindow-slide-animation {
       height: 100%;
       padding: @app-margin @app-margin 0;
       text-align: left;
@@ -60,8 +57,11 @@
       }
     }
   }
-  .next {
-    .slide-animation {
+  .gmf-displayquerywindow-animation-container-detailed {
+    height: @displayquerywindow-detailed-header-height + @displayquerywindow-detailed-details-height + @app-margin * 3;
+  }
+  .gmf-displayquerywindow-next {
+    .gmf-displayquerywindow-slide-animation {
       &.ng-enter {
         left: 100%;
       }
@@ -73,8 +73,8 @@
       }
     }
   }
-  .previous {
-    .slide-animation {
+  .gmf-displayquerywindow-previous {
+    .gmf-displayquerywindow-slide-animation {
       &.ng-enter {
         left: -100%;
       }
@@ -86,21 +86,21 @@
       }
     }
   }
-  .header {
+  .gmf-displayquerywindow-header {
     height: @displayquerywindow-detailed-header-height;
     margin-bottom: @app-margin;
-    .title {
-      font-weight: bold;
-    }
-    .subtitle {
-      margin-left: @app-margin;
-      min-height: 1em;
-    }
     p {
       margin-bottom: @app-margin;
     }
   }
-  .details {
+  .gmf-displayquerywindow-title {
+    font-weight: bold;
+  }
+  .gmf-displayquerywindow-subtitle {
+    margin-left: @app-margin;
+    min-height: 1em;
+  }
+  .gmf-displayquerywindow-details {
     height: @displayquerywindow-detailed-details-height;
     line-height: @displayquerywindow-detailed-details-line-height;
     overflow-x: hidden;
@@ -109,7 +109,7 @@
     table {
       font-size: @font-size-base;
     }
-    .key {
+    .gmf-displayquerywindow-details-key {
       padding-right: @app-margin;
       /** prevent glitch for swipe animation **/
       min-width: @displayquerywindow-tablet-width * 0.3 - @app-margin;
@@ -117,45 +117,45 @@
       overflow-x: hidden;
       text-overflow: ellipsis;
     }
-    .value {
+    .gmf-displayquerywindow-details-value {
       white-space: pre-wrap;
       word-break: break-all;
       /** prevent glitch for swipe animation **/
       min-width: @displayquerywindow-tablet-width * 0.7 - @app-margin;
       max-width: @displayquerywindow-tablet-width * 0.7 - @app-margin;
     }
-    .slide-animation.ng-enter-active .details .value {
+    .gmf-displayquerywindow-slide-animation.ng-enter-active .gmf-displayquerywindow-details .gmf-displayquerywindow-details-value {
       white-space: nowrap;
     }
   }
-  .navigate {
+  .gmf-displayquerywindow-navigate {
     margin-top: @app-margin;
     border-top: solid 1px @border-color;
     height: @map-tools-size;
     display: flex;
     justify-content: space-between;
-    .placeholder {
+    .gmf-displayquerywindow-placeholder {
       // these elements are necessary when only the middle element (results)
       // is shown to center it in the middle (with 'justify-content')
       height: 100%;
     }
-    .results {
+    .gmf-displayquerywindow-results {
       line-height: 0.9 * @map-tools-size;
       .dropup {
         display: inline;
       }
     }
-    .previous {
+    .gmf-displayquerywindow-previous {
       &::before {
         content: @fa-var-chevron-left;
       }
     }
-    .next {
+    .gmf-displayquerywindow-next {
       &::after {
         content: @fa-var-chevron-right;
       }
     }
-    .inactive {
+    .gmf-displayquerywindow-inactive {
       color: @main-bg-color;
     }
     button {
@@ -187,14 +187,14 @@
   }
 }
 
-.displayquerywindow-mobile {
+.gmf-displayquerywindow-mobile {
   button.close {
     font-size: 21px;
   }
 }
 
 @media (max-width: @screen-sm-min) {
-  .displayquerywindow-mobile {
+  .gmf-displayquerywindow-mobile {
     width: 100%;
     max-width: 100%;
     margin-left: -50%;
@@ -202,12 +202,12 @@
     left: 50%;
     bottom: 0;
     /** prevent glitch for swipe animation **/
-    .details table {
-      .key {
+    .gmf-displayquerywindow-details table {
+      .gmf-displayquerywindow-details-key {
         min-width: calc(~"30vw -" 2 * @app-margin);
         max-width: calc(~"30vw -" 2 * @app-margin);
       }
-      .value {
+      .gmf-displayquerywindow-details-value {
         min-width: calc(~"70vw -" 2 * @app-margin);
         max-width: calc(~"70vw -" 2 * @app-margin);
       }
@@ -217,11 +217,11 @@
 
 @media (orientation:landscape) {
   /* mobile landscape orientation */
-  .displayquerywindow-mobile {
-    .animation-container.detailed {
+  .gmf-displayquerywindow-mobile {
+    .gmf-displayquerywindow-animation-container.detailed {
       height: (@displayquerywindow-detailed-header-height + @displayquerywindow-detailed-details-height / 2 + @app-margin * 3);
     }
-    .details {
+    .gmf-displayquerywindow-details {
       height: @displayquerywindow-detailed-details-height / 2;
     }
   }

--- a/contribs/gmf/src/directives/partials/displayquerywindow.html
+++ b/contribs/gmf/src/directives/partials/displayquerywindow.html
@@ -1,63 +1,140 @@
-<div class="displayquerywindow" ng-class="{'displayquerywindow-desktop': ctrl.desktop, 'displayquerywindow-mobile': !ctrl.desktop}"
-     ng-show="ctrl.open" ng-swipe-disable-mouse ng-swipe-left="ctrl.next()" ng-swipe-right="ctrl.previous()">
-  <button class="collapse-button" type="button" ng-show="::!ctrl.desktop"
-          ng-click="ctrl.collapsed = !ctrl.collapsed" ng-class="[ctrl.collapsed ? 'up' : 'down']"></button>
-  <div class="displayquerywindow-container">
-    <button type="button" class="btn fa-close close" ng-click="ctrl.close()"></button>
-    <div class="animation-container" ng-class="[ctrl.collapsed ? '' : 'detailed', ctrl.isNext ? 'next' : 'previous']">
-      <div ng-animate-swap="ctrl.animate" class="slide-animation">
-        <div class="header">
-          <p class="title">{{ctrl.source.label | translate}}</p>
-          <p class="subtitle">{{ctrl.getFeatureValues()[ctrl.source.identifierAttributeField]}}</p>
+<div
+  class="gmf-displayquerywindow"
+  ng-class="{'gmf-displayquerywindow-desktop': ctrl.desktop, 'gmf-displayquerywindow-mobile': !ctrl.desktop}"
+  ng-show="ctrl.open"
+  ng-swipe-disable-mouse
+  ng-swipe-left="ctrl.next()"
+  ng-swipe-right="ctrl.previous()">
+
+  <button
+    class="gmf-displayquerywindow-collapse-button"
+    type="button"
+    ng-show="::!ctrl.desktop"
+    ng-click="ctrl.collapsed = !ctrl.collapsed"
+    ng-class="[ctrl.collapsed ? 'gmf-displayquerywindow-collapse-button-up' : 'gmf-displayquerywindow-collapse-button-down']">
+  </button>
+
+  <div class="gmf-displayquerywindow-container">
+
+    <button
+      type="button"
+      class="btn fa-close close"
+      ng-click="ctrl.close()">
+    </button>
+
+    <div
+      class="gmf-displayquerywindow-animation-container"
+      ng-class="[ctrl.collapsed ? '' : 'gmf-displayquerywindow-animation-container-detailed', ctrl.isNext ? 'gmf-displayquerywindow-next' : 'gmf-displayquerywindow-previous']">
+
+      <div
+        ng-animate-swap="ctrl.animate"
+        class="gmf-displayquerywindow-slide-animation">
+
+        <div class="gmf-displayquerywindow-header">
+          <p
+            class="gmf-displayquerywindow-title"
+            >{{ctrl.source.label | translate}}</p>
+          <p
+            class="gmf-displayquerywindow-subtitle"
+            >{{ctrl.getFeatureValues()[ctrl.source.identifierAttributeField]}}</p>
         </div>
-        <div class="details">
+
+        <div class="gmf-displayquerywindow-details">
           <table>
-            <tr ng-repeat="(key, value) in ctrl.getFeatureValues()" ng-if="value !== undefined">
-              <td class="key" title="{{key | translate}}">{{key | translate}}</td>
-              <td class="value" title="{{value}}" ng-bind-html="value"></td>
+            <tr
+              ng-repeat="(key, value) in ctrl.getFeatureValues()"
+              ng-if="value !== undefined">
+              <td
+                class="gmf-displayquerywindow-details-key"
+                title="{{key | translate}}"
+                >{{key | translate}}</td>
+              <td
+                class="gmf-displayquerywindow-details-value"
+                title="{{value}}"
+                ng-bind-html="value"
+                ></td>
             </tr>
           </table>
         </div>
       </div>
     </div>
-    <div class="navigate">
-      <div class="placeholder">
-        <button type="button" class="previous" ng-class="{'inactive': ctrl.isFirst()}"
-                ng-show="ctrl.getResultLength() > 1" ng-click="ctrl.previous()">
+
+    <div class="gmf-displayquerywindow-navigate">
+
+      <div class="gmf-displayquerywindow-placeholder">
+        <button
+          type="button"
+          class="gmf-displayquerywindow-previous"
+          ng-class="{'inactive': ctrl.isFirst()}"
+          ng-show="ctrl.getResultLength() > 1"
+          ng-click="ctrl.previous()">
           <span ng-show="::ctrl.desktop">{{'Prev.' | translate}}</span>
         </button>
       </div>
-      <div class="results">
+
+      <div class="gmf-displayquerywindow-results">
         <span ng-show="::!ctrl.desktop">{{'Result' | translate}}</span>
         <span>{{ctrl.currentResult + 1}}</span>
         <span>/</span>
         <span>{{ctrl.getResultLength()}}</span>
-        <div ng-show="::ctrl.desktop" class="dropup">
-          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+        <div
+          ng-show="::ctrl.desktop"
+          class="dropup">
+
+          <button
+            type="button"
+            class="btn btn-default dropdown-toggle"
+            data-toggle="dropdown"
+            aria-expanded="false">
             <span class="fa fa-filter"></span>
             <span class="fa fa-caret-up"></span>
           </button>
-          <ul class="dropdown-menu dropdown-menu-right" role="menu">
+
+          <ul
+            class="dropdown-menu dropdown-menu-right"
+            role="menu">
+
             <li>
-              <a href="#" ng-click="ctrl.setSelectedSource(null)">
-                <i class="fa fa-fw" ng-class="{'fa-check': ctrl.selectedSource === null}"></i>
-                {{'All layers' | translate}} ({{ctrl.ngeoQueryResult.total}})
+              <a
+                href="#"
+                ng-click="ctrl.setSelectedSource(null)">
+                <i
+                  class="fa fa-fw"
+                  ng-class="{'fa-check': ctrl.selectedSource === null}">
+                </i>
+                <span>{{'All layers' | translate}} ({{ctrl.ngeoQueryResult.total}})</span>
               </a>
             </li>
-            <li role="separator" class="divider"></li>
-            <li ng-repeat-start="source in ctrl.ngeoQueryResult.sources | filter: ctrl.sourcesFilter" ng-repeat-end
-                ng-class="{'disabled': source.features.length <= 0}">
-              <a href="#" ng-click="ctrl.setSelectedSource(source)">
-                <i class="fa fa-fw" ng-class="{'fa-check': ctrl.selectedSource === source}"></i>
-                {{source.label | translate}} ({{source.features.length}})
+
+            <li
+              role="separator"
+              class="divider">
+            </li>
+
+            <li
+              ng-repeat-start="source in ctrl.ngeoQueryResult.sources | filter: ctrl.sourcesFilter" ng-repeat-end
+              ng-class="{'disabled': source.features.length <= 0}">
+              <a
+                href="#"
+                ng-click="ctrl.setSelectedSource(source)">
+                <i
+                  class="fa fa-fw"
+                  ng-class="{'fa-check': ctrl.selectedSource === source}">
+                </i>
+                <span>{{source.label | translate}} ({{source.features.length}})</span>
               </a>
             </li>
           </ul>
         </div>
       </div>
-      <div class="placeholder">
-        <button type="button" class="next" ng-class="{'inactive': ctrl.isLast()}"
-                ng-show="ctrl.getResultLength() > 1" ng-click="ctrl.next()">
+
+      <div class="gmf-displayquerywindow-placeholder">
+        <button
+          type="button"
+          class="gmf-displayquerywindow-next"
+          ng-class="{'gmf-displayquerywindow-inactive': ctrl.isLast()}"
+          ng-show="ctrl.getResultLength() > 1"
+          ng-click="ctrl.next()">
           <span ng-show="::ctrl.desktop">{{'Next' | translate}}</span>
         </button>
       </div>


### PR DESCRIPTION
This PR fixes the CSS class name for the gmf displayquerywindow directive.  Changes are made in the example, desktop application and template.  See #1680.  Note that this is one among many PR that will come to fix #1680.

I also made trivial changes to the template to make it more easilly readable.

## Todo

 * ~~The demo server of GMF is currently returning errors when using the desktop app.  This needs to be investigated first.~~
 * [x] Review

## Live examples

 * (example) https://adube.github.io/ngeo/1680-css-fix-displayquerywindow/examples/contribs/gmf/displayquerywindow.html
 * (desktop app) https://adube.github.io/ngeo/1680-css-fix-displayquerywindow/examples/contribs/gmf/apps/desktop/index.html