### PR TITLE
Use the label property to match the layer name

### DIFF
--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -382,7 +382,7 @@ gmf.AbstractController = function(config, $scope, $injector) {
           var background = backgrounds[0];
           this.gmfThemes_.getBgLayers(this.dimensions).then(function(layers) {
             var layer = ol.array.find(layers, function(layer) {
-              return layer.name === background;
+              return layer.get('label') === background;
             });
             if (layer) {
               backgroundLayerMgr.set(map, layer);
@@ -413,7 +413,7 @@ gmf.AbstractController = function(config, $scope, $injector) {
           if (defaultBasemapArray.length > 0) {
             var defaultBasemapLabel = defaultBasemapArray[0];
             background = ol.array.find(layers, function(layer) {
-              return layer.name === defaultBasemapLabel;
+              return layer.get('label') === defaultBasemapLabel;
             });
           }
         }

--- a/contribs/gmf/src/services/themesservice.js
+++ b/contribs/gmf/src/services/themesservice.js
@@ -217,7 +217,7 @@ gmf.Themes.getFlatNodes = function(node, nodes) {
 /**
  * Get background layers.
  * @param {Object.<string, string>} appDimensions Dimensions.
- * @return {angular.$q.Promise.<Array.<GmfLayer>>} Promise.
+ * @return {angular.$q.Promise.<Array.<ol.layer.Base>>} Promise.
  */
 gmf.Themes.prototype.getBgLayers = function(appDimensions) {
   if (this.bgLayerPromise_) {


### PR DESCRIPTION
`layer.name` was used but was never defined.
The layer param passed to the promise is an array of ol.layer.Base not GmfLayer