### PR TITLE
Rename properties in editfeature selector direct. for incoming snapping

### DIFF
--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -53,7 +53,10 @@ goog.require('ol.style.Text');
  *         gmf-editfeature-vector="::ctrl.vectorLayer">
  *     </gmf-editfeature>
  *
- * @htmlAttribute {GmfThemesNode} gmf-editfeature-editable The GMF node
+ * @htmlAttribute {boolean} gmf-editfeature-dirty Flag that is toggled as soon
+ *     as the feature changes, i.e. if any of its properties change, which
+ *     includes the geometry.
+ * @htmlAttribute {GmfThemesNode} gmf-editfeature-editablenode The GMF node
  *     representing the editable layer.
  * @htmlAttribute {ol.layer.Image|ol.layer.Tile} gmf-editfeature-editablewmslayer
  *     The WMS layer to refresh after each saved modification.

--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -45,16 +45,18 @@ goog.require('ol.style.Text');
  *
  *     <gmf-editfeature
  *         gmf-editfeature-dirty="ctrl.dirty"
- *         gmf-editfeature-layer="::ctrl.layer"
+ *         gmf-editfeature-editablenode="::ctrl.node"
+ *         gmf-editfeature-editablewmslayer="::ctrl.selectedWMSLayer"
  *         gmf-editfeature-map="::ctrl.map"
  *         gmf-editfeature-state="efsCtrl.state"
  *         gmf-editfeature-tolerance="::ctrl.tolerance"
- *         gmf-editfeature-vector="::ctrl.vectorLayer"
- *         gmf-editfeature-wmslayer="::ctrl.selectedWMSLayer">
+ *         gmf-editfeature-vector="::ctrl.vectorLayer">
  *     </gmf-editfeature>
  *
- * @htmlAttribute {GmfThemesNode} gmf-editfeature-layer The GMF node of the
- *     editable layer.
+ * @htmlAttribute {GmfThemesNode} gmf-editfeature-editable The GMF node
+ *     representing the editable layer.
+ * @htmlAttribute {ol.layer.Image|ol.layer.Tile} gmf-editfeature-editablewmslayer
+ *     The WMS layer to refresh after each saved modification.
  * @htmlAttribute {ol.Map} gmf-editfeature-map The map.
  * @htmlAttribute {string} gmf-editfeature-stopeditingrequest Stop editing
  *     state.
@@ -62,8 +64,6 @@ goog.require('ol.style.Text');
  *     buffer in pixels to use when making queries to get the features.
  * @htmlAttribute {ol.layer.Vector} gmf-editfeature-vector The vector layer in
  *     which to draw the vector features.
- * @htmlAttribute {ol.layer.Image|ol.layer.Tile} gmf-editfeature-wmslayer The
- *     WMS layer to refresh after each saved modification.
  * @return {angular.Directive} The directive specs.
  * @ngdoc directive
  * @ngname gmfEditfeature
@@ -74,11 +74,12 @@ gmf.editfeatureDirective = function() {
     scope: {
       'dirty': '=gmfEditfeatureDirty',
       'layer': '=gmfEditfeatureLayer',
+      'editableNode': '=gmfEditfeatureEditablenode',
+      'editableWMSLayer': '<gmfEditfeatureEditablewmslayer',
       'map': '<gmfEditfeatureMap',
       'state': '=gmfEditfeatureState',
       'tolerance': '<?gmfEditfeatureTolerance',
-      'vectorLayer': '<gmfEditfeatureVector',
-      'wmsLayer': '<gmfEditfeatureWmslayer'
+      'vectorLayer': '<gmfEditfeatureVector'
     },
     bindToController: true,
     controllerAs: 'efCtrl',
@@ -126,7 +127,13 @@ gmf.EditfeatureController = function($element, $scope, $timeout, $q,
    * @type {GmfThemesNode}
    * @export
    */
-  this.layer;
+  this.editableNode;
+
+  /**
+   * @type {ol.layer.Image|ol.layer.Tile}
+   * @export
+   */
+  this.editableWMSLayer;
 
   /**
    * @type {ol.Map}
@@ -171,12 +178,6 @@ gmf.EditfeatureController = function($element, $scope, $timeout, $q,
    * @export
    */
   this.vectorLayer;
-
-  /**
-   * @type {ol.layer.Image|ol.layer.Tile}
-   * @export
-   */
-  this.wmsLayer;
 
   /**
    * @type {angular.JQLite}
@@ -453,7 +454,7 @@ gmf.EditfeatureController = function($element, $scope, $timeout, $q,
    */
   this.geomType = null;
 
-  gmfXSDAttributes.getAttributes(this.layer.id).then(
+  gmfXSDAttributes.getAttributes(this.editableNode.id).then(
     this.setAttributes_.bind(this));
 
   var uid = goog.getUid(this);
@@ -495,14 +496,14 @@ gmf.EditfeatureController.prototype.save = function() {
 
   if (id) {
     this.editFeatureService_.updateFeature(
-      this.layer.id,
+      this.editableNode.id,
       feature
     ).then(
       this.handleEditFeature_.bind(this)
     );
   } else {
     this.editFeatureService_.insertFeatures(
-      this.layer.id,
+      this.editableNode.id,
       [feature]
     ).then(
       this.handleEditFeature_.bind(this)
@@ -584,7 +585,7 @@ gmf.EditfeatureController.prototype.delete = function() {
 
     // (1) Launch request
     this.editFeatureService_.deleteFeature(
-      this.layer.id,
+      this.editableNode.id,
       this.feature
     ).then(
       this.handleDeleteFeature_.bind(this)
@@ -620,7 +621,7 @@ gmf.EditfeatureController.prototype.handleEditFeature_ = function(resp) {
   var features = new ol.format.GeoJSON().readFeatures(resp.data);
   if (features.length) {
     this.feature.setId(features[0].getId());
-    this.layerHelper_.refreshWMSLayer(this.wmsLayer);
+    this.layerHelper_.refreshWMSLayer(this.editableWMSLayer);
   }
   if (this.confirmDeferred_) {
     this.confirmDeferred_.resolve();
@@ -635,7 +636,7 @@ gmf.EditfeatureController.prototype.handleEditFeature_ = function(resp) {
  */
 gmf.EditfeatureController.prototype.handleDeleteFeature_ = function(resp) {
   this.pending = false;
-  this.layerHelper_.refreshWMSLayer(this.wmsLayer);
+  this.layerHelper_.refreshWMSLayer(this.editableWMSLayer);
 };
 
 
@@ -728,7 +729,7 @@ gmf.EditfeatureController.prototype.toggle_ = function(active) {
 
   this.modify_.setActive(active);
   this.mapSelectActive = active;
-  this.layer['editing'] = active;
+  this.editableNode['editing'] = active;
 
 };
 
@@ -814,7 +815,7 @@ gmf.EditfeatureController.prototype.handleMapClick_ = function(evt) {
     );
 
     // (3) Launch query to fetch features
-    this.editFeatureService_.getFeatures([this.layer.id], extent).then(
+    this.editFeatureService_.getFeatures([this.editableNode.id], extent).then(
       this.handleGetFeatures_.bind(this));
 
     // (4) Clear any previously selected feature

--- a/contribs/gmf/src/directives/partials/editfeatureselector.html
+++ b/contribs/gmf/src/directives/partials/editfeatureselector.html
@@ -32,12 +32,12 @@
 
     <gmf-editfeature
         gmf-editfeature-dirty="efsCtrl.dirty"
-        gmf-editfeature-layer="::efsCtrl.selectedEditableNode"
+        gmf-editfeature-editablenode="::efsCtrl.selectedEditableNode"
+        gmf-editfeature-editablewmslayer="::efsCtrl.selectedEditableWMSLayer"
         gmf-editfeature-map="::efsCtrl.map"
         gmf-editfeature-state="efsCtrl.state"
         gmf-editfeature-tolerance="::efsCtrl.tolerance"
-        gmf-editfeature-vector="::efsCtrl.vectorLayer"
-        gmf-editfeature-wmslayer="::efsCtrl.selectedEditableWMSLayer">
+        gmf-editfeature-vector="::efsCtrl.vectorLayer">
     </gmf-editfeature>
 
   </div>

--- a/contribs/gmf/src/directives/partials/editfeatureselector.html
+++ b/contribs/gmf/src/directives/partials/editfeatureselector.html
@@ -1,22 +1,24 @@
 <div
-    ng-switch="efsCtrl.selectedLayer">
+    ng-switch="efsCtrl.selectedEditableNode">
 
   <div ng-switch-when="null">
     <select
         class="form-control"
-        ng-model="efsCtrl.selectedLayer"
-        ng-show="efsCtrl.availableLayers.length > 0"
-        ng-options="layer.name | translate for layer in efsCtrl.availableLayers">
+        ng-model="efsCtrl.selectedEditableNode"
+        ng-show="efsCtrl.availableEditableNodes.length > 0"
+        ng-options="layer.name | translate for layer in efsCtrl.availableEditableNodes">
       <option value="" translate>-- Choose a layer --</option>
     </select>
-    <span ng-show="efsCtrl.availableLayers.length == 0" translate>No editable layer available!</span>
+    <span
+      ng-show="efsCtrl.availableEditableNodes.length == 0"
+      translate>No editable layer available!</span>
   </div>
 
   <div ng-switch-default>
     <div class="row">
       <div class="col-sm-12">
         <span translate>Currently editing: </span>
-        <b>{{ efsCtrl.selectedLayer.name | translate }}</b>
+        <b>{{ efsCtrl.selectedEditableNode.name | translate }}</b>
         <span class="fa fa-pencil"></span>
         <br>
         <button
@@ -30,12 +32,12 @@
 
     <gmf-editfeature
         gmf-editfeature-dirty="efsCtrl.dirty"
-        gmf-editfeature-layer="::efsCtrl.selectedLayer"
+        gmf-editfeature-layer="::efsCtrl.selectedEditableNode"
         gmf-editfeature-map="::efsCtrl.map"
         gmf-editfeature-state="efsCtrl.state"
         gmf-editfeature-tolerance="::efsCtrl.tolerance"
         gmf-editfeature-vector="::efsCtrl.vectorLayer"
-        gmf-editfeature-wmslayer="::efsCtrl.selectedWMSLayer">
+        gmf-editfeature-wmslayer="::efsCtrl.selectedEditableWMSLayer">
     </gmf-editfeature>
 
   </div>


### PR DESCRIPTION
This PR renames lots of inner properties inside the `gmf-editfeature` and `gmf-editfeatureselector` directives to prepare the ground for the introduction of the snapping.  There's not actual change to the logic here, only renaming.