### PR TITLE
Avoid text flickering in display query window

### DIFF
--- a/contribs/gmf/less/displayquerywindow.less
+++ b/contribs/gmf/less/displayquerywindow.less
@@ -62,7 +62,8 @@
   }
   .gmf-displayquerywindow-next {
     .gmf-displayquerywindow-slide-animation {
-      &.ng-enter {
+      &.ng-enter,
+      &.ng-enter-prepare {
         left: 100%;
       }
       &.ng-enter-active, &.ng-leave {
@@ -75,7 +76,8 @@
   }
   .gmf-displayquerywindow-previous {
     .gmf-displayquerywindow-slide-animation {
-      &.ng-enter {
+      &.ng-enter,
+      &.ng-enter-prepare {
         left: -100%;
       }
       &.ng-enter-active, &.ng-leave {

--- a/contribs/gmf/src/directives/displayquerywindow.js
+++ b/contribs/gmf/src/directives/displayquerywindow.js
@@ -96,12 +96,6 @@ gmf.DisplayquerywindowController = function($scope, ngeoQueryResult,
     ngeoFeatureHelper, ngeoFeatureOverlayMgr) {
 
   /**
-   * @type {angular.Scope}
-   * @private
-   */
-  this.scope_ = $scope;
-
-  /**
    * @type {boolean}
    * @export
    */
@@ -226,7 +220,7 @@ gmf.DisplayquerywindowController = function($scope, ngeoQueryResult,
    */
   this.open = false;
 
-  this.scope_.$watchCollection(
+  $scope.$watchCollection(
       function() {
         return ngeoQueryResult;
       },
@@ -398,9 +392,7 @@ gmf.DisplayquerywindowController.prototype.getFeatureValues = function() {
  */
 gmf.DisplayquerywindowController.prototype.animate_ = function(isNext) {
   this.isNext = isNext;
-  this.scope_.$evalAsync(function() {
-    this.animate++;
-  }.bind(this));
+  this.animate++;
 };
 
 


### PR DESCRIPTION
Fixes #1694.

Demo: https://pgiraud.github.io/ngeo/query_window_animation_flickr/examples/contribs/gmf/apps/mobile