### PR TITLE
#1680 - Fix CSS class names in gmf profile

### DIFF
--- a/contribs/gmf/examples/profile.html
+++ b/contribs/gmf/examples/profile.html
@@ -15,15 +15,15 @@
           width: 80rem;
           height: 40rem;
         }
-        .profile-container {
+        .gmf-profile-container {
           display: flex;
         }
-        .profile-container .profile {
+        .gmf-profile-container .ngeo-profile {
           display: inline-block;
           width: calc(100% - 15rem);
           height: 20rem;
         }
-        .profile-container .profile-legend {
+        .gmf-profile-container .gmf-profile-legend {
           display: inline-block;
           vertical-align: top;
           list-style-type: none;

--- a/contribs/gmf/less/profile.less
+++ b/contribs/gmf/less/profile.less
@@ -1,5 +1,5 @@
 @profile-height: 20rem;
-.profile-container {
+.gmf-profile-container {
   position: relative;
   overflow: hidden;
   @profile-legend-width: 15rem;
@@ -9,24 +9,24 @@
   height: @profile-height;
   display: flex;
 
-  .profile {
+  .ngeo-profile {
     width: ~"calc(100% - @{profile-legend-width})";
     background-color: #f5f5f5;
   }
 
-  .profile-legend {
+  .gmf-profile-legend {
     list-style-type: none;
     width: @profile-legend-width;
     padding: @app-margin;
   }
 
-  .profile-export {
+  .gmf-profile-export {
     position: absolute;
     right: @app-margin;
     bottom: @app-margin;
   }
 
-  .profile-error {
+  .gmf-profile-error {
     width: 100%;
   }
 

--- a/contribs/gmf/src/directives/partials/profile.html
+++ b/contribs/gmf/src/directives/partials/profile.html
@@ -1,22 +1,60 @@
-<div class="profile-container panel" ng-show="ctrl.active">
-  <div class="profile" ng-show="!ctrl.isErrored" ngeo-profile="ctrl.profileData"
-      ngeo-profile-highlight="ctrl.profileHighlight"
-      ngeo-profile-options="::ctrl.profileOptions">
+<div
+  class="gmf-profile-container panel"
+  ng-show="ctrl.active">
+
+  <div
+    class="ngeo-profile"
+    ng-show="!ctrl.isErrored"
+    ngeo-profile="ctrl.profileData"
+    ngeo-profile-highlight="ctrl.profileHighlight"
+    ngeo-profile-options="::ctrl.profileOptions">
   </div>
-  <ul class="profile-legend" ng-show="!ctrl.isErrored">
-    <li ng-repeat="name in ::ctrl.getLayersNames()"><i class="fa fa-minus" style="color:{{::ctrl.getColor(name)}};"></i>&nbsp;{{name | translate}}&nbsp;{{ctrl.currentPoint.elevations[name]}}&nbsp;{{ctrl.currentPoint.yUnits}}
+
+  <ul
+    class="gmf-profile-legend"
+    ng-show="!ctrl.isErrored">
+
+    <li ng-repeat="name in ::ctrl.getLayersNames()">
+      <i
+        class="fa fa-minus"
+        style="color:{{::ctrl.getColor(name)}};"></i>
+      &nbsp;{{name | translate}}&nbsp;{{ctrl.currentPoint.elevations[name]}}&nbsp;{{ctrl.currentPoint.yUnits}}
     </li>
   </ul>
-  <div class="profile-export btn-group dropup" ng-show="!ctrl.isErrored">
-    <a class="dropdown-toggle" href="" ng-show="ctrl.profileData.length !== 0" data-toggle="dropdown" aria-expanded="false">
+
+  <div
+    class="gmf-profile-export btn-group dropup"
+    ng-show="!ctrl.isErrored">
+
+    <a
+      class="dropdown-toggle"
+      href=""
+      ng-show="ctrl.profileData.length !== 0"
+      data-toggle="dropdown"
+      aria-expanded="false">
       {{'Export' | translate}}&nbsp;<i class="fa fa-caret-up"></i>
     </a>
-    <ul class="dropdown-menu dropdown-menu-right" role="menu">
-      <li><a href="" ng-click="::ctrl.downloadCsv()"><i class="fa fa-table"></i>&nbsp;{{'Download CSV' | translate}}</a></li>
+
+    <ul
+      class="dropdown-menu dropdown-menu-right"
+      role="menu">
+
+      <li>
+      <a
+        href=""
+        ng-click="::ctrl.downloadCsv()">
+        <i class="fa fa-table"></i>&nbsp;{{'Download CSV' | translate}}</a>
+      </li>
     </ul>
   </div>
-  <div class="profile-error" ng-show="ctrl.isErrored">
+
+  <div
+    class="gmf-profile-error"
+    ng-show="ctrl.isErrored">
+
     <p>{{'The profile service does not respond, please try later.' | translate}}</p>
   </div>
-  <div class="close" ng-click="ctrl.line = null">&times;</div>
+  <div
+    class="close"
+    ng-click="ctrl.line = null">&times;</div>
 </div>


### PR DESCRIPTION
This PR fixes the CSS class name for the gmf profile directive.  Changes are made in the example, applications and template.  See #1680.  Note that this is one among many PR that will come to fix #1680.

I also made trivial changes to the template to make it more easilly readable.

## Todo

 * [ ] Review

## Live examples

 * (example) https://adube.github.io/ngeo/1680-css-fix-profile/examples/contribs/gmf/profile.html
 * (desktop_alt app) https://adube.github.io/ngeo/1680-css-fix-profile/examples/contribs/gmf/apps/desktop_alt/index.html