### PR TITLE
Don't display 'already loaded' message for themes on startup

### DIFF
--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -511,7 +511,7 @@ gmf.AbstractController.prototype.updateCurrentTheme_ = function() {
     }
     if (themeName) {
       var theme = gmf.Themes.findThemeByName(themes, /** @type {string} */ (themeName));
-      this.gmfThemeManager.addTheme(theme);
+      this.gmfThemeManager.addTheme(theme, true);
     }
   }.bind(this));
 };

--- a/contribs/gmf/src/directives/themeselector.js
+++ b/contribs/gmf/src/directives/themeselector.js
@@ -143,11 +143,13 @@ gmf.ThemeselectorController.prototype.setThemes_ = function() {
 
 /**
  * @param {gmfThemes.GmfTheme} theme Theme.
+ * @param {boolean=} opt_silent if true it will be no user message if
+ *     the theme should be added but it's already added.
  * @export
  */
-gmf.ThemeselectorController.prototype.setTheme = function(theme) {
+gmf.ThemeselectorController.prototype.setTheme = function(theme, opt_silent) {
   if (theme) {
-    this.gmfThemeManager.addTheme(theme);
+    this.gmfThemeManager.addTheme(theme, opt_silent);
   }
 };
 

--- a/contribs/gmf/src/services/thememanager.js
+++ b/contribs/gmf/src/services/thememanager.js
@@ -71,9 +71,11 @@ gmf.ThemeManager = function(gmfThemes, gmfTreeManagerModeFlush, gmfTreeManager, 
  * Set the current theme name (mode 'flush' only) and add its children. Add
  * only groups that are not already in the tree.
  * @param {gmfThemes.GmfTheme} theme A theme object.
+ * @param {boolean=} opt_silent if true it will be no user message if
+ *     the theme should be added but it's already added.
  * @export
  */
-gmf.ThemeManager.prototype.addTheme = function(theme) {
+gmf.ThemeManager.prototype.addTheme = function(theme, opt_silent) {
   if (this.modeFlush) {
     this.ngeoStateManager_.updateState({
       'theme' : theme.name
@@ -81,7 +83,7 @@ gmf.ThemeManager.prototype.addTheme = function(theme) {
     this.themeName = theme.name;
     this.gmfTreeManager_.setFirstLevelGroups(theme.children);
   } else {
-    this.gmfTreeManager_.addFirstLevelGroups(theme.children);
+    this.gmfTreeManager_.addFirstLevelGroups(theme.children, false, opt_silent);
   }
 };
 


### PR DESCRIPTION
Fix #1988 

Example: https://ger-benjamin.github.io/ngeo/already_loaded_theme/examples/contribs/gmf/apps/desktop_alt