### PR TITLE
#1680 - Fix active CSS class name in ngeo grid

### DIFF
--- a/contribs/gmf/less/displayquerygrid.less
+++ b/contribs/gmf/less/displayquerygrid.less
@@ -25,7 +25,7 @@
     font-weight: bold;
   }
 
-  .table > tbody > tr.active > td {
+  .table > tbody > tr.ngeo-grid-active > td {
     background-color: #C9C9C9;
   }
 

--- a/examples/grid.html
+++ b/examples/grid.html
@@ -32,7 +32,7 @@
           background-color: #f9f9f9;
       }
 
-      .table > tbody > tr.active > td {
+      .table > tbody > tr.ngeo-grid-active > td {
         background-color: #C9C9C9;
       }
     </style>

--- a/src/directives/partials/grid.html
+++ b/src/directives/partials/grid.html
@@ -13,7 +13,7 @@
     </thead>
     <tbody>
       <tr ng-repeat="attributes in ctrl.configuration.data"
-          ng-class="['row-' + ctrl.configuration.getRowUid(attributes), ctrl.configuration.isRowSelected(attributes) ? 'active': '']"
+          ng-class="['row-' + ctrl.configuration.getRowUid(attributes), ctrl.configuration.isRowSelected(attributes) ? 'ngeo-grid-active': '']"
           ng-click="ctrl.clickRow(attributes, $event)" ng-mousedown="ctrl.preventTextSelection($event)">
         <td ng-repeat="columnDefs in ctrl.configuration.columnDefs" ng-bind-html="attributes[columnDefs.name] | ngeoTrustHtml"></td>
       </tr>


### PR DESCRIPTION
This PR fixes the `active` CSS class name in the `grid` directive, in ngeo.  See #1680.

## Todo

 * [ ] Review

## Live examples

 * (example) https://adube.github.io/ngeo/1680-css-fix-grid-active/examples/grid.html
 * (desktop app) https://adube.github.io/ngeo/1680-css-fix-grid-active/examples/contribs/gmf/apps/desktop_alt/index.html