### PR TITLE
Add gmf-objectediting to OE application

### DIFF
--- a/contribs/gmf/apps/oeedit/index.html
+++ b/contribs/gmf/apps/oeedit/index.html
@@ -66,10 +66,18 @@
           <div ng-show="mainCtrl.oeEditActive" class="row">
             <div class="col-sm-12">
               <div class="gmf-app-tools-content-heading">
-                {{'Object Edititing' | translate}}
+                {{'Object Editing' | translate}}
                 <a class="btn close" ng-click="mainCtrl.oeEditActive = false">&times;</a>
               </div>
-              Edit
+              <gmf-objectediting
+                ng-if="mainCtrl.oeFeature && mainCtrl.oeLayerNodeId"
+                gmf-objectediting-active="mainCtrl.oeActive"
+                gmf-objectediting-feature="mainCtrl.oeFeature"
+                gmf-objectediting-geomtype="::mainCtrl.oeGeomType"
+                gmf-objectediting-layernodeid="::mainCtrl.oeLayerNodeId"
+                gmf-objectediting-map="::mainCtrl.map"
+                gmf-objectediting-sketchfeatures="::mainCtrl.sketchFeatures">
+              </gmf-objectediting>
             </div>
           </div>
         </div>
@@ -169,6 +177,7 @@
     <script src="../../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
     <script src="../../../../node_modules/angular-dynamic-locale/dist/tmhDynamicLocale.js"></script>
     <script src="../../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../../../../node_modules/jsts/dist/jsts.min.js"></script>
     <script src="../../../../node_modules/d3/d3.min.js"></script>
     <script src="../../../../node_modules/file-saver/FileSaver.min.js"></script>
     <script src="/@?main=oeedit/js/controller.js"></script>
@@ -193,7 +202,7 @@
         });
 
         var module = angular.module('app');
-        module.constant('defaultTheme', 'OSM');
+        module.constant('defaultTheme', 'ObjectEditing');
         module.constant('defaultLang', 'en');
         module.constant('langUrls', langUrls);
         module.constant('cacheVersion', cacheVersion);

--- a/contribs/gmf/apps/oeedit/js/controller.js
+++ b/contribs/gmf/apps/oeedit/js/controller.js
@@ -18,6 +18,7 @@ goog.require('ngeo.proj.EPSG2056');
 /** @suppress {extraRequire} */
 goog.require('ngeo.proj.EPSG21781');
 
+/** @suppress {extraRequire} */
 goog.require('gmf.objecteditingDirective');
 goog.require('gmf.ObjectEditingManager');
 goog.require('gmf.Themes');
@@ -37,8 +38,6 @@ goog.require('ol.source.Vector');
  * @export
  */
 app.OEEditController = function($scope, $injector, $timeout) {
-
-  console.log(this);
 
   /**
    * @type {boolean}

--- a/contribs/gmf/examples/objecteditinghub.js
+++ b/contribs/gmf/examples/objecteditinghub.js
@@ -61,6 +61,7 @@ gmfapp.MainController = function($http, $q, $scope, gmfThemes, gmfXSDAttributes)
    * @export
    */
   this.urls = [
+    '../apps/oeedit/',
     'objectediting.html'
   ];
 


### PR DESCRIPTION
This PR is a follow-up of #2037.  It adds the `gmf-objectediting` directive to the OEEdit applicaition.  The hub example is also updated to be able to load the app from there.