### PR TITLE
#1680 - Fix CSS class names in gmf time-slider

### DIFF
--- a/contribs/gmf/less/timeslider.less
+++ b/contribs/gmf/less/timeslider.less
@@ -36,15 +36,15 @@
   .tooltip {
     min-width: 6.5rem;
   }
+}
 
-  .displayed-dates {
-    display: flex;
-    justify-content: space-between;
-  }
+.gmf-time-slider-displayed-dates {
+  display: flex;
+  justify-content: space-between;
+}
 
-  .start-date,
-  .end-date {
-    font-size : @font-size-small;
-    margin-top: @half-app-margin;
-  }
+.gmf-time-slider-start-date,
+.gmf-time-slider-end-date {
+  font-size : @font-size-small;
+  margin-top: @half-app-margin;
 }

--- a/contribs/gmf/src/directives/partials/timeslider.html
+++ b/contribs/gmf/src/directives/partials/timeslider.html
@@ -1,16 +1,34 @@
 <div class="gmf-time-slider">
-  <div ui-slider="sliderCtrl.sliderOptions" ng-model="sliderCtrl.dates">
-    <span class="ui-slider-handle ui-state-default ui-corner-all" tabindex="0" data-toggle="tooltip" title=""></span>
+
+  <div
+    ui-slider="sliderCtrl.sliderOptions"
+    ng-model="sliderCtrl.dates">
+    <span
+      class="ui-slider-handle ui-state-default ui-corner-all"
+      tabindex="0"
+      data-toggle="tooltip"
+      title="">
+    </span>
   </div>
-  <div class="displayed-dates">
-    <div class="start-date" ng-if="::sliderCtrl.time.mode === 'range'">
-      <span >{{sliderCtrl.dates[0] | date : 'shortDate'}}</span>
+
+  <div class="gmf-time-slider-displayed-dates">
+    <div
+      class="start-date"
+      ng-if="::sliderCtrl.time.mode === 'range'">
+      <span>{{sliderCtrl.dates[0] | date : 'shortDate'}}</span>
     </div>
-    <div class="start-date" ng-if="::sliderCtrl.time.mode === 'value'">
+
+    <div
+      class="gmf-time-slider-start-date"
+      ng-if="::sliderCtrl.time.mode === 'value'">
       <span>{{sliderCtrl.dates | date : 'shortDate'}}</span>
     </div>
-    <div class="end-date" ng-if="::sliderCtrl.time.mode === 'range'">
+
+    <div
+      class="gmf-time-slider-end-date"
+      ng-if="::sliderCtrl.time.mode === 'range'">
       <span>{{sliderCtrl.dates[1] | date : 'shortDate'}}</span>
     </div>
   </div>
+
 </div>


### PR DESCRIPTION
This PR fixes the CSS class name for the gmf time-slider directive.  Changes are made in the applications and template of the directive.  See #1680.  Note that this is one among many PR that will come to fix #1680.

## Todo

 * [ ] Review