### PR TITLE
Reorder delete

### DIFF
--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -246,6 +246,32 @@ gmf.LayertreeController = function($http, $sce, $scope, ngeoCreatePopup,
     this.map.render();
   }.bind(this));
 
+  // watch any change on root children to update the layers on the map
+  $scope.$watchCollection(function() {
+    return this.gmfTreeManager_.root.children;
+  }.bind(this),
+  function(newValue, oldValue) {
+    // we want to watch for order change only
+    if (newValue != oldValue &&
+        newValue.length == oldValue.length &&
+        this.gmfTreeManager_.rootCtrl) {
+      // create a new children array with the new order
+      var newChildren = new Array(newValue.length);
+      oldValue.forEach(function(item, index) {
+        newChildren[newValue.indexOf(item)] =
+            this.gmfTreeManager_.rootCtrl.children[index];
+      }, this);
+      // update the root controller with the new children's order
+      this.gmfTreeManager_.rootCtrl.children = newChildren;
+
+      // then update the layers order
+      this.layers.length = 0;
+      this.gmfTreeManager_.rootCtrl.children.forEach(function(child) {
+        this.layers.push(child.layer);
+      }, this);
+    }
+  }.bind(this));
+
   // watch any change on dimensions object to refresh the layers
   $scope.$watchCollection(function() {
     if (this.gmfTreeManager_.rootCtrl) {

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -5,7 +5,7 @@
 
   <div
     class="ngeo-sortable-handle"
-    ng-show="layertreeCtrl.depth === 1 && gmfLayertreeCtrl.layers.length > 1">
+    ng-show="layertreeCtrl.depth === 1 && layertreeCtrl.parent.children.length > 1">
     <i class="gmf-layertree-sortable-handle-icon fa fa-ellipsis-v"></i>
   </div>
 
@@ -180,7 +180,7 @@
   id="gmf-layertree-layer-group-{{::layertreeCtrl.uid}}"
   ng-if="::layertreeCtrl.node.children"
   ng-class="{collapse: !layertreeCtrl.isRoot, in : layertreeCtrl.node.metadata.isExpanded}"
-  ngeo-sortable="::layertreeCtrl.isRoot && gmfLayertreeCtrl.layers"
+  ngeo-sortable="::layertreeCtrl.isRoot && layertreeCtrl.node.children"
   ngeo-sortable-options="{handleClassName: 'ngeo-sortable-handle', draggerClassName: 'gmf-layertree-dragger', currDragItemClassName : 'gmf-layertree-curr-drag-item'}">
 
   <li


### PR DESCRIPTION
Fixes #1744 

This pull request aim is to fix the problem with layertree DOM elements being messed up after a reordering (drag&drop).
The main issue is due to the fact that the `ng-repeat` directive relies on HTML comments to work properly.

In order to get the comments and DOM elements being correctly ordered it is mandatory that the variable used as configuration for `ng-repeat` is updated after the reorder. The simplest solution is to use the same variable.
https://github.com/camptocamp/ngeo/commit/91e7b9a74956e1db99a3860bb3dfecf697849674

Once done, there's no issue with the deletion of groups anymore. However, the order of layers in the map is updated.

In order to do that, I watch for changes in the order of `root.children` (list of children config, used in the ng-repeat), then update the `rootCtrl.children` to apply the same order change. We can then loop into the first level groups, get the layers and update the gmfLayerTreeCtrl.layers which will eventually change the order of layers in the map.

https://github.com/camptocamp/ngeo/commit/a179cb77555390a9dde98716694ee80bf03cb9b1

Note : In my opinion, this should not be so complex.
Note 1 : I'm not sure that the permalink is updated when the order is changed.