### PR TITLE
Include jsdoc folder in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,7 +10,6 @@
 /.build/
 /examples/
 /docs/
-/jsdoc/
 /contribs/gmf/examples/
 /contribs/gmf/apps/
 /contribs/gmf/build/


### PR DESCRIPTION
This is required for projects that re-use the jsdoc tools of ngeo. Currently, the folder `jsdoc` is excluded in `.npmignore`, so it is not available when installing ngeo as normal npm package.

I would propose to remove `jsdoc` from  `.npmignore` so that the scripts can be re-used.