### PR TITLE
WIP - ObjectEditing directive without tools

### DIFF
--- a/contribs/gmf/examples/editfeature.js
+++ b/contribs/gmf/examples/editfeature.js
@@ -146,7 +146,7 @@ app.MainController.prototype.handleMapSingleClick_ = function(evt) {
     buffer
   );
 
-  this.editFeature_.getFeatures([this.layerId_], extent).then(
+  this.editFeature_.getFeaturesInExtent([this.layerId_], extent).then(
     this.handleGetFeatures_.bind(this));
 
   // (2) Clear any previously selected feature

--- a/contribs/gmf/examples/objectediting-hub.html
+++ b/contribs/gmf/examples/objectediting-hub.html
@@ -52,7 +52,7 @@
 
       <div class="form-group">
         <button
-          ng-disabled="ctrl.selectedFeature === null || ctrl.selectedGmfLayerNode === null"
+          ng-disabled="ctrl.selectedFeature === null || ctrl.selectedGmfLayerNode === null || ctrl.selectedGeomType === null"
           ng-click="ctrl.run()"
           type="button"
           class="form-control btn btn-primary"

--- a/contribs/gmf/examples/objectediting-hub.js
+++ b/contribs/gmf/examples/objectediting-hub.js
@@ -52,7 +52,7 @@ app.MainController = function($http, $q, $scope, gmfThemes) {
    * @export
    */
   this.urls = [
-    'authentication.html'
+    'objectediting.html'
   ];
 
   /**
@@ -179,7 +179,7 @@ app.MainController = function($http, $q, $scope, gmfThemes) {
 app.MainController.prototype.run = function() {
 
   var feature = this.selectedFeature;
-  var layer = this.selectedGmfLayerNode.name;
+  var layer = this.selectedGmfLayerNode.id;
   var property = 'name';
   var id = feature.get(property);
 

--- a/contribs/gmf/examples/objectediting-hub.js
+++ b/contribs/gmf/examples/objectediting-hub.js
@@ -228,7 +228,7 @@ app.MainController.prototype.run = function() {
 /**
  * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
  * @return {angular.$q.Promise} The promise attached to the deferred object.
- * @export
+ * @private
  */
 app.MainController.prototype.getFeatures_ = function(gmfLayerNode) {
 
@@ -248,7 +248,7 @@ app.MainController.prototype.getFeatures_ = function(gmfLayerNode) {
 
 /**
  * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
- * @export
+ * @private
  */
 app.MainController.prototype.issueGetFeatures_ = function(gmfLayerNode) {
 
@@ -274,7 +274,7 @@ app.MainController.prototype.issueGetFeatures_ = function(gmfLayerNode) {
 
 /**
  * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
- * @export
+ * @private
  */
 app.MainController.prototype.handleGetFeatures_ = function(gmfLayerNode) {
   var features = /** @type Array.<ol.Feature> */ (
@@ -287,7 +287,7 @@ app.MainController.prototype.handleGetFeatures_ = function(gmfLayerNode) {
 /**
  * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
  * @return {?Array.<ol.Feature>} List of features
- * @export
+ * @private
  */
 app.MainController.prototype.getFeaturesFromCache_ = function(gmfLayerNode) {
   var id = gmfLayerNode.id;
@@ -299,7 +299,7 @@ app.MainController.prototype.getFeaturesFromCache_ = function(gmfLayerNode) {
 /**
  * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
  * @return {angular.$q.Promise} The promise attached to the deferred object.
- * @export
+ * @private
  */
 app.MainController.prototype.getGeometryType_ = function(gmfLayerNode) {
 
@@ -319,7 +319,7 @@ app.MainController.prototype.getGeometryType_ = function(gmfLayerNode) {
 
 /**
  * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
- * @export
+ * @private
  */
 app.MainController.prototype.issueGetAttributesRequest_ = function(
   gmfLayerNode
@@ -341,7 +341,7 @@ app.MainController.prototype.issueGetAttributesRequest_ = function(
 
 /**
  * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
- * @export
+ * @private
  */
 app.MainController.prototype.handleGetGeometryType_ = function(gmfLayerNode) {
   var geomType = /** @type {string} */ (
@@ -353,7 +353,7 @@ app.MainController.prototype.handleGetGeometryType_ = function(gmfLayerNode) {
 /**
  * @param {gmfThemes.GmfLayerWMS} gmfLayerNode Layer node.
  * @return {?string} The type of geometry.
- * @export
+ * @private
  */
 app.MainController.prototype.getGeometryTypeFromCache_ = function(
   gmfLayerNode

--- a/contribs/gmf/examples/objectediting.html
+++ b/contribs/gmf/examples/objectediting.html
@@ -7,11 +7,20 @@
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="mobile-web-app-capable" content="yes">
     <link rel="stylesheet" href="../../../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/font-awesome/css/font-awesome.css" type="text/css">
     <link rel="stylesheet" href="../../../third-party/jquery-ui/jquery-ui.min.css">
     <style>
       gmf-map > div {
         width: 600px;
         height: 400px;
+      }
+      gmf-objectediting {
+        border: 1px solid #ddd;
+        display: block;
+        margin: 10px 0;
+        padding: 4px;
+        width: 400px;
       }
     </style>
   </head>
@@ -31,10 +40,11 @@
     <h2>ObjectEditing</h2>
 
     <gmf-objectediting
-      ng-if="ctrl.objectEditingFeature"
+      ng-if="ctrl.objectEditingFeature && ctrl.objectEditingLayerNodeId"
       ng-show="ctrl.objectEditingActive === true"
       gmf-objectediting-active="ctrl.objectEditingActive"
       gmf-objectediting-feature="ctrl.objectEditingFeature"
+      gmf-objectediting-layernodeid="::ctrl.objectEditingLayerNodeId"
       gmf-objectediting-map="::ctrl.map">
     </gmf-objectediting>
 
@@ -49,6 +59,7 @@
     <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
     <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
     <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
+    <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
     <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="../../../node_modules/angular-ui-date/dist/date.js"></script>
     <script src="../../../node_modules/angular-float-thead/angular-floatThead.js"></script>

--- a/contribs/gmf/examples/objectediting.html
+++ b/contribs/gmf/examples/objectediting.html
@@ -27,6 +27,11 @@
   <body ng-controller="MainController as ctrl">
     <gmf-map gmf-map-map="ctrl.map"></gmf-map>
 
+    <gmf-layertree
+        class="panel panel-default panel-body"
+        gmf-layertree-map="::ctrl.map">
+    </gmf-layertree>
+
     <input type="checkbox"
        id="checkbox-objectediting"
        ng-model="ctrl.objectEditingActive" />

--- a/contribs/gmf/examples/objectediting.html
+++ b/contribs/gmf/examples/objectediting.html
@@ -17,10 +17,32 @@
   </head>
   <body ng-controller="MainController as ctrl">
     <gmf-map gmf-map-map="ctrl.map"></gmf-map>
+
+    <input type="checkbox"
+       id="checkbox-objectediting"
+       ng-model="ctrl.objectEditingActive" />
+    <label for="checkbox-objectediting"> ObjectEditing</label>
+
+    <input type="checkbox"
+       id="checkbox-dummy"
+       ng-model="ctrl.dummyActive" />
+    <label for="checkbox-dummy"> Dummy tool</label>
+
+    <h2>ObjectEditing</h2>
+
+    <gmf-objectediting
+      ng-if="ctrl.objectEditingFeature"
+      ng-show="ctrl.objectEditingActive === true"
+      gmf-objectediting-active="ctrl.objectEditingActive"
+      gmf-objectediting-feature-="ctrl.objectEditingFeature"
+      gmf-objectediting-map="::ctrl.map">
+    </gmf-objectediting>
+
     <p id="desc">
       This example shows how to use the <code>gmf-objectediting</code>
       directive to edit a single feature with advanced editing tools.
     </p>
+
     <script src="../../../node_modules/jquery/dist/jquery.js"></script>
     <script src="../../../third-party/jquery-ui/jquery-ui.min.js"></script>
     <script src="../../../node_modules/angular/angular.js"></script>

--- a/contribs/gmf/examples/objectediting.html
+++ b/contribs/gmf/examples/objectediting.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>ObjectEditing example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../../../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../../../third-party/jquery-ui/jquery-ui.min.css">
+    <style>
+      gmf-map > div {
+        width: 600px;
+        height: 400px;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <gmf-map gmf-map-map="ctrl.map"></gmf-map>
+    <p id="desc">
+      This example shows how to use the <code>gmf-objectediting</code>
+      directive to edit a single feature with advanced editing tools.
+    </p>
+    <script src="../../../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../../../third-party/jquery-ui/jquery-ui.min.js"></script>
+    <script src="../../../node_modules/angular/angular.js"></script>
+    <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
+    <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
+    <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="../../../node_modules/angular-ui-date/dist/date.js"></script>
+    <script src="../../../node_modules/angular-float-thead/angular-floatThead.js"></script>
+    <script src="../../../node_modules/proj4/dist/proj4.js"></script>
+    <script src="../../../node_modules/floatthead/dist/jquery.floatThead.min.js"></script>
+    <script src="../../../node_modules/angular-ui-slider/src/slider.js"></script>
+    <script src="../../../node_modules/angular-dynamic-locale/dist/tmhDynamicLocale.js"></script>
+    <script src="/@?main=objectediting.js"></script>
+    <script src="default.js"></script>
+    <script src="../../../utils/watchwatchers.js"></script>
+    <script>
+      var gmfModule = angular.module('gmf');
+      gmfModule.constant('defaultTheme', 'OSM');
+      gmfModule.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
+    </script>
+  </body>
+</html>

--- a/contribs/gmf/examples/objectediting.html
+++ b/contribs/gmf/examples/objectediting.html
@@ -78,6 +78,7 @@
     <script>
       var gmfModule = angular.module('gmf');
       gmfModule.constant('defaultTheme', 'OSM');
+      gmfModule.constant('gmfTreeManagerModeFlush', true);
       gmfModule.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
     </script>
   </body>

--- a/contribs/gmf/examples/objectediting.html
+++ b/contribs/gmf/examples/objectediting.html
@@ -34,7 +34,7 @@
       ng-if="ctrl.objectEditingFeature"
       ng-show="ctrl.objectEditingActive === true"
       gmf-objectediting-active="ctrl.objectEditingActive"
-      gmf-objectediting-feature-="ctrl.objectEditingFeature"
+      gmf-objectediting-feature="ctrl.objectEditingFeature"
       gmf-objectediting-map="::ctrl.map">
     </gmf-objectediting>
 

--- a/contribs/gmf/examples/objectediting.html
+++ b/contribs/gmf/examples/objectediting.html
@@ -22,6 +22,9 @@
         padding: 4px;
         width: 400px;
       }
+      gmf-layertree {
+        display: none;
+      }
     </style>
   </head>
   <body ng-controller="MainController as ctrl">

--- a/contribs/gmf/examples/objectediting.html
+++ b/contribs/gmf/examples/objectediting.html
@@ -77,7 +77,9 @@
     <script src="../../../utils/watchwatchers.js"></script>
     <script>
       var gmfModule = angular.module('gmf');
-      gmfModule.constant('defaultTheme', 'OSM');
+      gmfModule.constant('defaultTheme', 'ObjectEditing');
+      gmfModule.constant('gmfLayersUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/layers/');
+      gmfModule.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
       gmfModule.constant('gmfTreeManagerModeFlush', true);
       gmfModule.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
     </script>

--- a/contribs/gmf/examples/objectediting.js
+++ b/contribs/gmf/examples/objectediting.js
@@ -1,0 +1,56 @@
+goog.provide('gmf-objectediting');
+
+goog.require('gmf.mapDirective');
+goog.require('ngeo.proj.EPSG21781');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+
+
+/** @const **/
+var app = {};
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', ['gmf']);
+
+
+app.module.value('gmfTreeUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
+
+
+app.module.value('gmfLayersUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/layers/');
+
+
+/**
+ * @constructor
+ */
+app.MainController = function() {
+
+  var projection = ol.proj.get('EPSG:21781');
+  projection.setExtent([485869.5728, 76443.1884, 837076.5648, 299941.7864]);
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      })
+    ],
+    view: new ol.View({
+      projection: projection,
+      resolutions: [200, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5],
+      center: [537635, 152640],
+      zoom: 2
+    })
+  });
+
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/contribs/gmf/examples/objectediting.js
+++ b/contribs/gmf/examples/objectediting.js
@@ -74,6 +74,12 @@ app.MainController = function(gmfObjectEditingManager, ngeoToolActivateMgr) {
   });
 
   /**
+   * @type {?number}
+   * @export
+   */
+  this.objectEditingLayerNodeId = gmfObjectEditingManager.getLayerNodeId();
+
+  /**
    * @type {boolean}
    * @export
    */

--- a/contribs/gmf/examples/objectediting.js
+++ b/contribs/gmf/examples/objectediting.js
@@ -9,7 +9,9 @@ goog.require('ngeo.proj.EPSG21781');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Tile');
+goog.require('ol.layer.Vector');
 goog.require('ol.source.OSM');
+goog.require('ol.source.Vector');
 
 
 /** @const **/
@@ -41,6 +43,18 @@ app.MainController = function(gmfObjectEditingManager, ngeoToolActivateMgr) {
   projection.setExtent([485869.5728, 76443.1884, 837076.5648, 299941.7864]);
 
   /**
+   * @type {ol.source.Vector}
+   * @private
+   */
+  this.vectorSource_ = new ol.source.Vector({
+    wrapX: false
+  });
+
+  var vectorLayer = new ol.layer.Vector({
+    source: this.vectorSource_
+  });
+
+  /**
    * @type {ol.Map}
    * @export
    */
@@ -48,7 +62,8 @@ app.MainController = function(gmfObjectEditingManager, ngeoToolActivateMgr) {
     layers: [
       new ol.layer.Tile({
         source: new ol.source.OSM()
-      })
+      }),
+      vectorLayer
     ],
     view: new ol.View({
       projection: projection,
@@ -88,6 +103,9 @@ app.MainController = function(gmfObjectEditingManager, ngeoToolActivateMgr) {
 
   gmfObjectEditingManager.getFeature().then(function(feature) {
     this.objectEditingFeature = feature;
+    if (feature) {
+      this.vectorSource_.addFeature(feature);
+    }
   }.bind(this));
 
 };

--- a/contribs/gmf/examples/objectediting.js
+++ b/contribs/gmf/examples/objectediting.js
@@ -1,6 +1,8 @@
 goog.provide('gmf-objectediting');
 
 goog.require('gmf.mapDirective');
+/** @suppress {extraRequire} */
+goog.require('gmf.ObjectEditingManager');
 goog.require('ngeo.proj.EPSG21781');
 goog.require('ol.Map');
 goog.require('ol.View');

--- a/contribs/gmf/examples/objectediting.js
+++ b/contribs/gmf/examples/objectediting.js
@@ -85,14 +85,6 @@ app.MainController = function(gmfObjectEditingManager, gmfThemes,
 
   gmfThemes.getThemesObject().then(function(themes) {
     if (themes) {
-      // Add 'ObjectEditing' theme, i.e. the one with id 168
-      for (var i = 0, ii = themes.length; i < ii; i++) {
-        if (themes[i].id === 168) {
-          this.gmfTreeManager_.setFirstLevelGroups(themes[i].children);
-          break;
-        }
-      }
-
       // Add layer vector after
       this.map.addLayer(this.vectorLayer_);
     }

--- a/contribs/gmf/examples/objectediting.js
+++ b/contribs/gmf/examples/objectediting.js
@@ -1,8 +1,10 @@
 goog.provide('gmf-objectediting');
 
 goog.require('gmf.mapDirective');
-/** @suppress {extraRequire} */
+goog.require('gmf.objecteditingDirective');
 goog.require('gmf.ObjectEditingManager');
+goog.require('ngeo.ToolActivate');
+goog.require('ngeo.ToolActivateMgr');
 goog.require('ngeo.proj.EPSG21781');
 goog.require('ol.Map');
 goog.require('ol.View');
@@ -27,9 +29,13 @@ app.module.value('gmfLayersUrl',
 
 
 /**
+ * @param {gmf.ObjectEditingManager} gmfObjectEditingManager The gmf
+ *     ObjectEditing manager service.
+ * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
+ *     service.
  * @constructor
  */
-app.MainController = function() {
+app.MainController = function(gmfObjectEditingManager, ngeoToolActivateMgr) {
 
   var projection = ol.proj.get('EPSG:21781');
   projection.setExtent([485869.5728, 76443.1884, 837076.5648, 299941.7864]);
@@ -51,6 +57,38 @@ app.MainController = function() {
       zoom: 2
     })
   });
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.objectEditingActive = true;
+
+  var objectEditingToolActivate = new ngeo.ToolActivate(
+    this, 'objectEditingActive');
+  ngeoToolActivateMgr.registerTool(
+    'mapTools', objectEditingToolActivate, true);
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.dummyActive = false;
+
+  var dummyToolActivate = new ngeo.ToolActivate(
+    this, 'dummyActive');
+  ngeoToolActivateMgr.registerTool(
+    'mapTools', dummyToolActivate, false);
+
+  /**
+   * @type {?ol.Feature}
+   * @export
+   */
+  this.objectEditingFeature = null;
+
+  gmfObjectEditingManager.getFeature().then(function(feature) {
+    this.objectEditingFeature = feature;
+  }.bind(this));
 
 };
 

--- a/contribs/gmf/examples/objectediting.js
+++ b/contribs/gmf/examples/objectediting.js
@@ -26,17 +26,6 @@ var app = {};
 app.module = angular.module('app', ['gmf']);
 
 
-app.module.value('gmfTreeUrl',
-    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
-
-
-app.module.value('gmfLayersUrl',
-    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/layers/');
-
-
-gmf.module.value('gmfTreeManagerModeFlush', true);
-
-
 /**
  * @param {gmf.ObjectEditingManager} gmfObjectEditingManager The gmf
  *     ObjectEditing manager service.

--- a/contribs/gmf/examples/objectediting.js
+++ b/contribs/gmf/examples/objectediting.js
@@ -1,5 +1,9 @@
 goog.provide('gmf-objectediting');
 
+goog.require('gmf');
+goog.require('gmf.Themes');
+goog.require('gmf.TreeManager');
+goog.require('gmf.layertreeDirective');
 goog.require('gmf.mapDirective');
 goog.require('gmf.objecteditingDirective');
 goog.require('gmf.ObjectEditingManager');
@@ -30,14 +34,28 @@ app.module.value('gmfLayersUrl',
     'https://geomapfish-demo.camptocamp.net/2.1/wsgi/layers/');
 
 
+gmf.module.value('gmfTreeManagerModeFlush', true);
+
+
 /**
  * @param {gmf.ObjectEditingManager} gmfObjectEditingManager The gmf
  *     ObjectEditing manager service.
+ * @param {gmf.Themes} gmfThemes The gmf themes service.
+ * @param {gmf.TreeManager} gmfTreeManager gmf Tree Manager service.
  * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
  *     service.
  * @constructor
  */
-app.MainController = function(gmfObjectEditingManager, ngeoToolActivateMgr) {
+app.MainController = function(gmfObjectEditingManager, gmfThemes,
+    gmfTreeManager, ngeoToolActivateMgr) {
+
+  /**
+   * @type {gmf.TreeManager}
+   * @private
+   */
+  this.gmfTreeManager_ = gmfTreeManager;
+
+  gmfThemes.loadThemes();
 
   var projection = ol.proj.get('EPSG:21781');
   projection.setExtent([485869.5728, 76443.1884, 837076.5648, 299941.7864]);
@@ -50,7 +68,11 @@ app.MainController = function(gmfObjectEditingManager, ngeoToolActivateMgr) {
     wrapX: false
   });
 
-  var vectorLayer = new ol.layer.Vector({
+  /**
+   * @type {ol.layer.Vector}
+   * @private
+   */
+  this.vectorLayer_ = new ol.layer.Vector({
     source: this.vectorSource_
   });
 
@@ -62,8 +84,7 @@ app.MainController = function(gmfObjectEditingManager, ngeoToolActivateMgr) {
     layers: [
       new ol.layer.Tile({
         source: new ol.source.OSM()
-      }),
-      vectorLayer
+      })
     ],
     view: new ol.View({
       projection: projection,
@@ -72,6 +93,21 @@ app.MainController = function(gmfObjectEditingManager, ngeoToolActivateMgr) {
       zoom: 2
     })
   });
+
+  gmfThemes.getThemesObject().then(function(themes) {
+    if (themes) {
+      // Add 'ObjectEditing' theme, i.e. the one with id 168
+      for (var i = 0, ii = themes.length; i < ii; i++) {
+        if (themes[i].id === 168) {
+          this.gmfTreeManager_.setFirstLevelGroups(themes[i].children);
+          break;
+        }
+      }
+
+      // Add layer vector after
+      this.map.addLayer(this.vectorLayer_);
+    }
+  }.bind(this));
 
   /**
    * @type {?number}

--- a/contribs/gmf/externs/gmfx.js
+++ b/contribs/gmf/externs/gmfx.js
@@ -11,6 +11,39 @@
  */
 var gmfx;
 
+
+/**
+ * @typedef {{
+ *     operator: (string),
+ *     property: (string),
+ *     value: (string)
+ * }}
+ */
+gmfx.ComparisonFilter;
+
+
+/**
+ * The type of operator for the comparison filter.
+ * @type {string}
+ */
+gmfx.ComparisonFilter.prototype.operator;
+
+
+/**
+ * The name of the property for the comparison filter.
+ * @type {string}
+ */
+gmfx.ComparisonFilter.prototype.property;
+
+
+/**
+ * The value for the comparison filter that must match the combinaison of
+ * the operator and property.
+ * @type {string}
+ */
+gmfx.ComparisonFilter.prototype.value;
+
+
 /**
  * A part of the application config.
  * @typedef {{

--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -850,8 +850,10 @@ gmf.EditfeatureController.prototype.handleMapClick_ = function(evt) {
     );
 
     // (3) Launch query to fetch features
-    this.editFeatureService_.getFeatures([this.editableNode_.id], extent).then(
-      this.handleGetFeatures_.bind(this));
+    this.editFeatureService_.getFeaturesInExtent(
+      [this.editableNode_.id],
+      extent
+    ).then(this.handleGetFeatures_.bind(this));
 
     // (4) Clear any previously selected feature
     this.cancel();

--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -2,6 +2,7 @@ goog.provide('gmf.ObjecteditingController');
 goog.provide('gmf.objecteditingDirective');
 
 goog.require('gmf');
+goog.require('gmf.EditFeature');
 goog.require('ngeo.DecorateInteraction');
 goog.require('ngeo.FeatureHelper');
 goog.require('ngeo.ToolActivate');
@@ -19,12 +20,14 @@ goog.require('ol.interaction.Modify');
  *     <gmf-objectediting
  *         gmf-objectediting-active="ctrl.objectEditingActive"
  *         gmf-objectediting-feature="ctrl.objectEditingFeature"
+ *         gmf-objectediting-layernodeid="ctrl.objectEditingLayerNodeId"
  *         gmf-objectediting-map="::ctrl.map">
  *     </gmf-objectediting>
  *
  * @htmlAttribute {boolean} gmf-objectediting-active Whether the directive is
  *     active or not.
  * @htmlAttribute {ol.Feature} gmf-objectediting-feature The feature to edit.
+ * @htmlAttribute {number} gmf-objectediting-layernodeid The GMF layer node id.
  * @htmlAttribute {ol.Map} gmf-objectediting-map The map.
  * @return {angular.Directive} The directive specs.
  * @ngInject
@@ -37,6 +40,7 @@ gmf.objecteditingDirective = function() {
     scope: {
       'active': '=gmfObjecteditingActive',
       'feature': '<gmfObjecteditingFeature',
+      'layerNodeId': '<gmfObjecteditingLayernodeid',
       'map': '<gmfObjecteditingMap'
     },
     bindToController: true,
@@ -49,6 +53,8 @@ gmf.module.directive('gmfObjectediting', gmf.objecteditingDirective);
 
 
 /**
+ * @param {!angular.Scope} $scope Angular scope.
+ * @param {gmf.EditFeature} gmfEditFeature Gmf edit feature service.
  * @param {ngeo.DecorateInteraction} ngeoDecorateInteraction Decorate
  *     interaction service.
  * @param {ngeo.FeatureHelper} ngeoFeatureHelper Ngeo feature helper service.
@@ -59,8 +65,8 @@ gmf.module.directive('gmfObjectediting', gmf.objecteditingDirective);
  * @ngdoc controller
  * @ngname GmfObjecteditingController
  */
-gmf.ObjecteditingController = function(ngeoDecorateInteraction,
-    ngeoFeatureHelper, ngeoToolActivateMgr) {
+gmf.ObjecteditingController = function($scope, gmfEditFeature,
+    ngeoDecorateInteraction, ngeoFeatureHelper, ngeoToolActivateMgr) {
 
   // == Scope properties ==
 
@@ -77,6 +83,12 @@ gmf.ObjecteditingController = function(ngeoDecorateInteraction,
   this.feature;
 
   /**
+   * @type {number}
+   * @export
+   */
+  this.layerNodeId;
+
+  /**
    * @type {ol.Map}
    * @export
    */
@@ -86,10 +98,49 @@ gmf.ObjecteditingController = function(ngeoDecorateInteraction,
   // == Injected properties ==
 
   /**
+   * @type {!angular.Scope}
+   * @private
+   */
+  this.scope_ = $scope;
+
+  /**
+   * @type {gmf.EditFeature}
+   * @private
+   */
+  this.gmfEditFeature_ = gmfEditFeature;
+
+  /**
    * @type {ngeo.DecorateInteraction}
    * @private
    */
   this.ngeoDecorateInteraction_ = ngeoDecorateInteraction;
+
+  /**
+   * @type {Array.<?ol.geom.Geometry>}
+   * @private
+   */
+  this.geometryChanges_ = [];
+
+  this.scope_.$watchCollection(
+    function() {
+      return this.geometryChanges_;
+    }.bind(this),
+    function(newVal, oldVal) {
+      if (newVal.length) {
+        if (newVal.length === 1) {
+          this.dirty = false;
+        } else {
+          this.dirty = true;
+        }
+      }
+    }.bind(this)
+  );
+
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.dirty = false; // FIXME
 
   /**
    * @type {ngeo.FeatureHelper}
@@ -105,6 +156,17 @@ gmf.ObjecteditingController = function(ngeoDecorateInteraction,
 
 
   // == Other properties ==
+
+  var geometry = this.feature.getGeometry();
+
+  /**
+   * The state of the feature determines whether the next 'save' request
+   * should be an 'insert' or 'update' one.
+   * @type {string}
+   * @private
+   */
+  this.state_ = geometry ? gmf.ObjecteditingController.State.UPDATE :
+    gmf.ObjecteditingController.State.INSERT;
 
   /**
    * @type {Array.<ol.EventsKey>}
@@ -146,7 +208,49 @@ gmf.ObjecteditingController = function(ngeoDecorateInteraction,
   this.initializeInteractions_();
   this.registerInteractions_();
   this.toggle_(true);
+  this.resetGeometryChanges_();
 
+};
+
+
+// == API methods ==
+
+
+/**
+ * Save the current modifications.
+ * @export
+ */
+gmf.ObjecteditingController.prototype.save = function() {
+  if (this.state_ === gmf.ObjecteditingController.State.INSERT) {
+    this.gmfEditFeature_.insertFeatures(
+      this.layerNodeId,
+      [this.feature]
+    ).then(
+      this.handleEditFeature_.bind(this)
+    );
+  } else if (this.state_ === gmf.ObjecteditingController.State.UPDATE) {
+    this.gmfEditFeature_.updateFeature(
+      this.layerNodeId,
+      this.feature
+    ).then(
+      this.handleEditFeature_.bind(this)
+    );
+  }
+};
+
+
+/**
+ * Called after an 'insert' or 'update' request.
+ * @param {angular.$http.Response} resp Ajax response.
+ * @private
+ */
+gmf.ObjecteditingController.prototype.handleEditFeature_ = function(resp) {
+  this.resetGeometryChanges_();
+  if (this.feature.getGeometry()) {
+    this.state_ = gmf.ObjecteditingController.State.UPDATE;
+  } else {
+    this.state_ = gmf.ObjecteditingController.State.INSERT;
+  }
 };
 
 
@@ -180,13 +284,70 @@ gmf.ObjecteditingController.prototype.registerInteractions_ = function() {
  */
 gmf.ObjecteditingController.prototype.toggle_ = function(active) {
 
+  var keys = this.listenerKeys_;
+
   if (active) {
-    console.log(active);
+
+    keys.push(
+      ol.events.listen(
+        this.modify_,
+        ol.interaction.Modify.EventType.MODIFYEND,
+        this.handleModifyInteractionModifyEnd_,
+        this
+      )
+    );
+
   } else {
-    console.log(active);
+
+    keys.forEach(function(key) {
+      ol.events.unlistenByKey(key);
+    }, this);
+
   }
 
   this.modify_.setActive(active);
+};
+
+
+/**
+ * Reset the array of geometry changes.  If the array is empty, that means
+ * the array hasn't been initialized yet. If there's only one item, no need
+ * to do anything (i.e. the geometry in there is the same as the feature).
+ * If there's more than one, that means there's mo
+ * @private
+ */
+gmf.ObjecteditingController.prototype.resetGeometryChanges_ = function() {
+  if (this.geometryChanges_.length === 0) {
+    this.geometryChanges_.push(this.feature.getGeometry());
+  } else if (this.geometryChanges_.length > 1) {
+    var firstGeom = this.geometryChanges_[0];
+    this.feature.setGeometry(firstGeom);
+    this.geometryChanges_.length = 0;
+    this.geometryChanges_.push(firstGeom);
+  }
+};
+
+
+/**
+ * @param {ol.interaction.Modify.Event} evt Event.
+ * @private
+ */
+gmf.ObjecteditingController.prototype.handleModifyInteractionModifyEnd_ = function(
+  evt
+) {
+  this.geometryChanges_.push(
+    this.feature.getGeometry()
+  );
+  this.scope_.$apply();
+};
+
+
+/**
+ * @enum {string}
+ */
+gmf.ObjecteditingController.State = {
+  INSERT: 'insert',
+  UPDATE: 'update'
 };
 
 

--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -187,6 +187,12 @@ gmf.ObjecteditingController = function($scope, gettextCatalog, gmfEditFeature,
   this.initializeStyles_(this.dirtyStyles_, [153, 51, 51]);
 
   /**
+   * Flag that is toggled while a request is pending.
+   * @private
+   */
+  this.pending = false;
+
+  /**
    * @type {boolean}
    * @private
    */
@@ -265,6 +271,7 @@ gmf.ObjecteditingController.prototype.delete = function() {
   // Confirm deletion first
   if (confirm(msg)) {
     this.dirty = false;
+    this.pending = true;
 
     this.gmfEditFeature_.deleteFeature(
       this.layerNodeId,
@@ -282,6 +289,9 @@ gmf.ObjecteditingController.prototype.delete = function() {
  * @export
  */
 gmf.ObjecteditingController.prototype.save = function() {
+
+  this.pending = true;
+
   if (this.state_ === gmf.ObjecteditingController.State.INSERT) {
     this.gmfEditFeature_.insertFeatures(
       this.layerNodeId,
@@ -341,6 +351,7 @@ gmf.ObjecteditingController.prototype.handleDeleteFeature_ = function(resp) {
   this.feature.setGeometry(null);
   this.resetGeometryChanges_();
   this.state_ = gmf.ObjecteditingController.State.INSERT;
+  this.pending = false;
 };
 
 
@@ -356,6 +367,7 @@ gmf.ObjecteditingController.prototype.handleEditFeature_ = function(resp) {
   } else {
     this.state_ = gmf.ObjecteditingController.State.INSERT;
   }
+  this.pending = false;
 };
 
 

--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -2,6 +2,12 @@ goog.provide('gmf.ObjecteditingController');
 goog.provide('gmf.objecteditingDirective');
 
 goog.require('gmf');
+goog.require('ngeo.DecorateInteraction');
+goog.require('ngeo.FeatureHelper');
+goog.require('ngeo.ToolActivate');
+goog.require('ngeo.ToolActivateMgr');
+goog.require('ol.Collection');
+goog.require('ol.interaction.Modify');
 
 
 /**
@@ -30,7 +36,7 @@ gmf.objecteditingDirective = function() {
     controller: 'GmfObjecteditingController',
     scope: {
       'active': '=gmfObjecteditingActive',
-      'feature': '=gmfObjecteditingFeature',
+      'feature': '<gmfObjecteditingFeature',
       'map': '<gmfObjecteditingMap'
     },
     bindToController: true,
@@ -43,12 +49,20 @@ gmf.module.directive('gmfObjectediting', gmf.objecteditingDirective);
 
 
 /**
+ * @param {ngeo.DecorateInteraction} ngeoDecorateInteraction Decorate
+ *     interaction service.
+ * @param {ngeo.FeatureHelper} ngeoFeatureHelper Ngeo feature helper service.
+ * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
+ *     service.
  * @constructor
  * @ngInject
  * @ngdoc controller
  * @ngname GmfObjecteditingController
  */
-gmf.ObjecteditingController = function() {
+gmf.ObjecteditingController = function(ngeoDecorateInteraction,
+    ngeoFeatureHelper, ngeoToolActivateMgr) {
+
+  // == Scope properties ==
 
   /**
    * @type {boolean}
@@ -68,6 +82,111 @@ gmf.ObjecteditingController = function() {
    */
   this.map;
 
+
+  // == Injected properties ==
+
+  /**
+   * @type {ngeo.DecorateInteraction}
+   * @private
+   */
+  this.ngeoDecorateInteraction_ = ngeoDecorateInteraction;
+
+  /**
+   * @type {ngeo.FeatureHelper}
+   * @private
+   */
+  this.featureHelper_ = ngeoFeatureHelper;
+
+  /**
+   * @type {ngeo.ToolActivateMgr}
+   * @private
+   */
+  this.ngeoToolActivateMgr_ = ngeoToolActivateMgr;
+
+
+  // == Other properties ==
+
+  /**
+   * @type {Array.<ol.EventsKey>}
+   * @private
+   */
+  this.listenerKeys_ = [];
+
+  /**
+   * @type {ol.Collection}
+   * @private
+   */
+  this.features_ = new ol.Collection();
+  this.features_.push(this.feature);
+
+  /**
+   * @type {ol.Collection}
+   * @private
+   */
+  this.interactions_ = new ol.Collection();
+
+  /**
+   * @type {ol.interaction.Modify}
+   * @private
+   */
+  this.modify_ = new ol.interaction.Modify({
+    features: this.features_,
+    style: ngeoFeatureHelper.getVertexStyle(false)
+  });
+  this.interactions_.push(this.modify_);
+
+  /**
+   * @type {ngeo.ToolActivate}
+   * @export
+   */
+  this.modifyToolActivate = new ngeo.ToolActivate(this.modify_, 'active');
+
+
+  // Toggle on
+  this.initializeInteractions_();
+  this.registerInteractions_();
+  this.toggle_(true);
+
+};
+
+
+/**
+ * Initialize interactions by setting them inactive and decorating them
+ * @private
+ */
+gmf.ObjecteditingController.prototype.initializeInteractions_ = function() {
+  this.interactions_.forEach(function(interaction) {
+    interaction.setActive(false);
+    this.ngeoDecorateInteraction_(interaction);
+  }, this);
+};
+
+
+/**
+ * Register interactions by adding them to the map
+ * @private
+ */
+gmf.ObjecteditingController.prototype.registerInteractions_ = function() {
+  this.interactions_.forEach(function(interaction) {
+    this.map.addInteraction(interaction);
+  }, this);
+};
+
+
+/**
+ * Activate or deactivate this directive.
+ * @param {boolean} active Whether to activate this directive or not.
+ * @private
+ */
+gmf.ObjecteditingController.prototype.toggle_ = function(active) {
+
+  if (active) {
+    console.log(active);
+  } else {
+    console.log(active);
+  }
+
+  this.modify_.setActive(active);
 };
 
 

--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -256,6 +256,7 @@ gmf.ObjecteditingController = function($scope, gettextCatalog, gmfEditFeature,
   this.resetGeometryChanges_();
 
   $scope.$on('$destroy', this.handleDestroy_.bind(this));
+
 };
 
 
@@ -426,6 +427,15 @@ gmf.ObjecteditingController.prototype.toggle_ = function(active) {
       )
     );
 
+    keys.push(
+      ol.events.listen(
+        window,
+        'beforeunload',
+        this.handleWindowBeforeUnload_,
+        this
+      )
+    );
+
   } else {
 
     keys.forEach(function(key) {
@@ -539,6 +549,23 @@ gmf.ObjecteditingController.prototype.initializeStyles_ = function(
     this.ngeoFeatureHelper_.getVertexStyle(true)
   ];
 
+};
+
+
+/**
+ * Called before the window unloads. Show a confirmation message if there are
+ * unsaved modifications.
+ * @param {Event} e Event.
+ * @return {string} Message
+ * @private
+ */
+gmf.ObjecteditingController.prototype.handleWindowBeforeUnload_ = function(e) {
+  if (this.dirty) {
+    var msg = this.gettextCatalog_.getString('There are unsaved changes.');
+    (e || window.event).returnValue = msg;
+    return msg;
+  }
+  return '';
 };
 
 

--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -1,0 +1,75 @@
+goog.provide('gmf.ObjecteditingController');
+goog.provide('gmf.objecteditingDirective');
+
+goog.require('gmf');
+
+
+/**
+ * Directive used to edit the geometry of a single feature using advanced
+ * tools.
+ *
+ * Example:
+ *
+ *     <gmf-objectediting
+ *         gmf-objectediting-active="ctrl.objectEditingActive"
+ *         gmf-objectediting-feature="ctrl.objectEditingFeature"
+ *         gmf-objectediting-map="::ctrl.map">
+ *     </gmf-objectediting>
+ *
+ * @htmlAttribute {boolean} gmf-objectediting-active Whether the directive is
+ *     active or not.
+ * @htmlAttribute {ol.Feature} gmf-objectediting-feature The feature to edit.
+ * @htmlAttribute {ol.Map} gmf-objectediting-map The map.
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname gmfObjectediting
+ */
+gmf.objecteditingDirective = function() {
+  return {
+    controller: 'GmfObjecteditingController',
+    scope: {
+      'active': '=gmfObjecteditingActive',
+      'feature': '=gmfObjecteditingFeature',
+      'map': '<gmfObjecteditingMap'
+    },
+    bindToController: true,
+    controllerAs: 'oeCtrl',
+    templateUrl: gmf.baseTemplateUrl + '/objectediting.html'
+  };
+};
+
+gmf.module.directive('gmfObjectediting', gmf.objecteditingDirective);
+
+
+/**
+ * @constructor
+ * @ngInject
+ * @ngdoc controller
+ * @ngname GmfObjecteditingController
+ */
+gmf.ObjecteditingController = function() {
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.active;
+
+  /**
+   * @type {ol.Feature}
+   * @export
+   */
+  this.feature;
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
+
+};
+
+
+gmf.module.controller(
+  'GmfObjecteditingController', gmf.ObjecteditingController);

--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -255,6 +255,7 @@ gmf.ObjecteditingController = function($scope, gettextCatalog, gmfEditFeature,
   this.toggle_(true);
   this.resetGeometryChanges_();
 
+  $scope.$on('$destroy', this.handleDestroy_.bind(this));
 };
 
 
@@ -395,6 +396,17 @@ gmf.ObjecteditingController.prototype.registerInteractions_ = function() {
 
 
 /**
+ * Unregister interactions, i.e. remove them from the map
+ * @private
+ */
+gmf.ObjecteditingController.prototype.unregisterInteractions_ = function() {
+  this.interactions_.forEach(function(interaction) {
+    this.map.removeInteraction(interaction);
+  }, this);
+};
+
+
+/**
  * Activate or deactivate this directive.
  * @param {boolean} active Whether to activate this directive or not.
  * @private
@@ -528,6 +540,19 @@ gmf.ObjecteditingController.prototype.initializeStyles_ = function(
   ];
 
 };
+
+
+/**
+ * @private
+ */
+gmf.ObjecteditingController.prototype.handleDestroy_ = function() {
+  this.features.clear();
+  this.toggle_(false);
+  this.unregisterInteractions_();
+};
+
+
+// == Static methods and type definitions ==
 
 
 /**

--- a/contribs/gmf/src/directives/partials/objectediting.html
+++ b/contribs/gmf/src/directives/partials/objectediting.html
@@ -1,1 +1,16 @@
-<div>ObjectEditing</div>
+<div>
+
+  <form
+    novalidate
+    name="form"
+    class="form gmf-objectediting-form">
+    <input
+      type="submit"
+      value="{{'Save' | translate}}"
+      class="btn btn-sm btn-default gmf-objectediting-btn-save"
+      ng-click="form.$valid && oeCtrl.save()"
+      ng-disabled="!oeCtrl.dirty"
+      title="{{'Save modifications | translate'}}"></input>
+  </form>
+
+</div>

--- a/contribs/gmf/src/directives/partials/objectediting.html
+++ b/contribs/gmf/src/directives/partials/objectediting.html
@@ -1,0 +1,1 @@
+<div>ObjectEditing</div>

--- a/contribs/gmf/src/directives/partials/objectediting.html
+++ b/contribs/gmf/src/directives/partials/objectediting.html
@@ -11,6 +11,12 @@
       ng-click="form.$valid && oeCtrl.save()"
       ng-disabled="!oeCtrl.dirty"
       title="{{'Save modifications | translate'}}"></input>
+    <a
+      class="btn btn-sm btn-link gmf-objectediting-btn-undo"
+      ng-click="oeCtrl.undo()"
+      ng-disabled="!oeCtrl.dirty"
+      title="{{'Undo latest modifications | translate'}}"
+      href>{{'Undo' | translate}}</a>
   </form>
 
 </div>

--- a/contribs/gmf/src/directives/partials/objectediting.html
+++ b/contribs/gmf/src/directives/partials/objectediting.html
@@ -17,6 +17,12 @@
       ng-disabled="!oeCtrl.dirty"
       title="{{'Undo latest modifications | translate'}}"
       href>{{'Undo' | translate}}</a>
+    <a
+      class="btn btn-sm btn-link gmf-objectediting-btn-delete"
+      ng-click="oeCtrl.delete()"
+      ng-disabled="oeCtrl.isStateInsert()"
+      title="{{'Delete the feature | translate'}}"
+      href>{{'Delete' | translate}}</a>
   </form>
 
 </div>

--- a/contribs/gmf/src/directives/partials/objectediting.html
+++ b/contribs/gmf/src/directives/partials/objectediting.html
@@ -9,18 +9,18 @@
       value="{{'Save' | translate}}"
       class="btn btn-sm btn-default gmf-objectediting-btn-save"
       ng-click="form.$valid && oeCtrl.save()"
-      ng-disabled="!oeCtrl.dirty"
+      ng-disabled="!oeCtrl.dirty || oeCtrl.pending"
       title="{{'Save modifications | translate'}}"></input>
     <a
       class="btn btn-sm btn-link gmf-objectediting-btn-undo"
       ng-click="oeCtrl.undo()"
-      ng-disabled="!oeCtrl.dirty"
+      ng-disabled="!oeCtrl.dirty || oeCtrl.pending"
       title="{{'Undo latest modifications | translate'}}"
       href>{{'Undo' | translate}}</a>
     <a
       class="btn btn-sm btn-link gmf-objectediting-btn-delete"
       ng-click="oeCtrl.delete()"
-      ng-disabled="oeCtrl.isStateInsert()"
+      ng-disabled="oeCtrl.isStateInsert() || oeCtrl.pending"
       title="{{'Delete the feature | translate'}}"
       href>{{'Delete' | translate}}</a>
   </form>

--- a/contribs/gmf/src/services/objecteditingmanager.js
+++ b/contribs/gmf/src/services/objecteditingmanager.js
@@ -131,6 +131,11 @@ gmf.ObjectEditingManager.Param = {
    * @type {string}
    * @export
    */
+  GEOM_TYPE: 'objectediting_geomtype',
+  /**
+   * @type {string}
+   * @export
+   */
   ID: 'objectediting_id',
   /**
    * @type {string}

--- a/contribs/gmf/src/services/objecteditingmanager.js
+++ b/contribs/gmf/src/services/objecteditingmanager.js
@@ -1,5 +1,126 @@
 goog.provide('gmf.ObjectEditingManager');
 
+goog.require('gmf.EditFeature');
+goog.require('ngeo.Location');
+goog.require('ol.Feature');
+
+
+/**
+ * A service that looks for certain parameters in the url and use them to fetch
+ * a feature using the GMF protocol.
+ *
+ * @param {angular.$q} $q Angular $q service.
+ * @param {gmf.EditFeature} gmfEditFeature Gmf edit feature service.
+ * @param {ngeo.Location} ngeoLocation ngeo location service.
+ * @constructor
+ * @struct
+ * @ngInject
+ */
+gmf.ObjectEditingManager = function($q, gmfEditFeature, ngeoLocation) {
+
+  /**
+   * @type {angular.$q}
+   * @private
+   */
+  this.q_ = $q;
+
+  /**
+   * @type {gmf.EditFeature}
+   * @private
+   */
+  this.gmfEditFeature_ = gmfEditFeature;
+
+  /**
+   * @type {ngeo.Location}
+   * @private
+   */
+  this.ngeoLocation_ = ngeoLocation;
+
+  /**
+   * @type {angular.$q.Deferred|null}
+   * @private
+   */
+  this.getFeatureDefered_ = null;
+
+};
+
+
+/**
+ * Use the EditFeature service to fetch a single feature using parameters in
+ * the url. The method returns a promise that has the feature as argument in
+ * the callback method. If any parameter in the url is missing, `null` is
+ * returned, otherwise the query is made. If the query returns a feature, it
+ * is returned, otherwise one is created with empty geometry and with the
+ * property set.
+ *
+ * @return {angular.$q.Promise} Promise.
+ * @export
+ */
+gmf.ObjectEditingManager.prototype.getFeature = function() {
+
+  if (!this.getFeatureDefered_) {
+    this.getFeatureDefered_ = this.q_.defer();
+
+    var id = this.ngeoLocation_.getParam(
+      gmf.ObjectEditingManager.Param.ID);
+    var layer = this.ngeoLocation_.getParam(
+      gmf.ObjectEditingManager.Param.LAYER);
+    var property = this.ngeoLocation_.getParam(
+      gmf.ObjectEditingManager.Param.PROPERTY);
+    var theme = this.ngeoLocation_.getParam(
+      gmf.ObjectEditingManager.Param.THEME);
+
+    if (id && layer && property && theme) {
+      this.gmfEditFeature_.getFeaturesWithComparisonFilters(
+        [layer],
+        [{
+          operator: 'eq',
+          property: property,
+          value: id
+        }]
+      ).then(this.handleGetFeatures_.bind(this, property, id));
+    } else {
+      this.getFeatureDefered_.resolve(null);
+    }
+  }
+
+  return this.getFeatureDefered_.promise;
+
+};
+
+
+/**
+ * Called after getting features with comparison filters. Resolve the defered
+ * promise with the first returned feature (if any), otherwise resolve it
+ * with a feature created with an empty geometry and the property key + value
+ * that was used in the attempt to fetch it.
+ *
+ * @param {string} key Property key.
+ * @param {string} value Property value.
+ * @param {Array.<ol.Feature>} features List of features.
+ * @private
+ */
+gmf.ObjectEditingManager.prototype.handleGetFeatures_ = function(
+  key, value, features
+) {
+
+  var feature;
+
+  if (features.length) {
+    feature = features[0];
+  } else {
+    var featureProperties = {};
+    featureProperties[key] = value;
+    featureProperties['geometry'] = null;
+    feature = new ol.Feature(featureProperties);
+  }
+
+  this.getFeatureDefered_.resolve(feature);
+};
+
+
+gmf.module.service('gmfObjectEditingManager', gmf.ObjectEditingManager);
+
 
 /**
  * @enum {string}

--- a/contribs/gmf/src/services/objecteditingmanager.js
+++ b/contribs/gmf/src/services/objecteditingmanager.js
@@ -90,6 +90,16 @@ gmf.ObjectEditingManager.prototype.getFeature = function() {
 
 
 /**
+ * @return {?number} The gmf layer node id.
+ * @export
+ */
+gmf.ObjectEditingManager.prototype.getLayerNodeId = function() {
+  return this.ngeoLocation_.getParamAsInt(
+    gmf.ObjectEditingManager.Param.LAYER) || null;
+};
+
+
+/**
  * Called after getting features with comparison filters. Resolve the defered
  * promise with the first returned feature (if any), otherwise resolve it
  * with a feature created with an empty geometry and the property key + value

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -165,10 +165,6 @@ gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
    */
   this.gmfObjectEditingManager_ = gmfObjectEditingManager;
 
-  gmfObjectEditingManager.getFeature().then(function(feature) {
-    console.log(feature);
-  });
-
   /**
    * @type {gmf.Themes}
    * @private
@@ -578,8 +574,10 @@ gmf.Permalink.prototype.setMap = function(map) {
   }
 
   if (map) {
-    this.map_ = map;
-    this.registerMap_(map);
+    this.gmfObjectEditingManager_.getFeature().then(function(feature) {
+      this.map_ = map;
+      this.registerMap_(map, feature);
+    }.bind(this));
   }
 
 };
@@ -588,21 +586,31 @@ gmf.Permalink.prototype.setMap = function(map) {
 /**
  * Listen to the map view property change and update the state accordingly.
  * @param {ol.Map} map The ol3 map object.
+ * @param {?ol.Feature} oeFeature ObjectEditing feature
  * @private
  */
-gmf.Permalink.prototype.registerMap_ = function(map) {
+gmf.Permalink.prototype.registerMap_ = function(map, oeFeature) {
 
   var view = map.getView();
+  var size = map.getSize();
+  goog.asserts.assert(size);
+  var center;
+  var zoom;
 
-  // (1) Initialize the map view with the X, Y and Z available within the
-  //     permalink service, if available
-  var center = this.getMapCenter();
-  if (center !== null) {
-    view.setCenter(center);
-  }
-  var zoom = this.getMapZoom();
-  if (zoom !== null) {
-    view.setZoom(zoom);
+  // (1) Initialize the map view with either:
+  //     a) the given ObjectEditing feature
+  //     b) the X, Y and Z available within the permalink service, if available
+  if (oeFeature && oeFeature.getGeometry()) {
+    view.fit(oeFeature.getGeometry().getExtent(), size);
+  } else {
+    center = this.getMapCenter();
+    if (center !== null) {
+      view.setCenter(center);
+    }
+    zoom = this.getMapZoom();
+    if (zoom !== null) {
+      view.setZoom(zoom);
+    }
   }
 
 

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -574,8 +574,8 @@ gmf.Permalink.prototype.setMap = function(map) {
   }
 
   if (map) {
+    this.map_ = map;
     this.gmfObjectEditingManager_.getFeature().then(function(feature) {
-      this.map_ = map;
       this.registerMap_(map, feature);
     }.bind(this));
   }

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -2,6 +2,7 @@ goog.provide('gmf.Permalink');
 
 goog.require('gmf');
 goog.require('ngeo.AutoProjection');
+goog.require('gmf.ObjectEditingManager');
 goog.require('gmf.Themes');
 goog.require('gmf.ThemeManager');
 goog.require('gmf.TreeManager');
@@ -72,6 +73,8 @@ gmf.module.value('gmfPermalinkOptions',
  * @param {ol.Collection.<ol.Feature>} ngeoFeatures Collection of features.
  * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
  * @param {ngeo.StateManager} ngeoStateManager The ngeo StateManager service.
+ * @param {gmf.ObjectEditingManager} gmfObjectEditingManager The gmf
+ *     ObjectEditing manager service.
  * @param {gmf.Themes} gmfThemes The gmf Themes service.
  * @param {gmf.ThemeManager} gmfThemeManager The gmf ThemeManager service.
  * @param {gmf.TreeManager} gmfTreeManager The gmf gmfTreeManager service.
@@ -89,7 +92,8 @@ gmf.module.value('gmfPermalinkOptions',
  */
 gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
     ngeoFeatureOverlayMgr, ngeoFeatureHelper, ngeoFeatures, ngeoLayerHelper,
-    ngeoStateManager, gmfThemes, gmfThemeManager, gmfTreeManager, gmfPermalinkOptions, defaultTheme,
+    ngeoStateManager, gmfObjectEditingManager, gmfThemes, gmfThemeManager,
+    gmfTreeManager, gmfPermalinkOptions, defaultTheme,
     ngeoLocation, ngeoWfsPermalink, ngeoAutoProjection, $rootScope, $injector) {
 
   // == listener keys ==
@@ -154,6 +158,16 @@ gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
   if (gmfPermalinkOptions.useLocalStorage === false) {
     this.ngeoStateManager_.localStorage.isAvailable = ol.functions.FALSE;
   }
+
+  /**
+   * @type {gmf.ObjectEditingManager}
+   * @private
+   */
+  this.gmfObjectEditingManager_ = gmfObjectEditingManager;
+
+  gmfObjectEditingManager.getFeature().then(function(feature) {
+    console.log(feature);
+  });
 
   /**
    * @type {gmf.Themes}

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -3,7 +3,6 @@ goog.provide('gmf.Permalink');
 goog.require('gmf');
 goog.require('ngeo.AutoProjection');
 goog.require('gmf.Themes');
-goog.require('gmf.ThemeManager');
 goog.require('gmf.TreeManager');
 goog.require('ngeo.BackgroundEventType');
 goog.require('ngeo.BackgroundLayerMgr');
@@ -73,7 +72,6 @@ gmf.module.value('gmfPermalinkOptions',
  * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
  * @param {ngeo.StateManager} ngeoStateManager The ngeo StateManager service.
  * @param {gmf.Themes} gmfThemes The gmf Themes service.
- * @param {gmf.ThemeManager} gmfThemeManager The gmf ThemeManager service.
  * @param {gmf.TreeManager} gmfTreeManager The gmf gmfTreeManager service.
  * @param {gmfx.PermalinkOptions} gmfPermalinkOptions The options to configure
  *     the gmf permalink service with.
@@ -89,7 +87,7 @@ gmf.module.value('gmfPermalinkOptions',
  */
 gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
     ngeoFeatureOverlayMgr, ngeoFeatureHelper, ngeoFeatures, ngeoLayerHelper,
-    ngeoStateManager, gmfThemes, gmfThemeManager,
+    ngeoStateManager, gmfThemes,
     gmfTreeManager, gmfPermalinkOptions, defaultTheme,
     ngeoLocation, ngeoWfsPermalink, ngeoAutoProjection, $rootScope, $injector) {
 
@@ -179,13 +177,15 @@ gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
    * @type {gmf.ThemeManager}
    * @private
    */
-  this.gmfThemeManager_ = gmfThemeManager;
+  this.gmfThemeManager_ = $injector.has('gmfThemeManager') ?
+    $injector.get('gmfThemeManager') : undefined;
 
   /**
    * @type {gmfx.User|undefined}
    * @private
    */
-  this.gmfUser_ = $injector.has('gmfUser') ? $injector.get('gmfUser') : undefined;
+  this.gmfUser_ = $injector.has('gmfUser') ?
+    $injector.get('gmfUser') : undefined;
 
   /**
    * @type {string}
@@ -364,11 +364,13 @@ gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
     }, this);
   }.bind(this));
 
-  $rootScope.$watch(function() {
-    return this.gmfThemeManager_.themeName;
-  }.bind(this), function(name) {
-    this.setThemeInUrl_();
-  }.bind(this));
+  if (this.gmfThemeManager_) {
+    $rootScope.$watch(function() {
+      return this.gmfThemeManager_.themeName;
+    }.bind(this), function(name) {
+      this.setThemeInUrl_();
+    }.bind(this));
+  }
 
   this.initLayers_();
 };
@@ -777,7 +779,7 @@ gmf.Permalink.prototype.themeInUrl_ = function(pathElements) {
  * @private
  */
 gmf.Permalink.prototype.setThemeInUrl_ = function() {
-  if (this.gmfThemeManager_.themeName) {
+  if (this.gmfThemeManager_ && this.gmfThemeManager_.themeName) {
     var pathElements = this.ngeoLocation_.getPath().split('/');
     goog.asserts.assert(pathElements.length > 1);
     if (pathElements[pathElements.length - 1] === '') {
@@ -817,7 +819,7 @@ gmf.Permalink.prototype.initLayers_ = function() {
       // fallback to the default theme
       themeName = this.defaultTheme_;
     }
-    if (this.gmfThemeManager_.modeFlush) {
+    if (this.gmfThemeManager_ && this.gmfThemeManager_.modeFlush) {
       this.gmfThemeManager_.themeName = themeName;
     }
 

--- a/src/ol-ext/format/xsdattribute.js
+++ b/src/ol-ext/format/xsdattribute.js
@@ -103,6 +103,12 @@ ngeo.format.XSDAttribute.prototype.readFromElementNode_ = function(node) {
         attribute.geomType = ol.geom.GeometryType.LINE_STRING;
       } else if (/^gml:Polygon/.exec(type)) {
         attribute.geomType = ol.geom.GeometryType.POLYGON;
+      } else if (/^gml:MultiPoint/.exec(type)) {
+        attribute.geomType = ol.geom.GeometryType.MULTI_POINT;
+      } else if (/^gml:MultiLineString/.exec(type)) {
+        attribute.geomType = ol.geom.GeometryType.MULTI_LINE_STRING;
+      } else if (/^gml:MultiPolygon/.exec(type)) {
+        attribute.geomType = ol.geom.GeometryType.MULTI_POLYGON;
       }
     } else if (type === 'xsd:string') {
       attribute.type = ngeo.format.XSDAttributeType.TEXT;

--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -436,15 +436,29 @@ ngeo.FeatureHelper.prototype.getVertexStyle = function(opt_incGeomFunc) {
         return;
       }
 
-      var coordinates;
+      var multiCoordinates = [];
+      var coordinates = [];
+      var i, ii;
       if (geom instanceof ol.geom.LineString) {
-        coordinates = feature.getGeometry().getCoordinates();
-        return new ol.geom.MultiPoint(coordinates);
+        coordinates = geom.getCoordinates();
+      } else if (geom instanceof ol.geom.MultiLineString) {
+        multiCoordinates = geom.getCoordinates();
       } else if (geom instanceof ol.geom.Polygon) {
-        coordinates = feature.getGeometry().getCoordinates()[0];
+        coordinates = geom.getCoordinates()[0];
+      } else if (geom instanceof ol.geom.MultiPolygon) {
+        multiCoordinates = geom.getCoordinates()[0];
+      }
+
+      if (multiCoordinates.length) {
+        for (i = 0, ii = multiCoordinates.length; i < ii; i++) {
+          coordinates = coordinates.concat(multiCoordinates[i]);
+        }
+      }
+
+      if (coordinates.length) {
         return new ol.geom.MultiPoint(coordinates);
       } else {
-        return feature.getGeometry();
+        return geom;
       }
     };
   }


### PR DESCRIPTION
This PR adds the `gmf-objectediting` directive without any tools. It features all possible actions:

 * save
 * undo
 * delete

It also supports showing a confirmation message before closing the page if there are unsaved modifications.

~~**Note** This PR doesn't include the refreshing of the WMS layer.  That's going to be a big patch, so it'll come in a separate PR.~~

It also supports refreshing the WMS layer after save / delete.

## Todo

 * [ ] Wait for PR #1999 to be merged before reviewing this
 * [ ] Review
 * [ ] Approve the 'close' behaviour with unsaved changes


## Live example

First, you must login.  Then, visit the 'hub' example.  Wait for it to load then click the 'Launch' button.  You can also change a different layer or feature before doing so.

After 'Launch', you'll be able to modify the feature in the map.  You can test:

 * moving the vertices around
 * save
 * undo
 * delete
 * the style is: green if there are no unsaved changes, otherwise it's red
 * close the window with unsaved changes should show a confirmation message
 * after saving or deleting, the WMS layer is refreshed.

**Note** The examples below are outdated.

 1) Login - https://adube.github.io/ngeo/oe-2594-oe-tools/examples/contribs/gmf/authentication.html
 2) Hub example - https://adube.github.io/ngeo/oe-2594-oe-tools/examples/contribs/gmf/objectediting-hub.html
