### PR TITLE
#1680 - Fix CSS class names in ngeo measure interaction

### DIFF
--- a/contribs/gmf/examples/drawfeature.html
+++ b/contribs/gmf/examples/drawfeature.html
@@ -86,15 +86,15 @@
         opacity: 0.7;
         white-space: nowrap;
       }
-      .tooltip-measure {
+      .ngeo-tooltip-measure {
         opacity: 1;
         font-weight: bold;
       }
-      .tooltip-static {
+      .ngeo-tooltip-static {
         display: none;
       }
-      .tooltip-measure:before,
-      .tooltip-static:before {
+      .ngeo-tooltip-measure:before,
+      .ngeo-tooltip-static:before {
         border-top: 6px solid rgba(0, 0, 0, 0.5);
         border-right: 6px solid transparent;
         border-left: 6px solid transparent;
@@ -104,7 +104,7 @@
         margin-left: -7px;
         left: 50%;
       }
-      .tooltip-static:before {
+      .ngeo-tooltip-static:before {
         border-top-color: #ffcc33;
       }
 

--- a/contribs/gmf/examples/editfeatureselector.html
+++ b/contribs/gmf/examples/editfeatureselector.html
@@ -53,15 +53,15 @@
         opacity: 0.7;
         white-space: nowrap;
       }
-      .tooltip-measure {
+      .ngeo-tooltip-measure {
         opacity: 1;
         font-weight: bold;
       }
-      .tooltip-static {
+      .ngeo-tooltip-static {
         display: none;
       }
-      .tooltip-measure:before,
-      .tooltip-static:before {
+      .ngeo-tooltip-measure:before,
+      .ngeo-tooltip-static:before {
         border-top: 6px solid rgba(0, 0, 0, 0.5);
         border-right: 6px solid transparent;
         border-left: 6px solid transparent;
@@ -71,7 +71,7 @@
         margin-left: -7px;
         left: 50%;
       }
-      .tooltip-static:before {
+      .ngeo-tooltip-static:before {
         border-top-color: #ffcc33;
       }
     </style>

--- a/contribs/gmf/examples/mobilemeasure.html
+++ b/contribs/gmf/examples/mobilemeasure.html
@@ -28,17 +28,17 @@
           opacity: 0.7;
           white-space: nowrap;
         }
-        .tooltip-measure {
+        .ngeo-tooltip-measure {
           opacity: 1;
           font-weight: bold;
         }
-        .tooltip-static {
+        .ngeo-tooltip-static {
           background-color: #ffcc33;
           color: black;
           border: 1px solid white;
         }
-        .tooltip-measure:before,
-        .tooltip-static:before {
+        .ngeo-tooltip-measure:before,
+        .ngeo-tooltip-static:before {
           border-top: 6px solid rgba(0, 0, 0, 0.5);
           border-right: 6px solid transparent;
           border-left: 6px solid transparent;
@@ -48,7 +48,7 @@
           margin-left: -7px;
           left: 50%;
         }
-        .tooltip-static:before {
+        .ngeo-tooltip-static:before {
           border-top-color: #ffcc33;
         }
 

--- a/contribs/gmf/examples/profile.html
+++ b/contribs/gmf/examples/profile.html
@@ -39,11 +39,11 @@
           opacity: 0.7;
           white-space: nowrap;
         }
-        .tooltip-measure {
+        .ngeo-tooltip-measure {
           opacity: 1;
           font-weight: bold;
         }
-        .tooltip-measure:before {
+        .ngeo-tooltip-measure:before {
           border-top: 0.5rem solid rgba(0, 0, 0, 0.5);
           border-right: 0.5rem solid transparent;
           border-left: 0.5rem solid transparent;

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -380,15 +380,15 @@ gmf-drawfeature h2 {
     opacity: 0.7;
     white-space: nowrap;
   }
-  .tooltip-measure {
+  .ngeo-tooltip-measure {
     opacity: 1;
     font-weight: bold;
   }
-  .tooltip-static {
+  .ngeo-tooltip-static {
     display: none;
   }
-  .tooltip-measure:before,
-  .tooltip-static:before {
+  .ngeo-tooltip-measure:before,
+  .ngeo-tooltip-static:before {
     border-top: 6px solid rgba(0, 0, 0, 0.5);
     border-right: 6px solid transparent;
     border-left: 6px solid transparent;
@@ -398,7 +398,7 @@ gmf-drawfeature h2 {
     margin-left: -7px;
     left: 50%;
   }
-  .tooltip-static:before {
+  .ngeo-tooltip-static:before {
     border-top-color: #ffcc33;
   }
 }

--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -57,18 +57,18 @@ gmf-map {
     opacity: 0.7;
     white-space: nowrap;
   }
-  .tooltip-measure {
+  .ngeo-tooltip-measure {
     opacity: 1;
     font-weight: bold;
     z-index: @content-index;
   }
-  .tooltip-static {
+  .ngeo-tooltip-static {
     background-color: #ffcc33;
     color: @color;
     border: 1px solid white;
   }
-  .tooltip-measure::before,
-  .tooltip-static::before {
+  .ngeo-tooltip-measure::before,
+  .ngeo-tooltip-static::before {
     border-top: @half-app-margin solid @border-color;
     border-right: @half-app-margin solid transparent;
     border-left: @half-app-margin solid transparent;
@@ -78,7 +78,7 @@ gmf-map {
     margin-left: -@half-app-margin;
     left: 50%;
   }
-  .tooltip-static::before {
+  .ngeo-tooltip-static::before {
     border-top-color: #ffcc33;
   }
 }

--- a/contribs/gmf/src/directives/profile.js
+++ b/contribs/gmf/src/directives/profile.js
@@ -523,7 +523,7 @@ gmf.ProfileController.prototype.getTooltipHTML_ = function() {
 gmf.ProfileController.prototype.createMeasureTooltip_ = function() {
   this.removeMeasureTooltip_();
   this.measureTooltipElement_ = document.createElement('div');
-  this.measureTooltipElement_.className += 'tooltip tooltip-measure';
+  this.measureTooltipElement_.className += 'tooltip ngeo-tooltip-measure';
   this.measureTooltip_ = new ol.Overlay({
     element: this.measureTooltipElement_,
     offset: [0, -15],

--- a/examples/createfeature.html
+++ b/examples/createfeature.html
@@ -32,15 +32,15 @@
         opacity: 0.7;
         white-space: nowrap;
       }
-      .tooltip-measure {
+      .ngeo-tooltip-measure {
         opacity: 1;
         font-weight: bold;
       }
-      .tooltip-static {
+      .ngeo-tooltip-static {
         display: none;
       }
-      .tooltip-measure:before,
-      .tooltip-static:before {
+      .ngeo-tooltip-measure:before,
+      .ngeo-tooltip-static:before {
         border-top: 6px solid rgba(0, 0, 0, 0.5);
         border-right: 6px solid transparent;
         border-left: 6px solid transparent;
@@ -50,7 +50,7 @@
         margin-left: -7px;
         left: 50%;
       }
-      .tooltip-static:before {
+      .ngeo-tooltip-static:before {
         border-top-color: #ffcc33;
       }
     </style>

--- a/examples/drawfeature.html
+++ b/examples/drawfeature.html
@@ -44,15 +44,15 @@
         opacity: 0.7;
         white-space: nowrap;
       }
-      .tooltip-measure {
+      .ngeo-tooltip-measure {
         opacity: 1;
         font-weight: bold;
       }
-      .tooltip-static {
+      .ngeo-tooltip-static {
         display: none;
       }
-      .tooltip-measure:before,
-      .tooltip-static:before {
+      .ngeo-tooltip-measure:before,
+      .ngeo-tooltip-static:before {
         border-top: 6px solid rgba(0, 0, 0, 0.5);
         border-right: 6px solid transparent;
         border-left: 6px solid transparent;
@@ -62,7 +62,7 @@
         margin-left: -7px;
         left: 50%;
       }
-      .tooltip-static:before {
+      .ngeo-tooltip-static:before {
         border-top-color: #ffcc33;
       }
     </style>

--- a/examples/measure.html
+++ b/examples/measure.html
@@ -25,17 +25,17 @@
           opacity: 0.7;
           white-space: nowrap;
         }
-        .tooltip-measure {
+        .ngeo-tooltip-measure {
           opacity: 1;
           font-weight: bold;
         }
-        .tooltip-static {
+        .ngeo-tooltip-static {
           background-color: #ffcc33;
           color: black;
           border: 1px solid white;
         }
-        .tooltip-measure:before,
-        .tooltip-static:before {
+        .ngeo-tooltip-measure:before,
+        .ngeo-tooltip-static:before {
           border-top: 6px solid rgba(0, 0, 0, 0.5);
           border-right: 6px solid transparent;
           border-left: 6px solid transparent;
@@ -45,7 +45,7 @@
           margin-left: -7px;
           left: 50%;
         }
-        .tooltip-static:before {
+        .ngeo-tooltip-static:before {
           border-top-color: #ffcc33;
         }
 

--- a/src/ol-ext/interaction/measure.js
+++ b/src/ol-ext/interaction/measure.js
@@ -397,7 +397,7 @@ ngeo.interaction.Measure.prototype.onDrawStart_ = function(evt) {
  * @private
  */
 ngeo.interaction.Measure.prototype.onDrawEnd_ = function(evt) {
-  goog.dom.classlist.add(this.measureTooltipElement_, 'tooltip-static');
+  goog.dom.classlist.add(this.measureTooltipElement_, 'ngeo-tooltip-static');
   this.measureTooltipOverlay_.setOffset([0, -7]);
   this.dispatchEvent(new ngeo.MeasureEvent(ngeo.MeasureEventType.MEASUREEND,
       this.sketchFeature));
@@ -451,7 +451,7 @@ ngeo.interaction.Measure.prototype.createMeasureTooltip_ = function() {
   this.removeMeasureTooltip_();
   this.measureTooltipElement_ = goog.dom.createDom(goog.dom.TagName.DIV);
   goog.dom.classlist.addAll(this.measureTooltipElement_,
-      ['tooltip', 'tooltip-measure']);
+      ['tooltip', 'ngeo-tooltip-measure']);
   this.measureTooltipOverlay_ = new ol.Overlay({
     element: this.measureTooltipElement_,
     offset: [0, -15],


### PR DESCRIPTION
This PR fixes the CSS class name for the ngeo measure interaction, more precisely the `tooltip` class names.  Changes are made in the example, applications and the interaction.  See #1680.  Note that this is one among many PR that will come to fix #1680.

## Todo

 * [ ] Review

## Live examples

 * (ngeo example, draw a line)
  * https://adube.github.io/ngeo/1680-css-fix-tooltip/examples/measure.html
 * (gmf example, draw a line)
  * https://adube.github.io/ngeo/1680-css-fix-tooltip/examples/contribs/gmf/drawfeature.html
 * (gmf desktop_alt app, draw a line with the draw tools)
  * https://adube.github.io/ngeo/1680-css-fix-tooltip/examples/contribs/gmf/apps/desktop_alt/index.html