### PR TITLE
Layertree order delete

### DIFF
--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -246,32 +246,6 @@ gmf.LayertreeController = function($http, $sce, $scope, ngeoCreatePopup,
     this.map.render();
   }.bind(this));
 
-  // watch any change on root children to update the layers on the map
-  $scope.$watchCollection(function() {
-    return this.gmfTreeManager_.root.children;
-  }.bind(this),
-  function(newValue, oldValue) {
-    // we want to watch for order change only
-    if (newValue != oldValue &&
-        newValue.length == oldValue.length &&
-        this.gmfTreeManager_.rootCtrl) {
-      // create a new children array with the new order
-      var newChildren = new Array(newValue.length);
-      oldValue.forEach(function(item, index) {
-        newChildren[newValue.indexOf(item)] =
-            this.gmfTreeManager_.rootCtrl.children[index];
-      }, this);
-      // update the root controller with the new children's order
-      this.gmfTreeManager_.rootCtrl.children = newChildren;
-
-      // then update the layers order
-      this.layers.length = 0;
-      this.gmfTreeManager_.rootCtrl.children.forEach(function(child) {
-        this.layers.push(child.layer);
-      }, this);
-    }
-  }.bind(this));
-
   // watch any change on dimensions object to refresh the layers
   $scope.$watchCollection(function() {
     if (this.gmfTreeManager_.rootCtrl) {
@@ -283,6 +257,7 @@ gmf.LayertreeController = function($http, $sce, $scope, ngeoCreatePopup,
     }
   }.bind(this));
 };
+
 
 /**
  * @param {ngeo.LayertreeController} treeCtrl Layer tree controller.
@@ -566,6 +541,37 @@ gmf.LayertreeController.prototype.displayMetadata = function(treeCtrl) {
       infoPopup.setOpen(true);
     });
   }
+};
+
+
+/**
+ * Update the layers order in the map and the treeCtrl in the treeManager after
+ * a reorder of the first-level groups.
+ * @export
+ */
+gmf.LayertreeController.prototype.syncTreeAndLayers = function() {
+  var groupNodes = this.gmfTreeManager_.rootCtrl.node.children;
+  var currentTreeCtrls = this.gmfTreeManager_.rootCtrl.children;
+  var treeCtrls = [];
+
+  // Get order of first-level groups for treectrl and layers;
+  groupNodes.forEach(function(node) {
+    currentTreeCtrls.some(function(treeCtrl) {
+      if (treeCtrl.node === node) {
+        treeCtrls.push(treeCtrl);
+        return;
+      }
+    });
+  }, this);
+
+  // Update gmfTreeManager rootctrl children order
+  this.gmfTreeManager_.rootCtrl.children = treeCtrls;
+
+  // Update map 'data' groupe layers order
+  this.layers.length = 0;
+  this.gmfTreeManager_.rootCtrl.children.forEach(function(child) {
+    this.layers.push(child.layer);
+  }, this);
 };
 
 

--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -246,6 +246,32 @@ gmf.LayertreeController = function($http, $sce, $scope, ngeoCreatePopup,
     this.map.render();
   }.bind(this));
 
+  // watch any change on root children to update the layers on the map
+  $scope.$watchCollection(function() {
+    return this.gmfTreeManager_.root.children;
+  }.bind(this),
+  function(newValue, oldValue) {
+    // we want to watch for order change only
+    if (newValue != oldValue &&
+        newValue.length == oldValue.length &&
+        this.gmfTreeManager_.rootCtrl) {
+      // create a new children array with the new order
+      var newChildren = new Array(newValue.length);
+      oldValue.forEach(function(item, index) {
+        newChildren[newValue.indexOf(item)] =
+            this.gmfTreeManager_.rootCtrl.children[index];
+      }, this);
+      // update the root controller with the new children's order
+      this.gmfTreeManager_.rootCtrl.children = newChildren;
+
+      // then update the layers order
+      this.layers.length = 0;
+      this.gmfTreeManager_.rootCtrl.children.forEach(function(child) {
+        this.layers.push(child.layer);
+      }, this);
+    }
+  }.bind(this));
+
   // watch any change on dimensions object to refresh the layers
   $scope.$watchCollection(function() {
     if (this.gmfTreeManager_.rootCtrl) {

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -5,7 +5,7 @@
 
   <div
     class="ngeo-sortable-handle"
-    ng-show="layertreeCtrl.depth === 1 && gmfLayertreeCtrl.layers.length > 1">
+    ng-show="layertreeCtrl.depth === 1 && layertreeCtrl.parent.children.length > 1">
     <i class="gmf-layertree-sortable-handle-icon fa fa-ellipsis-v"></i>
   </div>
 
@@ -180,7 +180,7 @@
   id="gmf-layertree-layer-group-{{::layertreeCtrl.uid}}"
   ng-if="::layertreeCtrl.node.children"
   ng-class="{collapse: !layertreeCtrl.isRoot, in : layertreeCtrl.node.metadata.isExpanded}"
-  ngeo-sortable="::layertreeCtrl.isRoot && gmfLayertreeCtrl.layers"
+  ngeo-sortable="::layertreeCtrl.isRoot && layertreeCtrl.node.children"
   ngeo-sortable-options="{handleClassName: 'ngeo-sortable-handle', draggerClassName: 'gmf-layertree-dragger', currDragItemClassName : 'gmf-layertree-curr-drag-item'}">
 
   <li

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -181,7 +181,9 @@
   ng-if="::layertreeCtrl.node.children"
   ng-class="{collapse: !layertreeCtrl.isRoot, in : layertreeCtrl.node.metadata.isExpanded}"
   ngeo-sortable="::layertreeCtrl.isRoot && layertreeCtrl.node.children"
-  ngeo-sortable-options="{handleClassName: 'ngeo-sortable-handle', draggerClassName: 'gmf-layertree-dragger', currDragItemClassName : 'gmf-layertree-curr-drag-item'}">
+  ngeo-sortable-options="{handleClassName: 'ngeo-sortable-handle', draggerClassName: 'gmf-layertree-dragger', currDragItemClassName : 'gmf-layertree-curr-drag-item'}"
+  ngeo-sortable-callback="::gmfLayertreeCtrl.syncTreeAndLayers"
+  ngeo-sortable-callback-ctx="::gmfLayertreeCtrl">
 
   <li
     class="gmf-layertree-node"

--- a/src/directives/sortable.js
+++ b/src/directives/sortable.js
@@ -46,7 +46,12 @@ ngeo.SortableOptions;
  * See our live example: {@link ../examples/layerorder.html}
  *
  * @htmlAttribute {Array.<ol.layer.Base>} ngeo-sortable The layers to sort.
- * @htmlAttribute {!ngeo.SortableOptions} ngeo-sortable The options.
+ * @htmlAttribute {!ngeo.SortableOptions} ngeo-sortable-options The options.
+ * @htmlAttribute {Function(angular.JQLite, Array)?} ngeo-sortable-callback
+ *     Callback function called after the move end. The Function will be called
+ *     with the element and the sort array as arguments.
+ * @htmlAttribute {Object?} ngeo-sortable-callback-ctx Context to apply at
+ *     the call of the callback function.
  * @param {angular.$timeout} $timeout Angular timeout service.
  * @return {angular.Directive} The directive specs.
  * @ngInject
@@ -70,6 +75,9 @@ ngeo.sortableDirective = function($timeout) {
 
           var optionsObject = scope.$eval(attrs['ngeoSortableOptions']);
           var options = getOptions(optionsObject);
+
+          var callbackFn = scope.$eval(attrs['ngeoSortableCallback']);
+          var callbackCtx = scope.$eval(attrs['ngeoSortableCallbackCtx']);
 
           /**
            * @type {goog.fx.DragListGroup}
@@ -174,6 +182,10 @@ ngeo.sortableDirective = function($timeout) {
                 scope.$apply(function() {
                   sortable.push(sortable.splice(idx, 1)[0]);
                 });
+              }
+              // Call the callback function if it exists.
+              if (callbackFn instanceof Function) {
+                callbackFn.apply(callbackCtx, [element, sortable]);
               }
             });
 


### PR DESCRIPTION
Replace: #1948 
Fix: #1744 
Example: https://ger-benjamin.github.io/ngeo/layertree_order_delete/examples/contribs/gmf/apps/desktop_alt

(More explanation in the PR of pgiraud)
- The order is now done on the same object that the ng-repeat build the layertree (Group node of the root treeCtrl)
- There is now a callback function that is called after the move end of the sortable directive
- Via that, after move end, the gmf layertree update the treeCtrls order and layers from the map

Also, there is a problem with the permalink but it's not bound with this issue I think.
