### PR TITLE
#1841 - Use class instead of id in MousePosition

### DIFF
--- a/contribs/gmf/src/directives/mouseposition.js
+++ b/contribs/gmf/src/directives/mouseposition.js
@@ -43,6 +43,7 @@ gmf.module.directive('gmfMouseposition', gmf.mousepositionDirective);
 
 
 /**
+ * @param {angular.JQLite} $element Element.
  * @param {angular.$filter} $filter Angular filter
  * @param {gettext} gettext Gettext service.
  * @constructor
@@ -51,7 +52,7 @@ gmf.module.directive('gmfMouseposition', gmf.mousepositionDirective);
  * @ngdoc controller
  * @ngname gmfMousepositionController
  */
-gmf.MousepositionController = function($filter, gettext) {
+gmf.MousepositionController = function($element, $filter, gettext) {
   /**
    * @type {ol.Map}
    * @export
@@ -83,7 +84,7 @@ gmf.MousepositionController = function($filter, gettext) {
   this.control = new ol.control.MousePosition({
     className: 'gmf-mouseposition-control',
     coordinateFormat: formatFn.bind(this),
-    target: document.getElementById('gmf-mouseposition-control-target'),
+    target: angular.element('.gmf-mouseposition-control-target', $element)[0],
     undefinedHTML: gettext('Coordinates')
   });
 

--- a/contribs/gmf/src/directives/partials/mouseposition.html
+++ b/contribs/gmf/src/directives/partials/mouseposition.html
@@ -1,6 +1,6 @@
 <div class="btn-group dropup">
   <a type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-    <span id="gmf-mouseposition-control-target"></span>
+    <span class="gmf-mouseposition-control-target"></span>
     <span class="caret"></span>
   </a>
   <ul class="dropdown-menu dropdown-menu-right" role="menu">


### PR DESCRIPTION
This PR fixes the mouse position directive in gmf to no longer use an `id` of the element where to render the mouse position control.  Instead, a CSS class name is used with the angular `$element` service.

## Todo

 * [ ] review

## Live example

 * https://adube.github.io/ngeo/1841-mouseposition-id/examples/contribs/gmf/mouseposition.html