### PR TITLE
ObjectEditing - Undo all changes on deactivation

### DIFF
--- a/contribs/gmf/examples/objectediting.html
+++ b/contribs/gmf/examples/objectediting.html
@@ -80,8 +80,7 @@
     <h2>ObjectEditing</h2>
 
     <gmf-objectediting
-      ng-if="ctrl.objectEditingFeature && ctrl.objectEditingLayerNodeId"
-      ng-show="ctrl.objectEditingActive === true"
+      ng-if="ctrl.objectEditingActive === true && ctrl.objectEditingFeature && ctrl.objectEditingLayerNodeId"
       gmf-objectediting-active="ctrl.objectEditingActive"
       gmf-objectediting-feature="ctrl.objectEditingFeature"
       gmf-objectediting-geomtype="::ctrl.objectEditingGeomType"

--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -614,6 +614,8 @@ gmf.ObjecteditingController.prototype.toggle_ = function(active) {
 
   } else {
 
+    this.undoAllChanges_();
+
     keys.forEach(function(key) {
       ol.events.unlistenByKey(key);
     }, this);
@@ -624,6 +626,21 @@ gmf.ObjecteditingController.prototype.toggle_ = function(active) {
   }
 
   this.modify_.setActive(active);
+};
+
+
+/**
+ * Undo all current changes.
+ * @private
+ */
+gmf.ObjecteditingController.prototype.undoAllChanges_ = function() {
+  var clone = gmf.ObjecteditingController.cloneGeometry_(
+    this.geometryChanges_[0]);
+  this.feature.setGeometry(clone);
+
+  this.resetGeometryChanges_();
+  this.dirty = false;
+  this.setFeatureStyle_();
 };
 
 
@@ -961,7 +978,7 @@ gmf.ObjecteditingController.prototype.handleGetQueryableLayersInfo_ = function(
  * @private
  */
 gmf.ObjecteditingController.prototype.handleDestroy_ = function() {
-  this.features.clear();
+  this.features_.clear();
   this.toggle_(false);
   this.unregisterInteractions_();
 };


### PR DESCRIPTION
This PR introduces the 'undoing' of all modifications when deactivating the ObjectEditing directive.