### PR TITLE
WIP ObjectEditing 2594 Tools

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,7 @@
     "gmf": false,
     "app": false,
     "gmfapp": false,
-    "inject": false
+    "inject": false,
+    "jsts": false
   }
 }

--- a/buildtools/mako_build.json
+++ b/buildtools/mako_build.json
@@ -53,6 +53,7 @@ _ngeo_folder = '' if ngeo_folder is UNDEFINED else ngeo_folder
       "${_ngeo_folder}externs/jqueryui.js",
       "${_ngeo_folder}externs/angular-dynamic-locale.js",
       "${_ngeo_folder}externs/file-saver.js",
+      "${_ngeo_folder}externs/jsts.js",
       ".build/externs/angular-1.5.js",
       ".build/externs/angular-1.5-q_templated.js",
       ".build/externs/angular-1.5-http-promise_templated.js",

--- a/contribs/gmf/examples/objectediting.html
+++ b/contribs/gmf/examples/objectediting.html
@@ -7,26 +7,111 @@
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="mobile-web-app-capable" content="yes">
     <link rel="stylesheet" href="../../../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/font-awesome/css/font-awesome.css" type="text/css">
     <link rel="stylesheet" href="../../../third-party/jquery-ui/jquery-ui.min.css">
     <style>
       gmf-map > div {
         width: 600px;
         height: 400px;
       }
+      gmf-objectediting {
+        border: 1px solid #ddd;
+        display: block;
+        margin: 10px 0;
+        padding: 4px;
+        width: 400px;
+      }
+      gmf-layertree {
+        display: none;
+      }
+
+      /* measure tooltips  */
+      .tooltip {
+        position: relative;
+        background: rgba(0, 0, 0, 0.5);
+        border-radius: 4px;
+        color: white;
+        padding: 4px 8px;
+        opacity: 0.7;
+        white-space: nowrap;
+      }
+      .ngeo-tooltip-measure {
+        opacity: 1;
+        font-weight: bold;
+      }
+      .ngeo-tooltip-static {
+        display: none;
+      }
+      .ngeo-tooltip-measure:before,
+      .ngeo-tooltip-static:before {
+        border-top: 6px solid rgba(0, 0, 0, 0.5);
+        border-right: 6px solid transparent;
+        border-left: 6px solid transparent;
+        content: "";
+        position: absolute;
+        bottom: -6px;
+        margin-left: -7px;
+        left: 50%;
+      }
+      .ngeo-tooltip-static:before {
+        border-top-color: #ffcc33;
+      }
     </style>
   </head>
   <body ng-controller="MainController as ctrl">
     <gmf-map gmf-map-map="ctrl.map"></gmf-map>
+
+    <gmf-layertree
+        class="panel panel-default panel-body"
+        gmf-layertree-map="::ctrl.map">
+    </gmf-layertree>
+
+    <input type="checkbox"
+       id="checkbox-objectediting"
+       ng-model="ctrl.objectEditingActive" />
+    <label for="checkbox-objectediting"> ObjectEditing</label>
+
+    <input type="checkbox"
+       id="checkbox-dummy"
+       ng-model="ctrl.dummyActive" />
+    <label for="checkbox-dummy"> Dummy tool</label>
+
+    <h2>ObjectEditing</h2>
+
+    <gmf-objectediting
+      ng-if="ctrl.objectEditingFeature && ctrl.objectEditingLayerNodeId"
+      ng-show="ctrl.objectEditingActive === true"
+      gmf-objectediting-active="ctrl.objectEditingActive"
+      gmf-objectediting-feature="ctrl.objectEditingFeature"
+      gmf-objectediting-geomtype="::ctrl.objectEditingGeomType"
+      gmf-objectediting-layernodeid="::ctrl.objectEditingLayerNodeId"
+      gmf-objectediting-map="::ctrl.map"
+      gmf-objectediting-sketchfeatures="::ctrl.sketchFeatures">
+    </gmf-objectediting>
+
     <p id="desc">
       This example shows how to use the <code>gmf-objectediting</code>
       directive to edit a single feature with advanced editing tools.
     </p>
+    <p>
+      In order for this example to work properly, you must:
+      <ul>
+        <li>be <a href="authentication.html">logged in</a> first</li>
+        <li>
+          come from the
+          <a href="objecteditinghub.html">ObjectEditing Hub</a> example page
+        </li>
+      </ul>
+    </p>
+
     <script src="../../../node_modules/jquery/dist/jquery.js"></script>
     <script src="../../../third-party/jquery-ui/jquery-ui.min.js"></script>
     <script src="../../../node_modules/angular/angular.js"></script>
     <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
     <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
     <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
+    <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
     <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="../../../node_modules/angular-ui-date/dist/date.js"></script>
     <script src="../../../node_modules/angular-float-thead/angular-floatThead.js"></script>
@@ -34,12 +119,16 @@
     <script src="../../../node_modules/floatthead/dist/jquery.floatThead.min.js"></script>
     <script src="../../../node_modules/angular-ui-slider/src/slider.js"></script>
     <script src="../../../node_modules/angular-dynamic-locale/dist/tmhDynamicLocale.js"></script>
+    <script src="../../../node_modules/jsts/dist/jsts.min.js"></script>
     <script src="/@?main=objectediting.js"></script>
     <script src="default.js"></script>
     <script src="../../../utils/watchwatchers.js"></script>
     <script>
       var gmfModule = angular.module('gmf');
-      gmfModule.constant('defaultTheme', 'OSM');
+      gmfModule.constant('defaultTheme', 'ObjectEditing');
+      gmfModule.constant('gmfLayersUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/layers/');
+      gmfModule.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
+      gmfModule.constant('gmfTreeManagerModeFlush', true);
       gmfModule.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
     </script>
   </body>

--- a/contribs/gmf/examples/objectediting.js
+++ b/contribs/gmf/examples/objectediting.js
@@ -1,6 +1,5 @@
 goog.provide('gmfapp.objectediting');
 
-goog.require('gmf');
 goog.require('gmf.Themes');
 goog.require('gmf.TreeManager');
 goog.require('gmf.layertreeDirective');

--- a/contribs/gmf/examples/objectediting.js
+++ b/contribs/gmf/examples/objectediting.js
@@ -1,34 +1,85 @@
 goog.provide('gmfapp.objectediting');
 
-/** @suppress {extraRequire} */
+goog.require('gmf');
+goog.require('gmf.Themes');
+goog.require('gmf.TreeManager');
+goog.require('gmf.layertreeDirective');
 goog.require('gmf.mapDirective');
-/** @suppress {extraRequire} */
+goog.require('gmf.objecteditingDirective');
 goog.require('gmf.ObjectEditingManager');
-/** @suppress {extraRequire} */
+goog.require('ngeo.ToolActivate');
+goog.require('ngeo.ToolActivateMgr');
 goog.require('ngeo.proj.EPSG21781');
+goog.require('ol.Collection');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Tile');
+goog.require('ol.layer.Vector');
 goog.require('ol.source.OSM');
+goog.require('ol.source.Vector');
 
 
 /** @type {!angular.Module} **/
 gmfapp.module = angular.module('gmfapp', ['gmf']);
 
 
-gmfapp.module.value('gmfTreeUrl',
-    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
-
-
-gmfapp.module.value('gmfLayersUrl',
-    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/layers/');
-
-
 /**
+ * @param {gmf.ObjectEditingManager} gmfObjectEditingManager The gmf
+ *     ObjectEditing manager service.
+ * @param {gmf.Themes} gmfThemes The gmf themes service.
+ * @param {gmf.TreeManager} gmfTreeManager gmf Tree Manager service.
+ * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
+ *     service.
  * @constructor
  * @ngInject
  */
-gmfapp.MainController = function() {
+gmfapp.MainController = function(gmfObjectEditingManager, gmfThemes,
+    gmfTreeManager, ngeoToolActivateMgr) {
+
+  /**
+   * @type {gmf.TreeManager}
+   * @private
+   */
+  this.gmfTreeManager_ = gmfTreeManager;
+
+  gmfThemes.loadThemes();
+
+  var projection = ol.proj.get('EPSG:21781');
+  projection.setExtent([485869.5728, 76443.1884, 837076.5648, 299941.7864]);
+
+  /**
+   * @type {ol.source.Vector}
+   * @private
+   */
+  this.vectorSource_ = new ol.source.Vector({
+    wrapX: false
+  });
+
+  /**
+   * @type {ol.layer.Vector}
+   * @private
+   */
+  this.vectorLayer_ = new ol.layer.Vector({
+    source: this.vectorSource_
+  });
+
+  /**
+   * @type {ol.Collection.<ol.Feature>}
+   * @export
+   */
+  this.sketchFeatures = new ol.Collection();
+
+  /**
+   * @type {ol.layer.Vector}
+   * @private
+   */
+  this.sketchLayer_ = new ol.layer.Vector({
+    source: new ol.source.Vector({
+      features: this.sketchFeatures,
+      wrapX: false
+    })
+  });
+
   /**
    * @type {ol.Map}
    * @export
@@ -46,6 +97,62 @@ gmfapp.MainController = function() {
       zoom: 2
     })
   });
+
+  gmfThemes.getThemesObject().then(function(themes) {
+    if (themes) {
+      // Add layer vector after
+      this.map.addLayer(this.vectorLayer_);
+      this.map.addLayer(this.sketchLayer_);
+    }
+  }.bind(this));
+
+  /**
+   * @type {?string}
+   * @export
+   */
+  this.objectEditingGeomType = gmfObjectEditingManager.getGeomType();
+
+  /**
+   * @type {?number}
+   * @export
+   */
+  this.objectEditingLayerNodeId = gmfObjectEditingManager.getLayerNodeId();
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.objectEditingActive = true;
+
+  var objectEditingToolActivate = new ngeo.ToolActivate(
+    this, 'objectEditingActive');
+  ngeoToolActivateMgr.registerTool(
+    'mapTools', objectEditingToolActivate, true);
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.dummyActive = false;
+
+  var dummyToolActivate = new ngeo.ToolActivate(
+    this, 'dummyActive');
+  ngeoToolActivateMgr.registerTool(
+    'mapTools', dummyToolActivate, false);
+
+  /**
+   * @type {?ol.Feature}
+   * @export
+   */
+  this.objectEditingFeature = null;
+
+  gmfObjectEditingManager.getFeature().then(function(feature) {
+    this.objectEditingFeature = feature;
+    if (feature) {
+      this.vectorSource_.addFeature(feature);
+    }
+  }.bind(this));
+
 };
 
 gmfapp.module.controller('MainController', gmfapp.MainController);

--- a/contribs/gmf/examples/objecteditinghub.js
+++ b/contribs/gmf/examples/objecteditinghub.js
@@ -114,7 +114,7 @@ gmfapp.MainController = function($http, $q, $scope, gmfThemes, gmfXSDAttributes)
 
   /**
    * @type {Object.<number, string>}
-   * @export
+   * @private
    */
   this.geomTypeCache_ = {};
 

--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -1,0 +1,1039 @@
+goog.provide('gmf.ObjecteditingController');
+goog.provide('gmf.objecteditingDirective');
+
+goog.require('gmf');
+/** @suppress {extraRequire} */
+goog.require('gmf.objecteditingtoolsDirective');
+goog.require('gmf.EditFeature');
+goog.require('gmf.ObjectEditingQuery');
+goog.require('ngeo.DecorateInteraction');
+goog.require('ngeo.FeatureHelper');
+goog.require('ngeo.LayerHelper');
+goog.require('ngeo.ToolActivate');
+goog.require('ngeo.ToolActivateMgr');
+goog.require('ol.Collection');
+goog.require('ol.geom.MultiLineString');
+goog.require('ol.geom.MultiPoint');
+goog.require('ol.geom.MultiPolygon');
+goog.require('ol.interaction.Modify');
+goog.require('ol.style.Circle');
+goog.require('ol.style.Fill');
+goog.require('ol.style.Stroke');
+goog.require('ol.style.Style');
+
+
+/**
+ * Directive used to edit the geometry of a single feature using advanced
+ * tools. The geometry must be Multi.
+ *
+ * Example:
+ *
+ *     <gmf-objectediting
+ *         gmf-objectediting-active="ctrl.objectEditingActive"
+ *         gmf-objectediting-feature="ctrl.objectEditingFeature"
+ *         gmf-objectediting-geomtype="ctrl.objectEditingGeomType"
+ *         gmf-objectediting-layernodeid="ctrl.objectEditingLayerNodeId"
+ *         gmf-objectediting-map="::ctrl.map"
+ *         gmf-objectediting-sketchfeatures="::ctrl.sketchFeatures">
+ *     </gmf-objectediting>
+ *
+ * @htmlAttribute {boolean} gmf-objectediting-active Whether the directive is
+ *     active or not.
+ * @htmlAttribute {ol.Feature} gmf-objectediting-feature The feature to edit.
+ * @htmlAttribute {string} gmf-objectediting-geomtype The geometry type.
+ * @htmlAttribute {number} gmf-objectediting-layernodeid The GMF layer node id.
+ * @htmlAttribute {ol.Map} gmf-objectediting-map The map.
+ * @htmlAttribute {ol.Collection.<ol.Feature>} gmf-objectediting-sketchfeatures
+ *     Collection of temporary features being drawn by the tools.
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname gmfObjectediting
+ */
+gmf.objecteditingDirective = function() {
+  return {
+    controller: 'GmfObjecteditingController',
+    scope: {
+      'active': '=gmfObjecteditingActive',
+      'feature': '<gmfObjecteditingFeature',
+      'geomType': '<gmfObjecteditingGeomtype',
+      'layerNodeId': '<gmfObjecteditingLayernodeid',
+      'map': '<gmfObjecteditingMap',
+      'sketchFeatures': '<gmfObjecteditingSketchfeatures'
+    },
+    bindToController: true,
+    controllerAs: 'oeCtrl',
+    templateUrl: gmf.baseTemplateUrl + '/objectediting.html'
+  };
+};
+
+gmf.module.directive('gmfObjectediting', gmf.objecteditingDirective);
+
+
+/**
+ * @param {!angular.Scope} $scope Angular scope.
+ * @param {angular.$timeout} $timeout Angular timeout service.
+ * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
+ * @param {gmf.EditFeature} gmfEditFeature Gmf edit feature service.
+ * @param {gmf.ObjectEditingQuery} gmfObjectEditingQuery Gmf ObjectEditing
+ *     query service.
+ * @param {gmf.TreeManager} gmfTreeManager The gmf TreeManager service.
+ * @param {ngeo.DecorateInteraction} ngeoDecorateInteraction Decorate
+ *     interaction service.
+ * @param {ngeo.FeatureHelper} ngeoFeatureHelper Ngeo feature helper service.
+goog.require('ngeo.LayerHelper');
+ * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
+ * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
+ *     service.
+ * @constructor
+ * @ngInject
+ * @ngdoc controller
+ * @ngname GmfObjecteditingController
+ */
+gmf.ObjecteditingController = function($scope, $timeout, gettextCatalog,
+    gmfEditFeature, gmfObjectEditingQuery, gmfTreeManager,
+    ngeoDecorateInteraction, ngeoFeatureHelper, ngeoLayerHelper,
+    ngeoToolActivateMgr) {
+
+  // == Scope properties ==
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.active;
+
+  /**
+   * @type {ol.Feature}
+   * @export
+   */
+  this.feature;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.geomType;
+
+  /**
+   * @type {number}
+   * @export
+   */
+  this.layerNodeId;
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
+
+  /**
+   * @type {ol.Collection.<ol.Feature>}
+   * @export
+   */
+  this.sketchFeatures;
+
+
+  // == Injected properties ==
+
+  /**
+   * @type {!angular.Scope}
+   * @private
+   */
+  this.scope_ = $scope;
+
+  /**
+   * @type {angular.$timeout}
+   * @private
+   */
+  this.timeout_ = $timeout;
+
+  /**
+   * @private
+   */
+  this.gettextCatalog_ = gettextCatalog;
+
+  /**
+   * @type {gmf.EditFeature}
+   * @private
+   */
+  this.gmfEditFeature_ = gmfEditFeature;
+
+  /**
+   * @type {gmf.ObjectEditingQuery}
+   * @private
+   */
+  this.gmfObjectEditingQuery_ = gmfObjectEditingQuery;
+
+  /**
+   * @type {Array.<gmf.ObjectEditingQuery.QueryableLayerInfo>}
+   * @export
+   */
+  this.queryableLayersInfo;
+
+  gmfObjectEditingQuery.getQueryableLayersInfo().then(
+    this.handleGetQueryableLayersInfo_.bind(this)
+  );
+
+  /**
+   * @type {gmf.ObjectEditingQuery.QueryableLayerInfo}
+   * @export
+   */
+  this.selectedQueryableLayerInfo;
+
+  /**
+   * @type {ngeo.LayerHelper}
+   * @private
+   */
+  this.ngeoLayerHelper_ = ngeoLayerHelper;
+
+  /**
+   * @type {gmf.TreeManager}
+   * @private
+   */
+  this.gmfTreeManager_ = gmfTreeManager;
+
+  $scope.$watchCollection(
+    function() {
+      if (this.gmfTreeManager_.rootCtrl) {
+        return this.gmfTreeManager_.rootCtrl.children;
+      }
+    }.bind(this),
+    function(value) {
+      // Timeout required, because the collection event is fired before the
+      // leaf nodes are created and they are the ones we're looking for here.
+      this.timeout_(function() {
+        if (value) {
+          this.unregisterAllTreeCtrl_();
+          this.gmfTreeManager_.rootCtrl.traverseDepthFirst(
+            this.registerTreeCtrl_.bind(this)
+          );
+        }
+      }.bind(this));
+    }.bind(this)
+  );
+
+  /**
+   * @type {ngeo.DecorateInteraction}
+   * @private
+   */
+  this.ngeoDecorateInteraction_ = ngeoDecorateInteraction;
+
+  /**
+   * @type {ngeo.FeatureHelper}
+   * @private
+   */
+  this.ngeoFeatureHelper_ = ngeoFeatureHelper;
+
+  /**
+   * @type {ngeo.ToolActivateMgr}
+   * @private
+   */
+  this.ngeoToolActivateMgr_ = ngeoToolActivateMgr;
+
+
+  // == Other properties ==
+
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.skipGeometryChange_ = false;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.process = gmf.ObjecteditingtoolsController.ProcessType.ADD;
+
+  /**
+   * @type {null|ol.layer.Image|ol.layer.Tile}
+   * @private
+   */
+  this.editableWMSLayer_ = null;
+
+  /**
+   * @type {jsts.io.OL3Parser}
+   * @private
+   */
+  this.jstsOL3Parser_ = new jsts.io.OL3Parser();
+
+  var geometry = this.feature.getGeometry();
+
+  /**
+   * The state of the feature determines whether the next 'save' request
+   * should be an 'insert' or 'update' one.
+   * @type {string}
+   * @private
+   */
+  this.state_ = geometry ? gmf.ObjecteditingController.State.UPDATE :
+    gmf.ObjecteditingController.State.INSERT;
+
+  /**
+   * @type {Array.<?ol.geom.Geometry>}
+   * @private
+   */
+  this.geometryChanges_ = [];
+
+  this.scope_.$watchCollection(
+    function() {
+      return this.geometryChanges_;
+    }.bind(this),
+    function(newVal, oldVal) {
+      if (newVal.length) {
+        if (newVal.length === 1) {
+          this.dirty = false;
+        } else {
+          this.dirty = true;
+        }
+      }
+    }.bind(this)
+  );
+
+  var defaultColor = [39, 155, 145];
+  var dirtyColor = [153, 51, 51];
+
+  /**
+   * @type {gmf.ObjecteditingController.Styles}
+   * @private
+   */
+  this.defaultStyles_ = {};
+  this.initializeStyles_(this.defaultStyles_, defaultColor);
+
+  /**
+   * @type {gmf.ObjecteditingController.Styles}
+   * @private
+   */
+  this.defaultStylesWoVertice_ = {};
+  this.initializeStyles_(this.defaultStylesWoVertice_, defaultColor, false);
+
+  /**
+   * @type {gmf.ObjecteditingController.Styles}
+   * @private
+   */
+  this.dirtyStyles_ = {};
+  this.initializeStyles_(this.dirtyStyles_, dirtyColor);
+
+  /**
+   * @type {gmf.ObjecteditingController.Styles}
+   * @private
+   */
+  this.dirtyStylesWoVertice_ = {};
+  this.initializeStyles_(this.dirtyStylesWoVertice_, dirtyColor, false);
+
+  /**
+   * Flag that is toggled while a request is pending.
+   * @export
+   */
+  this.pending = false;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.dirty = false;
+
+  $scope.$watch(
+    function() {
+      return this.dirty;
+    }.bind(this),
+    this.setFeatureStyle_.bind(this)
+  );
+
+  /**
+   * @type {Array.<ol.EventsKey>}
+   * @private
+   */
+  this.listenerKeys_ = [];
+
+  /**
+   * @type {ol.Collection}
+   * @private
+   */
+  this.features_ = new ol.Collection();
+  this.features_.push(this.feature);
+
+  /**
+   * @type {ol.Collection}
+   * @private
+   */
+  this.interactions_ = new ol.Collection();
+
+  /**
+   * @type {ol.interaction.Modify}
+   * @private
+   */
+  this.modify_ = new ol.interaction.Modify({
+    features: this.features_,
+    style: ngeoFeatureHelper.getVertexStyle(false)
+  });
+  this.interactions_.push(this.modify_);
+
+  /**
+   * @type {ngeo.ToolActivate}
+   * @private
+   */
+  this.modifyToolActivate_ = new ngeo.ToolActivate(this.modify_, 'active');
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.toolsActive = false;
+
+  /**
+   * @type {ngeo.ToolActivate}
+   * @private
+   */
+  this.toolsToolActivate_ = new ngeo.ToolActivate(this, 'toolsActive');
+
+  // Toggle on
+  this.initializeInteractions_();
+  this.registerInteractions_();
+  this.toggle_(true);
+  this.resetGeometryChanges_();
+
+  $scope.$on('$destroy', this.handleDestroy_.bind(this));
+
+};
+
+
+// == API methods ==
+
+
+/**
+ * Delete the feature after asking for a confirmation.
+ * @export
+ */
+gmf.ObjecteditingController.prototype.delete = function() {
+  var msg = this.gettextCatalog_.getString(
+      'Do you really want to delete the feature?');
+  // Confirm deletion first
+  if (confirm(msg)) {
+    this.dirty = false;
+    this.pending = true;
+
+    this.gmfEditFeature_.deleteFeature(
+      this.layerNodeId,
+      this.feature
+    ).then(
+      this.handleDeleteFeature_.bind(this)
+    );
+  }
+
+};
+
+
+/**
+ * Save the current modifications.
+ * @export
+ */
+gmf.ObjecteditingController.prototype.save = function() {
+
+  this.pending = true;
+
+  if (this.state_ === gmf.ObjecteditingController.State.INSERT) {
+    this.gmfEditFeature_.insertFeatures(
+      this.layerNodeId,
+      [this.feature]
+    ).then(
+      this.handleEditFeature_.bind(this)
+    );
+  } else if (this.state_ === gmf.ObjecteditingController.State.UPDATE) {
+    this.gmfEditFeature_.updateFeature(
+      this.layerNodeId,
+      this.feature
+    ).then(
+      this.handleEditFeature_.bind(this)
+    );
+  }
+};
+
+
+/**
+ * Undo the latest modifications.
+ * @export
+ */
+gmf.ObjecteditingController.prototype.undo = function() {
+
+  if (this.geometryChanges_.length <= 1) {
+    return;
+  }
+
+  this.skipGeometryChange_ = true;
+
+  this.geometryChanges_.pop();
+  var clone = gmf.ObjecteditingController.cloneGeometry_(
+    this.geometryChanges_[this.geometryChanges_.length - 1]);
+
+  this.feature.setGeometry(clone);
+
+  this.skipGeometryChange_ = false;
+};
+
+
+/**
+ * Undo the latest modifications.
+ * @return {boolean} Whether the state is INSERT or not.
+ * @export
+ */
+gmf.ObjecteditingController.prototype.isStateInsert = function() {
+  return this.state_ === gmf.ObjecteditingController.State.INSERT;
+};
+
+
+// == Private methods ==
+
+
+/**
+ * Called after a delete request.
+ * @param {angular.$http.Response} resp Ajax response.
+ * @private
+ */
+gmf.ObjecteditingController.prototype.handleDeleteFeature_ = function(resp) {
+  this.feature.setGeometry(null);
+  this.resetGeometryChanges_();
+  this.state_ = gmf.ObjecteditingController.State.INSERT;
+  this.pending = false;
+  this.refreshWMSLayer_();
+};
+
+
+/**
+ * Called after an 'insert' or 'update' request.
+ * @param {angular.$http.Response} resp Ajax response.
+ * @private
+ */
+gmf.ObjecteditingController.prototype.handleEditFeature_ = function(resp) {
+  this.resetGeometryChanges_();
+  if (this.feature.getGeometry()) {
+    this.state_ = gmf.ObjecteditingController.State.UPDATE;
+  } else {
+    this.state_ = gmf.ObjecteditingController.State.INSERT;
+  }
+  this.pending = false;
+  this.refreshWMSLayer_();
+};
+
+
+/**
+ * Initialize interactions by setting them inactive and decorating them
+ * @private
+ */
+gmf.ObjecteditingController.prototype.initializeInteractions_ = function() {
+  this.interactions_.forEach(function(interaction) {
+    interaction.setActive(false);
+    this.ngeoDecorateInteraction_(interaction);
+  }, this);
+};
+
+
+/**
+ * Register interactions by adding them to the map
+ * @private
+ */
+gmf.ObjecteditingController.prototype.registerInteractions_ = function() {
+  this.interactions_.forEach(function(interaction) {
+    this.map.addInteraction(interaction);
+  }, this);
+};
+
+
+/**
+ * Unregister interactions, i.e. remove them from the map
+ * @private
+ */
+gmf.ObjecteditingController.prototype.unregisterInteractions_ = function() {
+  this.interactions_.forEach(function(interaction) {
+    this.map.removeInteraction(interaction);
+  }, this);
+};
+
+
+/**
+ * Activate or deactivate this directive.
+ * @param {boolean} active Whether to activate this directive or not.
+ * @private
+ */
+gmf.ObjecteditingController.prototype.toggle_ = function(active) {
+
+  var keys = this.listenerKeys_;
+  var uid = gmf.ObjecteditingController.NAMESPACE_ + '-' + goog.getUid(this);
+  var toolMgr = this.ngeoToolActivateMgr_;
+
+  if (active) {
+
+    keys.push(
+      ol.events.listen(
+        this.feature,
+        ol.Object.getChangeEventType(this.feature.getGeometryName()),
+        this.handleFeatureGeometryChange_,
+        this
+      )
+    );
+
+    keys.push(
+      ol.events.listen(
+        this.modify_,
+        ol.Object.getChangeEventType(
+          ol.interaction.Interaction.Property.ACTIVE),
+        this.setFeatureStyle_,
+        this
+      )
+    );
+
+    keys.push(
+      ol.events.listen(
+        this.modify_,
+        ol.interaction.Modify.EventType.MODIFYEND,
+        this.handleModifyInteractionModifyEnd_,
+        this
+      )
+    );
+
+    keys.push(
+      ol.events.listen(
+        window,
+        'beforeunload',
+        this.handleWindowBeforeUnload_,
+        this
+      )
+    );
+
+    keys.push(
+      ol.events.listen(
+        this.sketchFeatures,
+        ol.Collection.EventType.ADD,
+        this.handleSketchFeaturesAdd_,
+        this
+      )
+    );
+
+    toolMgr.registerTool(uid, this.modifyToolActivate_, true);
+    toolMgr.registerTool(uid, this.toolsToolActivate_, false);
+
+  } else {
+
+    keys.forEach(function(key) {
+      ol.events.unlistenByKey(key);
+    }, this);
+
+    toolMgr.unregisterTool(uid, this.modifyToolActivate_);
+    toolMgr.unregisterTool(uid, this.toolsToolActivate_);
+
+  }
+
+  this.modify_.setActive(active);
+};
+
+
+/**
+ * Reset the array of geometry changes.  If there are more than one changes,
+ * reset them entirely. Then, if there's no changes, clone the current geometry
+ * as the first entry. One entry means that there's no changes.
+ * @private
+ */
+gmf.ObjecteditingController.prototype.resetGeometryChanges_ = function() {
+  if (this.geometryChanges_.length > 1) {
+    this.geometryChanges_.length = 0;
+  }
+  if (this.geometryChanges_.length === 0) {
+    var geometry = this.feature.getGeometry();
+    var clone = gmf.ObjecteditingController.cloneGeometry_(geometry);
+    this.geometryChanges_.push(clone);
+  }
+};
+
+
+/**
+ * Called after the modification interaction has completed modifying the
+ * existing geometry. The new geometry is pushed in the changes array.
+ * If the geometry type is `MultiPolygon`, we check if any of the inner
+ * geometries intersects with one an other first. Those that does are merged
+ * before being pushed to the changes.
+ *
+ * @param {ol.interaction.Modify.Event} evt Event.
+ * @private
+ */
+gmf.ObjecteditingController.prototype.handleModifyInteractionModifyEnd_ = function(
+  evt
+) {
+  var geometry = this.feature.getGeometry();
+
+  if (geometry instanceof ol.geom.MultiPolygon) {
+    var jstsGeom = this.jstsOL3Parser_.read(geometry);
+    var jstsBuffered = jstsGeom.buffer(0);
+    geometry = gmf.ObjecteditingController.toMultiGeometry_(
+      this.jstsOL3Parser_.write(jstsBuffered)
+    );
+    this.skipGeometryChange_ = true;
+    this.feature.setGeometry(geometry.clone());
+    this.skipGeometryChange_ = false;
+  }
+
+  var clone = gmf.ObjecteditingController.cloneGeometry_(geometry);
+  this.geometryChanges_.push(clone);
+  this.scope_.$apply();
+};
+
+
+/**
+ * @param {gmf.ObjecteditingController.Styles} styles Hash of style.
+ * @param {ol.Color} color Color.
+ * @param {boolean=} opt_incVertice Whether to include vertice or not. Defaults
+ *     to `true`.
+ * @private
+ */
+gmf.ObjecteditingController.prototype.initializeStyles_ = function(
+  styles, color, opt_incVertice
+) {
+
+  var incVertice = opt_incVertice !== false;
+  var rgbaColor = color.slice();
+  rgbaColor.push(0.3);
+
+  var image = new ol.style.Circle({
+    radius: 8,
+    stroke: new ol.style.Stroke({color: color, width: 1}),
+    fill: new ol.style.Fill({color: rgbaColor})
+  });
+
+  styles[ol.geom.GeometryType.POINT] = new ol.style.Style({
+    image: image
+  });
+  styles[ol.geom.GeometryType.MULTI_POINT] = new ol.style.Style({
+    image: image
+  });
+
+  styles[ol.geom.GeometryType.LINE_STRING] = [
+    new ol.style.Style({
+      stroke: new ol.style.Stroke({
+        color: color,
+        width: 3
+      })
+    })
+  ];
+  if (incVertice) {
+    styles[ol.geom.GeometryType.LINE_STRING].push(
+      this.ngeoFeatureHelper_.getVertexStyle(true)
+    );
+  }
+  styles[ol.geom.GeometryType.MULTI_LINE_STRING] = [
+    new ol.style.Style({
+      stroke: new ol.style.Stroke({
+        color: color,
+        width: 3
+      })
+    })
+  ];
+  if (incVertice) {
+    styles[ol.geom.GeometryType.MULTI_LINE_STRING].push(
+      this.ngeoFeatureHelper_.getVertexStyle(true)
+    );
+  }
+
+  styles[ol.geom.GeometryType.POLYGON] = [
+    new ol.style.Style({
+      stroke: new ol.style.Stroke({
+        color: color,
+        width: 2
+      }),
+      fill: new ol.style.Fill({
+        color: rgbaColor
+      })
+    })
+  ];
+  if (incVertice) {
+    styles[ol.geom.GeometryType.POLYGON].push(
+      this.ngeoFeatureHelper_.getVertexStyle(true)
+    );
+  }
+  styles[ol.geom.GeometryType.MULTI_POLYGON] = [
+    new ol.style.Style({
+      stroke: new ol.style.Stroke({
+        color: color,
+        width: 2
+      }),
+      fill: new ol.style.Fill({
+        color: rgbaColor
+      })
+    })
+  ];
+  if (incVertice) {
+    styles[ol.geom.GeometryType.MULTI_POLYGON].push(
+      this.ngeoFeatureHelper_.getVertexStyle(true)
+    );
+  }
+
+};
+
+
+/**
+ * Set the style of the feature depending on:
+ *  - the geometry type
+ *  - the dirty state of the directive
+ *  - whether the modify control is active or not
+ *
+ * @private
+ */
+gmf.ObjecteditingController.prototype.setFeatureStyle_ = function() {
+  var geometry = this.feature.getGeometry();
+  if (geometry) {
+    var geomType = geometry.getType();
+    var modifyActive = this.modify_.getActive();
+    var style;
+    if (this.dirty) {
+      if (modifyActive) {
+        style = this.dirtyStyles_[geomType];
+      } else {
+        style = this.dirtyStylesWoVertice_[geomType];
+      }
+    } else {
+      if (modifyActive) {
+        style = this.defaultStyles_[geomType];
+      } else {
+        style = this.defaultStylesWoVertice_[geomType];
+      }
+    }
+    this.feature.setStyle(style);
+  }
+};
+
+
+/**
+ * Registers a newly added Layertree controller 'leaf', i.e. groups are
+ * excluded.
+ *
+ * If the Layertree controller node id is equal to the `layerNodeId` configured
+ * with this directive, then find the WMS layer associated with it for
+ * for refresh purpose.
+ *
+ * @param {ngeo.LayertreeController} treeCtrl Layertree controller to register
+ * @private
+ */
+gmf.ObjecteditingController.prototype.registerTreeCtrl_ = function(treeCtrl) {
+
+  // Skip any Layertree controller that has a node that is not a leaf
+  var node = /** @type {gmfThemes.GmfGroup|gmfThemes.GmfLayer} */ (
+    treeCtrl.node);
+  if (node.children && node.children.length) {
+    return;
+  }
+
+  // Set editable WMS layer for refresh purpose
+  if (node.id === this.layerNodeId) {
+    var layer = gmf.SyncLayertreeMap.getLayer(treeCtrl);
+    goog.asserts.assert(
+      layer instanceof ol.layer.Image || layer instanceof ol.layer.Tile);
+    this.editableWMSLayer_ = layer;
+  }
+
+};
+
+
+/**
+ * Unregisters all currently registered Layertree controllers.
+ *
+ * Unset the WMS layer associated with the `layerNodeId` configured with
+ * this directive.
+ *
+ * @private
+ */
+gmf.ObjecteditingController.prototype.unregisterAllTreeCtrl_ = function() {
+  this.editableWMSLayer_ = null;
+};
+
+
+/**
+ * Refresh the WMS layer, if set.
+ * @private
+ */
+gmf.ObjecteditingController.prototype.refreshWMSLayer_ = function() {
+  if (this.editableWMSLayer_) {
+    this.ngeoLayerHelper_.refreshWMSLayer(this.editableWMSLayer_);
+  }
+};
+
+
+/**
+ * Called before the window unloads. Show a confirmation message if there are
+ * unsaved modifications.
+ * @param {Event} e Event.
+ * @return {string} Message
+ * @private
+ */
+gmf.ObjecteditingController.prototype.handleWindowBeforeUnload_ = function(e) {
+  if (this.dirty) {
+    var msg = this.gettextCatalog_.getString('There are unsaved changes.');
+    (e || window.event).returnValue = msg;
+    return msg;
+  }
+  return '';
+};
+
+
+/**
+ * Called when a feature is added to the collection of sketch features.
+ * Depending on the current behaviour, use the added sketch feature to process
+ * the existing geometry.
+ *
+ * @param {ol.Collection.Event} evt Event.
+ * @private
+ */
+gmf.ObjecteditingController.prototype.handleSketchFeaturesAdd_ = function(evt) {
+  var sketchFeature = /** @type {ol.Feature} */ (evt.element);
+  var sketchGeom = /** @type {ol.geom.Geometry} */ (
+    sketchFeature.getGeometry());
+
+  var geom = this.feature.getGeometry();
+
+  if (geom) {
+    var jstsGeom = this.jstsOL3Parser_.read(geom);
+    var jstsSketchGeom = this.jstsOL3Parser_.read(sketchGeom);
+    var jstsProcessedGeom;
+
+    if (this.process === gmf.ObjecteditingtoolsController.ProcessType.ADD) {
+      jstsProcessedGeom = jstsGeom.union(jstsSketchGeom);
+    } else {
+      jstsProcessedGeom = jstsGeom.difference(jstsSketchGeom);
+    }
+
+    var processedGeom = this.jstsOL3Parser_.write(jstsProcessedGeom);
+    var multiGeom = gmf.ObjecteditingController.toMultiGeometry_(processedGeom);
+    this.feature.setGeometry(multiGeom.clone());
+
+  } else if (this.process === gmf.ObjecteditingtoolsController.ProcessType.ADD) {
+    this.feature.setGeometry(sketchGeom.clone());
+  }
+
+  this.sketchFeatures.clear();
+};
+
+
+/**
+ * Called when the geometry property of the feature changes, i.e. not when the
+ * geometry itself changes but when a new geometry is set to the feature.
+ *
+ * This happens either when resetting the geometry to null, in which case
+ * there's nothing to do here. Otherwise, it happens after the combinaison
+ * of a sketch geometry with the existing feature geometry. This new geom
+ * is pushed in the `geometryChanges_` array.
+ *
+ * @private
+ */
+gmf.ObjecteditingController.prototype.handleFeatureGeometryChange_ = function() {
+
+  if (this.skipGeometryChange_) {
+    return;
+  }
+
+  var geom = this.feature.getGeometry();
+  if (geom) {
+    // Use a timeout here, because there can be a scope digest already in
+    // progress. For example, with tools that requires the user to draw
+    // features on the map, we would need to manually call:
+    // this.scope_.$apply();
+    // For tools that use promises instead, such as the "copy/delete" from,
+    // a scope is already in progress so we must not invoke it again.
+    this.timeout_(function() {
+      this.geometryChanges_.push(geom.clone());
+    }.bind(this));
+  }
+};
+
+
+/**
+ * @param {Array.<gmf.ObjectEditingQuery.QueryableLayerInfo>} layersInfo List
+ *     of queryable layers information, which contains the node and ogcServer.
+ * @private
+ */
+gmf.ObjecteditingController.prototype.handleGetQueryableLayersInfo_ = function(
+  layersInfo
+) {
+  this.queryableLayersInfo = layersInfo;
+  if (this.queryableLayersInfo.length) {
+    this.selectedQueryableLayerInfo = this.queryableLayersInfo[0];
+  }
+};
+
+
+/**
+ * @private
+ */
+gmf.ObjecteditingController.prototype.handleDestroy_ = function() {
+  this.features.clear();
+  this.toggle_(false);
+  this.unregisterInteractions_();
+};
+
+
+// == Static methods and type definitions ==
+
+
+/**
+ * Utility method that gets the clone of a geometry, which can be null or
+ * undefined. In the latter case, a null value is returned instead of a
+ * geometry.
+ * @param {?ol.geom.Geometry|undefined} geometry A geometry, undefined or
+ *     null value.
+ * @return {?ol.geom.Geometry} A geometry clone or null value.
+ * @private
+ */
+gmf.ObjecteditingController.cloneGeometry_ = function(geometry) {
+  var clone = null;
+  if (geometry) {
+    clone = geometry.clone();
+  }
+  return clone;
+};
+
+
+/**
+ * Utility method that converts a simple geometry to its multi equivalent. If
+ * the geometry itself is already multi, it is returned as-is.
+ * @param {ol.geom.Geometry} geometry A geometry
+ * @return {ol.geom.Geometry} A multi geometry
+ * @private
+ */
+gmf.ObjecteditingController.toMultiGeometry_ = function(geometry) {
+  var multiGeom;
+  if (geometry instanceof ol.geom.Point) {
+    multiGeom = new ol.geom.MultiPoint([]);
+    multiGeom.appendPoint(geometry);
+  } else if (geometry instanceof ol.geom.LineString) {
+    multiGeom = new ol.geom.MultiLineString([]);
+    multiGeom.appendLineString(geometry);
+  } else if (geometry instanceof ol.geom.Polygon) {
+    multiGeom = new ol.geom.MultiPolygon([]);
+    multiGeom.appendPolygon(geometry);
+  } else {
+    multiGeom = geometry;
+  }
+  return multiGeom;
+};
+
+
+/**
+ * @const
+ * @private
+ */
+gmf.ObjecteditingController.NAMESPACE_ = 'oe';
+
+
+/**
+ * @enum {string}
+ */
+gmf.ObjecteditingController.State = {
+  INSERT: 'insert',
+  UPDATE: 'update'
+};
+
+
+/**
+ * @typedef {Object.<string, ol.style.Style|Array.<ol.style.Style>>}
+ */
+gmf.ObjecteditingController.Styles;
+
+
+gmf.module.controller(
+  'GmfObjecteditingController', gmf.ObjecteditingController);

--- a/contribs/gmf/src/directives/objecteditinggetwmsfeature.js
+++ b/contribs/gmf/src/directives/objecteditinggetwmsfeature.js
@@ -1,0 +1,159 @@
+goog.provide('gmf.ObjecteditinggetwmsfeatureController');
+goog.provide('gmf.objecteditinggetwmsfeatureDirective');
+
+goog.require('gmf');
+goog.require('gmf.ObjectEditingQuery');
+
+
+/**
+ * When activated, this directive registers clicks on an OL3 map and use the
+ * clicked coordinate to fetch a feature using the ObjectEditing query service.
+ * A feature returned is pushed to a collection.
+ *
+ * Example:
+ *
+ *     <gmf-objecteditinggetwmsfeature
+ *         gmf-objecteditinggetwmsfeature-active="ctrl.active"
+ *         gmf-objecteditinggetwmsfeature-features="ctrl.features"
+ *         gmf-objecteditinggetwmsfeature-layerinfo="ctrl.layerInfo"
+ *         gmf-objecteditinggetwmsfeature-map="::ctrl.map">
+ *     </gmf-objecteditinggetwmsfeature>
+ *
+ * @htmlAttribute {boolean} gmf-objecteditinggetwmsfeature-active Whether the
+ *     directive is active or not.
+ * @htmlAttribute {ol.Collection} gmf-objecteditinggetwmsfeature-features
+ *     The collection of features where to add those created by this directive.
+ * @htmlAttribute {gmf.ObjectEditingQuery.QueryableLayerInfo} gmf-objecteditinggetwmsfeature-layerinfo Queryable layer info.
+ * @htmlAttribute {ol.Map} gmf-objecteditinggetwmsfeature-map The map.
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname gmfObjecteditinggetwmsfeature
+ */
+gmf.objecteditinggetwmsfeatureDirective = function() {
+  return {
+    controller: 'GmfObjecteditinggetwmsfeatureController',
+    scope: {
+      'active': '=gmfObjecteditinggetwmsfeatureActive',
+      'features': '<gmfObjecteditinggetwmsfeatureFeatures',
+      'layerInfo': '=gmfObjecteditinggetwmsfeatureLayerinfo',
+      'map': '<gmfObjecteditinggetwmsfeatureMap'
+    },
+    bindToController: true,
+    controllerAs: 'gwfCtrl'
+  };
+};
+
+gmf.module.directive(
+  'gmfObjecteditinggetwmsfeature',
+  gmf.objecteditinggetwmsfeatureDirective);
+
+
+/**
+ * @param {!angular.Scope} $scope Scope.
+ * @param {gmf.ObjectEditingQuery} gmfObjectEditingQuery GMF ObjectEditing
+ *     query service.
+ * @constructor
+ * @ngInject
+ * @ngdoc controller
+ * @ngname GmfObjecteditinggetwmsfeatureController
+ */
+gmf.ObjecteditinggetwmsfeatureController = function($scope,
+    gmfObjectEditingQuery) {
+
+  // Scope properties
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.active;
+
+  $scope.$watch(
+    function() {
+      return this.active;
+    }.bind(this),
+    this.handleActiveChange_.bind(this)
+  );
+
+  /**
+   * @type {ol.Collection}
+   * @export
+   */
+  this.features;
+
+  /**
+   * @type {gmf.ObjectEditingQuery.QueryableLayerInfo}
+   * @export
+   */
+  this.layerInfo;
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
+
+
+  // Injected properties
+
+  /**
+   * @type {gmf.ObjectEditingQuery}
+   * @private
+   */
+  this.gmfObjectEditingQuery_ = gmfObjectEditingQuery;
+
+};
+
+
+/**
+ * @param {boolean} active Active.
+ * @private
+ */
+gmf.ObjecteditinggetwmsfeatureController.prototype.handleActiveChange_ = function(
+  active
+) {
+
+  if (active) {
+    ol.events.listen(
+      this.map,
+      ol.MapBrowserEvent.EventType.CLICK,
+      this.handleMapClick_,
+      this
+    );
+  } else {
+    ol.events.unlisten(
+      this.map,
+      ol.MapBrowserEvent.EventType.CLICK,
+      this.handleMapClick_,
+      this
+    );
+  }
+
+};
+
+
+/**
+ * @param {ol.MapBrowserEvent} evt Event.
+ * @private
+ */
+gmf.ObjecteditinggetwmsfeatureController.prototype.handleMapClick_ = function(
+  evt
+) {
+
+  this.gmfObjectEditingQuery_.getFeatureInfo(
+    this.layerInfo,
+    evt.coordinate,
+    this.map
+  ).then(function(feature) {
+    if (feature) {
+      this.features.push(feature);
+    }
+  }.bind(this));
+
+};
+
+
+gmf.module.controller(
+  'GmfObjecteditinggetwmsfeatureController',
+  gmf.ObjecteditinggetwmsfeatureController);

--- a/contribs/gmf/src/directives/objecteditingtools.js
+++ b/contribs/gmf/src/directives/objecteditingtools.js
@@ -1,0 +1,313 @@
+goog.provide('gmf.ObjecteditingtoolsController');
+goog.provide('gmf.objecteditingtoolsDirective');
+
+/** @suppress {extraRequire} */
+goog.require('gmf.objecteditinggetwmsfeatureDirective');
+/** @suppress {extraRequire} */
+goog.require('ngeo.btnDirective');
+/** @suppress {extraRequire} */
+goog.require('ngeo.createfeatureDirective');
+/** @suppress {extraRequire} */
+goog.require('ngeo.createregularpolygonfromclickDirective');
+goog.require('ngeo.DecorateInteraction');
+goog.require('ngeo.ToolActivate');
+goog.require('ngeo.ToolActivateMgr');
+
+
+/**
+ * Directive used to edit the geometry of a single feature using advanced
+ * tools.
+ *
+ * Example:
+ *
+ *     <gmf-objecteditingtools
+ *         gmf-objecteditingtools-active="ctrl.objectEditingActive"
+ *         gmf-objecteditingtools-feature="ctrl.objectEditingFeature"
+ *         gmf-objecteditingtools-geomtype="ctrl.objectEditingGeomType"
+ *         gmf-objecteditingtools-map="::ctrl.map"
+ *         gmf-objecteditingtools-process="::ctrl.process"
+ *         gmf-objecteditingtools-queryablelayerinfo="::ctrl.queryableLayerInfo"
+ *         gmf-objecteditingtools-sketchfeatures="::ctrl.sketchFeatures">
+ *     </gmf-objecteditingtools>
+ *
+ * @htmlAttribute {boolean} gmf-objecteditingtools-active Whether the
+ *     directive is active or not.
+ * @htmlAttribute {ol.Feature} gmf-objecteditingtools-feature The feature to
+ *     edit.
+ * @htmlAttribute {string} gmf-objecteditingtools-geomtype The geometry type.
+ * @htmlAttribute {ol.Map} gmf-objecteditingtools-map The map.
+ * @htmlAttribute {string} gmf-objectediting-process Determines the
+ *     behavior to adopt when sketch features are added.
+ * @htmlAttribute {gmf.ObjectEditingQuery.QueryableLayerInfo} gmf-objectediting-queryablelayerinfo
+ *     Queryable layer information.
+ * @htmlAttribute {ol.Collection.<ol.Feature>} gmf-objectediting-sketchfeatures
+ *     Collection of temporary features being drawn by the tools.
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname gmfObjecteditingtools
+ */
+gmf.objecteditingtoolsDirective = function() {
+  return {
+    controller: 'GmfObjecteditingtoolsController',
+    scope: {
+      'active': '=gmfObjecteditingtoolsActive',
+      'feature': '<gmfObjecteditingtoolsFeature',
+      'geomType': '<gmfObjecteditingtoolsGeomtype',
+      'map': '<gmfObjecteditingtoolsMap',
+      'process': '=gmfObjecteditingtoolsProcess',
+      'queryableLayerInfo': '=gmfObjecteditingtoolsQueryablelayerinfo',
+      'sketchFeatures': '<gmfObjecteditingtoolsSketchfeatures'
+    },
+    bindToController: true,
+    controllerAs: 'oetCtrl',
+    templateUrl: gmf.baseTemplateUrl + '/objecteditingtools.html'
+  };
+};
+
+gmf.module.directive('gmfObjecteditingtools', gmf.objecteditingtoolsDirective);
+
+
+/**
+ * @param {!angular.Scope} $scope Scope.
+ * @param {ngeo.DecorateInteraction} ngeoDecorateInteraction Decorate
+ *     interaction service.
+ * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
+ *     service.
+ * @constructor
+ * @ngInject
+ * @ngdoc controller
+ * @ngname GmfObjecteditingtoolsController
+ */
+gmf.ObjecteditingtoolsController = function($scope, ngeoDecorateInteraction,
+    ngeoToolActivateMgr) {
+
+  // == Scope properties ==
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.active;
+
+  /**
+   * @type {ol.Feature}
+   * @export
+   */
+  this.feature;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.geomType;
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
+
+  /**
+   * @type {gmf.ObjectEditingQuery.QueryableLayerInfo}
+   * @export
+   */
+  this.queryableLayerInfo;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.process;
+
+  /**
+   * @type {ol.Collection.<ol.Feature>}
+   * @export
+   */
+  this.sketchFeatures;
+
+
+  // == Injected properties ==
+
+  /**
+   * @type {!angular.Scope} $scope Scope.
+   * @private
+   */
+  this.scope_ = $scope;
+
+  /**
+   * @type {ngeo.DecorateInteraction}
+   * @private
+   */
+  this.ngeoDecorateInteraction_ = ngeoDecorateInteraction;
+
+  /**
+   * @type {ngeo.ToolActivateMgr}
+   * @private
+   */
+  this.ngeoToolActivateMgr_ = ngeoToolActivateMgr;
+
+  // == Other properties ==
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.geomTypePolygon = ngeo.GeometryType.POLYGON;
+
+  /**
+   * @type {Array.<string>}
+   * @private
+   */
+  this.toolActiveNames_ = [];
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.drawActive = false;
+
+  this.registerTool_('drawActive',
+    gmf.ObjecteditingtoolsController.ProcessType.ADD);
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.eraseActive = false;
+
+  this.registerTool_('eraseActive',
+    gmf.ObjecteditingtoolsController.ProcessType.DELETE);
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.drawTriangleActive = false;
+
+  /**
+   * @type {number}
+   * @export
+   */
+  this.triangleAngle = Math.PI / 180 * 90; // 90 degrees
+
+  /**
+   * @type {number}
+   * @export
+   */
+  this.triangleRadius = 100;
+
+  this.registerTool_('drawTriangleActive',
+    gmf.ObjecteditingtoolsController.ProcessType.ADD);
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.copyFromActive = false;
+
+  this.registerTool_('copyFromActive',
+    gmf.ObjecteditingtoolsController.ProcessType.ADD);
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.deleteFromActive = false;
+
+  this.registerTool_('deleteFromActive',
+    gmf.ObjecteditingtoolsController.ProcessType.DELETE);
+
+  $scope.$on('$destroy', this.handleDestroy_.bind(this));
+};
+
+
+/**
+ * Register a tool using its `active` property name and what behavior it should
+ * have when it is active and a sketch feature is added
+ *
+ * This method:
+ *  - registers a watcher on the tool active property to manage this directive
+ *    main active property, i.e the directive is considered active when one
+ *    of the tools is active,  otherwise it's not active.
+ *
+ *  - creates a `ngeo.ToolActivate` object and registers it in a group so
+ *    that only one tool can be active at a time
+ *
+ * @param {string} toolActiveName The name of the active property for the tool.
+ * @param {string} process The behavior the tool should use when active
+ *     and when sketch features are added.
+ * @private
+ */
+gmf.ObjecteditingtoolsController.prototype.registerTool_ = function(
+  toolActiveName, process
+) {
+
+  this.scope_.$watch(
+    function() {
+      return this[toolActiveName];
+    }.bind(this),
+    this.handleToolActiveChange_.bind(this, process)
+  );
+
+  var group = gmf.ObjecteditingtoolsController.NAMESPACE_ +
+      '-' + goog.getUid(this);
+  var toolActivate = new ngeo.ToolActivate(this, toolActiveName);
+  this.ngeoToolActivateMgr_.registerTool(group, toolActivate, false);
+
+  this.toolActiveNames_.push(toolActiveName);
+
+};
+
+
+/**
+ * Called when any of the tool 'active' property changes.
+ * @param {string} process The behavior the tool should use when active.
+ * @param {boolean|undefined} newVal New value.
+ * @private
+ */
+gmf.ObjecteditingtoolsController.prototype.handleToolActiveChange_ = function(
+  process, newVal
+) {
+
+  // Update process if a tool was activated.
+  if (newVal) {
+    this.process = process;
+  }
+
+  // Update active property
+  var active = false;
+  for (var i = 0, ii = this.toolActiveNames_.length; i < ii; i++) {
+    active = active || this[this.toolActiveNames_[i]];
+    if (active) {
+      break;
+    }
+  }
+  this.active = active;
+};
+
+
+/**
+ * @private
+ */
+gmf.ObjecteditingtoolsController.prototype.handleDestroy_ = function() {};
+
+
+gmf.module.controller(
+  'GmfObjecteditingtoolsController', gmf.ObjecteditingtoolsController);
+
+
+/**
+ * @const
+ * @private
+ */
+gmf.ObjecteditingtoolsController.NAMESPACE_ = 'oet';
+
+
+/**
+ * @enum {string}
+ */
+gmf.ObjecteditingtoolsController.ProcessType = {
+  ADD: 'add',
+  DELETE: 'delete'
+};

--- a/contribs/gmf/src/directives/partials/objectediting.html
+++ b/contribs/gmf/src/directives/partials/objectediting.html
@@ -1,0 +1,43 @@
+<gmf-objecteditingtools
+  gmf-objecteditingtools-active="oeCtrl.toolsActive"
+  gmf-objecteditingtools-feature="oeCtrl.feature"
+  gmf-objecteditingtools-geomtype="::oeCtrl.geomType"
+  gmf-objecteditingtools-map="::oeCtrl.map"
+  gmf-objecteditingtools-process="oeCtrl.process"
+  gmf-objecteditingtools-queryablelayerinfo="oeCtrl.selectedQueryableLayerInfo"
+  gmf-objecteditingtools-sketchfeatures="::oeCtrl.sketchFeatures">
+</gmf-objecteditingtools>
+
+<div class="form-group">
+  <select
+    class="form-control"
+    ng-model="oeCtrl.selectedQueryableLayerInfo"
+    ng-options="layerInfo.layerNode.name | translate for layerInfo in oeCtrl.queryableLayersInfo">
+  </select>
+</div>
+
+<form
+  novalidate
+  name="form"
+  class="form gmf-objectediting-form">
+  <input
+    type="submit"
+    value="{{'Save' | translate}}"
+    class="btn btn-sm btn-default gmf-objectediting-btn-save"
+    ng-click="form.$valid && oeCtrl.save()"
+    ng-disabled="!oeCtrl.dirty || oeCtrl.pending"
+    title="{{'Save modifications | translate'}}"></input>
+  <a
+    class="btn btn-sm btn-link gmf-objectediting-btn-undo"
+    ng-click="oeCtrl.undo()"
+    ng-disabled="!oeCtrl.dirty || oeCtrl.pending"
+    title="{{'Undo latest modifications | translate'}}"
+    href>{{'Undo' | translate}}</a>
+  <a
+    class="btn btn-sm btn-link gmf-objectediting-btn-delete"
+    ng-click="oeCtrl.delete()"
+    ng-disabled="oeCtrl.isStateInsert() || oeCtrl.pending"
+    title="{{'Delete the feature | translate'}}"
+    href>{{'Delete' | translate}}</a>
+</form>
+

--- a/contribs/gmf/src/directives/partials/objectediting.html
+++ b/contribs/gmf/src/directives/partials/objectediting.html
@@ -40,4 +40,3 @@
     title="{{'Delete the feature | translate'}}"
     href>{{'Delete' | translate}}</a>
 </form>
-

--- a/contribs/gmf/src/directives/partials/objecteditingtools.html
+++ b/contribs/gmf/src/directives/partials/objecteditingtools.html
@@ -1,0 +1,112 @@
+<div class="btn-group" role="group" aria-label="">
+  <a
+    href
+    ngeo-btn
+    ngeo-createfeature
+    ngeo-createfeature-active="oetCtrl.drawActive"
+    ngeo-createfeature-features="::oetCtrl.sketchFeatures"
+    ngeo-createfeature-geom-type="::oetCtrl.geomType"
+    ngeo-createfeature-map="::oetCtrl.map"
+    class="btn btn-default"
+    ng-class="{active: oetCtrl.drawActive}"
+    ng-model="oetCtrl.drawActive">
+    <span ng-switch="::oetCtrl.geomType">
+      <span
+        class="gmf-icon gmf-icon-point"
+        title="{{'Add a point to the geometry' | translate}}"
+        ng-switch-when="MultiPoint">
+        {{'Draw' | translate}}
+      </span>
+      <span
+        class="gmf-icon gmf-icon-line"
+        title="{{'Add a linestring to the geometry' | translate}}"
+        ng-switch-when="MultiLineString">
+        {{'Draw' | translate}}
+      </span>
+      <span
+        class="gmf-icon gmf-icon-polygon"
+        title="{{'Add a polygon to the geometry' | translate}}"
+        ng-switch-when="MultiPolygon">
+        {{'Draw' | translate}}
+      </span>
+    </span>
+  </a>
+
+  <a
+    href
+    ngeo-btn
+    ngeo-createfeature
+    ngeo-createfeature-active="oetCtrl.eraseActive"
+    ngeo-createfeature-features="::oetCtrl.sketchFeatures"
+    ngeo-createfeature-geom-type="::oetCtrl.geomTypePolygon"
+    ngeo-createfeature-map="::oetCtrl.map"
+    class="btn btn-default"
+    ng-class="{active: oetCtrl.eraseActive}"
+    ng-model="oetCtrl.eraseActive">
+    <span
+      class="gmf-icon gmf-icon-polygon"
+      title="{{'Erase geometry' | translate}}">
+      {{'Erase' | translate}}
+    </span>
+  </a>
+
+  <a
+    href
+    translate
+    ng-if="::oetCtrl.geomType === 'MultiPolygon'"
+    ngeo-btn
+    ngeo-createregularpolygonfromclick
+    ngeo-createregularpolygonfromclick-active="oetCtrl.drawTriangleActive"
+    ngeo-createregularpolygonfromclick-angle="oetCtrl.triangleAngle"
+    ngeo-createregularpolygonfromclick-features="::oetCtrl.sketchFeatures"
+    ngeo-createregularpolygonfromclick-map="::oetCtrl.map"
+    ngeo-createregularpolygonfromclick-radius="::oetCtrl.triangleRadius"
+    class="btn btn-default ngeo-createregularpolygonfromclick"
+    ng-class="{active: oetCtrl.drawTriangleActive}"
+    ng-model="oetCtrl.drawTriangleActive">
+    <span
+      class="gmf-icon gmf-icon-polygon"
+      title="{{'Draw a triangle' | translate}}">
+      {{'Triangle' | translate}}
+    </span>
+  </a>
+
+  <a
+    href
+    translate
+    ngeo-btn
+    gmf-objecteditinggetwmsfeature
+    gmf-objecteditinggetwmsfeature-active="oetCtrl.copyFromActive"
+    gmf-objecteditinggetwmsfeature-features="::oetCtrl.sketchFeatures"
+    gmf-objecteditinggetwmsfeature-layerinfo="oetCtrl.queryableLayerInfo"
+    gmf-objecteditinggetwmsfeature-map="::oetCtrl.map"
+    class="btn btn-default gmf-objecteditinggetwmsfeature-add"
+    ng-class="{active: oetCtrl.copyFromActive}"
+    ng-model="oetCtrl.copyFromActive">
+    <span
+      class="gmf-icon gmf-icon-polygon"
+      title="{{'Copy from external WMS feature' | translate}}">
+      {{'Copy from' | translate}}
+    </span>
+  </a>
+
+  <a
+    href
+    translate
+    ngeo-btn
+    gmf-objecteditinggetwmsfeature
+    gmf-objecteditinggetwmsfeature-active="oetCtrl.deleteFromActive"
+    gmf-objecteditinggetwmsfeature-features="::oetCtrl.sketchFeatures"
+    gmf-objecteditinggetwmsfeature-layerinfo="oetCtrl.queryableLayerInfo"
+    gmf-objecteditinggetwmsfeature-map="::oetCtrl.map"
+    class="btn btn-default gmf-objecteditinggetwmsfeature-delete"
+    ng-class="{active: oetCtrl.deleteFromActive}"
+    ng-model="oetCtrl.deleteFromActive">
+    <span
+      class="gmf-icon gmf-icon-polygon"
+      title="{{'Delete from external WMS feature' | translate}}">
+      {{'Delete from' | translate}}
+    </span>
+  </a>
+
+</div>

--- a/contribs/gmf/src/services/objecteditingmanager.js
+++ b/contribs/gmf/src/services/objecteditingmanager.js
@@ -61,6 +61,8 @@ gmf.ObjectEditingManager.prototype.getFeature = function() {
   if (!this.getFeatureDefered_) {
     this.getFeatureDefered_ = this.q_.defer();
 
+    var geomType = this.ngeoLocation_.getParam(
+      gmf.ObjectEditingManager.Param.GEOM_TYPE);
     var id = this.ngeoLocation_.getParam(
       gmf.ObjectEditingManager.Param.ID);
     var layer = this.ngeoLocation_.getParam(
@@ -70,7 +72,7 @@ gmf.ObjectEditingManager.prototype.getFeature = function() {
     var theme = this.ngeoLocation_.getParam(
       gmf.ObjectEditingManager.Param.THEME);
 
-    if (id && layer && property && theme) {
+    if (geomType && id && layer && property && theme) {
       this.gmfEditFeature_.getFeaturesWithComparisonFilters(
         [layer],
         [{
@@ -86,6 +88,26 @@ gmf.ObjectEditingManager.prototype.getFeature = function() {
 
   return this.getFeatureDefered_.promise;
 
+};
+
+
+/**
+ * @return {?string} The geometry type.
+ * @export
+ */
+gmf.ObjectEditingManager.prototype.getGeomType = function() {
+  return this.ngeoLocation_.getParam(
+    gmf.ObjectEditingManager.Param.GEOM_TYPE) || null;
+};
+
+
+/**
+ * @return {?number} The gmf layer node id.
+ * @export
+ */
+gmf.ObjectEditingManager.prototype.getLayerNodeId = function() {
+  return this.ngeoLocation_.getParamAsInt(
+    gmf.ObjectEditingManager.Param.LAYER) || null;
 };
 
 

--- a/contribs/gmf/src/services/objecteditingquery.js
+++ b/contribs/gmf/src/services/objecteditingquery.js
@@ -1,0 +1,217 @@
+goog.provide('gmf.ObjectEditingQuery');
+
+goog.require('gmf');
+goog.require('gmf.Themes');
+goog.require('ol.format.WMSGetFeatureInfo');
+goog.require('ol.source.ImageWMS');
+
+
+/**
+ * A service that collects all queryable layer nodes from all themes, stores
+ * them and use them to make WMS GetFeatureInfo queries. Queries can be made
+ * regardless of the associated layer visibility. The layer nodes are also
+ * loaded only once.
+ *
+ * @param {angular.$http} $http Angular $http service.
+ * @param {angular.$q} $q Angular $q service.
+ * @param {gmf.Themes} gmfThemes The gmf themes service.
+ * @constructor
+ * @struct
+ * @ngInject
+ */
+gmf.ObjectEditingQuery = function($http, $q, gmfThemes) {
+
+  /**
+   * @type {angular.$http}
+   * @private
+   */
+  this.http_ = $http;
+
+  /**
+   * @type {angular.$q}
+   * @private
+   */
+  this.q_ = $q;
+
+  /**
+   * @type {gmf.Themes}
+   * @private
+   */
+  this.gmfThemes_ = gmfThemes;
+
+  /**
+   * @type {?angular.$q.Deferred}
+   * @private
+   */
+  this.getQueryableLayerNodesDefered_ = null;
+
+};
+
+
+/**
+ * @return {angular.$q.Promise} Promise.
+ * @export
+ */
+gmf.ObjectEditingQuery.prototype.getQueryableLayersInfo = function() {
+
+  if (!this.getQueryableLayerNodesDefered_) {
+    this.getQueryableLayerNodesDefered_ = this.q_.defer();
+    this.gmfThemes_.getOgcServersObject().then(function(ogcServers) {
+      this.gmfThemes_.getThemesObject().then(function(themes) {
+        if (!themes) {
+          return;
+        }
+
+        var queryableLayersInfo =
+            gmf.ObjectEditingQuery.getQueryableLayersInfoFromThemes(
+              themes,
+              ogcServers
+            );
+
+        // FIXME - missing checking of ObjectEditing config. Do this here...
+        // ...
+
+        this.getQueryableLayerNodesDefered_.resolve(queryableLayersInfo);
+      }.bind(this));
+    }.bind(this));
+  }
+
+  return this.getQueryableLayerNodesDefered_.promise;
+
+};
+
+
+/**
+ * From a list of theme nodes, collect all WMS layer nodes that are queryable.
+ * A list of OGC servers is given in order to bind each queryable layer node
+ * to its associated server and be able to build requests.
+ *
+ * @param {Array.<gmfThemes.GmfTheme>} themes List of theme nodes.
+ * @param {gmfThemes.GmfOgcServers} ogcServers List of ogc servers
+ * @return {Array.<gmf.ObjectEditingQuery.QueryableLayerInfo>} List of
+ *     queryable layers information.
+ * @export
+ */
+gmf.ObjectEditingQuery.getQueryableLayersInfoFromThemes = function(
+  themes, ogcServers
+) {
+  var queryableLayersInfo = [];
+  var theme;
+  var group;
+  var nodes;
+  var node;
+
+  for (var i = 0, ii = themes.length; i < ii; i++) {
+    theme = /** @type {gmfThemes.GmfTheme} */ (themes[i]);
+    for (var j = 0, jj = theme.children.length; j < jj; j++) {
+      group = /** @type {gmfThemes.GmfGroup} */ (theme.children[j]);
+
+      // Skip groups that don't have an ogcServer set
+      if (!group.ogcServer) {
+        continue;
+      }
+
+      nodes = [];
+      gmf.Themes.getFlatNodes(group, nodes);
+
+      for (var k = 0, kk = nodes.length; k < kk; k++) {
+        node = /** @type {gmfThemes.GmfGroup|gmfThemes.GmfLayerWMS} */ (
+          nodes[k]);
+
+        // Skip groups within groups
+        if (node.children && node.children.length) {
+          continue;
+        }
+
+        if (node.childLayers &&
+          node.childLayers[0] &&
+          node.childLayers[0].queryable
+        ) {
+          queryableLayersInfo.push({
+            layerNode: node,
+            ogcServer: ogcServers[group.ogcServer]
+          });
+        }
+      }
+    }
+  }
+
+  return queryableLayersInfo;
+};
+
+
+/**
+ * From a queryable layer (WMS layer node), use its associated OGC server
+ * to issue a single WMS GetFeatureInfo request at a specific location on a
+ * specific map to fetch a single feature. If no feature is found, a `null`
+ * value is returned.
+ *
+ * @param {gmf.ObjectEditingQuery.QueryableLayerInfo} layerInfo Queryable layer
+ *     information.
+ * @param {ol.Coordinate} coordinate Coordinate.
+ * @param {ol.Map} map Map.
+ * @return {angular.$q.Promise} Promise.
+ * @export
+ */
+gmf.ObjectEditingQuery.prototype.getFeatureInfo = function(
+  layerInfo,
+  coordinate,
+  map
+) {
+
+  var view = map.getView();
+  var projCode = view.getProjection().getCode();
+  var resolution = /** @type {number} */(view.getResolution());
+  var infoFormat = ngeo.QueryInfoFormatType.GML;
+  var layerNode = layerInfo.layerNode;
+  var layersParam = layerNode.layers.split(',');
+  var ogcServer = layerInfo.ogcServer;
+
+  var format = new ol.format.WMSGetFeatureInfo({
+    layers: layersParam
+  });
+
+  var wmsSource = new ol.source.ImageWMS({
+    url: ogcServer.url,
+    params: {
+      layers: layersParam
+    }
+  });
+
+  var url = /** @type {string} */ (
+    wmsSource.getGetFeatureInfoUrl(coordinate, resolution, projCode, {
+      'INFO_FORMAT': infoFormat,
+      'FEATURE_COUNT': 1,
+      'QUERY_LAYERS': layersParam
+    })
+  );
+
+  return this.http_.get(url).then(
+    function(format, response) {
+      var features = format.readFeatures(response.data);
+      return (features && features[0]) ? features[0] : null;
+    }.bind(this, format)
+  );
+
+};
+
+
+gmf.module.service('gmfObjectEditingQuery', gmf.ObjectEditingQuery);
+
+
+/**
+ * @typedef {{
+ *     ogcServers: (gmfThemes.GmfOgcServers),
+ *     queryableLayerNodes: (Array.<gmfThemes.GmfLayerWMS>)
+ * }}
+ */
+gmf.ObjectEditingQuery.GetQueryableLayerNodesResponse;
+
+
+/**
+ * @typedef {{
+ *     ogcServer: (gmfThemes.GmfOgcServer),
+ *     layerNode: (gmfThemes.GmfLayerWMS)
+ * }}
+ */
+gmf.ObjectEditingQuery.QueryableLayerInfo;

--- a/contribs/gmf/src/services/objecteditingquery.js
+++ b/contribs/gmf/src/services/objecteditingquery.js
@@ -192,7 +192,6 @@ gmf.ObjectEditingQuery.prototype.getFeatureInfo = function(
       return (features && features[0]) ? features[0] : null;
     }.bind(this, format)
   );
-
 };
 
 

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -3,7 +3,6 @@ goog.provide('gmf.Permalink');
 goog.require('gmf');
 goog.require('ngeo.AutoProjection');
 goog.require('gmf.Themes');
-goog.require('gmf.ThemeManager');
 goog.require('gmf.TreeManager');
 goog.require('ngeo.BackgroundEventType');
 goog.require('ngeo.BackgroundLayerMgr');
@@ -73,7 +72,6 @@ gmf.module.value('gmfPermalinkOptions',
  * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
  * @param {ngeo.StateManager} ngeoStateManager The ngeo StateManager service.
  * @param {gmf.Themes} gmfThemes The gmf Themes service.
- * @param {gmf.ThemeManager} gmfThemeManager The gmf ThemeManager service.
  * @param {gmf.TreeManager} gmfTreeManager The gmf gmfTreeManager service.
  * @param {gmfx.PermalinkOptions} gmfPermalinkOptions The options to configure
  *     the gmf permalink service with.
@@ -89,7 +87,7 @@ gmf.module.value('gmfPermalinkOptions',
  */
 gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
     ngeoFeatureOverlayMgr, ngeoFeatureHelper, ngeoFeatures, ngeoLayerHelper,
-    ngeoStateManager, gmfThemes, gmfThemeManager,
+    ngeoStateManager, gmfThemes,
     gmfTreeManager, gmfPermalinkOptions, defaultTheme,
     ngeoLocation, ngeoWfsPermalink, ngeoAutoProjection, $rootScope, $injector) {
 
@@ -179,13 +177,15 @@ gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
    * @type {gmf.ThemeManager}
    * @private
    */
-  this.gmfThemeManager_ = gmfThemeManager;
+  this.gmfThemeManager_ = $injector.has('gmfThemeManager') ?
+    $injector.get('gmfThemeManager') : undefined;
 
   /**
    * @type {gmfx.User|undefined}
    * @private
    */
-  this.gmfUser_ = $injector.has('gmfUser') ? $injector.get('gmfUser') : undefined;
+  this.gmfUser_ = $injector.has('gmfUser') ?
+    $injector.get('gmfUser') : undefined;
 
   /**
    * @type {string}
@@ -364,11 +364,13 @@ gmf.Permalink = function($timeout, ngeoBackgroundLayerMgr, ngeoDebounce,
     }, this);
   }.bind(this));
 
-  $rootScope.$watch(function() {
-    return this.gmfThemeManager_.themeName;
-  }.bind(this), function(name) {
-    this.setThemeInUrl_();
-  }.bind(this));
+  if (this.gmfThemeManager_) {
+    $rootScope.$watch(function() {
+      return this.gmfThemeManager_.themeName;
+    }.bind(this), function(name) {
+      this.setThemeInUrl_();
+    }.bind(this));
+  }
 
   this.initLayers_();
 };
@@ -777,7 +779,7 @@ gmf.Permalink.prototype.themeInUrl_ = function(pathElements) {
  * @private
  */
 gmf.Permalink.prototype.setThemeInUrl_ = function() {
-  if (this.gmfThemeManager_.themeName) {
+  if (this.gmfThemeManager_ && this.gmfThemeManager_.themeName) {
     var pathElements = this.ngeoLocation_.getPath().split('/');
     goog.asserts.assert(pathElements.length > 1);
     if (pathElements[pathElements.length - 1] === '') {
@@ -817,7 +819,7 @@ gmf.Permalink.prototype.initLayers_ = function() {
       // fallback to the default theme
       themeName = this.defaultTheme_;
     }
-    if (this.gmfThemeManager_.modeFlush) {
+    if (this.gmfThemeManager_ && this.gmfThemeManager_.modeFlush) {
       this.gmfThemeManager_.themeName = themeName;
     }
 

--- a/externs/jsts.js
+++ b/externs/jsts.js
@@ -1,0 +1,60 @@
+/**
+ * @const
+ * @suppress {const|duplicate}
+ */
+var jsts = {};
+
+
+/** @const */
+jsts.geom = {};
+
+
+/**
+ * @constructor
+ */
+jsts.geom.Geometry = function() {};
+
+
+/**
+ * @param {number} buffer Buffer in meters.
+ * @return {jsts.geom.Geometry} A JSTS geometry object.
+ */
+jsts.geom.Geometry.prototype.buffer = function(buffer) {};
+
+
+/**
+ * @param {jsts.geom.Geometry} jstsGeom A JSTS geometry object.
+ * @return {jsts.geom.Geometry} A JSTS geometry object.
+ */
+jsts.geom.Geometry.prototype.difference = function(jstsGeom) {};
+
+
+/**
+ * @param {jsts.geom.Geometry} jstsGeom A JSTS geometry object.
+ * @return {jsts.geom.Geometry} A JSTS geometry object.
+ */
+jsts.geom.Geometry.prototype.union = function(jstsGeom) {};
+
+
+/** @const */
+jsts.io = {};
+
+
+/**
+ * @constructor
+ */
+jsts.io.OL3Parser = function() {};
+
+
+/**
+ * @param {ol.geom.Geometry} ol3Geom A OL3 geometry object.
+ * @return {jsts.geom.Geometry} A JSTS geometry object.
+ */
+jsts.io.OL3Parser.prototype.read = function(ol3Geom) {};
+
+
+/**
+ * @param {jsts.geom.Geometry} jstsGeom A JSTS geometry object.
+ * @return {ol.geom.Geometry} A OL3 geometry object.
+ */
+jsts.io.OL3Parser.prototype.write = function(jstsGeom) {};

--- a/externs/ngeox.js
+++ b/externs/ngeox.js
@@ -660,6 +660,43 @@ ngeox.WfsPermalinkOptions.prototype.maxFeatures;
 
 
 /**
+ * DrawRegularPolygonFromClick Interaction
+ * @typedef {{
+ *     angle: (number|undefined),
+ *     radius: (number),
+ *     sides: (number|undefined),
+ * }}
+ */
+ngeox.interaction.DrawRegularPolygonFromClickOptions;
+
+
+/**
+ * Angle in radians. A value of 0 will have one of the shape's point facing up.
+ * Default value is 0.
+ * @type {number|undefined}
+ * @api
+ */
+ngeox.interaction.DrawRegularPolygonFromClickOptions.prototype.angle;
+
+
+/**
+ * Radius size in map units.
+ * @type {number|undefined}
+ * @api
+ */
+ngeox.interaction.DrawRegularPolygonFromClickOptions.prototype.radius;
+
+
+/**
+ * The number of sides for the regular polygon.
+ * Default value is 3.
+ * @type {number|undefined}
+ * @api
+ */
+ngeox.interaction.DrawRegularPolygonFromClickOptions.prototype.sides;
+
+
+/**
  * MobileDraw Interaction
  * @typedef {{
  *     minPoints: (number|undefined),

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gaze": "1.1.2",
     "jasmine-core": "2.5.2",
     "jquery": "2.2.4",
+    "jsts": "1.2.1",
     "angular-ui-date": "1.1.1",
     "angular-ui-slider": "0.3.2",
     "jsdoc": "3.4.3",

--- a/src/directives/createfeature.js
+++ b/src/directives/createfeature.js
@@ -124,11 +124,15 @@ ngeo.CreatefeatureController = function(gettext, $compile, $filter, $scope,
   var interaction;
   var helpMsg;
   var contMsg;
-  if (this.geomType === ngeo.GeometryType.POINT) {
+  if (this.geomType === ngeo.GeometryType.POINT ||
+      this.geomType === ngeo.GeometryType.MULTI_POINT
+  ) {
     interaction = new ol.interaction.Draw({
       type: ol.geom.GeometryType.POINT
     });
-  } else if (this.geomType === ngeo.GeometryType.LINE_STRING) {
+  } else if (this.geomType === ngeo.GeometryType.LINE_STRING ||
+      this.geomType === ngeo.GeometryType.MULTI_LINE_STRING
+  ) {
     helpMsg = gettext('Click to start drawing length');
     contMsg = gettext(
       'Click to continue drawing<br/>' +
@@ -143,7 +147,9 @@ ngeo.CreatefeatureController = function(gettext, $compile, $filter, $scope,
         continueMsg: $compile('<div translate>' + contMsg + '</div>')($scope)[0]
       }
     );
-  } else if (this.geomType === ngeo.GeometryType.POLYGON) {
+  } else if (this.geomType === ngeo.GeometryType.POLYGON ||
+      this.geomType === ngeo.GeometryType.MULTI_POLYGON
+  ) {
     helpMsg = gettext('Click to start drawing area');
     contMsg = gettext(
       'Click to continue drawing<br/>' +

--- a/src/directives/createregularpolygonfromclick.js
+++ b/src/directives/createregularpolygonfromclick.js
@@ -1,0 +1,188 @@
+goog.provide('ngeo.CreateregularpolygonfromclickController');
+goog.provide('ngeo.createregularpolygonfromclickDirective');
+
+goog.require('ngeo');
+goog.require('ngeo.interaction.DrawRegularPolygonFromClick');
+goog.require('ol.Feature');
+
+
+/**
+ * A directive used to draw vector features of a single geometry type using
+ * either a 'draw' or 'measure' interaction. Once a feature is finished being
+ * drawn, it is added to a collection of features.
+ *
+ * The geometry types supported are:
+ *  - Point
+ *  - LineString
+ *  - Polygon
+ *
+ * Example:
+ *
+ *     <a
+ *       href
+ *       translate
+ *       ngeo-btn
+ *       ngeo-createregularpolygonfromclick
+ *       ngeo-createregularpolygonfromclick-active="ctrl.active"
+ *       ngeo-createregularpolygonfromclick-angle="::ctrl.angle"
+ *       ngeo-createregularpolygonfromclick-features="ctrl.features"
+ *       ngeo-createregularpolygonfromclick-map="::ctrl.map"
+ *       ngeo-createregularpolygonfromclick-radius="::ctrl.radius"
+ *       ngeo-createregularpolygonfromclick-sides="::ctrl.sides"
+ *       class="btn btn-default ngeo-createregularpolygonfromclick"
+ *       ng-class="{active: ctrl.active}"
+ *       ng-model="ctrl.active">
+ *     </a>
+ *
+ * @htmlAttribute {boolean} ngeo-createregularpolygonfromclick-active Whether
+ *     the directive is active or not.
+ * @htmlAttribute {number|undefined} ngeo-createregularpolygonfromclick-angle
+ *     Angle in radians. A value of 0 will have one of the shape's point
+ *     facing up. Default value is 0.
+ * @htmlAttribute {ol.Collection} ngeo-createregularpolygonfromclick-features
+ *     The collection of features where to add those created by this directive.
+ * @htmlAttribute {ol.Map} ngeo-createregularpolygonfromclick-map The map.
+ * @htmlAttribute {number} ngeo-createregularpolygonfromclick-radius Radius
+ *     size in map units.
+ * @htmlAttribute {number|undefined} ngeo-createregularpolygonfromclick-sides
+ *     The number of sides for the regular polygon. Default value is 3.
+ * @return {angular.Directive} The directive specs.
+ * @ngInject
+ * @ngdoc directive
+ * @ngname ngeoCreateregularpolygonfromclick
+ */
+ngeo.createregularpolygonfromclickDirective = function() {
+  return {
+    controller: 'ngeoCreateregularpolygonfromclickController',
+    bindToController: true,
+    scope: {
+      'active': '=ngeoCreateregularpolygonfromclickActive',
+      'angle': '<?ngeoCreateregularpolygonfromclickAngle',
+      'features': '=ngeoCreateregularpolygonfromclickFeatures',
+      'map': '=ngeoCreateregularpolygonfromclickMap',
+      'radius': '<ngeoCreateregularpolygonfromclickRadius',
+      'sides': '<?ngeoCreateregularpolygonfromclickSides'
+    },
+    controllerAs: 'crpfcCtrl'
+  };
+};
+
+ngeo.module.directive(
+  'ngeoCreateregularpolygonfromclick',
+  ngeo.createregularpolygonfromclickDirective);
+
+
+/**
+ * @param {!angular.Scope} $scope Scope.
+ * @constructor
+ * @struct
+ * @ngInject
+ * @ngdoc controller
+ * @ngname ngeoCreateregularpolygonfromclickController
+ */
+ngeo.CreateregularpolygonfromclickController = function($scope) {
+
+  // == Scope properties ==
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.active = this.active === true;
+
+  $scope.$watch(
+    function() {
+      return this.active;
+    }.bind(this),
+    function(newVal) {
+      this.interaction_.setActive(newVal);
+    }.bind(this)
+  );
+
+  /**
+   * @type {number|undefined}
+   * @export
+   */
+  this.angle;
+
+  /**
+   * @type {ol.Collection.<ol.Feature>}
+   * @export
+   */
+  this.features;
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
+
+  /**
+   * @type {number}
+   * @export
+   */
+  this.radius;
+
+  /**
+   * @type {number|undefined}
+   * @export
+   */
+  this.sides;
+
+
+  // == Other properties ==
+
+  /**
+   * @type {ngeo.interaction.DrawRegularPolygonFromClick}
+   * @private
+   */
+  this.interaction_ = new ngeo.interaction.DrawRegularPolygonFromClick({
+    angle: this.angle,
+    radius: this.radius,
+    sides: this.sides
+  });
+  this.interaction_.setActive(this.active);
+  this.map.addInteraction(this.interaction_);
+
+  /**
+   * @type {ol.EventsKey}
+   * @private
+   */
+  this.interactionListenerKey_ = ol.events.listen(
+    this.interaction_,
+    ol.interaction.Draw.EventType.DRAWEND,
+    this.handleDrawEnd_,
+    this
+  );
+
+  $scope.$on('$destroy', this.handleDestroy_.bind(this));
+
+};
+
+
+/**
+ * Called when a feature is finished being drawn. Add the feature to the
+ * collection.
+ * @param {ol.interaction.Draw.Event} evt Event.
+ * @private
+ */
+ngeo.CreateregularpolygonfromclickController.prototype.handleDrawEnd_ = function(evt) {
+  var feature = new ol.Feature(evt.feature.getGeometry());
+  this.features.push(feature);
+};
+
+
+/**
+ * Cleanup event listeners and remove the interaction from the map.
+ * @private
+ */
+ngeo.CreateregularpolygonfromclickController.prototype.handleDestroy_ = function() {
+  ol.events.unlistenByKey(this.interactionListenerKey_);
+  this.interaction_.setActive(false);
+  this.map.removeInteraction(this.interaction_);
+};
+
+
+ngeo.module.controller(
+  'ngeoCreateregularpolygonfromclickController',
+  ngeo.CreateregularpolygonfromclickController);

--- a/src/ngeo.js
+++ b/src/ngeo.js
@@ -114,6 +114,21 @@ ngeo.GeometryType = {
    * @type {string}
    * @export
    */
+  MULTI_LINE_STRING: 'MultiLineString',
+  /**
+   * @type {string}
+   * @export
+   */
+  MULTI_POINT: 'MultiPoint',
+  /**
+   * @type {string}
+   * @export
+   */
+  MULTI_POLYGON: 'MultiPolygon',
+  /**
+   * @type {string}
+   * @export
+   */
   POINT: 'Point',
   /**
    * @type {string}

--- a/src/ol-ext/interaction/drawregularpolygonfromclick.js
+++ b/src/ol-ext/interaction/drawregularpolygonfromclick.js
@@ -1,0 +1,151 @@
+goog.provide('ngeo.interaction.DrawRegularPolygonFromClick');
+
+goog.require('ol.Feature');
+goog.require('ol.geom.Circle');
+goog.require('ol.interaction.Draw');
+goog.require('ol.interaction.Interaction');
+
+
+/**
+ * @classdesc
+ * This interactions allows drawing regular polygons of a pre-determined number
+ * of sides and size a a clicked location on the map.
+ *
+ * @constructor
+ * @struct
+ * @fires ol.interaction.Draw.Event
+ * @extends {ol.interaction.Interaction}
+ * @param {ngeox.interaction.DrawRegularPolygonFromClickOptions} options Options
+ * @export
+ */
+ngeo.interaction.DrawRegularPolygonFromClick = function(options) {
+
+  /**
+   * @type {number}
+   * @private
+   */
+  this.angle_ = options.angle !== undefined ? options.angle : 0;
+
+  /**
+   * @type {number}
+   * @private
+   */
+  this.radius_ = options.radius;
+
+  /**
+   * @type {number}
+   * @private
+   */
+  this.sides_ = options.sides !== undefined ? options.sides : 3;
+
+  /**
+   * @type {!Array.<ol.EventsKey>}
+   * @private
+   */
+  this.listenerKeys_ = [];
+
+  ol.interaction.Interaction.call(this, {
+    handleEvent: goog.functions.TRUE
+  });
+
+};
+ol.inherits(
+  ngeo.interaction.DrawRegularPolygonFromClick, ol.interaction.Interaction);
+
+
+/**
+ * Activate or deactivate the interaction.
+ * @param {boolean} active Active.
+ * @export
+ */
+ngeo.interaction.DrawRegularPolygonFromClick.prototype.setActive = function(
+  active
+) {
+
+  ol.interaction.Interaction.prototype.setActive.call(this, active);
+
+  if (this.getMap()) {
+    if (active) {
+      this.enable_();
+    } else {
+      this.disable_();
+    }
+  }
+};
+
+
+/**
+ * @inheritDoc
+ */
+ngeo.interaction.DrawRegularPolygonFromClick.prototype.setMap = function(map) {
+
+  var active = this.getActive();
+
+  var currentMap = this.getMap();
+  if (currentMap && active) {
+    this.disable_();
+  }
+
+  ol.interaction.Interaction.prototype.setMap.call(this, map);
+
+  if (map && active) {
+    this.enable_();
+  }
+
+};
+
+
+/**
+ * Enable the interaction. Called when added to a map AND active.
+ * @private
+ */
+ngeo.interaction.DrawRegularPolygonFromClick.prototype.enable_ = function() {
+  var map = this.getMap();
+  goog.asserts.assert(map, 'Map should be set.');
+  this.listenerKeys_.push(
+    ol.events.listen(
+      map,
+      ol.MapBrowserEvent.EventType.CLICK,
+      this.handleMapClick_,
+      this
+    )
+  );
+};
+
+
+/**
+ * Disable the interaction. Called when removed from a map or deactivated.
+ * @private
+ */
+ngeo.interaction.DrawRegularPolygonFromClick.prototype.disable_ = function() {
+  var map = this.getMap();
+  goog.asserts.assert(map, 'Map should be set.');
+  this.listenerKeys_.forEach(ol.events.unlistenByKey, this);
+  this.listenerKeys_.length = 0;
+};
+
+
+/**
+ * Called the the map is clicked. Create a regular polygon at the clicked
+ * location using the configuration
+ * @param {ol.MapBrowserEvent} evt Map browser event.
+ * @private
+ */
+ngeo.interaction.DrawRegularPolygonFromClick.prototype.handleMapClick_ = function(
+  evt
+) {
+
+  var center = evt.coordinate;
+  var geometry = ol.geom.Polygon.fromCircle(
+    new ol.geom.Circle(center), this.sides_
+  );
+
+  ol.geom.Polygon.makeRegular(geometry, center, this.radius_, this.angle_);
+
+  this.dispatchEvent(
+    new ol.interaction.Draw.Event(
+      ol.interaction.Draw.EventType.DRAWEND,
+      new ol.Feature(geometry)
+    )
+  );
+};

--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -437,15 +437,33 @@ ngeo.FeatureHelper.prototype.getVertexStyle = function(opt_incGeomFunc) {
         return;
       }
 
-      var coordinates;
+      var innerMultiCoordinates;
+      var multiCoordinates = [];
+      var coordinates = [];
+      var i, ii;
       if (geom instanceof ol.geom.LineString) {
-        coordinates = feature.getGeometry().getCoordinates();
-        return new ol.geom.MultiPoint(coordinates);
+        coordinates = geom.getCoordinates();
+      } else if (geom instanceof ol.geom.MultiLineString) {
+        multiCoordinates = geom.getCoordinates();
       } else if (geom instanceof ol.geom.Polygon) {
-        coordinates = feature.getGeometry().getCoordinates()[0];
+        coordinates = geom.getCoordinates()[0];
+      } else if (geom instanceof ol.geom.MultiPolygon) {
+        innerMultiCoordinates = geom.getCoordinates();
+      }
+
+      if (innerMultiCoordinates) {
+        for (i = 0, ii = innerMultiCoordinates.length; i < ii; i++) {
+          multiCoordinates = multiCoordinates.concat(innerMultiCoordinates[i]);
+        }
+      }
+      for (i = 0, ii = multiCoordinates.length; i < ii; i++) {
+        coordinates = coordinates.concat(multiCoordinates[i]);
+      }
+
+      if (coordinates.length) {
         return new ol.geom.MultiPoint(coordinates);
       } else {
-        return feature.getGeometry();
+        return geom;
       }
     };
   }


### PR DESCRIPTION
This PR adds the `gmf-objectediting` and `gmf-objecteditingtools` directives, which includes all possible actions to do:

 * action: save
 * action: undo
 * action: delete
 * tool: draw/add
 * tool: draw/delete
 * tool: triangle
 * tool: copy from
 * tool: delete from

Additionnal features of this PR:

 * show a confirmation message before closing the page if there are unsaved modifications.
 * refresh the WMS layer after save or delete
 * addition of the JSTS library
 * support of Multi geometries in the feature helper
 * addition of `ngeo.interaction.DrawRegularPolygonFromClick` interaction and `ngeo-drawregularpolygonfromclick` directive

## Todo

 * [x] Approve the 'close' behaviour with unsaved changes
 * [x] Wait for PR #1999 to be merged before reviewing this
 * [ ] Review


## Feature not included

The following features are not included in this PR.  They will come in separate PRs.

 * Proper CSS styling of the tools
 * Make the radius of the triangles configurable
 * Use the proper configuration to obtain the queryable layers (currently, all queryable layers are returned)
 * Limit the list of queryable layers to only those of the same geometry type as the feature being edited
 * The list of queryable layers should be hidden and only shown when using the "Copy from" or "Delete from" tools.
 * Make an 'instersect' query before executing a delete process to avoid pushing 'blank' change states of geometries

## Live example

First, you must login.  Then, visit the 'hub' example.  Wait for it to load then click the 'Launch' button.  You can also change a different layer or feature before doing so.

After 'Launch', you'll be able to modify the feature in the map.  You can test:

 * moving the vertices around
 * save
 * undo
 * delete
 * the style is: green if there are no unsaved changes, otherwise it's red
 * close the window with unsaved changes should show a confirmation message
 * after saving or deleting, the WMS layer is refreshed.

**Note** Url to the example is coming soon...