### PR TITLE
Add public getTreeCtrlReferences method

### DIFF
--- a/contribs/gmf/src/services/treemanager.js
+++ b/contribs/gmf/src/services/treemanager.js
@@ -477,6 +477,16 @@ gmf.TreeManager.prototype.notifyCantAddGroups_ = function(groups) {
 
 
 /**
+ * Returns the treeCtrls list kept as reference.
+ * @return {Array.<ngeo.LayertreeController>} List of Layertree controllers.
+ * @public
+ */
+gmf.TreeManager.prototype.getTreeCtrlReferences = function() {
+  return this.treeCtrlReferences_;
+};
+
+
+/**
  * Add a treeCtrl to kept in reference.
  * @param {ngeo.LayertreeController} treeCtrl ngeoLayer tree controller.
  * @public


### PR DESCRIPTION
This PR adds a method to the treemanager to return the Layertree controllers kept as reference. The goal of this is to make possible to watch the array for newly added or removed elements.