### PR TITLE
Display disclaimers in a modal in desktop_alt

### DIFF
--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -176,7 +176,8 @@
             </gmf-backgroundlayerselector>
           </div>
           <gmf-disclaimer
-            gmf-disclaimer-map="::mainCtrl.map">
+            gmf-disclaimer-map="::mainCtrl.map"
+            gmf-disclaimer-modal="::true">
           </gmf-disclaimer>
         </div>
         <gmf-map class="gmf-map" gmf-map-map="mainCtrl.map"


### PR DESCRIPTION
Fix: #1967 

Example: https://ger-benjamin.github.io/ngeo/modal_disclaimer_for_desktop_alt/examples/contribs/gmf/apps/desktop_alt
(open theme osm, look at the disclaimer in a popup)