### PR TITLE
Prevent editing button to briefly show up at startup

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -58,7 +58,7 @@
             </button>
             <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.editFeatureActive"
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Editing'|translate}}"
-              ng-show="mainCtrl.hasEditableLayers">
+              ng-show="mainCtrl.hasEditableLayers" ng-cloak>
               <span class="fa fa-pencil"></span>
             </button>
             <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.drawProfilePanelActive"

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -56,7 +56,7 @@
             </button>
             <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.editFeatureActive"
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Editing'|translate}}"
-              ng-show="mainCtrl.hasEditableLayers">
+              ng-show="mainCtrl.hasEditableLayers" ng-cloak>
               <span class="fa fa-pencil"></span>
             </button>
             <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.drawProfilePanelActive"

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -438,7 +438,7 @@ gmf.AbstractController = function(config, $scope, $injector) {
    * @type {boolean}
    * @export
    */
-  this.hasEditableLayers = true;
+  this.hasEditableLayers = false;
 
   /**
    * @private


### PR DESCRIPTION
Currently the editing button shows up on the interface and then disappears if user doesn't have any layer to edit.

Demo: https://pgiraud.github.io/ngeo/editing_startup/examples/contribs/gmf/apps/desktop

Please review.