### PR TITLE
#2600 - Add ObjectEditing Hub example

### DIFF
--- a/contribs/gmf/examples/objectediting-hub.html
+++ b/contribs/gmf/examples/objectediting-hub.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>ObjectEditing - Hub</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../../../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/font-awesome/css/font-awesome.css" type="text/css">
+    <link rel="stylesheet" href="../../../third-party/jquery-ui/jquery-ui.min.css">
+    <style>
+      .gmf-oe-hub-form {
+        padding: 10px;
+        width: 300px;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+
+    <p id="desc">
+      This example serves as a hub for other examples and applications
+      that uses the ObjectEditing tools. You need to be logged in too.
+    </p>
+
+    <div class='gmf-oe-hub-form'>
+      <div class="form-group">
+        <select
+          class="form-control"
+          ng-model="ctrl.selectedUrl"
+          ng-options="url as url for url in ctrl.urls">
+        </select>
+      </div>
+
+      <div class="form-group">
+        <select
+          class="form-control"
+          ng-model="ctrl.selectedGmfLayerNode"
+          ng-options="gmfTreeNode.layers | translate for gmfTreeNode in ctrl.gmfLayerNodes">
+        <option value="" translate>-- Choose a layer --</option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <select
+          class="form-control"
+          ng-model="ctrl.selectedFeature"
+          ng-options="feature.get('name') | translate for feature in ctrl.features">
+        <option value="">-- Choose a feature --</option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <button
+          ng-disabled="ctrl.selectedFeature === null || ctrl.selectedGmfLayerNode === null"
+          ng-click="ctrl.run()"
+          type="button"
+          class="form-control btn btn-primary"
+          aria-label="Left Align">
+          </span> Launch
+        </button>
+      </div>
+
+    </div>
+
+    <script src="../../../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../../../third-party/jquery-ui/jquery-ui.min.js"></script>
+    <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../../../node_modules/angular/angular.js"></script>
+    <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
+    <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
+    <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="../../../node_modules/angular-ui-date/dist/date.js"></script>
+    <script src="../../../node_modules/angular-float-thead/angular-floatThead.js"></script>
+    <script src="../../../node_modules/proj4/dist/proj4.js"></script>
+    <script src="../../../node_modules/floatthead/dist/jquery.floatThead.min.js"></script>
+    <script src="../../../node_modules/angular-ui-slider/src/slider.js"></script>
+    <script src="../../../node_modules/angular-dynamic-locale/dist/tmhDynamicLocale.js"></script>
+    <script src="/@?main=objectediting-hub.js"></script>
+    <script src="default.js"></script>
+    <script src="../../../utils/watchwatchers.js"></script>
+    <script>
+      var gmfModule = angular.module('gmf');
+      gmfModule.constant('defaultTheme', 'OSM');
+      gmfModule.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
+    </script>
+  </body>
+</html>

--- a/contribs/gmf/examples/objectediting-hub.js
+++ b/contribs/gmf/examples/objectediting-hub.js
@@ -1,0 +1,295 @@
+goog.provide('gmf-objectediting-hub');
+
+goog.require('ngeo.proj.EPSG21781');
+goog.require('gmf');
+goog.require('gmf.ObjectEditingManager');
+goog.require('gmf.Themes');
+goog.require('ol.format.WFS');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['gmf']);
+
+
+app.module.value('gmfTreeUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
+
+
+/**
+ * @param {angular.$http} $http Angular $http service.
+ * @param {angular.$q} $q Angular $q service.
+ * @param {!angular.Scope} $scope Angular scope.
+ * @param {gmf.Themes} gmfThemes The gmf themes service.
+ * @constructor
+ */
+app.MainController = function($http, $q, $scope, gmfThemes) {
+
+  /**
+   * @type {angular.$http}
+   * @private
+   */
+  this.http_ = $http;
+
+  /**
+   * @type {angular.$q}
+   * @private
+   */
+  this.q_ = $q;
+
+  /**
+   * @type {gmf.Themes}
+   * @private
+   */
+  this.gmfThemes_ = gmfThemes;
+
+  /**
+   * @type {Array.<string>} List of example and application urls that contain
+   *     ObjectEditing tools.
+   * @export
+   */
+  this.urls = [
+    'authentication.html'
+  ];
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.selectedUrl = this.urls[0];
+
+  /**
+   * @type {gmfThemes.GmfOgcServers} ogcServers OGC servers.
+   * @private
+   */
+  this.gmfServers_;
+
+  /**
+   * @type {gmfThemes.GmfOgcServer} ogcServer OGC server to use.
+   * @private
+   */
+  this.gmfServer_;
+
+  /**
+   * @type {Array.<gmfThemes.GmfLayerWMS>}
+   * @export
+   */
+  this.gmfLayerNodes = [];
+
+  /**
+   * @type {?gmfThemes.GmfLayerWMS}
+   * @export
+   */
+  this.selectedGmfLayerNode = null;
+
+  /**
+   * @type {Object.<number, Array.<ol.Feature>>}
+   * @export
+   */
+  this.featuresCache_ = {};
+
+  /**
+   * @type {Array.<ol.Feature>}
+   * @export
+   */
+  this.features = null;
+
+  /**
+   * @type {?ol.Feature}
+   * @export
+   */
+  this.selectedFeature = null;
+
+  $scope.$watch(
+    function() {
+      return this.selectedGmfLayerNode;
+    }.bind(this),
+    function(newVal, oldVal) {
+      this.selectedFeature = null;
+
+      if (newVal) {
+        this.getFeatures_(newVal).then(
+          this.handleGetFeatures_.bind(this, newVal)
+        );
+      }
+    }.bind(this)
+  );
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.themeName = 'ObjectEditing';
+
+
+  this.gmfThemes_.loadThemes();
+
+  this.gmfThemes_.getOgcServersObject().then(function(ogcServers) {
+
+    // (1) Set OGC servers
+    this.gmfServers_ = ogcServers;
+
+    this.gmfThemes_.getThemesObject().then(function(themes) {
+      if (!themes) {
+        return;
+      }
+
+      // (2) Find OE theme
+      var theme;
+      for (var i = 0, ii = themes.length; i < ii; i++) {
+        if (themes[i].name === this.themeName) {
+          theme = themes[i];
+          break;
+        }
+      }
+
+      if (!theme) {
+        return;
+      }
+
+      // (3) Get first group node
+      var groupNode = theme.children[0];
+
+      // (4) Set OGC server, which must support WFS for this example to work
+      var gmfServer = this.gmfServers_[groupNode.ogcServer];
+      if (gmfServer && gmfServer.wfsSupport === true && gmfServer.urlWfs) {
+        this.gmfServer_ = gmfServer;
+      } else {
+        return;
+      }
+
+      // (5) Set layer nodes
+      this.gmfLayerNodes = groupNode.children;
+
+      // (6) Select 'polygon' for the purpose of simplifying the demo
+      this.selectedGmfLayerNode = this.gmfLayerNodes[1];
+
+    }.bind(this));
+  }.bind(this));
+
+};
+
+
+/**
+ * @export
+ */
+app.MainController.prototype.run = function() {
+
+  var feature = this.selectedFeature;
+  var layer = this.selectedGmfLayerNode.name;
+  var property = 'name';
+  var id = feature.get(property);
+
+  var params = {};
+  params[gmf.ObjectEditingManager.Param.ID] = id;
+  params[gmf.ObjectEditingManager.Param.LAYER] = layer;
+  params[gmf.ObjectEditingManager.Param.THEME] = this.themeName;
+  params[gmf.ObjectEditingManager.Param.PROPERTY] = property;
+
+  var url = app.MainController.appendParams(this.selectedUrl, params);
+
+  window.open(url);
+
+};
+
+
+/**
+ * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
+ * @return {angular.$q.Promise} The promise attached to the deferred object.
+ * @export
+ */
+app.MainController.prototype.getFeatures_ = function(gmfLayerNode) {
+
+  this.getFeaturesDeferred_ = this.q_.defer();
+
+  var features = this.getFeaturesFromCache_(gmfLayerNode);
+
+  if (features) {
+    this.getFeaturesDeferred_.resolve();
+  } else {
+    this.issueGetFeatures_(gmfLayerNode);
+  }
+
+  return this.getFeaturesDeferred_.promise;
+};
+
+
+/**
+ * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
+ * @export
+ */
+app.MainController.prototype.issueGetFeatures_ = function(gmfLayerNode) {
+
+  var id = gmfLayerNode.id;
+
+  var url = app.MainController.appendParams(
+    this.gmfServer_.urlWfs,
+    {
+      'SERVICE': 'WFS',
+      'REQUEST': 'GetFeature',
+      'VERSION': '1.1.0',
+      'TYPENAME': gmfLayerNode.layers
+    }
+  );
+
+  this.http_.get(url).then(function(response) {
+    var features = new ol.format.WFS().readFeatures(response.data);
+    this.featuresCache_[id] = features;
+    this.getFeaturesDeferred_.resolve();
+  }.bind(this));
+};
+
+
+/**
+ * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
+ * @export
+ */
+app.MainController.prototype.handleGetFeatures_ = function(gmfLayerNode) {
+  var features = /** @type Array.<ol.Feature> */ (
+    this.getFeaturesFromCache_(gmfLayerNode));
+  this.features = features;
+  this.selectedFeature = this.features[0];
+};
+
+
+/**
+ * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
+ * @return {?Array.<ol.Feature>} List of features
+ * @export
+ */
+app.MainController.prototype.getFeaturesFromCache_ = function(gmfLayerNode) {
+  var id = gmfLayerNode.id;
+  var features = this.featuresCache_[id] || null;
+  return features;
+};
+
+
+/**
+ * Appends query parameters to a URI.
+ *
+ * @param {string} uri The original URI, which may already have query data.
+ * @param {!Object} params An object where keys are URI-encoded parameter keys,
+ *     and the values are arbitrary types or arrays.
+ * @return {string} The new URI.
+ */
+app.MainController.appendParams = function(uri, params) {
+  var keyParams = [];
+  // Skip any null or undefined parameter values
+  Object.keys(params).forEach(function(k) {
+    if (params[k] !== null && params[k] !== undefined) {
+      keyParams.push(k + '=' + encodeURIComponent(params[k]));
+    }
+  });
+  var qs = keyParams.join('&');
+  // remove any trailing ? or &
+  uri = uri.replace(/[?&]$/, '');
+  // append ? or & depending on whether uri has existing parameters
+  uri = uri.indexOf('?') === -1 ? uri + '?' : uri + '&';
+  return uri + qs;
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/contribs/gmf/src/services/objecteditingmanager.js
+++ b/contribs/gmf/src/services/objecteditingmanager.js
@@ -1,0 +1,29 @@
+goog.provide('gmf.ObjectEditingManager');
+
+
+/**
+ * @enum {string}
+ * @export
+ */
+gmf.ObjectEditingManager.Param = {
+  /**
+   * @type {string}
+   * @export
+   */
+  ID: 'objectediting_id',
+  /**
+   * @type {string}
+   * @export
+   */
+  LAYER: 'objectediting_layer',
+  /**
+   * @type {string}
+   * @export
+   */
+  PROPERTY: 'objectediting_property',
+  /**
+   * @type {string}
+   * @export
+   */
+  THEME: 'objectediting_theme'
+};

--- a/contribs/gmf/src/services/themesservice.js
+++ b/contribs/gmf/src/services/themesservice.js
@@ -1,6 +1,7 @@
 goog.provide('gmf.Themes');
 goog.provide('gmf.ThemesEventType');
 
+goog.require('goog.asserts');
 goog.require('gmf');
 goog.require('ngeo.LayerHelper');
 goog.require('ol.array');
@@ -424,6 +425,7 @@ gmf.Themes.prototype.getBackgroundLayersObject = function() {
 /**
  * Get the `ogcServers` object.
  * @return {angular.$q.Promise.<gmfThemes.GmfOgcServers>} Promise.
+ * @export
  */
 gmf.Themes.prototype.getOgcServersObject = function() {
   goog.asserts.assert(this.promise_ !== null);


### PR DESCRIPTION
This PR features a "Hub" example that will be the point of entry to open examples and applications that use the ObjectEditing tools.

**Note** For now, the example opens the authentication example.  This will be changed when we have an example featuring the ObjectEditing tools.

## Todo

 * [ ] Review


## Live example

 * https://adube.github.io/ngeo/oe-2600-hub-example/examples/contribs/gmf/objectediting-hub.html