### PR TITLE
ObjectEditing - Check intersects b4 deleting

### DIFF
--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -895,12 +895,17 @@ gmf.ObjecteditingController.prototype.handleSketchFeaturesAdd_ = function(evt) {
     if (this.process === gmf.ObjecteditingtoolsController.ProcessType.ADD) {
       jstsProcessedGeom = jstsGeom.union(jstsSketchGeom);
     } else {
-      jstsProcessedGeom = jstsGeom.difference(jstsSketchGeom);
+      if (jstsGeom.intersects(jstsSketchGeom)) {
+        jstsProcessedGeom = jstsGeom.difference(jstsSketchGeom);
+      }
     }
 
-    var processedGeom = this.jstsOL3Parser_.write(jstsProcessedGeom);
-    var multiGeom = gmf.ObjecteditingController.toMultiGeometry_(processedGeom);
-    this.feature.setGeometry(multiGeom.clone());
+    if (jstsProcessedGeom) {
+      var processedGeom = this.jstsOL3Parser_.write(jstsProcessedGeom);
+      var multiGeom = gmf.ObjecteditingController.toMultiGeometry_(
+        processedGeom);
+      this.feature.setGeometry(multiGeom.clone());
+    }
 
   } else if (this.process === gmf.ObjecteditingtoolsController.ProcessType.ADD) {
     this.feature.setGeometry(sketchGeom.clone());

--- a/externs/jsts.js
+++ b/externs/jsts.js
@@ -32,6 +32,13 @@ jsts.geom.Geometry.prototype.difference = function(jstsGeom) {};
 
 /**
  * @param {jsts.geom.Geometry} jstsGeom A JSTS geometry object.
+ * @return {boolean} Whether the geometries intersect with one an other.
+ */
+jsts.geom.Geometry.prototype.intersects = function(jstsGeom) {};
+
+
+/**
+ * @param {jsts.geom.Geometry} jstsGeom A JSTS geometry object.
  * @return {jsts.geom.Geometry} A JSTS geometry object.
  */
 jsts.geom.Geometry.prototype.union = function(jstsGeom) {};


### PR DESCRIPTION
This PR adds the following validation in the ObjectEditing tools that use the 'DELETE' process type:

Before applying the `difference` operator using JSTS, check if the geometries intersect first.  If they don't, no need to apply the `difference`.  This avoids pushing changes of geometries that have no actual changes when deleting.