### PR TITLE
Fix prev/next inactive state

### DIFF
--- a/contribs/gmf/less/displayquerywindow.less
+++ b/contribs/gmf/less/displayquerywindow.less
@@ -155,9 +155,6 @@
         content: @fa-var-chevron-right;
       }
     }
-    .gmf-displayquerywindow-inactive {
-      color: @main-bg-color;
-    }
     button {
       width: inherit;
       padding: 0 @app-margin;

--- a/contribs/gmf/src/directives/partials/displayquerywindow.html
+++ b/contribs/gmf/src/directives/partials/displayquerywindow.html
@@ -64,8 +64,8 @@
       <div class="gmf-displayquerywindow-placeholder">
         <button
           type="button"
-          class="gmf-displayquerywindow-previous"
-          ng-class="{'inactive': ctrl.isFirst()}"
+          class="gmf-displayquerywindow-previous btn"
+          ng-disabled="ctrl.isFirst()"
           ng-show="ctrl.getResultLength() > 1"
           ng-click="ctrl.previous()">
           <span ng-show="::ctrl.desktop">{{'Prev.' | translate}}</span>
@@ -131,8 +131,8 @@
       <div class="gmf-displayquerywindow-placeholder">
         <button
           type="button"
-          class="gmf-displayquerywindow-next"
-          ng-class="{'gmf-displayquerywindow-inactive': ctrl.isLast()}"
+          class="gmf-displayquerywindow-next btn"
+          ng-disabled="ctrl.isLast()"
           ng-show="ctrl.getResultLength() > 1"
           ng-click="ctrl.next()">
           <span ng-show="::ctrl.desktop">{{'Next' | translate}}</span>


### PR DESCRIPTION
There were a regression introduced with this change https://github.com/camptocamp/ngeo/commit/867bf981ae3d7728e3697e5c369504c85c4b6b55#diff-df063e76ea0d193b20ec188cb6b50b55R68

The previous arrow never got inactive anymore.
![screenshot from 2016-09-14 12 10 23](https://cloud.githubusercontent.com/assets/319774/18508390/3eb1d090-7a74-11e6-90d9-aa0f054492c9.png)

With the current pull request, I simplify the way we handle inactivation of the arrows by using already existing bootstrap's classes. The benefit is also that the button is really disabled (not only visually).

Demo: https://pgiraud.github.io/ngeo/query_window_arrows/examples/contribs/gmf/apps/mobile/?baselayer_ref=asitvd.fond_gris&lang=fr&map_x=558817&map_y=156629&map_zoom=2&tree_groups=Layers


