### PR TITLE
ObjectEditing - use metadata for copyable and editable layers

### DIFF
--- a/contribs/gmf/examples/objecteditinghub.js
+++ b/contribs/gmf/examples/objecteditinghub.js
@@ -161,9 +161,11 @@ gmfapp.MainController = function($http, $q, $scope, gmfThemes, gmfXSDAttributes)
         return;
       }
 
+      var i, ii;
+
       // (2) Find OE theme
       var theme;
-      for (var i = 0, ii = themes.length; i < ii; i++) {
+      for (i = 0, ii = themes.length; i < ii; i++) {
         if (themes[i].name === this.themeName) {
           theme = themes[i];
           break;
@@ -185,8 +187,15 @@ gmfapp.MainController = function($http, $q, $scope, gmfThemes, gmfXSDAttributes)
         return;
       }
 
+      var gmfLayerNodes = [];
+      for (i = 0, ii = groupNode.children.length; i < ii; i++) {
+        if (groupNode.children[i].metadata.identifierAttributeField) {
+          gmfLayerNodes.push(groupNode.children[i]);
+        }
+      }
+
       // (5) Set layer nodes
-      this.gmfLayerNodes = groupNode.children;
+      this.gmfLayerNodes = gmfLayerNodes;
 
       // (6) Select 'polygon' for the purpose of simplifying the demo
       this.selectedGmfLayerNode = this.gmfLayerNodes[1];
@@ -205,7 +214,7 @@ gmfapp.MainController.prototype.run = function() {
   var geomType = this.selectedGeomType;
   var feature = this.selectedFeature;
   var layer = this.selectedGmfLayerNode.id;
-  var property = 'name';
+  var property = this.selectedGmfLayerNode.metadata.identifierAttributeField;
   var id = feature.get(property);
 
   var params = {};

--- a/contribs/gmf/externs/gmf-themes.js
+++ b/contribs/gmf/externs/gmf-themes.js
@@ -350,10 +350,25 @@ gmfThemes.GmfMetaData = function() {};
 
 
 /**
+ * Whether the data of of this layer node can be queried in order to be copied
+ * in an other layer.
+ * @type {boolean|undefined}
+ */
+gmfThemes.GmfMetaData.prototype.copyable;
+
+
+/**
  * The disclaimer.
  * @type {string|undefined}
  */
 gmfThemes.GmfMetaData.prototype.disclaimer;
+
+
+/**
+ * The name of the attribute to be used as identifier for the ObjectEditing.
+ * @type {string|undefined}
+ */
+gmfThemes.GmfMetaData.prototype.identifierAttributeField;
 
 
 /**

--- a/contribs/gmf/externs/gmf-themes.js
+++ b/contribs/gmf/externs/gmf-themes.js
@@ -365,13 +365,6 @@ gmfThemes.GmfMetaData.prototype.disclaimer;
 
 
 /**
- * The name of the attribute to be used as identifier for the ObjectEditing.
- * @type {string|undefined}
- */
-gmfThemes.GmfMetaData.prototype.identifierAttributeField;
-
-
-/**
  * The icon URL visible in the layer tree.
  * @type {string|undefined}
  */

--- a/contribs/gmf/src/services/objecteditingquery.js
+++ b/contribs/gmf/src/services/objecteditingquery.js
@@ -62,14 +62,20 @@ gmf.ObjectEditingQuery.prototype.getQueryableLayersInfo = function() {
           return;
         }
 
-        var queryableLayersInfo =
+        // Get all queryable nodes
+        var allQueryableLayersInfo =
             gmf.ObjectEditingQuery.getQueryableLayersInfoFromThemes(
               themes,
               ogcServers
             );
 
-        // FIXME - missing checking of ObjectEditing config. Do this here...
-        // ...
+        // Narrow down to only those that have the 'copyable' metadata set
+        var queryableLayersInfo = [];
+        for (var i = 0, ii = allQueryableLayersInfo.length; i < ii; i++) {
+          if (allQueryableLayersInfo[i].layerNode.metadata.copyable) {
+            queryableLayersInfo.push(allQueryableLayersInfo[i]);
+          }
+        }
 
         this.getQueryableLayerNodesDefered_.resolve(queryableLayersInfo);
       }.bind(this));


### PR DESCRIPTION
This PR make use of the `metadata` available in the layer node (in the themes), to:

 * create a list of only the editable layers in the object editing hub example, i.e. those that have the `identifierAttributeField` metadata.
 * narrow down the list of queryable layers to only those that have the `copyable` metadata