### PR TITLE
Handle more branches in gh-pages branches cleanup

### DIFF
--- a/buildtools/cleanup-ghpages.py
+++ b/buildtools/cleanup-ghpages.py
@@ -13,7 +13,8 @@ urllib3.disable_warnings()
 
 def main():
     try:
-        url = "https://api.github.com/repos/%s/ngeo/branches" % argv[1]
+        url = "https://api.github.com/repos/%s/ngeo/branches?per_page=100" \
+            % argv[1]
         expected = [
             branch["name"] for branch in loads(requests.get(url).content)
         ]


### PR DESCRIPTION
When pushing branches to github pages, the `gh-pages` Makefile target also cleans up local repo by removing branches that are not in the remote repo (for example when they've been deleted).
Unfortunately we rely on a request on the github api which returns only a fragment of the branches list because of pagination. This results in branches not being sent to gh-pages because the list is truncated.

With this pull request I make sure that at least 100 branches are supported.

Please review.