### PR TITLE
Prefix gmfthemes

### DIFF
--- a/contribs/gmf/externs/gmf-themes.js
+++ b/contribs/gmf/externs/gmf-themes.js
@@ -22,11 +22,10 @@ gmfThemes.GmfThemesResponse;
 
 
 /**
- * @typedef {{
- *   children: Array.<gmfThemes.GmfGroup>
- * }}
+ * @constructor
+ * @struct
  */
-gmfThemes.GmfRootNode;
+gmfThemes.GmfRootNode = function() {};
 
 
 /**
@@ -36,13 +35,10 @@ gmfThemes.GmfRootNode.prototype.children;
 
 /**
  * Contains the common element of all the elements of the GeoMapFisf layer tree.
- * @typedef {{
- *   id: number,
- *   metadata: gmfThemes.GmfMetaData,
- *   name: string
- * }}
+ * @constructor
+ * @struct
  */
-gmfThemes.GmfBaseNode;
+gmfThemes.GmfBaseNode = function() {};
 
 
 /**
@@ -66,13 +62,11 @@ gmfThemes.GmfBaseNode.prototype.name;
 
 /**
  * The element we can select in the theme selector.
- * @typedef {{
- *   children: Array.<gmfThemes.GmfGroup>,
- *   functionalities: Object.<string, Array.<string|number>>
- * }}
+ * @constructor
+ * @struct
  * @extends gmfThemes.GmfBaseNode
  */
-gmfThemes.GmfTheme;
+gmfThemes.GmfTheme = function() {};
 
 
 /**
@@ -95,16 +89,11 @@ gmfThemes.GmfTheme.prototype.functionalities;
  * neither a WMS group.
  * This represent « first level group » (Block in the layer tree),
  * or all sub nodes that's not al leaf.
- * @typedef {{
- *   children: Array.<gmfThemes.GmfGroup|gmfThemes.GmfLayer>,
- *   dimensions: Object.<string, string>,
- *   mixed: boolean,
- *   ogcServer: (string|undefined),
- *   time: (ngeox.TimeProperty|undefined)
- * }}
+ * @constructor
+ * @struct
  * @extends gmfThemes.GmfBaseNode
  */
-gmfThemes.GmfGroup;
+gmfThemes.GmfGroup = function() {};
 
 
 /**
@@ -152,15 +141,11 @@ gmfThemes.GmfGroup.prototype.time;
  * not an OpenLayers layer
  * neither a WMS layer.
  * This is also the leaf of the tree.
- * @typedef {{
- *   dimensions: Object.<string, string>,
- *   editable: (boolean|undefined),
- *   style: (string|undefined),
- *   type: string
- * }}
+ * @constructor
+ * @struct
  * @extends gmfThemes.GmfBaseNode
  */
-gmfThemes.GmfLayer;
+gmfThemes.GmfLayer = function() {};
 
 
 /**
@@ -191,17 +176,11 @@ gmfThemes.GmfLayer.prototype.type;
 
 
 /**
- * @typedef {{
- *   childLayers: Array.<gmfThemes.GmfLayerChildLayer>,
- *   layers: string,
- *   maxResolutionHint: number,
- *   minResolutionHint: number,
- *   ogcServer: (string|undefined),
- *   time: (ngeox.TimeProperty|undefined)
- * }}
+ * @constructor
+ * @struct
  * @extends gmfThemes.GmfLayer
  */
-gmfThemes.GmfLayerWMS;
+gmfThemes.GmfLayerWMS = function() {};
 
 
 /**
@@ -245,15 +224,11 @@ gmfThemes.GmfLayerWMS.prototype.time;
 
 
 /**
- * @typedef {{
- *   imageType: string,
- *   layer: string,
- *   matrixSet: string,
- *   url: string
- * }}
+ * @constructor
+ * @struct
  * @extends gmfThemes.GmfLayer
  */
-gmfThemes.GmfLayerWMTS;
+gmfThemes.GmfLayerWMTS = function() {};
 
 
 /**
@@ -283,14 +258,10 @@ gmfThemes.GmfLayerWMTS.prototype.url;
 
 /**
  * Additional attributes related on a WMS layers (or WFS features type).
- * @typedef {{
- *   maxResolutionHint: number,
- *   minResolutionHint: number,
- *   name: string,
- *   queryable: boolean
- * }}
+ * @constructor
+ * @struct
  */
-gmfThemes.GmfLayerChildLayer;
+gmfThemes.GmfLayerChildLayer = function() {};
 
 
 /**
@@ -326,16 +297,10 @@ gmfThemes.GmfOgcServers;
 
 
 /**
- * @typedef {{
- *   imageType: string,
- *   isSingleTile: boolean,
- *   type: string,
- *   url: string,
- *   urlWfs: string,
- *   wfsSupport: boolean
- * }}
+ * @constructor
+ * @struct
  */
-gmfThemes.GmfOgcServer;
+gmfThemes.GmfOgcServer = function() {};
 
 
 /**
@@ -378,27 +343,10 @@ gmfThemes.GmfOgcServer.prototype.wfsSupport;
 
 
 /**
- * @typedef {{
- *   disclaimer: (string|undefined),
- *   iconUrl: (string|undefined),
- *   identifierAttributeField: (string|undefined),
- *   isChecked: (boolean|undefined),
- *   isExpanded: (boolean|undefined),
- *   isLegendExpanded: (boolean|undefined),
- *   legend: (boolean|undefined),
- *   legendImage: (string|undefined),
- *   legendRule: (string|undefined),
- *   maxResolution: (number|undefined),
- *   metadataUrl: (string|undefined),
- *   minResolution: (number|undefined),
- *   ogcServer: (string|undefined),
- *   printLayers: (string|undefined),
- *   snappingConfig: (gmfThemes.GmfSnappingConfig|undefined)
- *   thumbnail: (string|undefined),
- *   wmsLayers: (string|undefined),
- * }}
+ * @constructor
+ * @struct
  */
-gmfThemes.GmfMetaData;
+gmfThemes.GmfMetaData = function() {};
 
 
 /**
@@ -530,13 +478,10 @@ gmfThemes.GmfMetaData.prototype.wmsLayers;
 
 
 /**
- * @typedef {{
- *   edge: (boolean|undefined),
- *   tolerance: (number|undefined),
- *   vertex: (boolean|undefined)
- * }}
+ * @constructor
+ * @struct
  */
-gmfThemes.GmfSnappingConfig;
+gmfThemes.GmfSnappingConfig = function() {};
 
 
 /**

--- a/contribs/gmf/externs/gmf-themes.js
+++ b/contribs/gmf/externs/gmf-themes.js
@@ -6,76 +6,87 @@
 
 
 /**
+ * @type {Object}
+ */
+var gmfThemes;
+
+/**
  * @typedef {{
- *     background_layers: Array.<GmfLayer>,
+ *     background_layers: Array.<gmfThemes.GmfLayer>,
  *     errors: Array.<string>,
- *     ogcServers: GmfOgcServers,
- *     themes: Array.<GmfTheme>
+ *     ogcServers: gmfThemes.GmfOgcServers,
+ *     themes: Array.<gmfThemes.GmfTheme>
  * }}
  */
-var GmfThemesResponse;
+gmfThemes.GmfThemesResponse;
 
 
 /**
- * @constructor
- * @struct
+ * @typedef {{
+ *   children: Array.<gmfThemes.GmfGroup>
+ * }}
  */
-var GmfRootNode = function() {};
+gmfThemes.GmfRootNode;
 
 
 /**
- * @type {Array.<GmfGroup>}
+ * @type {Array.<gmfThemes.GmfGroup>}
  */
-GmfRootNode.prototype.children;
+gmfThemes.GmfRootNode.prototype.children;
 
 /**
  * Contains the common element of all the elements of the GeoMapFisf layer tree.
- * @constructor
- * @struct
+ * @typedef {{
+ *   id: number,
+ *   metadata: gmfThemes.GmfMetaData,
+ *   name: string
+ * }}
  */
-var GmfBaseNode = function() {};
+gmfThemes.GmfBaseNode;
 
 
 /**
  * @type {number}
  */
-GmfBaseNode.prototype.id;
+gmfThemes.GmfBaseNode.prototype.id;
+
+
+/**
+ * The related metadata.
+ * @type {gmfThemes.GmfMetaData}
+ */
+gmfThemes.GmfBaseNode.prototype.metadata;
 
 
 /**
  * @type {string}
  */
-GmfBaseNode.prototype.name;
-
-
-/**
- * The related metadata.
- * @type {GmfMetaData}
- */
-GmfBaseNode.prototype.metadata;
+gmfThemes.GmfBaseNode.prototype.name;
 
 
 /**
  * The element we can select in the theme selector.
- * @constructor
- * @struct
- * @extends GmfBaseNode
+ * @typedef {{
+ *   children: Array.<gmfThemes.GmfGroup>,
+ *   functionalities: Object.<string, Array.<string|number>>
+ * }}
+ * @extends gmfThemes.GmfBaseNode
  */
-var GmfTheme = function() {};
+gmfThemes.GmfTheme;
 
 
 /**
  * The first level layer groups.
- * @type {Array.<GmfGroup>}
+ * @type {Array.<gmfThemes.GmfGroup>}
  */
-GmfTheme.prototype.children;
+gmfThemes.GmfTheme.prototype.children;
 
 
 /**
  * The Functionalities related to the theme.
  * @type {Object.<string, Array.<string|number>>}
  */
-GmfTheme.prototype.functionalities;
+gmfThemes.GmfTheme.prototype.functionalities;
 
 
 /**
@@ -84,17 +95,30 @@ GmfTheme.prototype.functionalities;
  * neither a WMS group.
  * This represent « first level group » (Block in the layer tree),
  * or all sub nodes that's not al leaf.
- * @extends GmfBaseNode
- * @constructor
- * @struct
+ * @typedef {{
+ *   children: Array.<gmfThemes.GmfGroup|gmfThemes.GmfLayer>,
+ *   dimensions: Object.<string, string>,
+ *   mixed: boolean,
+ *   ogcServer: (string|undefined),
+ *   time: (ngeox.TimeProperty|undefined)
+ * }}
+ * @extends gmfThemes.GmfBaseNode
  */
-var GmfGroup = function() {};
+gmfThemes.GmfGroup;
 
 
 /**
- * @type {Array.<GmfGroup|GmfLayer>}
+ * @type {Array.<gmfThemes.GmfGroup|gmfThemes.GmfLayer>}
  */
-GmfGroup.prototype.children;
+gmfThemes.GmfGroup.prototype.children;
+
+
+/**
+ * The dimensions managed by the OpenLayers layer, if the value is null we will take the dimension from the application.
+ * This is present only on non mixed first level group.
+ * @type {Object.<string, string>}
+ */
+gmfThemes.GmfGroup.prototype.dimensions;
 
 
 /**
@@ -106,29 +130,21 @@ GmfGroup.prototype.children;
  * In other word, all the group of a first level group will have the same value.
  * @type {boolean}
  */
-GmfGroup.prototype.mixed;
+gmfThemes.GmfGroup.prototype.mixed;
 
 
 /**
  * On non mixed first level group it is the ogc server to use.
  * @type {string|undefined}
  */
-GmfGroup.prototype.ogcServer;
+gmfThemes.GmfGroup.prototype.ogcServer;
 
 
 /**
  * On non mixed first level group with more then one time layer, it is the time informations.
  * @type {ngeox.TimeProperty|undefined}
  */
-GmfGroup.prototype.time;
-
-
-/**
- * The dimensions managed by the OpenLayers layer, if the value is null we will take the dimension from the application.
- * This is present only on non mixed first level group.
- * @type {Object.<string, string>}
- */
-GmfGroup.prototype.dimensions;
+gmfThemes.GmfGroup.prototype.time;
 
 
 /**
@@ -136,18 +152,15 @@ GmfGroup.prototype.dimensions;
  * not an OpenLayers layer
  * neither a WMS layer.
  * This is also the leaf of the tree.
- * @constructor
- * @struct
- * @extends GmfBaseNode
+ * @typedef {{
+ *   dimensions: Object.<string, string>,
+ *   editable: (boolean|undefined),
+ *   style: (string|undefined),
+ *   type: string
+ * }}
+ * @extends gmfThemes.GmfBaseNode
  */
-var GmfLayer = function() {};
-
-
-/**
- * WMS or WMTS.
- * @type {string}
- */
-GmfLayer.prototype.type;
+gmfThemes.GmfLayer;
 
 
 /**
@@ -155,330 +168,375 @@ GmfLayer.prototype.type;
  * Present only on layer in a mixed group.
  * @type {Object.<string, string>}
  */
-GmfLayer.prototype.dimensions;
+gmfThemes.GmfLayer.prototype.dimensions;
 
 
 /**
  * @type {boolean|undefined}
  */
-GmfLayer.prototype.editable;
+gmfThemes.GmfLayer.prototype.editable;
 
 
 /**
  * @type {string|undefined}
  */
-GmfLayer.prototype.style;
+gmfThemes.GmfLayer.prototype.style;
 
 
 /**
- * @constructor
- * @struct
- * @extends GmfLayer
+ * WMS or WMTS.
+ * @type {string}
  */
-var GmfLayerWMS = function() {};
+gmfThemes.GmfLayer.prototype.type;
 
+
+/**
+ * @typedef {{
+ *   childLayers: Array.<gmfThemes.GmfLayerChildLayer>,
+ *   layers: string,
+ *   maxResolutionHint: number,
+ *   minResolutionHint: number,
+ *   ogcServer: (string|undefined),
+ *   time: (ngeox.TimeProperty|undefined)
+ * }}
+ * @extends gmfThemes.GmfLayer
+ */
+gmfThemes.GmfLayerWMS;
+
+
+/**
+ * @type {Array.<gmfThemes.GmfLayerChildLayer>}
+ */
+gmfThemes.GmfLayerWMS.prototype.childLayers;
 
 /**
  * The comma separated list of WMS layers or groups.
  * @type {string}
  */
-GmfLayerWMS.prototype.layers;
-
-
-/**
- * @type {Array.<GmfLayerChildLayer>}
- */
-GmfLayerWMS.prototype.childLayers;
-
-
-/**
- * The min resolution where the layer is visible.
- * @type {number}
- */
-GmfLayerWMS.prototype.minResolutionHint;
+gmfThemes.GmfLayerWMS.prototype.layers;
 
 
 /**
  * The max resolution where the layer is visible.
  * @type {number}
  */
-GmfLayerWMS.prototype.maxResolutionHint;
+gmfThemes.GmfLayerWMS.prototype.maxResolutionHint;
+
+
+/**
+ * The min resolution where the layer is visible.
+ * @type {number}
+ */
+gmfThemes.GmfLayerWMS.prototype.minResolutionHint;
 
 
 /**
  * @type {string|undefined}
  */
-GmfLayerWMS.prototype.ogcServer;
+gmfThemes.GmfLayerWMS.prototype.ogcServer;
 
 
 /**
- * The time informations if the layer directly manage it, see also {GmfGroup.time}.
+ * The time informations if the layer directly manage it, see
+ * also {gmfThemes.GmfGroup.time}.
  * @type {ngeox.TimeProperty|undefined}
  */
-GmfLayerWMS.prototype.time;
+gmfThemes.GmfLayerWMS.prototype.time;
 
 
 /**
- * @constructor
- * @extends GmfLayer
- * @struct
+ * @typedef {{
+ *   imageType: string,
+ *   layer: string,
+ *   matrixSet: string,
+ *   url: string
+ * }}
+ * @extends gmfThemes.GmfLayer
  */
-var GmfLayerWMTS = function() {};
-
-
-/**
- * @type {string}
- */
-GmfLayerWMTS.prototype.url;
-
-
-/**
- * @type {string}
- */
-GmfLayerWMTS.prototype.layer;
+gmfThemes.GmfLayerWMTS;
 
 
 /**
  * 'image/png' or 'image/jpeg'.
  * @type {string}
  */
-GmfLayerWMTS.prototype.imageType;
+gmfThemes.GmfLayerWMTS.prototype.imageType;
 
 
 /**
  * @type {string}
  */
-GmfLayerWMTS.prototype.matrixSet;
+gmfThemes.GmfLayerWMTS.prototype.layer;
+
+
+/**
+ * @type {string}
+ */
+gmfThemes.GmfLayerWMTS.prototype.matrixSet;
+
+
+/**
+ * @type {string}
+ */
+gmfThemes.GmfLayerWMTS.prototype.url;
 
 
 /**
  * Additional attributes related on a WMS layers (or WFS features type).
- * @constructor
- * @struct
+ * @typedef {{
+ *   maxResolutionHint: number,
+ *   minResolutionHint: number,
+ *   name: string,
+ *   queryable: boolean
+ * }}
  */
-var GmfLayerChildLayer = function() {};
+gmfThemes.GmfLayerChildLayer;
 
 
 /**
  * The min resolution where the layer is visible.
  * @type {number}
  */
-GmfLayerChildLayer.prototype.maxResolutionHint;
+gmfThemes.GmfLayerChildLayer.prototype.maxResolutionHint;
 
 
 /**
  * The max resolution where the layer is visible.
  * @type {number}
  */
-GmfLayerChildLayer.prototype.minResolutionHint;
+gmfThemes.GmfLayerChildLayer.prototype.minResolutionHint;
 
 
 /**
  * @type {string}
  */
-GmfLayerChildLayer.prototype.name;
+gmfThemes.GmfLayerChildLayer.prototype.name;
 
 
 /**
  * @type {boolean}
  */
-GmfLayerChildLayer.prototype.queryable;
-
-
-
-
-/**
- * @typedef {Object<string, GmfOgcServer>}
- */
-var GmfOgcServers;
+gmfThemes.GmfLayerChildLayer.prototype.queryable;
 
 
 /**
- * @constructor
- * @struct
+ * @typedef {Object<string, gmfThemes.GmfOgcServer>}
  */
-var GmfOgcServer = function() {};
+gmfThemes.GmfOgcServers;
+
+
+/**
+ * @typedef {{
+ *   imageType: string,
+ *   isSingleTile: boolean,
+ *   type: string,
+ *   url: string,
+ *   urlWfs: string,
+ *   wfsSupport: boolean
+ * }}
+ */
+gmfThemes.GmfOgcServer;
 
 
 /**
  * 'image/png' or 'image/jpeg'.
  * @type {string}
  */
-GmfOgcServer.prototype.imageType;
+gmfThemes.GmfOgcServer.prototype.imageType;
 
 
 /**
  * @type {boolean}
  */
-GmfOgcServer.prototype.isSingleTile;
+gmfThemes.GmfOgcServer.prototype.isSingleTile;
 
 
 /**
  * 'mapserver', 'qgisserver', 'geoserver' or 'other'.
  * @type {string}
  */
-GmfOgcServer.prototype.type;
+gmfThemes.GmfOgcServer.prototype.type;
 
 
 /**
  * @type {string}
  */
-GmfOgcServer.prototype.url;
+gmfThemes.GmfOgcServer.prototype.url;
 
 
 /**
  * The WFS URL.
  * @type {string}
  */
-GmfOgcServer.prototype.urlWfs;
+gmfThemes.GmfOgcServer.prototype.urlWfs;
 
 
 /**
  * @type {boolean}
  */
-GmfOgcServer.prototype.wfsSupport;
+gmfThemes.GmfOgcServer.prototype.wfsSupport;
 
 
 /**
- * @constructor
- * @struct
+ * @typedef {{
+ *   disclaimer: (string|undefined),
+ *   iconUrl: (string|undefined),
+ *   identifierAttributeField: (string|undefined),
+ *   isChecked: (boolean|undefined),
+ *   isExpanded: (boolean|undefined),
+ *   isLegendExpanded: (boolean|undefined),
+ *   legend: (boolean|undefined),
+ *   legendImage: (string|undefined),
+ *   legendRule: (string|undefined),
+ *   maxResolution: (number|undefined),
+ *   metadataUrl: (string|undefined),
+ *   minResolution: (number|undefined),
+ *   ogcServer: (string|undefined),
+ *   printLayers: (string|undefined),
+ *   snappingConfig: (gmfThemes.GmfSnappingConfig|undefined)
+ *   thumbnail: (string|undefined),
+ *   wmsLayers: (string|undefined),
+ * }}
  */
-var GmfMetaData = function() {};
-
-
-/**
- * Group expanded by default.
- * @type {boolean|undefined}
- */
-GmfMetaData.prototype.isExpanded;
-
-
-/**
- * Display the legend (default true).
- * @type {boolean|undefined}
- */
-GmfMetaData.prototype.legend;
-
-
-/**
- * Legend expanded by default.
- * @type {boolean|undefined}
- */
-GmfMetaData.prototype.isLegendExpanded;
-
-
-/**
- * The WMS rule used to get the icon visible in the layer tree.
- * @type {string|undefined}
- */
-GmfMetaData.prototype.legendRule;
-
-
-/**
- * The URL to the image used as a legend in the layer tree.
- * @type {string|undefined}
- */
-GmfMetaData.prototype.legendImage;
-
-
-/**
- * The icon URL visible in the layer tree.
- * @type {string|undefined}
- */
-GmfMetaData.prototype.iconUrl;
-
-
-/**
- * The Metadata URL.
- * @type {string|undefined}
- */
-GmfMetaData.prototype.metadataUrl;
+gmfThemes.GmfMetaData;
 
 
 /**
  * The disclaimer.
  * @type {string|undefined}
  */
-GmfMetaData.prototype.disclaimer;
+gmfThemes.GmfMetaData.prototype.disclaimer;
 
 
 /**
- * Is the layer checked by default.
- * @type {boolean|undefined}
- */
-GmfMetaData.prototype.isChecked;
-
-
-/**
- * The min resolution where the layer is visible.
- * @type {number|undefined}
- */
-GmfMetaData.prototype.minResolution;
-
-
-/**
- * The max resolution where the layer is visible.
- * @type {number|undefined}
- */
-GmfMetaData.prototype.maxResolution;
-
-
-/**
- * The icon visible in the theme selector.
+ * The icon URL visible in the layer tree.
  * @type {string|undefined}
  */
-GmfMetaData.prototype.thumbnail;
+gmfThemes.GmfMetaData.prototype.iconUrl;
 
 
 /**
  * The field used in the display query window as feature title.
  * @type {string|undefined}
  */
-GmfMetaData.prototype.identifierAttributeField;
+gmfThemes.GmfMetaData.prototype.identifierAttributeField;
+
+
+/**
+ * Is the layer checked by default.
+ * @type {boolean|undefined}
+ */
+gmfThemes.GmfMetaData.prototype.isChecked;
+
+
+/**
+ * Group expanded by default.
+ * @type {boolean|undefined}
+ */
+gmfThemes.GmfMetaData.prototype.isExpanded;
+
+
+/**
+ * Legend expanded by default.
+ * @type {boolean|undefined}
+ */
+gmfThemes.GmfMetaData.prototype.isLegendExpanded;
+
+
+/**
+ * Display the legend (default true).
+ * @type {boolean|undefined}
+ */
+gmfThemes.GmfMetaData.prototype.legend;
+
+
+/**
+ * The URL to the image used as a legend in the layer tree.
+ * @type {string|undefined}
+ */
+gmfThemes.GmfMetaData.prototype.legendImage;
+
+
+/**
+ * The WMS rule used to get the icon visible in the layer tree.
+ * @type {string|undefined}
+ */
+gmfThemes.GmfMetaData.prototype.legendRule;
+
+
+/**
+ * The max resolution where the layer is visible.
+ * @type {number|undefined}
+ */
+gmfThemes.GmfMetaData.prototype.maxResolution;
+
+
+/**
+ * The Metadata URL.
+ * @type {string|undefined}
+ */
+gmfThemes.GmfMetaData.prototype.metadataUrl;
+
+
+/**
+ * The min resolution where the layer is visible.
+ * @type {number|undefined}
+ */
+gmfThemes.GmfMetaData.prototype.minResolution;
 
 
 /**
  * The corresponding OGC server for GeoMapFish layer WMTS.
  * @type {string|undefined}
  */
-GmfMetaData.prototype.ogcServer;
-
-
-/**
- * On GeoMapFish layer WMTS the corresponding WMS layers.
- * @type {string|undefined}
- */
-GmfMetaData.prototype.wmsLayers;
-
-
-/**
- * On GeoMapFish layer WMTS the WMS layers used to query.
- * @type {string|undefined}
- */
-GmfMetaData.prototype.queryLayers;
+gmfThemes.GmfMetaData.prototype.ogcServer;
 
 
 /**
  * On GeoMapFish layer WMTS the WMS layers used in the print.
  * @type {string|undefined}
  */
-GmfMetaData.prototype.printLayers;
+gmfThemes.GmfMetaData.prototype.printLayers;
+
+
+/**
+ * On GeoMapFish layer WMTS the WMS layers used to query.
+ * @type {string|undefined}
+ */
+gmfThemes.GmfMetaData.prototype.queryLayers;
+
+
+/**
+ * The icon visible in the theme selector.
+ * @type {string|undefined}
+ */
+gmfThemes.GmfMetaData.prototype.thumbnail;
 
 
 /**
  * The snapping configuration for the leaf. If set, the leaf's layer is
  * considered to be "snappable", even if the config itself is empty.
  *
- * @type {GmfSnappingConfig|undefined}
+ * @type {gmfThemes.GmfSnappingConfig|undefined}
  */
-GmfMetaData.prototype.snappingConfig;
+gmfThemes.GmfMetaData.prototype.snappingConfig;
 
 
 /**
- * @constructor
- * @struct
+ * On GeoMapFish layer WMTS the corresponding WMS layers.
+ * @type {string|undefined}
  */
-var GmfSnappingConfig = function() {};
+gmfThemes.GmfMetaData.prototype.wmsLayers;
+
+
+/**
+ * @typedef {{
+ *   edge: (boolean|undefined),
+ *   tolerance: (number|undefined),
+ *   vertex: (boolean|undefined)
+ * }}
+ */
+gmfThemes.GmfSnappingConfig;
 
 
 /**
@@ -486,7 +544,7 @@ var GmfSnappingConfig = function() {};
  * or not. Defaults to `true`.
  * @type {boolean|undefined}
  */
-GmfSnappingConfig.prototype.edge;
+gmfThemes.GmfSnappingConfig.prototype.edge;
 
 
 /**
@@ -494,7 +552,7 @@ GmfSnappingConfig.prototype.edge;
  * Defaults to `10`.
  * @type {number|undefined}
  */
-GmfSnappingConfig.prototype.tolerance;
+gmfThemes.GmfSnappingConfig.prototype.tolerance;
 
 
 /**
@@ -502,4 +560,4 @@ GmfSnappingConfig.prototype.tolerance;
  * snapped or not. Defaults to `true`.
  * @type {boolean|undefined}
  */
-GmfSnappingConfig.prototype.vertex;
+gmfThemes.GmfSnappingConfig.prototype.vertex;

--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -180,10 +180,10 @@ gmf.EditfeatureController = function($element, $scope, $timeout, $q,
   this.vectorLayer;
 
   /**
-   * @type {GmfLayer}
+   * @type {gmfThemes.GmfLayer}
    * @private
    */
-  this.editableNode_ = /** @type {GmfLayer} */ (
+  this.editableNode_ = /** @type {gmfThemes.GmfLayer} */ (
     this.editableTreeCtrl.node);
 
 

--- a/contribs/gmf/src/directives/editfeatureselector.js
+++ b/contribs/gmf/src/directives/editfeatureselector.js
@@ -103,7 +103,7 @@ gmf.EditfeatureselectorController = function($scope, $timeout, gmfThemes,
   // === Injected services ===
 
   /**
-   * @type {!angular.Scope} $scope Angular scope.
+   * @type {!angular.Scope}
    * @private
    */
   this.scope_ = $scope;

--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -168,7 +168,7 @@ gmf.LayertreeController = function($http, $sce, $scope, ngeoCreatePopup,
   this.gmfTreeManager_ = gmfTreeManager;
 
   /**
-   * @type {GmfRootNode}
+   * @type {gmfThemes.GmfRootNode}
    * @export
    */
   this.root = gmfTreeManager.root;
@@ -275,7 +275,7 @@ gmf.LayertreeController.prototype.updateDimensions_ = function(treeCtrl) {
 
 /**
  * @param {ol.layer.Layer} layer Layer to update.
- * @param {GmfGroup|GmfLayer} node Layer tree node.
+ * @param {gmfThemes.GmfGroup|gmfThemes.GmfLayer} node Layer tree node.
  * @private
  */
 gmf.LayertreeController.prototype.updateLayerDimensions_ = function(layer, node) {
@@ -328,7 +328,7 @@ gmf.LayertreeController.prototype.getLayer = function(treeCtrl) {
           this.dataLayerGroup_, opt_position);
 
   if (layer instanceof ol.layer.Layer) {
-    var node = /** @type {GmfGroup|GmfLayer} */ (treeCtrl.node);
+    var node = /** @type {gmfThemes.GmfGroup|gmfThemes.GmfLayer} */ (treeCtrl.node);
     this.updateLayerDimensions_(layer, node);
   }
 
@@ -356,7 +356,7 @@ gmf.LayertreeController.prototype.listeners = function(scope, treeCtrl) {
 /**
  * Return 'out-of-resolution' if the current resolution of the map is out of
  * the min/max resolution in the node.
- * @param {GmfLayerWMS} gmfLayerWMS the GeoMapFish Layer WMS.
+ * @param {gmfThemes.GmfLayerWMS} gmfLayerWMS the GeoMapFish Layer WMS.
  * @return {?string} 'out-of-resolution' or null.
  * @export
  */
@@ -414,7 +414,7 @@ gmf.LayertreeController.prototype.updateWMSTimeLayerState = function(
   var layer = /** @type {ol.layer.Image} */ (
       gmf.SyncLayertreeMap.getLayer(layertreeCtrl));
   if (layer) {
-    var node = /** @type {GmfGroup} */ (layertreeCtrl.node);
+    var node = /** @type {gmfThemes.GmfGroup} */ (layertreeCtrl.node);
     var wmsTime = /** @type {ngeox.TimeProperty} */ (node.time);
     var source = /** @type {ol.source.ImageWMS} */ (layer.getSource());
     var timeParam = this.gmfWMSTime_.formatWMSTimeParam(wmsTime, time);
@@ -432,11 +432,11 @@ gmf.LayertreeController.prototype.updateWMSTimeLayerState = function(
  * @export
  */
 gmf.LayertreeController.prototype.getLegendIconURL = function(treeCtrl) {
-  if (/** @type GmfGroup */ (treeCtrl.node).children !== undefined) {
+  if (/** @type gmfThemes.GmfGroup */ (treeCtrl.node).children !== undefined) {
     return undefined;
   }
 
-  var gmfLayer = /** @type {GmfLayer} */ (treeCtrl.node);
+  var gmfLayer = /** @type {gmfThemes.GmfLayer} */ (treeCtrl.node);
   var iconUrl = gmfLayer.metadata.iconUrl;
 
   if (iconUrl !== undefined) {
@@ -447,7 +447,7 @@ gmf.LayertreeController.prototype.getLegendIconURL = function(treeCtrl) {
     return undefined;
   }
 
-  var gmfLayerWMS = /** @type {GmfLayerWMS} */ (gmfLayer);
+  var gmfLayerWMS = /** @type {gmfThemes.GmfLayerWMS} */ (gmfLayer);
 
   var legendRule = gmfLayerWMS.metadata.legendRule;
 
@@ -455,7 +455,8 @@ gmf.LayertreeController.prototype.getLegendIconURL = function(treeCtrl) {
     return undefined;
   }
 
-  //In case of multiple layers for a gmfLayerWMS, always take the first layer name to get the icon
+  //In case of multiple layers for a gmfLayerWMS, always take the first layer
+  //name to get the icon
   var layerName = gmfLayerWMS.layers.split(',')[0];
   var gmfOgcServer = this.gmfTreeManager_.getOgcServer(treeCtrl);
   return this.layerHelper_.getWMSLegendURL(
@@ -472,11 +473,11 @@ gmf.LayertreeController.prototype.getLegendIconURL = function(treeCtrl) {
  * @export
  */
 gmf.LayertreeController.prototype.getLegendURL = function(treeCtrl) {
-  if (/** @type GmfGroup */ (treeCtrl.node).children !== undefined) {
+  if (/** @type gmfThemes.GmfGroup */ (treeCtrl.node).children !== undefined) {
     return undefined;
   }
 
-  var gmfLayer = /** @type {GmfLayer} */ (treeCtrl.node);
+  var gmfLayer = /** @type {gmfThemes.GmfLayer} */ (treeCtrl.node);
   var layersNames;
 
   if (gmfLayer.metadata.legendImage) {
@@ -488,7 +489,7 @@ gmf.LayertreeController.prototype.getLegendURL = function(treeCtrl) {
     goog.asserts.assertInstanceof(layer, ol.layer.Tile);
     return this.layerHelper_.getWMTSLegendURL(layer);
   } else {
-    var gmfLayerWMS = /** @type {GmfLayerWMS} */ (gmfLayer);
+    var gmfLayerWMS = /** @type {gmfThemes.GmfLayerWMS} */ (gmfLayer);
     layersNames = gmfLayerWMS.layers.split(',');
     if (layersNames.length > 1) {
       // not supported, the administrator should give a legendImage metadata
@@ -543,7 +544,7 @@ gmf.LayertreeController.prototype.displayMetadata = function(treeCtrl) {
 
 
 /**
- * @param {GmfGroup} node Layer tree node to remove.
+ * @param {gmfThemes.GmfGroup} node Layer tree node to remove.
  * @export
  */
 gmf.LayertreeController.prototype.removeNode = function(node) {
@@ -558,7 +559,7 @@ gmf.LayertreeController.prototype.removeNode = function(node) {
  * @export
  */
 gmf.LayertreeController.prototype.zoomToResolution = function(treeCtrl) {
-  var gmfLayer = /** @type {GmfLayerWMS} */ (treeCtrl.node);
+  var gmfLayer = /** @type {gmfThemes.GmfLayerWMS} */ (treeCtrl.node);
   var view = this.map.getView();
   var resolution = gmfLayer.minResolutionHint || gmfLayer.maxResolutionHint;
   if (resolution !== undefined) {
@@ -583,11 +584,11 @@ gmf.LayertreeController.prototype.toggleNodeLegend = function(legendNodeId) {
  * Get the snapping configuration object from a Layertree controller
  *
  * @param {ngeo.LayertreeController} treeCtrl Layertree controller,
- * @return {?GmfSnappingConfig} Snapping configuration, if found.
+ * @return {?gmfThemes.GmfSnappingConfig} Snapping configuration, if found.
  * @export
  */
 gmf.LayertreeController.getSnappingConfig = function(treeCtrl) {
-  var node = /** @type {GmfLayer} */ (treeCtrl.node);
+  var node = /** @type {gmfThemes.GmfLayer} */ (treeCtrl.node);
   var config = (node.metadata && node.metadata.snappingConfig !== undefined) ?
       node.metadata.snappingConfig : null;
   return config;

--- a/contribs/gmf/src/directives/themeselector.js
+++ b/contribs/gmf/src/directives/themeselector.js
@@ -106,7 +106,7 @@ gmf.ThemeselectorController.prototype.setThemes_ = function() {
 
 
 /**
- * @param {GmfTheme} theme Theme.
+ * @param {gmfThemes.GmfTheme} theme Theme.
  * @export
  */
 gmf.ThemeselectorController.prototype.setTheme = function(theme) {

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -789,7 +789,7 @@ gmf.Permalink.prototype.initLayers_ = function() {
     }
 
     /**
-     * @type {Array<(GmfGroup)>}
+     * @type {Array<(gmfThemes.GmfGroup)>}
      */
     var firstLevelGroups = [];
     // check if we have the groups in the permalink

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -224,8 +224,8 @@ gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
   this.ngeoAutoProjection_ = ngeoAutoProjection;
 
   /**
-   * @type {?Array.<ol.proj.Projection>} A list of projections that the coordinates
-   *    in the permalink can be in.
+   * A list of projections that the coordinates in the permalink can be in.
+   * @type {?Array.<ol.proj.Projection>}
    * @private
    */
   this.sourceProjections_ = null;

--- a/contribs/gmf/src/services/querymanager.js
+++ b/contribs/gmf/src/services/querymanager.js
@@ -113,9 +113,9 @@ gmf.QueryManager.prototype.handleThemesChange_ = function() {
  * Create and add a source for the query service from the GMF theme node if
  * it has no children, otherwise create the sources for each child node if
  * it has any.
- * @param {GmfGroup} firstLevelGroup A node.
- * @param {GmfGroup|GmfLayer} node A node.
- * @param {GmfOgcServers} ogcServers OGC servers.
+ * @param {gmfThemes.GmfGroup} firstLevelGroup A node.
+ * @param {gmfThemes.GmfGroup|gmfThemes.GmfLayer} node A node.
+ * @param {gmfThemes.GmfOgcServers} ogcServers OGC servers.
  * @private
  */
 gmf.QueryManager.prototype.createSources_ = function(firstLevelGroup, node, ogcServers) {
@@ -133,12 +133,12 @@ gmf.QueryManager.prototype.createSources_ = function(firstLevelGroup, node, ogcS
   // (and non minified) version.
 
   var id = node.id;
-  var meta = /** @type {GmfMetaData} */ (node.metadata);
+  var meta = /** @type {gmfThemes.GmfMetaData} */ (node.metadata);
   var identifierAttributeField = meta.identifierAttributeField;
   var layers;
   var name = node.name;
   var validateLayerParams = false;
-  var gmfLayer = /** @type GmfLayer */ (node);
+  var gmfLayer = /** @type gmfThemes.GmfLayer */ (node);
   var ogcServer;
 
   // Don't create sources for WMTS layers without wmsUrl and ogcServer,
@@ -155,7 +155,7 @@ gmf.QueryManager.prototype.createSources_ = function(firstLevelGroup, node, ogcS
   validateLayerParams = gmfLayer.type === 'WMS';
   var gmfLayerWMS;
   if (gmfLayer.type === 'WMS') {
-    gmfLayerWMS = /** @type GmfLayerWMS */ (gmfLayer);
+    gmfLayerWMS = /** @type gmfThemes.GmfLayerWMS */ (gmfLayer);
     layers = gmfLayerWMS.layers;
     if (firstLevelGroup.mixed) {
       goog.asserts.assert(gmfLayerWMS.ogcServer);

--- a/contribs/gmf/src/services/share.js
+++ b/contribs/gmf/src/services/share.js
@@ -92,20 +92,18 @@ gmf.ShareService.prototype.postShortUrl_ = function(params) {
 
 
 /**
- * Max length defined for the complete url
+ * Max length defined for the complete url.
+ * Check IE limits, see {@link http://support.microsoft.com/kb/208427}
  * @constant
  * @type {number}
- * Check IE limits
- * @see {@link http://support.microsoft.com/kb/208427}
  */
 gmf.ShareService.URL_MAX_LEN = 2083;
 
 /**
- * Max length defined for the url parth section
+ * Max length defined for the url parth section.
+ * Check IE limits, see {@link http://support.microsoft.com/kb/208427}
  * @constant
  * @type {number}
- * Check IE limits
- * @see {@link http://support.microsoft.com/kb/208427}
  */
 gmf.ShareService.URL_PATH_MAX_LEN = 2048;
 

--- a/contribs/gmf/src/services/snapping.js
+++ b/contribs/gmf/src/services/snapping.js
@@ -105,7 +105,7 @@ gmf.Snapping = function($http, $q, $rootScope, $timeout, gmfThemes,
 
   /**
    * A reference to the OGC servers loaded by the theme service.
-   * @type {GmfOgcServers}
+   * @type {gmfThemes.GmfOgcServers}
    * @private
    */
   this.ogcServers_ = null;
@@ -226,7 +226,7 @@ gmf.Snapping.prototype.handleThemesChange_ = function() {
 gmf.Snapping.prototype.registerTreeCtrl_ = function(treeCtrl) {
 
   // Skip any Layertree controller that has a node that is not a leaf
-  var node = /** @type {GmfGroup|GmfLayer} */ (treeCtrl.node);
+  var node = /** @type {gmfThemes.GmfGroup|gmfThemes.GmfLayer} */ (treeCtrl.node);
   if (node.children) {
     return;
   }
@@ -315,14 +315,14 @@ gmf.Snapping.prototype.getWFSConfig_ = function(treeCtrl) {
     return null;
   }
 
-  var gmfLayer = /** @type {GmfLayer} */ (treeCtrl.node);
+  var gmfLayer = /** @type {gmfThemes.GmfLayer} */ (treeCtrl.node);
 
   // (2)
   if (gmfLayer.type !== gmf.Themes.NodeType.WMS) {
     return null;
   }
 
-  var gmfLayerWMS = /** @type {GmfLayerWMS} */ (gmfLayer);
+  var gmfLayerWMS = /** @type {gmfThemes.GmfLayerWMS} */ (gmfLayer);
 
   // (3)
   var featureTypes = [];
@@ -337,12 +337,12 @@ gmf.Snapping.prototype.getWFSConfig_ = function(treeCtrl) {
 
   // (4)
   var ogcServerName;
-  var gmfGroup = /** @type {GmfGroup} */ (treeCtrl.parent.node);
+  var gmfGroup = /** @type {gmfThemes.GmfGroup} */ (treeCtrl.parent.node);
   if (gmfGroup.mixed) {
     ogcServerName = gmfLayerWMS.ogcServer;
   } else {
     var firstTreeCtrl = ngeo.LayertreeController.getFirstParentTree(treeCtrl);
-    var firstNode = /** @type {GmfGroup} */ (firstTreeCtrl.node);
+    var firstNode = /** @type {gmfThemes.GmfGroup} */ (firstTreeCtrl.node);
     ogcServerName = firstNode.ogcServer;
   }
   if (!ogcServerName) {
@@ -564,7 +564,7 @@ gmf.Snapping.Cache;
  *     interaction: (?ol.interaction.Snap),
  *     maxFeatures: (number),
  *     requestDeferred: (?angular.$q.Deferred),
- *     snappingConfig: (GmfSnappingConfig),
+ *     snappingConfig: (gmfThemes.GmfSnappingConfig),
  *     stateWatcherUnregister: (Function),
  *     treeCtrl: (ngeo.LayertreeController),
  *     wfsConfig: (gmf.Snapping.WFSConfig)

--- a/contribs/gmf/src/services/snapping.js
+++ b/contribs/gmf/src/services/snapping.js
@@ -48,7 +48,7 @@ gmf.Snapping = function($http, $q, $rootScope, $timeout, gmfThemes,
   this.q_ = $q;
 
   /**
-   * @type {!angular.Scope} $rootScope Angular scope.
+   * @type {!angular.Scope}
    * @private
    */
   this.rootScope_ = $rootScope;

--- a/contribs/gmf/src/services/syncLayertreeMap.js
+++ b/contribs/gmf/src/services/syncLayertreeMap.js
@@ -35,7 +35,7 @@ gmf.SyncLayertreeMap = function($rootScope, ngeoLayerHelper, gmfThemes, gmfWMSTi
   this.gmfWMSTime_ = gmfWMSTime;
 
   /**
-   * @type {GmfOgcServers}
+   * @type {gmfThemes.GmfOgcServers}
    * @private
    */
   this.ogcServersObject_;
@@ -154,7 +154,7 @@ gmf.SyncLayertreeMap.prototype.updateLayerState_ = function(layer, treeCtrl) {
  */
 gmf.SyncLayertreeMap.prototype.createGroup_ = function(treeCtrl, map,
     dataLayerGroup, opt_position) {
-  var groupNode = /** @type {GmfGroup} */ (treeCtrl.node);
+  var groupNode = /** @type {gmfThemes.GmfGroup} */ (treeCtrl.node);
   var layer = null;
   var isFirstLevelGroup = treeCtrl.parent.isRoot;
 
@@ -188,7 +188,7 @@ gmf.SyncLayertreeMap.prototype.createGroup_ = function(treeCtrl, map,
 gmf.SyncLayertreeMap.prototype.createLayerFromGroup_ = function(treeCtrl,
     mixed) {
   var layer;
-  var groupNode = /** @type {GmfGroup} */ (treeCtrl.node);
+  var groupNode = /** @type {gmfThemes.GmfGroup} */ (treeCtrl.node);
   if (mixed) { // Will be one ol.layer per each node.
     layer = this.layerHelper_.createBasicGroup();
   } else { // Will be one ol.layer for multiple WMS nodes.
@@ -222,13 +222,13 @@ gmf.SyncLayertreeMap.prototype.createLayerFromGroup_ = function(treeCtrl,
  * @private
  */
 gmf.SyncLayertreeMap.prototype.createLeafInAMixedGroup_ = function(treeCtrl, map) {
-  var gmfLayer = /** @type {GmfLayer} */ (treeCtrl.node);
+  var gmfLayer = /** @type {gmfThemes.GmfLayer} */ (treeCtrl.node);
   var layer;
   // Make layer.
   if (gmfLayer.type === 'WMTS') {
-    layer = this.createWMTSLayer_(/** @type GmfLayerWMTS */ (gmfLayer));
+    layer = this.createWMTSLayer_(/** @type gmfThemes.GmfLayerWMTS */ (gmfLayer));
   } else {
-    var gmfLayerWMS = /** @type GmfLayerWMS */ (gmfLayer);
+    var gmfLayerWMS = /** @type gmfThemes.GmfLayerWMS */ (gmfLayer);
     var timeParam = this.getTimeParam_(treeCtrl);
     var ogcServer = this.ogcServersObject_[/** @type string */ (gmfLayerWMS.ogcServer)];
     goog.asserts.assert(ogcServer);
@@ -263,7 +263,7 @@ gmf.SyncLayertreeMap.prototype.createLeafInAMixedGroup_ = function(treeCtrl, map
  * @private
  */
 gmf.SyncLayertreeMap.prototype.initGmfLayerInANotMixedGroup_ = function(treeCtrl, map) {
-  var leafNode = /** @type {GmfLayer} */ (treeCtrl.node);
+  var leafNode = /** @type {gmfThemes.GmfLayer} */ (treeCtrl.node);
   var firstLevelGroup = this.getFirstLevelGroupCtrl_(treeCtrl);
   goog.asserts.assert(firstLevelGroup);
   var layer = /** @type {ol.layer.Image} */ (firstLevelGroup.layer);
@@ -279,7 +279,7 @@ gmf.SyncLayertreeMap.prototype.initGmfLayerInANotMixedGroup_ = function(treeCtrl
 
 /**
  * Create and return a Tile layer.
- * @param {GmfLayerWMTS} gmfLayerWMTS A leaf node.
+ * @param {gmfThemes.GmfLayerWMTS} gmfLayerWMTS A leaf node.
  * @return {ol.layer.Tile} a Tile WMTS layer. (Source and capabilities can come
  *     later).
  * @private
@@ -299,7 +299,7 @@ gmf.SyncLayertreeMap.prototype.createWMTSLayer_ = function(gmfLayerWMTS) {
 
 /**
  * Update properties of a layer with the node of a given leafNode.
- * @param {GmfLayer} leafNode a leaf node.
+ * @param {gmfThemes.GmfLayer} leafNode a leaf node.
  * @param {ol.layer.Base} layer A layer.
  * @private
  */

--- a/contribs/gmf/src/services/thememanager.js
+++ b/contribs/gmf/src/services/thememanager.js
@@ -70,7 +70,7 @@ gmf.ThemeManager = function(gmfThemes, gmfTreeManagerModeFlush, gmfTreeManager, 
 /**
  * Set the current theme name (mode 'flush' only) and add its children. Add
  * only groups that are not already in the tree.
- * @param {GmfTheme} theme A theme object.
+ * @param {gmfThemes.GmfTheme} theme A theme object.
  * @export
  */
 gmf.ThemeManager.prototype.addTheme = function(theme) {

--- a/contribs/gmf/src/services/themesservice.js
+++ b/contribs/gmf/src/services/themesservice.js
@@ -126,9 +126,9 @@ ol.inherits(gmf.Themes, ol.events.EventTarget);
 
 
 /**
- * @param {Array.<GmfTheme>} themes Array of "theme" objects.
+ * @param {Array.<gmfThemes.GmfTheme>} themes Array of "theme" objects.
  * @param {string} name The layer name.
- * @return {GmfGroup} The group.
+ * @return {gmfThemes.GmfGroup} The group.
  */
 gmf.Themes.findGroupByLayerNodeName = function(themes, name) {
   for (var i = 0, ii = themes.length; i < ii; i++) {
@@ -150,9 +150,9 @@ gmf.Themes.findGroupByLayerNodeName = function(themes, name) {
 
 /**
  * Find a layer group object by its name. Return null if not found.
- * @param {Array.<GmfTheme>} themes Array of "theme" objects.
+ * @param {Array.<gmfThemes.GmfTheme>} themes Array of "theme" objects.
  * @param {string} name The group name.
- * @return {GmfGroup} The group.
+ * @return {gmfThemes.GmfGroup} The group.
  */
 gmf.Themes.findGroupByName = function(themes, name) {
   for (var i = 0, ii = themes.length; i < ii; i++) {
@@ -185,9 +185,9 @@ gmf.Themes.findObjectByName_ = function(objects, objectName) {
 
 /**
  * Find a theme object by its name. Return null if not found.
- * @param {Array.<GmfTheme>} themes Array of "theme" objects.
+ * @param {Array.<gmfThemes.GmfTheme>} themes Array of "theme" objects.
  * @param {string} themeName The theme name.
- * @return {GmfTheme} The theme object.
+ * @return {gmfThemes.GmfTheme} The theme object.
  */
 gmf.Themes.findThemeByName = function(themes, themeName) {
   return gmf.Themes.findObjectByName_(themes, themeName);
@@ -197,8 +197,8 @@ gmf.Themes.findThemeByName = function(themes, themeName) {
 /**
  * Fill the given "nodes" array with all node in the given node including the
  * given node itself.
- * @param {GmfGroup|GmfLayer} node Layertree node.
- * @param {Array.<GmfGroup|GmfLayer>} nodes An array.
+ * @param {gmfThemes.GmfGroup|gmfThemes.GmfLayer} node Layertree node.
+ * @param {Array.<gmfThemes.GmfGroup|gmfThemes.GmfLayer>} nodes An array.
  * @export
  */
 gmf.Themes.getFlatNodes = function(node, nodes) {
@@ -227,7 +227,7 @@ gmf.Themes.prototype.getBgLayers = function(appDimensions) {
   var layerHelper = this.layerHelper_;
 
   /**
-   * @param {GmfGroup|GmfLayer} item A group or a leaf.
+   * @param {gmfThemes.GmfGroup|gmfThemes.GmfLayer} item A group or a leaf.
    * @param {Array.<number>} array Array of ids;
    */
   var getIds = function(item, array) {
@@ -239,7 +239,7 @@ gmf.Themes.prototype.getBgLayers = function(appDimensions) {
   };
 
   /**
-   * @param {GmfGroup|GmfLayer} item The item.
+   * @param {gmfThemes.GmfGroup|gmfThemes.GmfLayer} item The item.
    * @param {ol.layer.Base} layer The layer.
    * @return {ol.layer.Base} the provided layer.
    */
@@ -255,8 +255,8 @@ gmf.Themes.prototype.getBgLayers = function(appDimensions) {
   };
 
   /**
-   * @param {GmfOgcServers} ogcServers The ogc servers.
-   * @param {GmfGroup|GmfLayer} gmfLayer The item.
+   * @param {gmfThemes.GmfOgcServers} ogcServers The ogc servers.
+   * @param {gmfThemes.GmfGroup|gmfThemes.GmfLayer} gmfLayer The item.
    * @return {angular.$q.Promise.<ol.layer.Base>|ol.layer.Base} the created layer.
    */
   var layerLayerCreationFn = function(ogcServers, gmfLayer) {
@@ -268,7 +268,7 @@ gmf.Themes.prototype.getBgLayers = function(appDimensions) {
     }
 
     if (gmfLayer.type === 'WMTS') {
-      var gmfLayerWMTS = /** @type GmfLayerWMTS */ (gmfLayer);
+      var gmfLayerWMTS = /** @type gmfThemes.GmfLayerWMTS */ (gmfLayer);
       goog.asserts.assert(gmfLayerWMTS.url, 'Layer URL is required');
       return layerHelper.createWMTSLayerFromCapabilitites(
           gmfLayerWMTS.url,
@@ -280,7 +280,7 @@ gmf.Themes.prototype.getBgLayers = function(appDimensions) {
         return $q.resolve(undefined);
       });
     } else if (gmfLayer.type === 'WMS') {
-      var gmfLayerWMS = /** @type GmfLayerWMS */ (gmfLayer);
+      var gmfLayerWMS = /** @type gmfThemes.GmfLayerWMS */ (gmfLayer);
       goog.asserts.assert(gmfLayerWMS.ogcServer, 'An OGC server is required');
       var server = ogcServers[gmfLayerWMS.ogcServer];
       goog.asserts.assert(server, 'The OGC server was not found');
@@ -297,8 +297,8 @@ gmf.Themes.prototype.getBgLayers = function(appDimensions) {
   };
 
   /**
-   * @param {GmfOgcServers} ogcServers The ogc servers.
-   * @param {GmfGroup} item The item.
+   * @param {gmfThemes.GmfOgcServers} ogcServers The ogc servers.
+   * @param {gmfThemes.GmfGroup} item The item.
    * @return {angular.$q.Promise.<ol.layer.Group>} the created layer.
    */
   var layerGroupCreationFn = function(ogcServers, item) {
@@ -322,7 +322,8 @@ gmf.Themes.prototype.getBgLayers = function(appDimensions) {
   };
 
   /**
-   * @param {GmfThemesResponse} data The "themes" web service response.
+   * @param {gmfThemes.GmfThemesResponse} data The "themes" web service
+   *     response.
    * @return {angular.$q.Promise.<Array.<ol.layer.Base>>} Promise.
    */
   var promiseSuccessFn = function(data) {
@@ -367,14 +368,15 @@ gmf.Themes.prototype.getBgLayers = function(appDimensions) {
 /**
  * Get a theme object by its name.
  * @param {string} themeName Theme name.
- * @return {angular.$q.Promise.<GmfTheme>} Promise.
+ * @return {angular.$q.Promise.<gmfThemes.GmfTheme>} Promise.
  * @export
  */
 gmf.Themes.prototype.getThemeObject = function(themeName) {
   return this.promise_.then(
       /**
-       * @param {GmfThemesResponse} data The "themes" web service response.
-       * @return {GmfTheme} The theme object for themeName, or null if
+       * @param {gmfThemes.GmfThemesResponse} data The "themes" web service
+       *     response.
+       * @return {gmfThemes.GmfTheme} The theme object for themeName, or null if
        *     not found.
        */
       function(data) {
@@ -385,14 +387,15 @@ gmf.Themes.prototype.getThemeObject = function(themeName) {
 
 /**
  * Get an array of theme objects.
- * @return {angular.$q.Promise.<Array.<GmfTheme>>} Promise.
+ * @return {angular.$q.Promise.<Array.<gmfThemes.GmfTheme>>} Promise.
  * @export
  */
 gmf.Themes.prototype.getThemesObject = function() {
   return this.promise_.then(
       /**
-       * @param {GmfThemesResponse} data The "themes" web service response.
-       * @return {Array.<GmfTheme>} The themes object.
+       * @param {gmfThemes.GmfThemesResponse} data The "themes" web service
+       *     response.
+       * @return {Array.<gmfThemes.GmfTheme>} The themes object.
        */
       function(data) {
         return data.themes;
@@ -402,14 +405,15 @@ gmf.Themes.prototype.getThemesObject = function() {
 
 /**
  * Get an array of background layer objects.
- * @return {angular.$q.Promise.<Array.<GmfLayer>>} Promise.
+ * @return {angular.$q.Promise.<Array.<gmfThemes.GmfLayer>>} Promise.
  */
 gmf.Themes.prototype.getBackgroundLayersObject = function() {
   goog.asserts.assert(this.promise_ !== null);
   return this.promise_.then(
       /**
-       * @param {GmfThemesResponse} data The "themes" web service response.
-       * @return {Array.<GmfLayer>} The background layers object.
+       * @param {gmfThemes.GmfThemesResponse} data The "themes" web service
+       *     response.
+       * @return {Array.<gmfThemes.GmfLayer>} The background layers object.
        */
       function(data) {
         return data.background_layers;
@@ -419,14 +423,15 @@ gmf.Themes.prototype.getBackgroundLayersObject = function() {
 
 /**
  * Get the `ogcServers` object.
- * @return {angular.$q.Promise.<GmfOgcServers>} Promise.
+ * @return {angular.$q.Promise.<gmfThemes.GmfOgcServers>} Promise.
  */
 gmf.Themes.prototype.getOgcServersObject = function() {
   goog.asserts.assert(this.promise_ !== null);
   return this.promise_.then(
       /**
-       * @param {GmfThemesResponse} data The "themes" web service response.
-       * @return {GmfOgcServers} The `ogcServers` object.
+       * @param {gmfThemes.GmfThemesResponse} data The "themes" web service
+       *     response.
+       * @return {gmfThemes.GmfOgcServers} The `ogcServers` object.
        */
       function(data) {
         return data.ogcServers;
@@ -446,7 +451,7 @@ gmf.Themes.prototype.hasEditableLayers = function() {
 
 /**
  * Returns if one of the layers in the themes is editable.
- * @param {GmfThemesResponse} data The "themes" web service response.
+ * @param {gmfThemes.GmfThemesResponse} data The "themes" web service response.
  * @return {boolean} Editable layers?
  */
 gmf.Themes.prototype.hasEditableLayers_ = function(data) {
@@ -458,7 +463,7 @@ gmf.Themes.prototype.hasEditableLayers_ = function(data) {
 
 
 /**
- * @param {GmfGroup|GmfLayer} node Theme node
+ * @param {gmfThemes.GmfGroup|gmfThemes.GmfLayer} node Theme node
  * @return {boolean} Editable layers?
  */
 gmf.Themes.prototype.hasNodeEditableLayers_ = function(node) {

--- a/contribs/gmf/src/services/treemanager.js
+++ b/contribs/gmf/src/services/treemanager.js
@@ -63,7 +63,7 @@ gmf.TreeManager = function($timeout, gettextCatalog, ngeoLayerHelper,
    */
   this.gmfThemes_ = gmfThemes;
 
-  this.root = /** @type {GmfRootNode} */ ({
+  this.root = /** @type {gmfThemes.GmfRootNode} */ ({
     children: []
   });
 
@@ -89,7 +89,7 @@ gmf.TreeManager = function($timeout, gettextCatalog, ngeoLayerHelper,
 
   /**
    * A reference to the OGC servers loaded by the theme service.
-   * @type {GmfOgcServers}
+   * @type {gmfThemes.GmfOgcServers}
    * @private
    */
   this.ogcServers_ = null;
@@ -117,7 +117,7 @@ gmf.TreeManager.prototype.handleThemesChange_ = function() {
  * Set some groups as tree's children. If the service use mode 'flush', the
  * previous tree's children will be removed. Add only groups that are not
  * already in the tree.
- * @param{Array.<GmfGroup>} firstLevelGroups An array of gmf theme group.
+ * @param{Array.<gmfThemes.GmfGroup>} firstLevelGroups An array of gmf theme group.
  * @return{boolean} True if the group has been added. False otherwise.
  * @export
  */
@@ -131,7 +131,7 @@ gmf.TreeManager.prototype.setFirstLevelGroups = function(firstLevelGroups) {
  * Add some groups as tree's children. If the service use mode 'flush', the
  * previous tree's children will be removed. Add only groups that are not
  * already in the tree.
- * @param {Array.<GmfGroup>} firstLevelGroups An array of gmf theme group.
+ * @param {Array.<gmfThemes.GmfGroup>} firstLevelGroups An array of gmf theme group.
  * @param {boolean=} opt_add if true, force to use the 'add' mode this time.
  * @param {boolean=} opt_silent if true notifyCantAddGroups_ is not called.
  * @param {number=} opt_totalGroupsLength length of all group to add for this
@@ -161,7 +161,7 @@ gmf.TreeManager.prototype.addFirstLevelGroups = function(firstLevelGroups, opt_a
 
 /**
  * Update the application state with the list of first level groups in the tree
- * @param {Array.<GmfGroup>} groups firstlevel groups of the tree
+ * @param {Array.<gmfThemes.GmfGroup>} groups firstlevel groups of the tree
  * @private
  */
 gmf.TreeManager.prototype.updateTreeGroupsState_ = function(groups) {
@@ -176,7 +176,7 @@ gmf.TreeManager.prototype.updateTreeGroupsState_ = function(groups) {
 /**
  * Add a group as tree's children without consideration of this service 'mode'.
  * Add it only if it's not already in the tree.
- * @param {GmfGroup} group The group to add.
+ * @param {gmfThemes.GmfGroup} group The group to add.
  * @return {boolean} true if the group has been added.
  * @export
  */
@@ -258,7 +258,7 @@ gmf.TreeManager.prototype.addGroupByLayerName = function(layerName, opt_add, opt
 /**
  * Remove a group from this tree's children. The first group that is found (
  * based on its name) will be removed. If any is found, nothing will append.
- * @param {GmfGroup} group The group to remove.
+ * @param {gmfThemes.GmfGroup} group The group to remove.
  * @export
  */
 gmf.TreeManager.prototype.removeGroup = function(group) {
@@ -291,14 +291,14 @@ gmf.TreeManager.prototype.removeAll = function() {
 /**
  * Clone a group node and recursively set all child node `isChecked` using
  * the given list of layer names.
- * @param {GmfGroup} group The original group node.
+ * @param {gmfThemes.GmfGroup} group The original group node.
  * @param {Array.<string>} names Array of node names to check (i.e. that
  *     should have their checkbox checked)
- * @return {GmfGroup} Cloned node.
+ * @return {gmfThemes.GmfGroup} Cloned node.
  * @private
  */
 gmf.TreeManager.prototype.cloneGroupNode_ = function(group, names) {
-  var clone = /** @type {GmfGroup} */ (goog.object.unsafeClone(group));
+  var clone = /** @type {gmfThemes.GmfGroup} */ (goog.object.unsafeClone(group));
   this.toggleNodeCheck_(clone, names);
   return clone;
 };
@@ -307,7 +307,7 @@ gmf.TreeManager.prototype.cloneGroupNode_ = function(group, names) {
 /**
  * Set the child nodes metadata `isChecked` if its name is among the list of
  * given names. If a child node also has children, check those instead.
- * @param {GmfGroup|GmfLayer} node The original node.
+ * @param {gmfThemes.GmfGroup|gmfThemes.GmfLayer} node The original node.
  * @param {Array.<string>} names Array of node names to check (i.e. that
  *     should have their checkbox checked)
  * @private
@@ -329,7 +329,7 @@ gmf.TreeManager.prototype.toggleNodeCheck_ = function(node, names) {
 /**
  * Display a notification that informs that the given groups are already in the
  * tree.
- * @param {Array.<GmfGroup>} groups An array of groups that already in
+ * @param {Array.<gmfThemes.GmfGroup>} groups An array of groups that already in
  *   the tree.
  * @private
  */
@@ -371,11 +371,11 @@ gmf.TreeManager.prototype.getTreeCtrlByNodeId = function(id) {
  * Get the OGC server.
  * @param {ngeo.LayertreeController} treeCtrl ngeo layertree controller, from
  *     the current node.
- * @return {GmfOgcServer} The OGC server.
+ * @return {gmfThemes.GmfOgcServer} The OGC server.
  */
 gmf.TreeManager.prototype.getOgcServer = function(treeCtrl) {
   if (treeCtrl.parent.node.mixed) {
-    var gmfLayerWMS = /** @type {GmfLayerWMS} */ (treeCtrl.node);
+    var gmfLayerWMS = /** @type {gmfThemes.GmfLayerWMS} */ (treeCtrl.node);
     goog.asserts.assert(gmfLayerWMS.ogcServer);
     return this.ogcServers_[gmfLayerWMS.ogcServer];
   } else {
@@ -383,7 +383,7 @@ gmf.TreeManager.prototype.getOgcServer = function(treeCtrl) {
     while (!firstLevelGroupCtrl.parent.isRoot) {
       firstLevelGroupCtrl = firstLevelGroupCtrl.parent;
     }
-    var gmfGroup = /** @type {GmfGroup} */ (firstLevelGroupCtrl.node);
+    var gmfGroup = /** @type {gmfThemes.GmfGroup} */ (firstLevelGroupCtrl.node);
     goog.asserts.assert(gmfGroup.ogcServer);
     return this.ogcServers_[gmfGroup.ogcServer];
   }


### PR DESCRIPTION
Fix:  #1931 
Example: https://ger-benjamin.github.io/ngeo/prefix_gmfthemes/apidoc/

That's a little strange that almost all gmfThemes.* are _class_ and not _type_ . I've should leave theme defined as _class_ because _type_ doesn't support the `@extend` tag / function (see apidoc and commit 2 to understand)