### PR TITLE
Encode values for fragment parameters

### DIFF
--- a/src/services/location.js
+++ b/src/services/location.js
@@ -4,6 +4,7 @@ goog.provide('ngeo.MockLocationProvider');
 goog.require('goog.Uri');
 goog.require('goog.object');
 goog.require('ngeo');
+goog.require('ngeo.string');
 
 
 /**
@@ -133,7 +134,7 @@ ngeo.Location.prototype.getParam = function(key) {
  */
 ngeo.Location.prototype.getFragmentParam = function(key) {
   var val = /** @type {string} */ (this.getFragmentUri_().getQueryData().get(key));
-  return val !== undefined ? goog.string.urlDecode(val) : undefined;
+  return val !== undefined ? ngeo.string.urlDecode(val) : undefined;
 };
 
 
@@ -241,7 +242,7 @@ ngeo.Location.prototype.updateFragmentParams = function(params) {
   var fragmentUri = this.getFragmentUri_();
   var qd = fragmentUri.getQueryData();
   goog.object.forEach(params, function(val, key) {
-    val = val !== undefined ? goog.string.urlEncode(val) : undefined;
+    val = val !== undefined ? ngeo.string.urlEncode(val) : undefined;
     qd.set(key, val);
   });
   this.updateFragmentFromUri_(fragmentUri);

--- a/src/services/location.js
+++ b/src/services/location.js
@@ -128,11 +128,12 @@ ngeo.Location.prototype.getParam = function(key) {
 /**
  * Get a param from the fragment of the location's URI.
  * @param {string} key Param key.
- * @return {string} Param value.
+ * @return {string|undefined} Param value.
  * @export
  */
 ngeo.Location.prototype.getFragmentParam = function(key) {
-  return /** @type {string} */ (this.getFragmentUri_().getQueryData().get(key));
+  var val = /** @type {string} */ (this.getFragmentUri_().getQueryData().get(key));
+  return val !== undefined ? goog.string.urlDecode(val) : undefined;
 };
 
 
@@ -240,6 +241,7 @@ ngeo.Location.prototype.updateFragmentParams = function(params) {
   var fragmentUri = this.getFragmentUri_();
   var qd = fragmentUri.getQueryData();
   goog.object.forEach(params, function(val, key) {
+    val = val !== undefined ? goog.string.urlEncode(val) : undefined;
     qd.set(key, val);
   });
   this.updateFragmentFromUri_(fragmentUri);

--- a/src/string.js
+++ b/src/string.js
@@ -1,0 +1,19 @@
+goog.provide('ngeo.string');
+
+
+/**
+ * @param {*} str The string to url-encode.
+ * @return {string} The encoded string.
+ */
+ngeo.string.urlEncode = function(str) {
+  return encodeURIComponent(String(str));
+};
+
+
+/**
+ * @param {string} str The string to url decode.
+ * @return {string} The decoded string.
+ */
+ngeo.string.urlDecode = function(str) {
+  return decodeURIComponent(str.replace(/\+/g, ' '));
+};

--- a/test/spec/services/location.spec.js
+++ b/test/spec/services/location.spec.js
@@ -120,6 +120,11 @@ describe('ngeo.Location', function() {
         var value = ngeoLocation.getFragmentParam('key1');
         expect(value).toBe('value1');
       });
+
+      it('returns undefined for missing keys', function() {
+        var value = ngeoLocation.getFragmentParam('no-existing-key');
+        expect(value).toBe(undefined);
+      });
     });
 
     describe('#getFragmentParamAsInt', function() {
@@ -158,6 +163,12 @@ describe('ngeo.Location', function() {
         ngeoLocation.updateFragmentParams({'key1': 'new value'});
         var value = ngeoLocation.getFragmentParam('key1');
         expect(value).toBe('new value');
+      });
+
+      it('updates an existing param key with special chars', function() {
+        ngeoLocation.updateFragmentParams({'key1': '6+,7a+'});
+        var value = ngeoLocation.getFragmentParam('key1');
+        expect(value).toBe('6+,7a+');
       });
 
       it('adds a new param key', function() {


### PR DESCRIPTION
When using values like `6+,7a+` as fragment parameters, the values have to be url encoded/decoded.