### PR TITLE
Do not write null & undefined values in FeatureHash format

### DIFF
--- a/src/ol-ext/format/featurehash.js
+++ b/src/ol-ext/format/featurehash.js
@@ -1142,7 +1142,10 @@ ngeo.format.FeatureHash.prototype.writeFeatureText = function(feature, opt_optio
        * @param {string} key Key.
        */
       function(value, key) {
-        if (key !== feature.getGeometryName()) {
+        if (value !== undefined &&
+            value !== null &&
+            key !== feature.getGeometryName()
+        ) {
           if (encodedProperties.length !== 0) {
             encodedProperties.push('\'');
           }


### PR DESCRIPTION
This PR fixes the `ngeo.format.FeatureHash` when used with features that have `null` or `undefined` property values.

My use-case is this: I'm using the `ol.format.GPX`, which does the following:

    feature.set('extensionsNode_', undefined);

So, when attempting to use the featurehash format with features written by the gpx format, it fails because of this undefined property.