### PR TITLE
Disable print button while printing

### DIFF
--- a/contribs/gmf/src/directives/partials/print.html
+++ b/contribs/gmf/src/directives/partials/print.html
@@ -183,11 +183,13 @@
       <button
         ng-show="ctrl.fields.formats.png"
         class="btn btn-primary"
+        ng-disabled="ctrl.isState('PRINTING')"
         ng-click="ctrl.print('png')">Image</button>
 
       <button
         ng-show="ctrl.fields.formats.pdf"
         class="btn btn-primary"
+        ng-disabled="ctrl.isState('PRINTING')"
         ng-click="ctrl.print('pdf')">PDF</button>
     </div>
 


### PR DESCRIPTION
This avoids the print service to be killed by users clicking several times in a row on the print buttons

Fixes #2055.