### PR TITLE
Fix treemanager missing require

### DIFF
--- a/contribs/gmf/src/gmf.js
+++ b/contribs/gmf/src/gmf.js
@@ -39,3 +39,21 @@ gmf.DATALAYERGROUP_NAME = 'data';
  * @export
  */
 gmf.COORDINATES_LAYER_NAME = 'gmfCoordinatesLayerName';
+
+
+/**
+ * @enum {string}
+ */
+gmf.PermalinkParam = {
+  BG_LAYER: 'baselayer_ref',
+  FEATURES: 'rl_features',
+  MAP_CROSSHAIR: 'map_crosshair',
+  MAP_TOOLTIP: 'map_tooltip',
+  MAP_X: 'map_x',
+  MAP_Y: 'map_y',
+  MAP_Z: 'map_zoom',
+  TREE_GROUPS: 'tree_groups',
+  WFS_LAYER: 'wfs_layer',
+  WFS_NGROUPS: 'wfs_ngroups',
+  WFS_SHOW_FEATURES: 'wfs_showFeatures'
+};

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -30,23 +30,6 @@ goog.require('ol.style.Style');
 /**
  * @enum {string}
  */
-gmf.PermalinkParam = {
-  BG_LAYER: 'baselayer_ref',
-  FEATURES: 'rl_features',
-  MAP_CROSSHAIR: 'map_crosshair',
-  MAP_TOOLTIP: 'map_tooltip',
-  MAP_X: 'map_x',
-  MAP_Y: 'map_y',
-  MAP_Z: 'map_zoom',
-  TREE_GROUPS: 'tree_groups',
-  WFS_LAYER: 'wfs_layer',
-  WFS_NGROUPS: 'wfs_ngroups',
-  WFS_SHOW_FEATURES: 'wfs_showFeatures'
-};
-
-/**
- * @enum {string}
- */
 gmf.PermalinkOpenLayersLayerProperties = {
   OPACITY : 'opacity'
 };

--- a/contribs/gmf/src/services/treemanager.js
+++ b/contribs/gmf/src/services/treemanager.js
@@ -3,6 +3,7 @@ goog.provide('gmf.TreeManager');
 goog.require('gmf');
 goog.require('gmf.Themes');
 goog.require('ngeo.Notification');
+goog.require('ngeo.StateManager');
 
 
 /**
@@ -12,11 +13,11 @@ gmf.module.value('gmfTreeManagerModeFlush', true);
 
 
 /**
- * Manage a tree with children. This service can be used in mode 'flush' (default) or
- * not (mode 'add'). In mode 'flush', each theme, group or group by layer that
- * you add will replace the previous children's array. In mode 'add', children
- * will be just pushed in this array. The default state can be changed by setting
- * the value `gmfTreeManagerModeFlush`, e.g.:
+ * Manage a tree with children. This service can be used in mode 'flush'
+ * (default) or not (mode 'add'). In mode 'flush', each theme, group or group
+ * by layer that you add will replace the previous children's array. In mode
+ * 'add', children will be just pushed in this array. The default state can be
+ * changed by setting the value `gmfTreeManagerModeFlush`, e.g.:
  *
  *    var module = angular.module('app');
  *    module.value('gmfTreeManagerModeFlush', false);
@@ -35,8 +36,8 @@ gmf.module.value('gmfTreeManagerModeFlush', true);
  * @ngdoc service
  * @ngname gmfTreeManager
  */
-gmf.TreeManager = function($timeout, gettextCatalog, ngeoLayerHelper, ngeoNotification, gmfThemes,
-    gmfTreeManagerModeFlush, ngeoStateManager) {
+gmf.TreeManager = function($timeout, gettextCatalog, ngeoLayerHelper,
+    ngeoNotification, gmfThemes, gmfTreeManagerModeFlush, ngeoStateManager) {
 
   /**
    * @type {angular.$timeout}


### PR DESCRIPTION
This PR fixes the `gmf.TreeManager` service.

1. It was missing a require of the `ngeo.StateManager`
2. It is using the `gmf.PermalinkParam.TREE_GROUPS` constant but was not requiring the permalink service.  In the end, we can't do that because the permalink service already requires the tree manager as well and we would end up with a circular dependency.  To fix that, the constant `gmf.PermalinkParam` was moved to `gmf.js`.

I found this out while trying to view the theme selector example, which didn't work on dev.

## Todo

 * [ ] review

## Live example

 * https://adube.github.io/ngeo/fix-treemanager/examples/contribs/gmf/themeselector.html