### PR TITLE
Always set the gmfUser response

### DIFF
--- a/contribs/gmf/src/services/authenticationservice.js
+++ b/contribs/gmf/src/services/authenticationservice.js
@@ -271,14 +271,12 @@ gmf.Authentication.prototype.handleLogin_ = function(checkingLoginStatus, resp) 
  * @private
  */
 gmf.Authentication.prototype.setUser_ = function(respData, emitEvent) {
-  if (respData.username !== undefined) {
-    for (var key in respData) {
-      this.user_[key] = respData[key];
-    }
-    if (emitEvent) {
-      this.dispatchEvent(new gmf.AuthenticationEvent(
-        gmf.AuthenticationEventType.LOGIN, this.user_));
-    }
+  for (var key in respData) {
+    this.user_[key] = respData[key];
+  }
+  if (emitEvent && respData.username !== undefined) {
+    this.dispatchEvent(new gmf.AuthenticationEvent(
+      gmf.AuthenticationEventType.LOGIN, this.user_));
   }
 };
 


### PR DESCRIPTION
fixes #1937 

set all the fields from the authentication service but only dispatch a `gmf.AuthenticationEventType.LOGIN` event if the username is defined.
