### PR TITLE
Switch to glob2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,10 @@ examples-hosted: \
 		$(patsubst contribs/gmf/examples/%.html,.build/examples-hosted/contribs/gmf/%.html,$(GMF_EXAMPLES_HTML_FILES)) \
 		$(addprefix .build/examples-hosted/contribs/gmf/apps/,$(addsuffix /index.html,$(GMF_APPS)))
 
+.build/python-venv/lib/python2.7/site-packages/glob2: requirements.txt .build/python-venv
+	.build/python-venv/bin/pip install `grep ^glob2== $< --colour=never`
+	touch $@
+
 .build/python-venv/lib/python2.7/site-packages/requests: requirements.txt .build/python-venv
 	.build/python-venv/bin/pip install `grep ^requests== $< --colour=never`
 	touch $@
@@ -809,6 +813,7 @@ $(EXTERNS_JQUERY): github_versions
 # pattern is needed this should be changed.
 .PRECIOUS: .build/templatecache.js
 .build/templatecache.js: buildtools/templatecache.mako.js \
+		.build/python-venv/lib/python2.7/site-packages/glob2 \
 		.build/python-venv/bin/mako-render \
 		$(NGEO_DIRECTIVES_PARTIALS_FILES)
 	PYTHONIOENCODING=UTF-8 .build/python-venv/bin/mako-render \
@@ -817,6 +822,7 @@ $(EXTERNS_JQUERY): github_versions
 
 .PRECIOUS: .build/gmftemplatecache.js
 .build/gmftemplatecache.js: buildtools/templatecache.mako.js \
+		.build/python-venv/lib/python2.7/site-packages/glob2 \
 		.build/python-venv/bin/mako-render \
 		$(NGEO_DIRECTIVES_PARTIALS_FILES) $(GMF_DIRECTIVES_PARTIALS_FILES)
 	PYTHONIOENCODING=UTF-8 .build/python-venv/bin/mako-render \

--- a/buildtools/templatecache.mako.js
+++ b/buildtools/templatecache.mako.js
@@ -8,14 +8,14 @@
 <%
   import re
   import os
-  import glob
+  import glob2
   import htmlmin
   _partials = {}
   for p in partials.strip().split():
       dest_folder, source_folder = p.split(":")
       filenames = []
-      filenames += glob.glob("{}/*.html".format(source_folder))
-      filenames += glob.glob("{}/**/*.html".format(source_folder))
+      filenames += glob2.glob("{}/*.html".format(source_folder))
+      filenames += glob2.glob("{}/**/*.html".format(source_folder))
       for filename in filenames:
           f = file(filename)
           content = unicode(f.read().decode('utf8'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Mako==1.0.6
 htmlmin==0.1.10
 beautifulsoup4==4.5.1
 transifex-client==0.12.2
+glob2==0.5


### PR DESCRIPTION
Python 2.7 glob does not support '**' which is used in the template cache mako file.
Switching to glob2 makes it work automagically.