### PR TITLE
Fix editfeature dir. layer getting

### DIFF
--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -4,6 +4,7 @@ goog.provide('gmf.editfeatureDirective');
 
 goog.require('gmf');
 goog.require('gmf.EditFeature');
+goog.require('gmf.SyncLayertreeMap');
 goog.require('gmf.XSDAttributes');
 /** @suppress {extraRequire} */
 goog.require('ngeo.attributesDirective');
@@ -181,7 +182,7 @@ gmf.EditfeatureController = function($element, $scope, $timeout, $q,
     this.editableTreeCtrl.node);
 
 
-  var layer = this.editableTreeCtrl.parent.layer;
+  var layer = gmf.SyncLayertreeMap.getLayer(this.editableTreeCtrl);
   goog.asserts.assert(
     layer instanceof ol.layer.Image || layer instanceof ol.layer.Tile);
 

--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -396,7 +396,7 @@ gmf.LayertreeController.prototype.updateWMSTimeLayerState = function(
     return;
   }
   var layer = /** @type {ol.layer.Image} */ (
-          this.gmfSyncLayertreeMap_.getLayer(layertreeCtrl));
+      gmf.SyncLayertreeMap.getLayer(layertreeCtrl));
   if (layer) {
     var node = /** @type {GmfThemesGroup} */ (layertreeCtrl.node);
     var wmsTime = /** @type {ngeox.TimeProperty} */ (node.time);

--- a/contribs/gmf/src/services/syncLayertreeMap.js
+++ b/contribs/gmf/src/services/syncLayertreeMap.js
@@ -81,7 +81,7 @@ gmf.SyncLayertreeMap.prototype.sync = function(map, treeCtrl) {
   var treeCtrls = [];
   ngeo.LayertreeController.getFlatTree(treeCtrl, treeCtrls);
   treeCtrls.forEach(function(item) {
-    var layer = this.getLayer(item);
+    var layer = gmf.SyncLayertreeMap.getLayer(item);
     if (layer instanceof ol.layer.Image || layer instanceof ol.layer.Tile) {
       this.updateLayerState_(layer, item);
     }
@@ -187,7 +187,7 @@ gmf.SyncLayertreeMap.prototype.createGroup_ = function(treeCtrl, map,
     if (inAMixedGroup) {
       layer = this.createLayerFromGroup_(treeCtrl, true);
       var layerGroup = /** @type {ol.layer.Group} */ (
-              this.getLayer(treeCtrl.parent));
+              gmf.SyncLayertreeMap.getLayer(treeCtrl.parent));
       layerGroup.getLayers().insertAt(0, layer);
     }
   }
@@ -275,7 +275,8 @@ gmf.SyncLayertreeMap.prototype.createLeafInAMixedGroup_ = function(treeCtrl,
   }
   layer.setVisible(checked);
   // Insert layer in the map.
-  var layerGroup = /** @type {ol.layer.Group} */ (this.getLayer(treeCtrl));
+  var layerGroup = /** @type {ol.layer.Group} */ (
+    gmf.SyncLayertreeMap.getLayer(treeCtrl));
   layerGroup.getLayers().insertAt(0, layer);
   return layer;
 };
@@ -295,7 +296,7 @@ gmf.SyncLayertreeMap.prototype.createLeafInANotMixedGroup_ = function(treeCtrl,
   var notMixedTreeCtrl = this.getFirstNotMixedParentTreeCtrl_(treeCtrl);
   goog.asserts.assert(notMixedTreeCtrl);
   var wmsLayer = /** @type {ol.layer.Image} */ (
-          this.getLayer(notMixedTreeCtrl));
+          gmf.SyncLayertreeMap.getLayer(notMixedTreeCtrl));
   goog.asserts.assertInstanceof(wmsLayer, ol.layer.Image);
   //Update layer information and tree state.
   this.updateLayerReferences_(leafNode, wmsLayer);
@@ -386,24 +387,6 @@ gmf.SyncLayertreeMap.prototype.getTimeParam_ = function(treeCtrl) {
   return timeParam;
 };
 
-/**
- * Return the layer used by the given treeCtrl.
- * @param {ngeo.LayertreeController} treeCtrl ngeo layertree controller.
- * @return {ol.layer.Base} The layer.
- * @public
- */
-gmf.SyncLayertreeMap.prototype.getLayer = function(treeCtrl) {
-  var tree = treeCtrl;
-  var layer = null;
-  while (!tree.isRoot && layer === null) {
-    if (tree.layer) {
-      layer = tree.layer;
-    }
-    tree = tree.parent;
-  }
-  return layer;
-};
-
 
 /**
  * Return true if a parent tree is mixed, based on its node.
@@ -440,6 +423,25 @@ gmf.SyncLayertreeMap.prototype.getFirstNotMixedParentTreeCtrl_ = function(
     tree = tree.parent;
   }
   return notMixedParent;
+};
+
+
+/**
+ * Return the layer used by the given treeCtrl.
+ * @param {ngeo.LayertreeController} treeCtrl ngeo layertree controller.
+ * @return {ol.layer.Base} The layer.
+ * @public
+ */
+gmf.SyncLayertreeMap.getLayer = function(treeCtrl) {
+  var tree = treeCtrl;
+  var layer = null;
+  while (!tree.isRoot && layer === null) {
+    if (tree.layer) {
+      layer = tree.layer;
+    }
+    tree = tree.parent;
+  }
+  return layer;
 };
 
 

--- a/contribs/gmf/test/spec/services/syncLayertreeMap.spec.js
+++ b/contribs/gmf/test/spec/services/syncLayertreeMap.spec.js
@@ -88,7 +88,7 @@ describe('gmf.SyncLayertreeMap', function() {
 
     var treeGroup = roottreeCtrl.children[1]; // Group 'Layers'
     var treeLayer = treeGroup.children[0]; // Leaf 'cinema'
-    var layer = gmfSyncLayertreeMap.getLayer(treeLayer);
+    var layer = gmf.SyncLayertreeMap.getLayer(treeLayer);
 
     expect(treeLayer.layer).toBe(null);
     expect(layer.constructor).toBe(ol.layer.Image);


### PR DESCRIPTION
This PR fixes how the OpenLayers layer is obtained in the `gmf-editfeature` directive.  It used to only check the parent treeCtrl, but the layer may be in a higher level group (i.e. if we have groups inside groups).

To fix this, a new static method has been added to the gmf layertree controller.  It can be used to find a layer object from a ngeo treeCtrl that has a leaf as node (because I think it only makes sense to work from leaves when you want to know the associated layer, you don't really care about the ol.layer.Group).