### PR TITLE
#1786 - Prevent query to do request if no queryable source

### DIFF
--- a/src/services/query.js
+++ b/src/services/query.js
@@ -518,7 +518,7 @@ ngeo.Query.prototype.doGetFeatureInfoRequests_ = function(
     items.forEach(function(item) {
       item['resultSource'].pending = true;
       item['resultSource'].queried = true;
-    }.bind(this));
+    });
 
     var infoFormat = items[0].source.infoFormat;
     var wmsGetFeatureInfoUrl = items[0].source.wmsSource.getGetFeatureInfoUrl(

--- a/src/services/query.js
+++ b/src/services/query.js
@@ -444,9 +444,6 @@ ngeo.Query.prototype.getQueryableSources_ = function(map, wfsOnly) {
         }
       }
 
-      item['resultSource'].pending = true;
-      item['resultSource'].queried = true;
-
       if (item.source.wfsQuery) {
         // use WFS GetFeature
         url = item.source.urlWfs || item.source.wmsSource.getUrl();
@@ -470,8 +467,6 @@ ngeo.Query.prototype.getQueryableSources_ = function(map, wfsOnly) {
           this.pushSourceIfUnique_(item, wmsItemsByUrl[url]);
         } else {
           // TODO - support other kinds of infoFormats
-          item['resultSource'].pending = false;
-          item['resultSource'].queried = false;
         }
       }
     }
@@ -519,6 +514,12 @@ ngeo.Query.prototype.doGetFeatureInfoRequests_ = function(
   var resolution = /** @type {number} */(view.getResolution());
 
   angular.forEach(wmsItemsByUrl, function(items) {
+
+    items.forEach(function(item) {
+      item['resultSource'].pending = true;
+      item['resultSource'].queried = true;
+    }.bind(this));
+
     var infoFormat = items[0].source.infoFormat;
     var wmsGetFeatureInfoUrl = items[0].source.wmsSource.getGetFeatureInfoUrl(
         coordinate, resolution, projCode, {
@@ -589,10 +590,11 @@ ngeo.Query.prototype.doGetFeatureRequests_ = function(
 
       if (layers.length == 0 || layers[0] === '') {
         // do not query source if no valid layers
-        item['resultSource'].pending = false;
-        item['resultSource'].queried = false;
         return;
       }
+
+      item['resultSource'].pending = true;
+      item['resultSource'].queried = true;
 
       /** @type{olx.format.WFSWriteGetFeatureOptions} */
       var getFeatureOptions = {


### PR DESCRIPTION
This PR fixes the query service. When no queryable source is found, it doesn't launch new queries, which prevents the spinner to be shown indefinitively.

Fixes part 1 of #1786.

## Todo

 * [x] review
 * [x] 2nd review

## Live demo

 * https://adube.github.io/ngeo/1786-fix-query/examples/contribs/gmf/apps/desktop_alt/index.html?lang=en&map_x=560193&map_y=141696&map_zoom=7&tree_groups=OSM%20functions%20mixed&baselayer_ref=asitvd.fond_gris&tree_enable_osm_time_r_dp=false&tree_enable_osm_time_v_dp=false&tree_enable_osm_time_v_s=false&tree_enable_osm_time_r_s=false&tree_enable_osm_scale=true