### PR TITLE
ObjectEditing manager service

### DIFF
--- a/contribs/gmf/examples/editfeature.js
+++ b/contribs/gmf/examples/editfeature.js
@@ -146,7 +146,7 @@ app.MainController.prototype.handleMapSingleClick_ = function(evt) {
     buffer
   );
 
-  this.editFeature_.getFeatures([this.layerId_], extent).then(
+  this.editFeature_.getFeaturesInExtent([this.layerId_], extent).then(
     this.handleGetFeatures_.bind(this));
 
   // (2) Clear any previously selected feature

--- a/contribs/gmf/examples/objectediting-hub.html
+++ b/contribs/gmf/examples/objectediting-hub.html
@@ -52,7 +52,7 @@
 
       <div class="form-group">
         <button
-          ng-disabled="ctrl.selectedFeature === null || ctrl.selectedGmfLayerNode === null"
+          ng-disabled="ctrl.selectedFeature === null || ctrl.selectedGmfLayerNode === null || ctrl.selectedGeomType === null"
           ng-click="ctrl.run()"
           type="button"
           class="form-control btn btn-primary"

--- a/contribs/gmf/examples/objectediting-hub.js
+++ b/contribs/gmf/examples/objectediting-hub.js
@@ -52,7 +52,7 @@ app.MainController = function($http, $q, $scope, gmfThemes) {
    * @export
    */
   this.urls = [
-    'authentication.html'
+    'objectediting.html'
   ];
 
   /**
@@ -179,7 +179,7 @@ app.MainController = function($http, $q, $scope, gmfThemes) {
 app.MainController.prototype.run = function() {
 
   var feature = this.selectedFeature;
-  var layer = this.selectedGmfLayerNode.name;
+  var layer = this.selectedGmfLayerNode.id;
   var property = 'name';
   var id = feature.get(property);
 

--- a/contribs/gmf/examples/objectediting-hub.js
+++ b/contribs/gmf/examples/objectediting-hub.js
@@ -228,7 +228,7 @@ app.MainController.prototype.run = function() {
 /**
  * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
  * @return {angular.$q.Promise} The promise attached to the deferred object.
- * @export
+ * @private
  */
 app.MainController.prototype.getFeatures_ = function(gmfLayerNode) {
 
@@ -248,7 +248,7 @@ app.MainController.prototype.getFeatures_ = function(gmfLayerNode) {
 
 /**
  * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
- * @export
+ * @private
  */
 app.MainController.prototype.issueGetFeatures_ = function(gmfLayerNode) {
 
@@ -274,7 +274,7 @@ app.MainController.prototype.issueGetFeatures_ = function(gmfLayerNode) {
 
 /**
  * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
- * @export
+ * @private
  */
 app.MainController.prototype.handleGetFeatures_ = function(gmfLayerNode) {
   var features = /** @type Array.<ol.Feature> */ (
@@ -287,7 +287,7 @@ app.MainController.prototype.handleGetFeatures_ = function(gmfLayerNode) {
 /**
  * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
  * @return {?Array.<ol.Feature>} List of features
- * @export
+ * @private
  */
 app.MainController.prototype.getFeaturesFromCache_ = function(gmfLayerNode) {
   var id = gmfLayerNode.id;
@@ -299,7 +299,7 @@ app.MainController.prototype.getFeaturesFromCache_ = function(gmfLayerNode) {
 /**
  * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
  * @return {angular.$q.Promise} The promise attached to the deferred object.
- * @export
+ * @private
  */
 app.MainController.prototype.getGeometryType_ = function(gmfLayerNode) {
 
@@ -319,7 +319,7 @@ app.MainController.prototype.getGeometryType_ = function(gmfLayerNode) {
 
 /**
  * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
- * @export
+ * @private
  */
 app.MainController.prototype.issueGetAttributesRequest_ = function(
   gmfLayerNode
@@ -341,7 +341,7 @@ app.MainController.prototype.issueGetAttributesRequest_ = function(
 
 /**
  * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
- * @export
+ * @private
  */
 app.MainController.prototype.handleGetGeometryType_ = function(gmfLayerNode) {
   var geomType = /** @type {string} */ (
@@ -353,7 +353,7 @@ app.MainController.prototype.handleGetGeometryType_ = function(gmfLayerNode) {
 /**
  * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
  * @return {?string} The type of geometry.
- * @export
+ * @private
  */
 app.MainController.prototype.getGeometryTypeFromCache_ = function(
   gmfLayerNode

--- a/contribs/gmf/examples/objectediting.html
+++ b/contribs/gmf/examples/objectediting.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>ObjectEditing example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../../../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../../../third-party/jquery-ui/jquery-ui.min.css">
+    <style>
+      gmf-map > div {
+        width: 600px;
+        height: 400px;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <gmf-map gmf-map-map="ctrl.map"></gmf-map>
+    <p id="desc">
+      This example shows how to use the <code>gmf-objectediting</code>
+      directive to edit a single feature with advanced editing tools.
+    </p>
+    <script src="../../../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../../../third-party/jquery-ui/jquery-ui.min.js"></script>
+    <script src="../../../node_modules/angular/angular.js"></script>
+    <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
+    <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
+    <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="../../../node_modules/angular-ui-date/dist/date.js"></script>
+    <script src="../../../node_modules/angular-float-thead/angular-floatThead.js"></script>
+    <script src="../../../node_modules/proj4/dist/proj4.js"></script>
+    <script src="../../../node_modules/floatthead/dist/jquery.floatThead.min.js"></script>
+    <script src="../../../node_modules/angular-ui-slider/src/slider.js"></script>
+    <script src="../../../node_modules/angular-dynamic-locale/dist/tmhDynamicLocale.js"></script>
+    <script src="/@?main=objectediting.js"></script>
+    <script src="default.js"></script>
+    <script src="../../../utils/watchwatchers.js"></script>
+    <script>
+      var gmfModule = angular.module('gmf');
+      gmfModule.constant('defaultTheme', 'OSM');
+      gmfModule.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
+    </script>
+  </body>
+</html>

--- a/contribs/gmf/examples/objectediting.js
+++ b/contribs/gmf/examples/objectediting.js
@@ -1,0 +1,56 @@
+goog.provide('gmf-objectediting');
+
+goog.require('gmf.mapDirective');
+goog.require('ngeo.proj.EPSG21781');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['gmf']);
+
+
+app.module.value('gmfTreeUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
+
+
+app.module.value('gmfLayersUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/layers/');
+
+
+/**
+ * @constructor
+ */
+app.MainController = function() {
+
+  var projection = ol.proj.get('EPSG:21781');
+  projection.setExtent([485869.5728, 76443.1884, 837076.5648, 299941.7864]);
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      })
+    ],
+    view: new ol.View({
+      projection: projection,
+      resolutions: [200, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5],
+      center: [537635, 152640],
+      zoom: 2
+    })
+  });
+
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/contribs/gmf/examples/objectediting.js
+++ b/contribs/gmf/examples/objectediting.js
@@ -1,6 +1,8 @@
 goog.provide('gmf-objectediting');
 
 goog.require('gmf.mapDirective');
+/** @suppress {extraRequire} */
+goog.require('gmf.ObjectEditingManager');
 goog.require('ngeo.proj.EPSG21781');
 goog.require('ol.Map');
 goog.require('ol.View');

--- a/contribs/gmf/externs/gmfx.js
+++ b/contribs/gmf/externs/gmfx.js
@@ -11,6 +11,39 @@
  */
 var gmfx;
 
+
+/**
+ * @typedef {{
+ *     operator: (string),
+ *     property: (string),
+ *     value: (string)
+ * }}
+ */
+gmfx.ComparisonFilter;
+
+
+/**
+ * The type of operator for the comparison filter.
+ * @type {string}
+ */
+gmfx.ComparisonFilter.prototype.operator;
+
+
+/**
+ * The name of the property for the comparison filter.
+ * @type {string}
+ */
+gmfx.ComparisonFilter.prototype.property;
+
+
+/**
+ * The value for the comparison filter that must match the combinaison of
+ * the operator and property.
+ * @type {string}
+ */
+gmfx.ComparisonFilter.prototype.value;
+
+
 /**
  * A part of the application config.
  * @typedef {{

--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -850,8 +850,10 @@ gmf.EditfeatureController.prototype.handleMapClick_ = function(evt) {
     );
 
     // (3) Launch query to fetch features
-    this.editFeatureService_.getFeatures([this.editableNode_.id], extent).then(
-      this.handleGetFeatures_.bind(this));
+    this.editFeatureService_.getFeaturesInExtent(
+      [this.editableNode_.id],
+      extent
+    ).then(this.handleGetFeatures_.bind(this));
 
     // (4) Clear any previously selected feature
     this.cancel();

--- a/contribs/gmf/src/services/objecteditingmanager.js
+++ b/contribs/gmf/src/services/objecteditingmanager.js
@@ -131,6 +131,11 @@ gmf.ObjectEditingManager.Param = {
    * @type {string}
    * @export
    */
+  GEOM_TYPE: 'objectediting_geomtype',
+  /**
+   * @type {string}
+   * @export
+   */
   ID: 'objectediting_id',
   /**
    * @type {string}

--- a/contribs/gmf/src/services/objecteditingmanager.js
+++ b/contribs/gmf/src/services/objecteditingmanager.js
@@ -1,5 +1,126 @@
 goog.provide('gmf.ObjectEditingManager');
 
+goog.require('gmf.EditFeature');
+goog.require('ngeo.Location');
+goog.require('ol.Feature');
+
+
+/**
+ * A service that looks for certain parameters in the url and use them to fetch
+ * a feature using the GMF protocol.
+ *
+ * @param {angular.$q} $q Angular $q service.
+ * @param {gmf.EditFeature} gmfEditFeature Gmf edit feature service.
+ * @param {ngeo.Location} ngeoLocation ngeo location service.
+ * @constructor
+ * @struct
+ * @ngInject
+ */
+gmf.ObjectEditingManager = function($q, gmfEditFeature, ngeoLocation) {
+
+  /**
+   * @type {angular.$q}
+   * @private
+   */
+  this.q_ = $q;
+
+  /**
+   * @type {gmf.EditFeature}
+   * @private
+   */
+  this.gmfEditFeature_ = gmfEditFeature;
+
+  /**
+   * @type {ngeo.Location}
+   * @private
+   */
+  this.ngeoLocation_ = ngeoLocation;
+
+  /**
+   * @type {angular.$q.Deferred|null}
+   * @private
+   */
+  this.getFeatureDefered_ = null;
+
+};
+
+
+/**
+ * Use the EditFeature service to fetch a single feature using parameters in
+ * the url. The method returns a promise that has the feature as argument in
+ * the callback method. If any parameter in the url is missing, `null` is
+ * returned, otherwise the query is made. If the query returns a feature, it
+ * is returned, otherwise one is created with empty geometry and with the
+ * property set.
+ *
+ * @return {angular.$q.Promise} Promise.
+ * @export
+ */
+gmf.ObjectEditingManager.prototype.getFeature = function() {
+
+  if (!this.getFeatureDefered_) {
+    this.getFeatureDefered_ = this.q_.defer();
+
+    var id = this.ngeoLocation_.getParam(
+      gmf.ObjectEditingManager.Param.ID);
+    var layer = this.ngeoLocation_.getParam(
+      gmf.ObjectEditingManager.Param.LAYER);
+    var property = this.ngeoLocation_.getParam(
+      gmf.ObjectEditingManager.Param.PROPERTY);
+    var theme = this.ngeoLocation_.getParam(
+      gmf.ObjectEditingManager.Param.THEME);
+
+    if (id && layer && property && theme) {
+      this.gmfEditFeature_.getFeaturesWithComparisonFilters(
+        [layer],
+        [{
+          operator: 'eq',
+          property: property,
+          value: id
+        }]
+      ).then(this.handleGetFeatures_.bind(this, property, id));
+    } else {
+      this.getFeatureDefered_.resolve(null);
+    }
+  }
+
+  return this.getFeatureDefered_.promise;
+
+};
+
+
+/**
+ * Called after getting features with comparison filters. Resolve the defered
+ * promise with the first returned feature (if any), otherwise resolve it
+ * with a feature created with an empty geometry and the property key + value
+ * that was used in the attempt to fetch it.
+ *
+ * @param {string} key Property key.
+ * @param {string} value Property value.
+ * @param {Array.<ol.Feature>} features List of features.
+ * @private
+ */
+gmf.ObjectEditingManager.prototype.handleGetFeatures_ = function(
+  key, value, features
+) {
+
+  var feature;
+
+  if (features.length) {
+    feature = features[0];
+  } else {
+    var featureProperties = {};
+    featureProperties[key] = value;
+    featureProperties['geometry'] = null;
+    feature = new ol.Feature(featureProperties);
+  }
+
+  this.getFeatureDefered_.resolve(feature);
+};
+
+
+gmf.module.service('gmfObjectEditingManager', gmf.ObjectEditingManager);
+
 
 /**
  * @enum {string}

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -165,10 +165,6 @@ gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
    */
   this.gmfObjectEditingManager_ = gmfObjectEditingManager;
 
-  gmfObjectEditingManager.getFeature().then(function(feature) {
-    console.log(feature);
-  });
-
   /**
    * @type {gmf.Themes}
    * @private
@@ -578,8 +574,10 @@ gmf.Permalink.prototype.setMap = function(map) {
   }
 
   if (map) {
-    this.map_ = map;
-    this.registerMap_(map);
+    this.gmfObjectEditingManager_.getFeature().then(function(feature) {
+      this.map_ = map;
+      this.registerMap_(map, feature);
+    }.bind(this));
   }
 
 };
@@ -588,21 +586,31 @@ gmf.Permalink.prototype.setMap = function(map) {
 /**
  * Listen to the map view property change and update the state accordingly.
  * @param {ol.Map} map The ol3 map object.
+ * @param {?ol.Feature} oeFeature ObjectEditing feature
  * @private
  */
-gmf.Permalink.prototype.registerMap_ = function(map) {
+gmf.Permalink.prototype.registerMap_ = function(map, oeFeature) {
 
   var view = map.getView();
+  var size = map.getSize();
+  goog.asserts.assert(size);
+  var center;
+  var zoom;
 
-  // (1) Initialize the map view with the X, Y and Z available within the
-  //     permalink service, if available
-  var center = this.getMapCenter();
-  if (center !== null) {
-    view.setCenter(center);
-  }
-  var zoom = this.getMapZoom();
-  if (zoom !== null) {
-    view.setZoom(zoom);
+  // (1) Initialize the map view with either:
+  //     a) the given ObjectEditing feature
+  //     b) the X, Y and Z available within the permalink service, if available
+  if (oeFeature && oeFeature.getGeometry()) {
+    view.fit(oeFeature.getGeometry().getExtent(), size);
+  } else {
+    center = this.getMapCenter();
+    if (center !== null) {
+      view.setCenter(center);
+    }
+    zoom = this.getMapZoom();
+    if (zoom !== null) {
+      view.setZoom(zoom);
+    }
   }
 
 

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -574,8 +574,8 @@ gmf.Permalink.prototype.setMap = function(map) {
   }
 
   if (map) {
+    this.map_ = map;
     this.gmfObjectEditingManager_.getFeature().then(function(feature) {
-      this.map_ = map;
       this.registerMap_(map, feature);
     }.bind(this));
   }

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -2,6 +2,7 @@ goog.provide('gmf.Permalink');
 
 goog.require('gmf');
 goog.require('ngeo.AutoProjection');
+goog.require('gmf.ObjectEditingManager');
 goog.require('gmf.Themes');
 goog.require('gmf.ThemeManager');
 goog.require('gmf.TreeManager');
@@ -72,6 +73,8 @@ gmf.module.value('gmfPermalinkOptions',
  * @param {ol.Collection.<ol.Feature>} ngeoFeatures Collection of features.
  * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
  * @param {ngeo.StateManager} ngeoStateManager The ngeo StateManager service.
+ * @param {gmf.ObjectEditingManager} gmfObjectEditingManager The gmf
+ *     ObjectEditing manager service.
  * @param {gmf.Themes} gmfThemes The gmf Themes service.
  * @param {gmf.ThemeManager} gmfThemeManager The gmf ThemeManager service.
  * @param {gmf.TreeManager} gmfTreeManager The gmf gmfTreeManager service.
@@ -89,7 +92,8 @@ gmf.module.value('gmfPermalinkOptions',
  */
 gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
     ngeoFeatureOverlayMgr, ngeoFeatureHelper, ngeoFeatures, ngeoLayerHelper,
-    ngeoStateManager, gmfThemes, gmfThemeManager, gmfTreeManager, gmfPermalinkOptions, defaultTheme,
+    ngeoStateManager, gmfObjectEditingManager, gmfThemes, gmfThemeManager,
+    gmfTreeManager, gmfPermalinkOptions, defaultTheme,
     ngeoLocation, ngeoWfsPermalink, ngeoAutoProjection, $rootScope, $injector) {
 
   // == listener keys ==
@@ -154,6 +158,16 @@ gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
   if (gmfPermalinkOptions.useLocalStorage === false) {
     this.ngeoStateManager_.localStorage.isAvailable = ol.functions.FALSE;
   }
+
+  /**
+   * @type {gmf.ObjectEditingManager}
+   * @private
+   */
+  this.gmfObjectEditingManager_ = gmfObjectEditingManager;
+
+  gmfObjectEditingManager.getFeature().then(function(feature) {
+    console.log(feature);
+  });
 
   /**
    * @type {gmf.Themes}

--- a/src/ol-ext/format/xsdattribute.js
+++ b/src/ol-ext/format/xsdattribute.js
@@ -103,6 +103,12 @@ ngeo.format.XSDAttribute.prototype.readFromElementNode_ = function(node) {
         attribute.geomType = ol.geom.GeometryType.LINE_STRING;
       } else if (/^gml:Polygon/.exec(type)) {
         attribute.geomType = ol.geom.GeometryType.POLYGON;
+      } else if (/^gml:MultiPoint/.exec(type)) {
+        attribute.geomType = ol.geom.GeometryType.MULTI_POINT;
+      } else if (/^gml:MultiLineString/.exec(type)) {
+        attribute.geomType = ol.geom.GeometryType.MULTI_LINE_STRING;
+      } else if (/^gml:MultiPolygon/.exec(type)) {
+        attribute.geomType = ol.geom.GeometryType.MULTI_POLYGON;
       }
     } else if (type === 'xsd:string') {
       attribute.type = ngeo.format.XSDAttributeType.TEXT;


### PR DESCRIPTION
This PR introduces the ObjectEditing manager service, which is responsible of looking for parameters in the url, use them to build a request to the WFS Protocol to fetch a feature to use for the ObjectEditing tool.

The returned feature is also used within the Permalink service, i.e. if an ObjectEditing feature is returned, then the map is centered on it.  Otherwise, the default centering takes place.


## Todo

 * [x] Review


## Live demo

Once the hub page is completed loading, click on the "Launch" button.

 * https://adube.github.io/ngeo/oe-2593-oe-manager/examples/contribs/gmf/objectediting-hub.html

You can test with separate layers / features.  You can also try to modify the url of the opened page to see how it reacts to any parameter missing or if the query returns nothing.