### PR TITLE
Add configurable options for oe-tools draw reg.poly.

### DIFF
--- a/contribs/gmf/examples/objectediting.html
+++ b/contribs/gmf/examples/objectediting.html
@@ -128,6 +128,9 @@
       gmfModule.constant('gmfLayersUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/layers/');
       gmfModule.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
       gmfModule.constant('gmfTreeManagerModeFlush', true);
+      gmfModule.constant('gmfObjectEditingToolsOptions', {
+        regularPolygonRadius: 150
+      });
       gmfModule.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
     </script>
   </body>

--- a/contribs/gmf/externs/gmfx.js
+++ b/contribs/gmf/externs/gmfx.js
@@ -130,6 +130,24 @@ gmfx.MousePositionProjection.prototype.filter;
 
 
 /**
+ * Additional configuration options for the object editing tools directive.
+ * @typedef {{
+ *     regularPolygonRadius: (number|undefined)
+ * }}
+ */
+gmfx.ObjectEditingToolsOptions;
+
+
+/**
+ * The radius of the shapes created by the regular polygon radius creation
+ * tool. Default value is `100`. The value is in map units.
+ * @type {number|undefined}
+ */
+gmfx.ObjectEditingToolsOptions.prototype.regularPolygonRadius;
+
+
+
+/**
  * Configuration options for the permalink service.
  * @typedef {{
  *     crosshairStyle: (Array<(null|ol.style.Style)>|null|ol.FeatureStyleFunction|ol.style.Style|undefined),

--- a/contribs/gmf/src/directives/objecteditingtools.js
+++ b/contribs/gmf/src/directives/objecteditingtools.js
@@ -15,6 +15,15 @@ goog.require('ngeo.ToolActivateMgr');
 
 
 /**
+ * A list of additional options for this directive that are not defined as
+ * html attributes. All keys of this hash are optional. For the complete list
+ * of keys and their possible values, see in gmfx.js, under:
+ * `gmfx.ObjectEditingToolsOptions`.
+ */
+gmf.module.value('gmfObjectEditingToolsOptions', {});
+
+
+/**
  * Directive used to edit the geometry of a single feature using advanced
  * tools.
  *
@@ -203,8 +212,7 @@ gmf.ObjecteditingtoolsController = function($injector, $scope,
   this.triangleAngle = Math.PI / 180 * 90; // 90 degrees
 
   var oeToolsOptions = /** @type {gmfx.ObjectEditingToolsOptions} */ (
-    $injector.has('gmfObjectEditingToolsOptions') ?
-      $injector.get('gmfObjectEditingToolsOptions') : {});
+      $injector.get('gmfObjectEditingToolsOptions'));
 
   /**
    * @type {number}

--- a/contribs/gmf/src/directives/objecteditingtools.js
+++ b/contribs/gmf/src/directives/objecteditingtools.js
@@ -73,6 +73,7 @@ gmf.module.directive('gmfObjecteditingtools', gmf.objecteditingtoolsDirective);
 
 
 /**
+ * @param {angular.$injector} $injector Main injector.
  * @param {!angular.Scope} $scope Scope.
  * @param {ngeo.DecorateInteraction} ngeoDecorateInteraction Decorate
  *     interaction service.
@@ -83,8 +84,8 @@ gmf.module.directive('gmfObjecteditingtools', gmf.objecteditingtoolsDirective);
  * @ngdoc controller
  * @ngname GmfObjecteditingtoolsController
  */
-gmf.ObjecteditingtoolsController = function($scope, ngeoDecorateInteraction,
-    ngeoToolActivateMgr) {
+gmf.ObjecteditingtoolsController = function($injector, $scope,
+    ngeoDecorateInteraction, ngeoToolActivateMgr) {
 
   // == Scope properties ==
 
@@ -201,11 +202,16 @@ gmf.ObjecteditingtoolsController = function($scope, ngeoDecorateInteraction,
    */
   this.triangleAngle = Math.PI / 180 * 90; // 90 degrees
 
+  var oeToolsOptions = /** @type {gmfx.ObjectEditingToolsOptions} */ (
+    $injector.has('gmfObjectEditingToolsOptions') ?
+      $injector.get('gmfObjectEditingToolsOptions') : {});
+
   /**
    * @type {number}
    * @export
    */
-  this.triangleRadius = 100;
+  this.triangleRadius = oeToolsOptions.regularPolygonRadius !== undefined ?
+    oeToolsOptions.regularPolygonRadius : 100;
 
   this.registerTool_('drawTriangleActive',
     gmf.ObjecteditingtoolsController.ProcessType.ADD);


### PR DESCRIPTION
This PR allows to configure the radius of the shapes created by the "draw regular polygon from click" directive within the `gmf-objecteditingtools` directive.