### PR TITLE
ObjectEditing - show list of queryable layers only when needed

### DIFF
--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -182,6 +182,15 @@ gmf.ObjecteditingController = function($scope, $timeout, gettextCatalog,
   this.selectedQueryableLayerInfo;
 
   /**
+   * Whether to show or hide the queryable list of layers. It is shown only
+   * when a tool requires it, which is managed in the `gmf-objecteditingtools`
+   * directive.
+   * @type {boolean}
+   * @export
+   */
+  this.queryableLayerListShown = false;
+
+  /**
    * @type {ngeo.LayerHelper}
    * @private
    */

--- a/contribs/gmf/src/directives/partials/objectediting.html
+++ b/contribs/gmf/src/directives/partials/objectediting.html
@@ -5,10 +5,13 @@
   gmf-objecteditingtools-map="::oeCtrl.map"
   gmf-objecteditingtools-process="oeCtrl.process"
   gmf-objecteditingtools-queryablelayerinfo="oeCtrl.selectedQueryableLayerInfo"
+  gmf-objecteditingtools-requireslayer="oeCtrl.queryableLayerListShown"
   gmf-objecteditingtools-sketchfeatures="::oeCtrl.sketchFeatures">
 </gmf-objecteditingtools>
 
-<div class="form-group">
+<div
+  class="form-group"
+  ng-show="oeCtrl.queryableLayerListShown">
   <select
     class="form-control"
     ng-model="oeCtrl.selectedQueryableLayerInfo"


### PR DESCRIPTION
This PR ensures that the list of querable layers is only visible when a tool that requires it is activated.