### PR TITLE
Revert "use https for boundless and opengeo"

### DIFF
--- a/examples/backgroundlayer.js
+++ b/examples/backgroundlayer.js
@@ -149,7 +149,7 @@ app.MainController = function($scope) {
    */
   var overlay = new ol.layer.Image({
     source: new ol.source.ImageWMS({
-      url: 'https://demo.boundlessgeo.com/geoserver/wms',
+      url: 'http://demo.boundlessgeo.com/geoserver/wms',
       params: {'LAYERS': 'topp:states'},
       serverType: 'geoserver'
     })

--- a/examples/backgroundlayerdropdown.js
+++ b/examples/backgroundlayerdropdown.js
@@ -125,7 +125,7 @@ app.MainController = function($scope) {
    */
   var overlay = new ol.layer.Image({
     source: new ol.source.ImageWMS({
-      url: 'https://demo.boundlessgeo.com/geoserver/wms',
+      url: 'http://demo.boundlessgeo.com/geoserver/wms',
       params: {'LAYERS': 'topp:states'},
       serverType: 'geoserver'
     })

--- a/examples/layerloading.js
+++ b/examples/layerloading.js
@@ -39,7 +39,7 @@ app.MainController = function($scope, ngeoDecorateLayerLoading) {
    */
   this.wms = new ol.layer.Image({
     source: new ol.source.ImageWMS({
-      url: 'https://demo.boundlessgeo.com/geoserver/wms',
+      url: 'http://demo.boundlessgeo.com/geoserver/wms',
       params: {'LAYERS': 'topp:states'},
       serverType: 'geoserver'
     })

--- a/examples/layerorder.js
+++ b/examples/layerorder.js
@@ -38,7 +38,7 @@ app.MainController = function($scope, ngeoDecorateLayer, ngeoSyncArrays) {
   /** @type {ol.layer.Tile} */
   var boundaries = new ol.layer.Tile({
     source: new ol.source.TileWMS({
-      url: 'https://demo.opengeo.org/geoserver/wms',
+      url: 'http://demo.opengeo.org/geoserver/wms',
       params: {'LAYERS': 'topp:tasmania_state_boundaries'},
       serverType: 'geoserver'
     })
@@ -48,7 +48,7 @@ app.MainController = function($scope, ngeoDecorateLayer, ngeoSyncArrays) {
   /** @type {ol.layer.Tile} */
   var waterBodies = new ol.layer.Tile({
     source: new ol.source.TileWMS({
-      url: 'https://demo.opengeo.org/geoserver/wms',
+      url: 'http://demo.opengeo.org/geoserver/wms',
       params: {'LAYERS': 'topp:tasmania_water_bodies'},
       serverType: 'geoserver'
     })
@@ -58,7 +58,7 @@ app.MainController = function($scope, ngeoDecorateLayer, ngeoSyncArrays) {
   /** @type {ol.layer.Tile} */
   var cities = new ol.layer.Tile({
     source: new ol.source.TileWMS({
-      url: 'https://demo.opengeo.org/geoserver/wms',
+      url: 'http://demo.opengeo.org/geoserver/wms',
       params: {'LAYERS': 'topp:tasmania_cities'},
       serverType: 'geoserver'
     })
@@ -90,7 +90,7 @@ app.MainController = function($scope, ngeoDecorateLayer, ngeoSyncArrays) {
    */
   this.roads_ = new ol.layer.Tile({
     source: new ol.source.TileWMS({
-      url: 'https://demo.opengeo.org/geoserver/wms',
+      url: 'http://demo.opengeo.org/geoserver/wms',
       params: {'LAYERS': 'topp:tasmania_roads'},
       serverType: 'geoserver'
     })

--- a/examples/layervisibility.js
+++ b/examples/layervisibility.js
@@ -27,7 +27,7 @@ app.MainController = function(ngeoDecorateLayer) {
    */
   this.layer = new ol.layer.Tile({
     source: new ol.source.TileWMS({
-      url: 'https://demo.opengeo.org/geoserver/wms',
+      url: 'http://demo.opengeo.org/geoserver/wms',
       params: {'LAYERS': 'topp:states'},
       serverType: 'geoserver',
       extent: [-13884991, 2870341, -7455066, 6338219]


### PR DESCRIPTION
Related to: #2073

This reverts commit 72dbe4a097e666491b2b46bebd817ec239df96e1.

Seems that the servers was just down (sorry, I was in a hurry, and I'm too suspicious about http url now...)

But do we really want http url in our examples ? Someone know example served with https ?