### PR TITLE
Can query map server groups

### DIFF
--- a/contribs/gmf/src/services/querymanager.js
+++ b/contribs/gmf/src/services/querymanager.js
@@ -136,6 +136,7 @@ gmf.QueryManager.prototype.createSources_ = function(firstLevelGroup, node, ogcS
   var meta = /** @type {gmfThemes.GmfMetaData} */ (node.metadata);
   var identifierAttributeField = meta.identifierAttributeField;
   var layers;
+  var childLayers;
   var name = node.name;
   var validateLayerParams = false;
   var gmfLayer = /** @type gmfThemes.GmfLayer */ (node);
@@ -157,6 +158,7 @@ gmf.QueryManager.prototype.createSources_ = function(firstLevelGroup, node, ogcS
   if (gmfLayer.type === 'WMS') {
     gmfLayerWMS = /** @type gmfThemes.GmfLayerWMS */ (gmfLayer);
     layers = gmfLayerWMS.layers;
+    childLayers = layers;
     if (firstLevelGroup.mixed) {
       goog.asserts.assert(gmfLayerWMS.ogcServer);
       ogcServer = ogcServers[/** @type string */ (gmfLayerWMS.ogcServer)];
@@ -188,18 +190,20 @@ gmf.QueryManager.prototype.createSources_ = function(firstLevelGroup, node, ogcS
             childLayerNames.push(childLayer.name);
           }
         }, this);
-        layers = childLayerNames.join(',');
+        childLayers = childLayerNames.join(',');
       }
     }
 
     goog.asserts.assert(ogcServer.urlWfs);
+    goog.asserts.assert(childLayers);
     goog.asserts.assert(layers);
 
     var source = {
       'id': id,
       'identifierAttributeField': identifierAttributeField,
       'label': name,
-      'params': {'LAYERS': layers},
+      'params': {'LAYERS': childLayers},
+      'layers': layers,
       'dimensions': node.dimensions || firstLevelGroup.dimensions,
       'url': ogcServer.urlWfs,
       'validateLayerParams': validateLayerParams,

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -432,6 +432,7 @@ ngeox.QueryOptions.prototype.geometryName;
  *     infoFormat: (string|undefined),
  *     label: (string|undefined),
  *     layer: (ol.layer.Base|undefined),
+ *     layers: (string|undefined),
  *     params: (Object.<string, *>|undefined),
  *     serverType: (string|undefined),
  *     url: (string|undefined),
@@ -487,6 +488,14 @@ ngeox.QuerySource.prototype.label;
  * @type {ol.layer.Base|undefined}
  */
 ngeox.QuerySource.prototype.layer;
+
+
+/**
+ * A reference to the ol3 layers names. Multiple layers names can be separated
+ * by a comma.
+ * @type {string|undefined}
+ */
+ngeox.QuerySource.prototype.layers;
 
 
 /**

--- a/src/services/query.js
+++ b/src/services/query.js
@@ -441,12 +441,12 @@ ngeo.Query.prototype.getQueryableSources_ = function(map, wfsOnly) {
             'validateLayerParams option.'
         );
         var layerLayers = layerSource.getParams()['LAYERS'].split(',');
-        var cfgLayer = item.source.wmsSource.getParams()['LAYERS'].split(',');
+        var cfgLayer = item.source.layers.split(',');
 
-        var every = cfgLayer.every(function(layer) {
-          return layerLayers.indexOf(layer) != -1;
+        var layerIsOnTheMap = cfgLayer.some(function(layer) {
+          return layerLayers.indexOf(layer) > -1;
         });
-        if (!every) {
+        if (!layerIsOnTheMap) {
           continue;
         }
       }


### PR DESCRIPTION
Fix: #1977

Example: https://ger-benjamin.github.io/ngeo/query_mapserver_groups/examples/contribs/gmf/apps/desktop/

(Before it takes only the first childlayer and tests if it's on the map. Now it does this check on the layer)

(2000th PR :tada:  )