### PR TITLE
Typo in css class name

### DIFF
--- a/contribs/gmf/less/displayquerywindow.less
+++ b/contribs/gmf/less/displayquerywindow.less
@@ -217,7 +217,7 @@
 @media (orientation:landscape) {
   /* mobile landscape orientation */
   .gmf-displayquerywindow-mobile {
-    .gmf-displayquerywindow-animation-container.detailed {
+    .gmf-displayquerywindow-animation-container-detailed {
       height: (@displayquerywindow-detailed-header-height + @displayquerywindow-detailed-details-height / 2 + @app-margin * 3);
     }
     .gmf-displayquerywindow-details {


### PR DESCRIPTION
Fixes #1855.

Please review.

Demo:
https://pgiraud.github.io/ngeo/query_window/examples/contribs/gmf/apps/mobile/?baselayer_ref=asitvd.fond_gris&lang=fr&map_x=552517&map_y=152879&map_zoom=2&rl_features=Fa(57v1-3bcEgC8w*9t!hH90s6*~n*Polygon%25201%27c*%2523DB4436%27a*0%27o*0.2%27m*false%27s*10%27k*1)&tree_groups=Layers&tree_group_layers_Layers=hospitals%2Csustenance%2Centertainment%2Cosm_time%2Cpost_office%2Cpolice%2Ccinema