### PR TITLE
Fix printing rotated labels

### DIFF
--- a/src/services/print.js
+++ b/src/services/print.js
@@ -750,6 +750,8 @@ ngeo.Print.prototype.encodeTextStyle_ = function(symbolizers, textStyle) {
     if (labelRotation !== undefined) {
       // Mapfish Print expects a string, not a number to rotate text
       symbolizer.labelRotation = (labelRotation * 180 / Math.PI).toString();
+      // rotate around the vertical/horizontal center
+      symbolizer.labelAlign = 'cm';
     }
 
     var fontStyle = textStyle.getFont();


### PR DESCRIPTION
Closes https://github.com/camptocamp/ngeo/issues/1966

With https://github.com/mapfish/mapfish-print/pull/468 this change is no longer required, but this avoids having to update MFP/GMF.