### PR TITLE
#1680 - Fix CSS class names in gmf applications

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -14,8 +14,8 @@
       </div>
     </header>
     <main>
-      <div class="data-panel" ng-cloak>
-        <div class="header">
+      <div class="gmf-app-data-panel" ng-cloak>
+        <div class="gmf-app-header">
           <div class="dropdown">
             <a href class="btn btn-default btn-block btn-primary"
               data-toggle="dropdown">
@@ -32,7 +32,7 @@
             </gmf-themeselector>
           </div>
         </div>
-        <div class="content">
+        <div class="gmf-app-content">
           <gmf-layertree
             gmf-layertree-source="mainCtrl.theme"
             gmf-layertree-dimensions="mainCtrl.dimensions"
@@ -41,9 +41,9 @@
           </gmf-layertree>
         </div>
       </div>
-      <div class="tools" ngeo-resizemap="mainCtrl.map"
+      <div class="gmf-app-tools" ngeo-resizemap="mainCtrl.map"
         ngeo-resizemap-state="mainCtrl.toolsActive">
-        <div class="bar">
+        <div class="gmf-app-bar">
           <div ngeo-btn-group class="btn-group-vertical" ngeo-btn-group-active="mainCtrl.toolsActive">
             <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.loginActive"
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Login'|translate}}">
@@ -75,10 +75,10 @@
             </button>
           </span>
         </div>
-        <div class="tools-content container-fluid" ng-class="{active: mainCtrl.toolsActive}">
+        <div class="gmf-app-tools-content container-fluid" ng-class="{'gmf-app-active': mainCtrl.toolsActive}">
           <div ng-show="mainCtrl.loginActive" class="row">
             <div class="col-sm-12">
-              <div class="tools-content-heading">
+              <div class="gmf-app-tools-content-heading">
                 {{'Login' | translate}}
                 <a class="btn close" ng-click="mainCtrl.loginActive = false">&times;</a>
               </div>
@@ -87,7 +87,7 @@
           </div>
           <div ng-show="mainCtrl.printPanelActive" class="row">
             <div class="col-sm-12">
-              <div class="tools-content-heading">
+              <div class="gmf-app-tools-content-heading">
                 {{'Print' | translate}}
                 <a class="btn close" ng-click="mainCtrl.printPanelActive = false">&times;</a>
               </div>
@@ -99,7 +99,7 @@
           </div>
           <div ng-show="mainCtrl.drawFeatureActive" class="row">
             <div class="col-sm-12">
-              <div class="tools-content-heading">
+              <div class="gmf-app-tools-content-heading">
                 {{'Draw & Measure'|translate}}
                 <a class="btn close" ng-click="mainCtrl.drawFeatureActive = false">&times;</a>
               </div>
@@ -112,7 +112,7 @@
           </div>
           <div ng-show="mainCtrl.editFeatureActive" class="row">
             <div class="col-sm-12">
-              <div class="tools-content-heading">
+              <div class="gmf-app-tools-content-heading">
                 {{'Editing'|translate}}
                 <a class="btn close" ng-click="mainCtrl.editFeatureActive = false">&times;</a>
               </div>
@@ -131,7 +131,7 @@
           </div>
           <div ng-show="mainCtrl.drawProfilePanelActive" class="row">
             <div class="col-sm-12">
-              <div class="tools-content-heading">
+              <div class="gmf-app-tools-content-heading">
                 {{'Profile'|translate}}
                 <a class="btn close" ng-click="mainCtrl.drawProfilePanelActive = false">&times;</a>
               </div>
@@ -156,14 +156,14 @@
           </div>
         </div>
       </div>
-      <div class="map-container" ng-class="{'infobar-active': mainCtrl.showInfobar}">
+      <div class="gmf-app-map-container" ng-class="{'gmf-app-infobar-active': mainCtrl.showInfobar}">
         <gmf-search gmf-search-map="mainCtrl.map"
           gmf-search-datasources="mainCtrl.searchDatasources"
           gmf-search-coordinatesprojections="mainCtrl.searchCoordinatesProjections"
           gmf-search-colorchooser="false"
           gmf-search-clearbutton="true">
         </gmf-search>
-        <div class="map-bottom-controls">
+        <div class="gmf-app-map-bottom-controls">
           <div class="gmf-backgroundlayerbutton btn-group dropup">
             <button
                 class="btn btn-default dropdown-toggle"
@@ -199,8 +199,8 @@
         </gmf-map>
 
         <!--infobar-->
-        <div class="footer" ng-class="{'active': mainCtrl.showInfobar}">
-          <button class="btn fa map-info ng-cloak" ng-click="mainCtrl.showInfobar = !mainCtrl.showInfobar"
+        <div class="gmf-app-footer" ng-class="{'gmf-app-active': mainCtrl.showInfobar}">
+          <button class="btn fa gmf-app-map-info ng-cloak" ng-click="mainCtrl.showInfobar = !mainCtrl.showInfobar"
                   ng-class="{'fa-angle-double-up': !mainCtrl.showInfobar, 'fa-angle-double-down': mainCtrl.showInfobar}"></button>
 
           <div ngeo-scaleselector="mainCtrl.scaleSelectorValues"

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -14,8 +14,8 @@
       </div>
     </header>
     <main>
-      <div class="data-panel">
-        <div class="header">
+      <div class="gmf-app-data-panel">
+        <div class="gmf-app-header">
           <div class="dropdown">
             <a href class="btn btn-default btn-block btn-primary"
               data-toggle="dropdown">
@@ -30,7 +30,7 @@
             </gmf-themeselector>
           </div>
         </div>
-        <div class="content">
+        <div class="gmf-app-content">
           <gmf-layertree
             gmf-layertree-source="mainCtrl.theme"
             gmf-layertree-dimensions="mainCtrl.dimensions"
@@ -39,9 +39,9 @@
           </gmf-layertree>
         </div>
       </div>
-      <div class="tools" ngeo-resizemap="mainCtrl.map"
+      <div class="gmf-app-tools" ngeo-resizemap="mainCtrl.map"
         ngeo-resizemap-state="mainCtrl.toolsActive">
-        <div class="bar">
+        <div class="gmf-app-bar">
           <div ngeo-btn-group class="btn-group-vertical" ngeo-btn-group-active="mainCtrl.toolsActive">
             <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.loginActive"
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Login'|translate}}">
@@ -73,10 +73,10 @@
             </button>
           </span>
         </div>
-        <div class="tools-content container-fluid" ng-class="{active: mainCtrl.toolsActive}">
+        <div class="gmf-app-tools-content container-fluid" ng-class="{'gmf-app-active': mainCtrl.toolsActive}">
           <div ng-show="mainCtrl.loginActive" class="row">
             <div class="col-sm-12">
-              <div class="tools-content-heading">
+              <div class="gmf-app-tools-content-heading">
                 {{'Login' | translate}}
                 <a class="btn close" ng-click="mainCtrl.loginActive = false">&times;</a>
               </div>
@@ -85,7 +85,7 @@
           </div>
           <div ng-show="mainCtrl.printPanelActive" class="row">
             <div class="col-sm-12">
-              <div class="tools-content-heading">
+              <div class="gmf-app-tools-content-heading">
                 {{'Print' | translate}}
                 <a class="btn close" ng-click="mainCtrl.printPanelActive = false">&times;</a>
               </div>
@@ -98,7 +98,7 @@
           </div>
           <div ng-show="mainCtrl.drawFeatureActive" class="row">
             <div class="col-sm-12">
-              <div class="tools-content-heading">
+              <div class="gmf-app-tools-content-heading">
                 {{'Draw & Measure'|translate}}
                 <a class="btn close" ng-click="mainCtrl.drawFeatureActive = false">&times;</a>
               </div>
@@ -111,7 +111,7 @@
           </div>
           <div ng-show="mainCtrl.editFeatureActive" class="row">
             <div class="col-sm-12">
-              <div class="tools-content-heading">
+              <div class="gmf-app-tools-content-heading">
                 {{'Editing'|translate}}
                 <a class="btn close" ng-click="mainCtrl.editFeatureActive = false">&times;</a>
               </div>
@@ -130,7 +130,7 @@
           </div>
           <div ng-show="mainCtrl.drawProfilePanelActive" class="row">
             <div class="col-sm-12">
-              <div class="tools-content-heading">
+              <div class="gmf-app-tools-content-heading">
                 {{'Profile'|translate}}
                 <a class="btn close" ng-click="mainCtrl.drawProfilePanelActive = false">&times;</a>
               </div>
@@ -156,14 +156,14 @@
           </div>
         </div>
       </div>
-      <div class="map-container" ng-class="{'infobar-active': mainCtrl.showInfobar}">
+      <div class="gmf-app-map-container" ng-class="{'gmf-app-infobar-active': mainCtrl.showInfobar}">
         <gmf-search gmf-search-map="mainCtrl.map"
           gmf-search-datasources="mainCtrl.searchDatasources"
           gmf-search-coordinatesprojections="mainCtrl.searchCoordinatesProjections"
           gmf-search-colorchooser="true"
           gmf-search-clearbutton="true">
         </gmf-search>
-        <div class="map-bottom-controls">
+        <div class="gmf-app-map-bottom-controls">
           <div class="gmf-backgroundlayerbutton btn-group dropup">
             <button
                 class="btn btn-default dropdown-toggle"
@@ -192,8 +192,8 @@
         </gmf-map>
 
         <!--infobar-->
-        <div class="footer" ng-class="{'active': mainCtrl.showInfobar}">
-          <button class="btn fa map-info ng-cloak" ng-click="mainCtrl.showInfobar = !mainCtrl.showInfobar"
+        <div class="gmf-app-footer" ng-class="{'gmf-app-active': mainCtrl.showInfobar}">
+          <button class="btn fa gmf-app-map-info ng-cloak" ng-click="mainCtrl.showInfobar = !mainCtrl.showInfobar"
                   ng-class="{'fa-angle-double-up': !mainCtrl.showInfobar, 'fa-angle-double-down': mainCtrl.showInfobar}"></button>
 
           <div ngeo-scaleselector="mainCtrl.scaleSelectorValues"

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -21,14 +21,14 @@
         gmf-displayquerywindow-defaultcollapsed="false">
       </gmf-displayquerywindow>
       <div
-        class="measure-tools-control"
+        class="gmf-mobile-measure"
         gmf-mobile-measurelength
         gmf-mobile-measurelength-active="mainCtrl.measureLengthActive"
         gmf-mobile-measurelength-decimals="2"
         gmf-mobile-measurelength-map="::mainCtrl.map">
       </div>
       <div
-        class="measure-tools-control"
+        class="gmf-mobile-measure"
         gmf-mobile-measurepoint
         gmf-mobile-measurepoint-active="mainCtrl.measurePointActive"
         gmf-mobile-measurepoint-decimals="2"

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -58,7 +58,7 @@ main {
 
 @footer-height: @input-height-base + 2 * @padding-base-vertical;
 
-.map-container {
+.gmf-app-map-container {
   width: auto;
   height: 100%;
   overflow: hidden;
@@ -76,7 +76,7 @@ main {
     left: 0;
   }
 
-  .footer {
+  .gmf-app-footer {
     padding: @padding-small-vertical;
     position: absolute;
     z-index: 2;
@@ -91,14 +91,14 @@ main {
     transition: 0.2s ease-out all;
     border: solid @border-color;
     border-width: 1px 0 0;
-    &.active {
+    &.gmf-app-active {
       bottom: 0;
     }
     > div {
       display: inline-block;
     }
 
-    button.map-info {
+    button.gmf-app-map-info {
       position: absolute;
       /* button is supposed to be .btn-sm */
       bottom: @footer-height - 1;
@@ -188,7 +188,7 @@ gmf-search {
   top: @app-margin;
 }
 
-.data-panel {
+.gmf-app-data-panel {
   display: block;
   float: left;
   background-color: @brand-secondary;
@@ -197,12 +197,12 @@ gmf-search {
   display: flex;
   flex-flow: column;
 
-  .header {
+  .gmf-app-header {
     flex: 0 1 auto;
     padding: @app-margin @app-margin 0 @app-margin;
   }
 
-  .content {
+  .gmf-app-content {
     flex: 1 1 auto;
     overflow-y: auto;
     position: relative;
@@ -239,12 +239,12 @@ gmf-backgroundlayerselector {
   }
 }
 
-.tools {
+.gmf-app-tools {
   display: block;
   float: right;
   background-color: @brand-secondary;
 
-  .tools-content {
+  .gmf-app-tools-content {
     width: @right-panel-width;
     margin-right: -@right-panel-width;
     transition: margin-right 0.2s ease;
@@ -252,7 +252,7 @@ gmf-backgroundlayerselector {
     height: 100%;
     overflow: auto;
 
-    &.active {
+    &.gmf-app-active {
       margin-right: 0;
     }
 
@@ -266,7 +266,7 @@ gmf-backgroundlayerselector {
       resize: vertical;
     }
 
-    .tools-content-heading {
+    .gmf-app-tools-content-heading {
       @color: lighten(@text-color, @standard-variation);
       color: @color;
       padding-bottom: @app-margin;
@@ -276,7 +276,7 @@ gmf-backgroundlayerselector {
     }
   }
 
-  .bar {
+  .gmf-app-bar {
     background-color: @brand-primary;
     border-left: 1px solid @border-color;
 
@@ -321,8 +321,8 @@ gmf-backgroundlayerselector {
   }
 }
 
-.data-panel,
-.tools {
+.gmf-app-data-panel,
+.gmf-app-tools {
   height: 100%;
   position: relative;
 }
@@ -488,8 +488,8 @@ gmf-featurestyle {
 /**
  * Controls at the bottom of the map
  */
-.map-bottom-controls {
-  .infobar-active & {
+.gmf-app-map-bottom-controls {
+  .gmf-app-infobar-active & {
     bottom: @footer-height;
   }
   transition: 0.2s ease-out bottom;

--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -37,7 +37,7 @@ gmf-map {
   }
 }
 
-.measure-tools-control {
+.gmf-mobile-measure {
   bottom: @app-margin;
   right: @app-margin;
   a {
@@ -114,7 +114,7 @@ button[ngeo-mobile-geolocation] {
 
 // Overrides for tablet devices
 @media (min-width: @screen-sm-min) {
-  .measure-tools-control {
+  .gmf-mobile-measure {
     right: 2 * @app-margin + @map-tools-size;
   }
   .ol-zoom {


### PR DESCRIPTION
This PR fixes the a CSS class names defined in the 3 GMF applications.  See #1680.

The only class name I was unable to change is `overlay` in the mobile app.  I haven't found it in bootstrap and I'm not sure where it's coming from, but changing it to something else, i.e. `gmf-overlay` breaks the application.  I left it as is.

## Todo

 * [ ] Review

## Live examples

 * (desktop app) https://adube.github.io/ngeo/1680-css-fix-gmf-apps/examples/contribs/gmf/apps/desktop/index.html
 * (desktop_alt app) https://adube.github.io/ngeo/1680-css-fix-gmf-apps/examples/contribs/gmf/apps/desktop_alt/index.html
 * (mobile app) https://adube.github.io/ngeo/1680-css-fix-gmf-apps/examples/contribs/gmf/apps/mobile/index.html