### PR TITLE
Add an option to bypass the local storage

### DIFF
--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -299,7 +299,7 @@
                 {action: 'add_layer', title: 'Add a layer'}
         ]);
         module.constant('gmfTreeManagerModeFlush', false);
-        module.value('gmfPermalinkOptions', {projectionCodes: ['EPSG:21781', 'EPSG:2056', 'EPSG:4326']});
+        module.value('gmfPermalinkOptions', {projectionCodes: ['EPSG:21781', 'EPSG:2056', 'EPSG:4326'], useLocalStorage: false});
         module.value('ngeoWfsPermalinkOptions',
             /** @type {ngeox.WfsPermalinkOptions} */ ({
               url: 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/mapserv_proxy',

--- a/contribs/gmf/externs/gmfx.js
+++ b/contribs/gmf/externs/gmfx.js
@@ -100,7 +100,8 @@ gmfx.MousePositionProjection.prototype.filter;
  * Configuration options for the permalink service.
  * @typedef {{
  *     crosshairStyle: (Array<(null|ol.style.Style)>|null|ol.FeatureStyleFunction|ol.style.Style|undefined),
- *     projectionCodes: (Array.<string>|undefined)
+ *     projectionCodes: (Array.<string>|undefined),
+ *     useLocalStorage: (boolean|undefined)
  * }}
  */
 gmfx.PermalinkOptions;
@@ -120,6 +121,13 @@ gmfx.PermalinkOptions.prototype.crosshairStyle;
  * @type {Array.<string>|undefined}
  */
 gmfx.PermalinkOptions.prototype.projectionCodes;
+
+
+/**
+ * Store the values in the local storage. Default is `true`.
+ * @type {boolean|undefined}
+ */
+gmfx.PermalinkOptions.prototype.useLocalStorage;
 
 
 /**

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -19,6 +19,7 @@ goog.require('ngeo.format.FeatureHash');
 goog.require('ngeo.WfsPermalink');
 goog.require('goog.asserts');
 goog.require('ol.Feature');
+goog.require('ol.functions');
 goog.require('ol.geom.Point');
 goog.require('ol.proj');
 goog.require('ol.layer.Group');
@@ -146,6 +147,10 @@ gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
    * @private
    */
   this.ngeoStateManager_ = ngeoStateManager;
+
+  if (gmfPermalinkOptions.useLocalStorage === false) {
+    this.ngeoStateManager_.localStorage.isAvailable = ol.functions.FALSE;
+  }
 
   /**
    * @type {gmf.Themes}


### PR DESCRIPTION
Add a new options to gmfx.PermalinkOptions to deactivate to storage into the local storage.
The desktop_alt now uses this option.