### PR TITLE
#1680 - Additionnal fix for CSS class names in gmf bglyr sel.

### DIFF
--- a/contribs/gmf/examples/backgroundlayerselector.html
+++ b/contribs/gmf/examples/backgroundlayerselector.html
@@ -11,26 +11,35 @@
     <link rel="stylesheet" href="../../../third-party/jquery-ui/jquery-ui.min.css">
     <style>
       gmf-map > div {
-        width: 600px;
-        height: 400px;
+        width: 50rem;
+        height: 30rem;
       }
       .gmf-backgroundlayerselector {
         list-style: none;
         margin: 0;
         padding: 0;
-        width: 300px;
+        width: 20rem;
       }
       .gmf-backgroundlayerselector li {
         cursor: pointer;
-        margin: 10px;
+        margin: 0.2rem 0;
         display: flex;
         align-items: center;
+        padding: 0.5rem;
+        border: 0.1rem solid lightgrey;
       }
       .gmf-text {
         flex: 1;
       }
       .gmf-thumb {
         height: 60px;
+      }
+      li.gmf-backgroundlayerselector-active {
+        border: 0.1rem solid blue;
+      }
+      .gmf-backgroundlayerselector-active::after {
+        content: ' X';
+        color: blue;
       }
     </style>
   </head>
@@ -39,7 +48,6 @@
     <code>gmf-backgroundlayerselector</code>
     directive to select the map background layer.</p>
     <div>
-        <span>Select base layer:</span>
         <gmf-backgroundlayerselector
           gmf-backgroundlayerselector-dimensions="::ctrl.dimensions"
           gmf-backgroundlayerselector-map="::ctrl.map">

--- a/contribs/gmf/less/map.less
+++ b/contribs/gmf/less/map.less
@@ -81,11 +81,11 @@ button[ngeo-mobile-geolocation] {
       text-align: center;
     }
     &:hover,
-    &.active {
+    &.gmf-backgroundlayerselector-active {
       border-color: @brand-secondary;
       background-color: #f5f5f5;
     }
-    &.active {
+    &.gmf-backgroundlayerselector-active {
       &::before {
         font-family: FontAwesome;
         content: @fa-var-check;

--- a/contribs/gmf/src/directives/partials/backgroundlayerselector.html
+++ b/contribs/gmf/src/directives/partials/backgroundlayerselector.html
@@ -1,7 +1,7 @@
 <ul class="gmf-backgroundlayerselector">
   <li ng-repeat="layer in ::ctrl.bgLayers"
       ng-click="ctrl.setLayer(layer)"
-      ng-class="{'active': ctrl.bgLayer == layer}">
+      ng-class="{'gmf-backgroundlayerselector-active': ctrl.bgLayer == layer}">
     <img class="gmf-thumb"
          ng-src="{{::layer.get('metadata')['thumbnail']}}" />
     <span class="gmf-text">{{layer.get("label") | translate}}</span>


### PR DESCRIPTION
This PR fixes the a CSS class name from the gmf backgroundlayerselector directive that had been forgotten in a previous one, i.e. the `active` one.  Changes are made in the example, desktop application and template.  See #1680.

## Todo

 * [ ] Review

## Live examples

 * (example) https://adube.github.io/ngeo/1680-css-fix-bglayersel-active/examples/contribs/gmf/backgroundlayerselector.html
 * (desktop app) https://adube.github.io/ngeo/1680-css-fix-bglayersel-active/examples/contribs/gmf/apps/desktop_alt/index.html