### PR TITLE
Fix editfeature and selector directives for LayerTree refactoring

### DIFF
--- a/contribs/gmf/examples/editfeatureselector.html
+++ b/contribs/gmf/examples/editfeatureselector.html
@@ -94,6 +94,12 @@
         class="panel panel-default panel-body">
     </gmf-authentication>
 
+    <gmf-layertree
+        style="display:none;"
+        gmf-layertree-source="ctrl.treeSource"
+        gmf-layertree-map="::ctrl.map">
+    </gmf-layertree>
+
     <div
         ng-show="ctrl.gmfUser.username"
         class="panel panel-default panel-body">

--- a/contribs/gmf/examples/editfeatureselector.js
+++ b/contribs/gmf/examples/editfeatureselector.js
@@ -2,11 +2,12 @@ goog.provide('gmf-editfeatureselector');
 
 goog.require('gmf');
 goog.require('gmf.Themes');
+goog.require('gmf.TreeManager');
 goog.require('gmf.authenticationDirective');
 goog.require('gmf.editfeatureselectorDirective');
+goog.require('gmf.layertreeDirective');
 goog.require('gmf.mapDirective');
 goog.require('ngeo.FeatureHelper');
-goog.require('ngeo.LayerHelper');
 goog.require('ngeo.ToolActivate');
 goog.require('ngeo.ToolActivateMgr');
 goog.require('ngeo.proj.EPSG21781');
@@ -26,6 +27,14 @@ var app = {};
 /** @type {!angular.Module} **/
 app.module = angular.module('app', ['gmf']);
 
+
+app.module.value('gmfTreeUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
+
+
+app.module.value('gmfWmsUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy');
+
 app.module.value(
     'authenticationBaseUrl',
     'https://geomapfish-demo.camptocamp.net/2.1/wsgi');
@@ -42,15 +51,15 @@ app.module.value('gmfLayersUrl',
 /**
  * @param {!angular.Scope} $scope Angular scope.
  * @param {gmf.Themes} gmfThemes The gmf themes service.
+ * @param {gmf.TreeManager} gmfTreeManager gmf Tree Manager service.
  * @param {gmfx.User} gmfUser User.
  * @param {ngeo.FeatureHelper} ngeoFeatureHelper Ngeo feature helper service.
- * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
  * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
  *     service.
  * @constructor
  */
-app.MainController = function($scope, gmfThemes, gmfUser, ngeoFeatureHelper,
-    ngeoLayerHelper, ngeoToolActivateMgr) {
+app.MainController = function($scope, gmfThemes, gmfTreeManager, gmfUser,
+    ngeoFeatureHelper, ngeoToolActivateMgr) {
 
   /**
    * @type {!angular.Scope}
@@ -72,20 +81,15 @@ app.MainController = function($scope, gmfThemes, gmfUser, ngeoFeatureHelper,
 
   gmfThemes.loadThemes();
 
+  /**
+   * @type {gmf.TreeManager}
+   * @export
+   */
+  this.gmfTreeManager = gmfTreeManager;
+
   var projection = ol.proj.get('EPSG:21781');
   projection.setExtent([485869.5728, 76443.1884, 837076.5648, 299941.7864]);
 
-  /**
-   * @type {ol.layer.Image}
-   * @private
-   */
-  var wmsLayer = new ol.layer.Image({
-    editableIds: [111, 112, 113],
-    source: new ol.source.ImageWMS({
-      url: 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy',
-      params: {'LAYERS': 'point,line,polygon'}
-    })
-  });
 
   /**
    * @type {ol.layer.Vector}
@@ -100,6 +104,12 @@ app.MainController = function($scope, gmfThemes, gmfUser, ngeoFeatureHelper,
       return ngeoFeatureHelper.createEditingStyles(feature);
     }
   });
+
+  /**
+   * @type {Object|undefined}
+   * @export
+   */
+  this.treeSource = undefined;
 
   /**
    * @type {ol.Map}
@@ -119,14 +129,21 @@ app.MainController = function($scope, gmfThemes, gmfUser, ngeoFeatureHelper,
     })
   });
 
-  // Add the WMS layer to the 'data' group, which is what the layer tree
-  // would do
-  var dataLayerGroup = ngeoLayerHelper.getGroupFromMap(this.map,
-        gmf.DATALAYERGROUP_NAME);
-  dataLayerGroup.getLayers().push(wmsLayer);
+  gmfThemes.getThemesObject().then(function(themes) {
+    if (themes) {
+      // Add 'Edit' theme, i.e. the one with id 73
+      for (var i = 0, ii = themes.length; i < ii; i++) {
+        if (themes[i].id === 73) {
+          this.gmfTreeManager.addTheme(themes[i]);
+          break;
+        }
+      }
+      this.treeSource = this.gmfTreeManager.tree;
 
-  // Add layer vector after
-  this.map.addLayer(this.vectorLayer);
+      // Add layer vector after
+      this.map.addLayer(this.vectorLayer);
+    }
+  }.bind(this));
 
  /**
    * @type {boolean}

--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -45,8 +45,7 @@ goog.require('ol.style.Text');
  *
  *     <gmf-editfeature
  *         gmf-editfeature-dirty="ctrl.dirty"
- *         gmf-editfeature-editablenode="::ctrl.node"
- *         gmf-editfeature-editablewmslayer="::ctrl.selectedWMSLayer"
+ *         gmf-editfeature-editabletreectrl="::ctrl.treeCtrl"
  *         gmf-editfeature-map="::ctrl.map"
  *         gmf-editfeature-state="efsCtrl.state"
  *         gmf-editfeature-tolerance="::ctrl.tolerance"
@@ -56,10 +55,9 @@ goog.require('ol.style.Text');
  * @htmlAttribute {boolean} gmf-editfeature-dirty Flag that is toggled as soon
  *     as the feature changes, i.e. if any of its properties change, which
  *     includes the geometry.
- * @htmlAttribute {GmfThemesLeaf} gmf-editfeature-editablenode The GMF node
- *     representing the editable layer.
- * @htmlAttribute {ol.layer.Image|ol.layer.Tile} gmf-editfeature-editablewmslayer
- *     The WMS layer to refresh after each saved modification.
+ * @htmlAttribute {ngeo.LayertreeController} gmf-editfeature-editabletreectrl
+ *     A reference to the editable Layertree controller, which contains a
+ *     a reference to the node and WMS layer.
  * @htmlAttribute {ol.Map} gmf-editfeature-map The map.
  * @htmlAttribute {string} gmf-editfeature-stopeditingrequest Stop editing
  *     state.
@@ -77,8 +75,7 @@ gmf.editfeatureDirective = function() {
     scope: {
       'dirty': '=gmfEditfeatureDirty',
       'layer': '=gmfEditfeatureLayer',
-      'editableNode': '=gmfEditfeatureEditablenode',
-      'editableWMSLayer': '<gmfEditfeatureEditablewmslayer',
+      'editableTreeCtrl': '=gmfEditfeatureEditabletreectrl',
       'map': '<gmfEditfeatureMap',
       'state': '=gmfEditfeatureState',
       'tolerance': '<?gmfEditfeatureTolerance',
@@ -127,16 +124,10 @@ gmf.EditfeatureController = function($element, $scope, $timeout, $q,
   this.dirty = this.dirty === true;
 
   /**
-   * @type {GmfThemesLeaf}
+   * @type {ngeo.LayertreeController}
    * @export
    */
-  this.editableNode;
-
-  /**
-   * @type {ol.layer.Image|ol.layer.Tile}
-   * @export
-   */
-  this.editableWMSLayer;
+  this.editableTreeCtrl;
 
   /**
    * @type {ol.Map}
@@ -181,6 +172,24 @@ gmf.EditfeatureController = function($element, $scope, $timeout, $q,
    * @export
    */
   this.vectorLayer;
+
+  /**
+   * @type {GmfThemesLeaf}
+   * @private
+   */
+  this.editableNode_ = /** @type {GmfThemesLeaf} */ (
+    this.editableTreeCtrl.node);
+
+
+  var layer = this.editableTreeCtrl.parent.layer;
+  goog.asserts.assert(
+    layer instanceof ol.layer.Image || layer instanceof ol.layer.Tile);
+
+  /**
+   * @type {ol.layer.Image|ol.layer.Tile}
+   * @private
+   */
+  this.editableWMSLayer_ = layer;
 
   /**
    * @type {angular.JQLite}
@@ -457,7 +466,7 @@ gmf.EditfeatureController = function($element, $scope, $timeout, $q,
    */
   this.geomType = null;
 
-  gmfXSDAttributes.getAttributes(this.editableNode.id).then(
+  gmfXSDAttributes.getAttributes(this.editableNode_.id).then(
     this.setAttributes_.bind(this));
 
   var uid = goog.getUid(this);
@@ -499,14 +508,14 @@ gmf.EditfeatureController.prototype.save = function() {
 
   if (id) {
     this.editFeatureService_.updateFeature(
-      this.editableNode.id,
+      this.editableNode_.id,
       feature
     ).then(
       this.handleEditFeature_.bind(this)
     );
   } else {
     this.editFeatureService_.insertFeatures(
-      this.editableNode.id,
+      this.editableNode_.id,
       [feature]
     ).then(
       this.handleEditFeature_.bind(this)
@@ -588,7 +597,7 @@ gmf.EditfeatureController.prototype.delete = function() {
 
     // (1) Launch request
     this.editFeatureService_.deleteFeature(
-      this.editableNode.id,
+      this.editableNode_.id,
       this.feature
     ).then(
       this.handleDeleteFeature_.bind(this)
@@ -624,7 +633,7 @@ gmf.EditfeatureController.prototype.handleEditFeature_ = function(resp) {
   var features = new ol.format.GeoJSON().readFeatures(resp.data);
   if (features.length) {
     this.feature.setId(features[0].getId());
-    this.layerHelper_.refreshWMSLayer(this.editableWMSLayer);
+    this.layerHelper_.refreshWMSLayer(this.editableWMSLayer_);
   }
   if (this.confirmDeferred_) {
     this.confirmDeferred_.resolve();
@@ -639,7 +648,7 @@ gmf.EditfeatureController.prototype.handleEditFeature_ = function(resp) {
  */
 gmf.EditfeatureController.prototype.handleDeleteFeature_ = function(resp) {
   this.pending = false;
-  this.layerHelper_.refreshWMSLayer(this.editableWMSLayer);
+  this.layerHelper_.refreshWMSLayer(this.editableWMSLayer_);
 };
 
 
@@ -732,7 +741,7 @@ gmf.EditfeatureController.prototype.toggle_ = function(active) {
 
   this.modify_.setActive(active);
   this.mapSelectActive = active;
-  this.editableNode['editing'] = active;
+  this.editableNode_['editing'] = active;
 
 };
 
@@ -818,7 +827,7 @@ gmf.EditfeatureController.prototype.handleMapClick_ = function(evt) {
     );
 
     // (3) Launch query to fetch features
-    this.editFeatureService_.getFeatures([this.editableNode.id], extent).then(
+    this.editFeatureService_.getFeatures([this.editableNode_.id], extent).then(
       this.handleGetFeatures_.bind(this));
 
     // (4) Clear any previously selected feature
@@ -1072,24 +1081,24 @@ gmf.EditfeatureController.State = {
    * unsaved modifications were saved or discarded.
    * @type {string}
    */
-  DEACTIVATE_EXECUTE: 'execute',
+  DEACTIVATE_EXECUTE: 'deactivate_execute',
   /**
    * The state active when the deactivation of the editing tools is in
    * progress while there are unsaved modifications.
    * @type {string}
    */
-  DEACTIVATE_PENDING: 'pending',
+  DEACTIVATE_PENDING: 'deactivate_pending',
   /**
    * Final state set after the "stop editing" button has been clicked while
    * no unsaved modifications were made or if the user saved them or confirmed
    * to continue without saving.
    * @type {string}
    */
-  STOP_EDITING_EXECUTE: 'execute',
+  STOP_EDITING_EXECUTE: 'stop_editing_execute',
   /**
    * The state that is active while when the "stop editing" button has been
    * clicked but before any confirmation has been made to continue.
    * @type {string}
    */
-  STOP_EDITING_PENDING: 'pending'
+  STOP_EDITING_PENDING: 'stop_editing_pending'
 };

--- a/contribs/gmf/src/directives/partials/editfeatureselector.html
+++ b/contribs/gmf/src/directives/partials/editfeatureselector.html
@@ -1,16 +1,16 @@
 <div
-    ng-switch="efsCtrl.selectedEditableNode">
+    ng-switch="efsCtrl.selectedEditableTreeCtrl">
 
   <div ng-switch-when="null">
     <select
         class="form-control"
-        ng-model="efsCtrl.selectedEditableNode"
-        ng-show="efsCtrl.availableEditableNodes.length > 0"
-        ng-options="layer.name | translate for layer in efsCtrl.availableEditableNodes">
+        ng-model="efsCtrl.selectedEditableTreeCtrl"
+        ng-show="efsCtrl.editableTreeCtrls.length > 0"
+        ng-options="treeCtrl.node.name | translate for treeCtrl in efsCtrl.editableTreeCtrls">
       <option value="" translate>-- Choose a layer --</option>
     </select>
     <span
-      ng-show="efsCtrl.availableEditableNodes.length == 0"
+      ng-show="efsCtrl.editableTreeCtrls.length == 0"
       translate>No editable layer available!</span>
   </div>
 
@@ -18,7 +18,7 @@
     <div class="row">
       <div class="col-sm-12">
         <span translate>Currently editing: </span>
-        <b>{{ efsCtrl.selectedEditableNode.name | translate }}</b>
+        <b>{{ efsCtrl.selectedEditableTreeCtrl.name | translate }}</b>
         <span class="fa fa-pencil"></span>
         <br>
         <button
@@ -32,8 +32,7 @@
 
     <gmf-editfeature
         gmf-editfeature-dirty="efsCtrl.dirty"
-        gmf-editfeature-editablenode="::efsCtrl.selectedEditableNode"
-        gmf-editfeature-editablewmslayer="::efsCtrl.selectedEditableWMSLayer"
+        gmf-editfeature-editabletreectrl="::efsCtrl.selectedEditableTreeCtrl"
         gmf-editfeature-map="::efsCtrl.map"
         gmf-editfeature-state="efsCtrl.state"
         gmf-editfeature-tolerance="::efsCtrl.tolerance"


### PR DESCRIPTION
This PR fixes the editing tools, i.e. the `gmf-editfeature` and `gmf-editfeatureselector`.

Requires #1874 and #1870.