### PR TITLE
#1680 - Fix CSS class names in gmf share

### DIFF
--- a/contribs/gmf/src/directives/partials/share.html
+++ b/contribs/gmf/src/directives/partials/share.html
@@ -18,7 +18,7 @@
       </p>
     </div>
     <hr>
-    <div class="share-email" ng-if="::shareCtrl.enableEmail">
+    <div class="gmf-share-email" ng-if="::shareCtrl.enableEmail">
       <div class="form-group">
         <label for="gmfShareInputEmail" translate>Send this link to</label>
         <input type="email" class="form-control"  name="inputEmail" id="gmfShareInputEmail" placeholder="Email" ng-model="shareCtrl.email" required>


### PR DESCRIPTION
This PR fixes the CSS class name for the gmf share directive.  See #1680.

The only class name unique to gmf is not actually used anywhere (no specific CSS definition in the example and apps).