### PR TITLE
Improve readability of print directive template

### DIFF
--- a/contribs/gmf/src/directives/partials/print.html
+++ b/contribs/gmf/src/directives/partials/print.html
@@ -1,80 +1,213 @@
-<div class="print-panel">
+<div class="gmf-print">
   <div ng-show="ctrl.isState('CAPABILITIES_NOT_LOADED') !== true && ctrl.isState('ERROR_ON_GETCAPABILITIES') !== true">
-    <div ng-repeat="customField in ctrl.fields.customs" class="form-group">
-      <input ng-if="customField.type === 'number'" ng-model="customField.value" class="form-control" type="number" placeholder="{{customField.name | translate}}">
-      <input ng-if="customField.type === 'text'" ng-model="customField.value" class="form-control" type="text" placeholder="{{customField.name | translate}}">
-      <textarea ng-if="customField.type === 'textarea'" ng-model="customField.value" class="form-control" row="3" placeholder="{{customField.name | translate}}"></textarea>
-      <div ng-if="customField.type === 'checkbox'" class="checkbox">
+
+    <div
+      ng-repeat="customField in ctrl.fields.customs"
+      class="form-group">
+
+      <input
+        ng-if="customField.type === 'number'"
+        ng-model="customField.value"
+        class="form-control"
+        type="number"
+        placeholder="{{customField.name | translate}}" />
+
+      <input
+        ng-if="customField.type === 'text'"
+        ng-model="customField.value"
+        class="form-control"
+        type="text"
+        placeholder="{{customField.name | translate}}" />
+
+      <textarea
+        ng-if="customField.type === 'textarea'"
+        ng-model="customField.value"
+        class="form-control"
+        row="3"
+        placeholder="{{customField.name | translate}}">
+      </textarea>
+
+      <div
+        ng-if="customField.type === 'checkbox'"
+        class="checkbox">
         <label>
-          <input ng-model="customField.value" type="checkbox">
+          <input
+            ng-model="customField.value"
+            type="checkbox" />
           <span>{{customField.name | translate}}</span>
         </label>
       </div>
     </div>
-    <div ng-show="ctrl.fields.legend !== undefined" class="checkbox">
+
+    <div
+      ng-show="ctrl.fields.legend !== undefined"
+      class="checkbox">
       <label>
-        <input ng-model="ctrl.fields.legend" type="checkbox">
+        <input
+          ng-model="ctrl.fields.legend"
+          type="checkbox" />
         <span translate>Legend</span>
       </label>
     </div>
+
     <div class="form-horizontal">
-      <div ng-show="ctrl.fields.layouts.length !== 1" class="form-group">
-        <label class="control-label col-md-5" translate>Layout</label>
+      <div
+        ng-show="ctrl.fields.layouts.length !== 1"
+        class="form-group">
+
+        <label
+          class="control-label col-md-5"
+          translate>Layout</label>
+
         <div class="col-md-7">
           <div class="btn-group btn-block">
-            <button type="button" class="btn btn-default form-control" data-toggle="dropdown">{{ctrl.fields.layout | translate}}&nbsp;<i class="fa fa-caret-down"></i></button>
-            <ul class="dropdown-menu dropdown-menu-right btn-block" role="menu">
-              <li ng-repeat="layout in ctrl.fields.layouts"><a href="" ng-click="ctrl.setLayout(layout)">{{layout | translate}}</a></li>
+            <button
+              type="button"
+              class="btn btn-default form-control"
+              data-toggle="dropdown">
+              <span>{{ctrl.fields.layout | translate}}&nbsp;</span>
+              <i class="fa fa-caret-down"></i>
+            </button>
+            <ul
+              class="dropdown-menu dropdown-menu-right btn-block"
+              role="menu">
+              <li ng-repeat="layout in ctrl.fields.layouts">
+                <a
+                  ng-click="ctrl.setLayout(layout)"
+                  href="">{{layout | translate}}</a>
+              </li>
             </ul>
           </div>
         </div>
       </div>
-      <div ng-show="ctrl.fields.scales.length !== 1" class="form-group">
-        <label class="control-label col-md-5"translate>Scale</label>
+
+      <div
+        ng-show="ctrl.fields.scales.length !== 1"
+        class="form-group">
+
+        <label
+          class="control-label col-md-5"
+          translate>Scale</label>
+
         <div class="col-md-7">
           <div class="btn-group btn-block">
-            <button type="button" class="btn btn-default form-control" data-toggle="dropdown" aria-expanded="false">{{ctrl.fields.scale | ngeoScalify}}&nbsp;<i class="fa fa-caret-down"></i></button>
-            <ul class="dropdown-menu btn-block" role="menu">
-              <li ng-repeat="scale in ctrl.fields.scales"><a href="" ng-click="ctrl.setScale(scale)">{{scale | ngeoScalify}}</a></li>
+            <button
+              type="button"
+              class="btn btn-default form-control"
+              data-toggle="dropdown"
+              aria-expanded="false">
+              <span>{{ctrl.fields.scale | ngeoScalify}}&nbsp;</span>
+              <i class="fa fa-caret-down"></i>
+            </button>
+            <ul
+              class="dropdown-menu btn-block"
+              role="menu">
+              <li ng-repeat="scale in ctrl.fields.scales">
+                <a
+                  ng-click="ctrl.setScale(scale)"
+                  href="">{{scale | ngeoScalify}}</a>
+              </li>
             </ul>
           </div>
         </div>
       </div>
-      <div ng-show="ctrl.fields.dpis.length !== 1" class="form-group">
-        <label class="control-label col-md-3" translate>DPI</label>
+
+      <div
+        ng-show="ctrl.fields.dpis.length !== 1"
+        class="form-group">
+
+        <label
+          class="control-label col-md-3"
+          translate>DPI</label>
+
         <div class="col-md-5">
           <div class="btn-group btn-block">
-            <button type="button" class="btn btn-default form-control" data-toggle="dropdown" aria-expanded="false">{{ctrl.fields.dpi}}&nbsp;<i class="fa fa-caret-down"></i></button>
-            <ul class="dropdown-menu btn-block" role="menu">
-              <li ng-repeat="dpi in ctrl.fields.dpis"><a href="" ng-click="ctrl.setDpi(dpi)">{{dpi}}</a></li>
+            <button
+              type="button"
+              class="btn btn-default form-control"
+              data-toggle="dropdown"
+              aria-expanded="false">
+              <span>{{ctrl.fields.dpi}}&nbsp;</span>
+              <i class="fa fa-caret-down"></i>
+            </button>
+            <ul
+              class="dropdown-menu btn-block"
+              role="menu">
+              <li ng-repeat="dpi in ctrl.fields.dpis">
+                <a href="" ng-click="ctrl.setDpi(dpi)">{{dpi}}</a>
+              </li>
             </ul>
           </div>
         </div>
       </div>
+
       <div class="form-group">
-        <label class="control-label col-md-3" translate>Rotation</label>
+        <label
+          class="control-label col-md-3"
+          translate>Rotation</label>
+
         <div class="col-md-5">
-          <input class="form-control" type="range" ng-model="ctrl.getSetRotation" ng-model-options="{getterSetter: true}" min="-180" max="180" data-toggle="tooltip" title="{{'You can also use Alt+Shift on the map' | translate}}">
+          <input
+            class="form-control"
+            type="range"
+            ng-model="ctrl.getSetRotation"
+            ng-model-options="{getterSetter: true}"
+            min="-180"
+            max="180"
+            data-toggle="tooltip"
+            title="{{'You can also use Alt+Shift on the map' | translate}}" />
         </div>
+
         <div class="col-md-4">
-          <input class="form-control" type="number" ng-model="ctrl.getSetRotation" ng-model-options="{getterSetter: true}">
+          <input
+            class="form-control"
+            type="number"
+            ng-model="ctrl.getSetRotation"
+            ng-model-options="{getterSetter: true}" />
         </div>
       </div>
+
     </div>
+
     <div class="form-group pull-right">
-      <span ng-show="ctrl.isState('PRINTING')"><i class="fa fa-refresh fa-spin"></i></span>
-      <a ng-show="ctrl.isState('PRINTING')" class="btn btn-link" href="" ng-click="ctrl.cancel()" translate>Abort</a>
-      <button ng-show="ctrl.fields.formats.png" class="btn btn-primary" ng-click="ctrl.print('png')">Image</button>
-      <button ng-show="ctrl.fields.formats.pdf" class="btn btn-primary" ng-click="ctrl.print('pdf')">PDF</button>
+      <span ng-show="ctrl.isState('PRINTING')">
+        <i class="fa fa-refresh fa-spin"></i>
+      </span>
+
+      <a
+        ng-show="ctrl.isState('PRINTING')"
+        class="btn btn-link"
+        href=""
+        ng-click="ctrl.cancel()"
+        translate>Abort</a>
+
+      <button
+        ng-show="ctrl.fields.formats.png"
+        class="btn btn-primary"
+        ng-click="ctrl.print('png')">Image</button>
+
+      <button
+        ng-show="ctrl.fields.formats.pdf"
+        class="btn btn-primary"
+        ng-click="ctrl.print('pdf')">PDF</button>
     </div>
-    <div ng-show="ctrl.isState('ERROR_ON_REPORT')" class="form-group pull-left text-danger">
+
+    <div
+      ng-show="ctrl.isState('ERROR_ON_REPORT')"
+      class="form-group pull-left text-danger">
       <p>{{'Error during the print, please try again.' | translate}}</p>
     </div>
   </div>
-  <div ng-show="ctrl.isState('CAPABILITIES_NOT_LOADED')" class="form-group pull-left">
+
+  <div
+    ng-show="ctrl.isState('CAPABILITIES_NOT_LOADED')"
+    class="form-group pull-left">
     <p>{{'Connecting to the print server, please wait.' | translate}}</p>
   </div>
-  <div ng-show="ctrl.isState('ERROR_ON_GETCAPABILITIES')" class="form-group pull-left text-danger">
+
+  <div
+    ng-show="ctrl.isState('ERROR_ON_GETCAPABILITIES')"
+    class="form-group pull-left text-danger">
     <p>{{'The print server is unavailable. Please, try later.' | translate}}</p>
   </div>
 </div>

--- a/contribs/gmf/src/directives/partials/print.html
+++ b/contribs/gmf/src/directives/partials/print.html
@@ -10,22 +10,21 @@
         ng-model="customField.value"
         class="form-control"
         type="number"
-        placeholder="{{customField.name | translate}}" />
+        placeholder="{{customField.name | translate}}">
 
       <input
         ng-if="customField.type === 'text'"
         ng-model="customField.value"
         class="form-control"
         type="text"
-        placeholder="{{customField.name | translate}}" />
+        placeholder="{{customField.name | translate}}">
 
       <textarea
         ng-if="customField.type === 'textarea'"
         ng-model="customField.value"
         class="form-control"
         row="3"
-        placeholder="{{customField.name | translate}}">
-      </textarea>
+        placeholder="{{customField.name | translate}}"></textarea>
 
       <div
         ng-if="customField.type === 'checkbox'"
@@ -33,7 +32,7 @@
         <label>
           <input
             ng-model="customField.value"
-            type="checkbox" />
+            type="checkbox">
           <span>{{customField.name | translate}}</span>
         </label>
       </div>
@@ -45,7 +44,7 @@
       <label>
         <input
           ng-model="ctrl.fields.legend"
-          type="checkbox" />
+          type="checkbox">
         <span translate>Legend</span>
       </label>
     </div>
@@ -155,7 +154,7 @@
             min="-180"
             max="180"
             data-toggle="tooltip"
-            title="{{'You can also use Alt+Shift on the map' | translate}}" />
+            title="{{'You can also use Alt+Shift on the map' | translate}}">
         </div>
 
         <div class="col-md-4">
@@ -163,7 +162,7 @@
             class="form-control"
             type="number"
             ng-model="ctrl.getSetRotation"
-            ng-model-options="{getterSetter: true}" />
+            ng-model-options="{getterSetter: true}">
         </div>
       </div>
 

--- a/contribs/gmf/src/directives/print.js
+++ b/contribs/gmf/src/directives/print.js
@@ -2,6 +2,7 @@ goog.provide('gmf.PrintController');
 goog.provide('gmf.printDirective');
 
 goog.require('gmf');
+/** @suppress {extraRequire} */
 goog.require('gmf.authenticationDirective');
 goog.require('ngeo.CreatePrint');
 goog.require('ngeo.FeatureOverlayMgr');

--- a/contribs/gmf/src/directives/print.js
+++ b/contribs/gmf/src/directives/print.js
@@ -2,6 +2,7 @@ goog.provide('gmf.PrintController');
 goog.provide('gmf.printDirective');
 
 goog.require('gmf');
+goog.require('gmf.authenticationDirective');
 goog.require('ngeo.CreatePrint');
 goog.require('ngeo.FeatureOverlayMgr');
 goog.require('ngeo.LayerHelper');


### PR DESCRIPTION
This PR improves the readability of the gmf print directive html template.  The class name is also changed, but it's currently not used anywhere.  Finally, this PR also includes a missing `goog.require` for a missing dependency, which prevented the example from working in a dev environment.