### PR TITLE
#1680 - Fix active CSS class name in gmf themeselector

### DIFF
--- a/contribs/gmf/examples/themeselector.html
+++ b/contribs/gmf/examples/themeselector.html
@@ -21,12 +21,21 @@
         margin: 10px;
         display: flex;
         align-items: center;
+        border: 0.1rem solid black;
       }
       .gmf-text {
         flex: 1;
       }
       .gmf-thumb {
         height: 60px;
+      }
+      li.gmf-theme-selector-active {
+        border: 0.1rem solid blue;
+      }
+      .gmf-theme-selector-active::after {
+        color: blue;
+        content: 'X';
+        margin: 0 1rem 0 0;
       }
     </style>
   </head>

--- a/contribs/gmf/src/directives/partials/themeselector.html
+++ b/contribs/gmf/src/directives/partials/themeselector.html
@@ -2,7 +2,7 @@
   <li
       ng-repeat="theme in tsCtrl.themes"
       ng-click="tsCtrl.setTheme(theme)"
-      ng-class="{'active': tsCtrl.currentTheme['name'] == theme.name}">
+      ng-class="{'gmf-theme-selector-active': tsCtrl.currentTheme['name'] == theme.name}">
     <img class="gmf-thumb"
          ng-src="{{::theme.icon}}" />
     <span class="gmf-text">{{theme.name | translate}}</span>


### PR DESCRIPTION
This PR fixes the `active` CSS name defined in the `gmf-themeselector` directive.  It's not used in the applications and was not used in the example either, but since it's still somewhat a "feature" I added it in the example.

## Todo

 * [ ] review