### PR TITLE
#1680 - Fix CSS in gmf elevation widget

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -211,8 +211,7 @@
             <gmf-elevationwidget
                 gmf-elevationwidget-map="::mainCtrl.map"
                 gmf-elevationwidget-layers="::mainCtrl.elevationLayers"
-                gmf-elevationwidget-active="mainCtrl.showInfobar"
-                class="elevation">
+                gmf-elevationwidget-active="mainCtrl.showInfobar">
             </gmf-elevationwidget>
             <gmf-mouseposition
                  gmf-mouseposition-map="mainCtrl.map"

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -204,8 +204,7 @@
             <gmf-elevationwidget
                 gmf-elevationwidget-map="::mainCtrl.map"
                 gmf-elevationwidget-layers="::mainCtrl.elevationLayers"
-                gmf-elevationwidget-active="mainCtrl.showInfobar"
-                class="elevation">
+                gmf-elevationwidget-active="mainCtrl.showInfobar">
             </gmf-elevationwidget>
             <gmf-mouseposition
                  gmf-mouseposition-map="mainCtrl.map"

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -137,10 +137,10 @@ main {
     display: inline-block;
     min-width: 18rem;
   }
-  .elevation {
+  gmf-elevationwidget {
     display: inline-block;
   }
-  .elevation-value {
+  .gmf-elevationwidget-value {
     display: inline-block;
     min-width: 8rem;
   }

--- a/contribs/gmf/src/directives/partials/elevationwidget.html
+++ b/contribs/gmf/src/directives/partials/elevationwidget.html
@@ -9,7 +9,7 @@
     ng-class="::{'dropdown-toggle': ctrl.layers.length > 1}"
     ng-attr-data-toggle="{{::(ctrl.layers.length > 1) ? 'dropdown' : ''}}"
     >
-    <span class="elevation-value">
+    <span class="gmf-elevationwidget-value">
       {{ctrl.elevationValue | number}}<span ng-show="ctrl.elevationValue"> m</span>
       <span ng-show="ctrl.elevationLoading" class="fa fa-spinner"></span>
       <span ng-show="!ctrl.elevationValue && !ctrl.elevationLoading" translate>Elevation…</span>


### PR DESCRIPTION
This PR fixes the CSS class name for the gmf elevation widget directive.  Changes are made in the desktop application and template of the directive.  See #1680.  Note that this is one among many PR that will come to fix #1680.

## Todo

 * [ ] Review

## Live examples

 * (desktop app) https://adube.github.io/ngeo/1680-css-fix-elevation/examples/contribs/gmf/apps/desktop_alt/index.html