### PR TITLE
Export symbols and properties from ol required by JSTS

### DIFF
--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -8,6 +8,8 @@ goog.require('gmf.EditFeature');
 goog.require('gmf.ObjectEditingQuery');
 goog.require('ngeo.DecorateInteraction');
 goog.require('ngeo.FeatureHelper');
+/** @suppress {extraRequire} */
+goog.require('ngeo.jstsExports');
 goog.require('ngeo.LayerHelper');
 goog.require('ngeo.ToolActivate');
 goog.require('ngeo.ToolActivateMgr');

--- a/src/ol-ext/jstsexports.js
+++ b/src/ol-ext/jstsexports.js
@@ -1,0 +1,88 @@
+goog.provide('ngeo.jstsExports');
+
+goog.require('ol.geom.Geometry');
+goog.require('ol.geom.GeometryCollection');
+goog.require('ol.geom.LineString');
+goog.require('ol.geom.LinearRing');
+goog.require('ol.geom.MultiLineString');
+goog.require('ol.geom.MultiPoint');
+goog.require('ol.geom.MultiPolygon');
+goog.require('ol.geom.Point');
+goog.require('ol.geom.Polygon');
+
+
+goog.exportSymbol(
+  'ol.geom.Geometry',
+  ol.geom.Geometry);
+
+goog.exportSymbol(
+  'ol.geom.GeometryCollection',
+  ol.geom.GeometryCollection);
+
+goog.exportProperty(
+    ol.geom.GeometryCollection.prototype,
+    'getGeometries',
+    ol.geom.GeometryCollection.prototype.getGeometries);
+
+goog.exportSymbol(
+  'ol.geom.LineString',
+  ol.geom.LineString);
+
+goog.exportProperty(
+  ol.geom.LineString.prototype,
+  'getCoordinates',
+  ol.geom.LineString.prototype.getCoordinates);
+
+goog.exportSymbol(
+  'ol.geom.LinearRing',
+  ol.geom.LinearRing);
+
+goog.exportProperty(
+  ol.geom.LinearRing.prototype,
+  'getCoordinates',
+  ol.geom.LinearRing.prototype.getCoordinates);
+
+goog.exportSymbol(
+  'ol.geom.MultiLineString',
+  ol.geom.MultiLineString);
+
+goog.exportProperty(
+  ol.geom.MultiLineString.prototype,
+  'getLineStrings',
+  ol.geom.MultiLineString.prototype.getLineStrings);
+
+goog.exportSymbol(
+  'ol.geom.MultiPoint',
+  ol.geom.MultiPoint);
+
+goog.exportProperty(
+  ol.geom.MultiPoint.prototype,
+  'getPoints',
+  ol.geom.MultiPoint.prototype.getPoints);
+
+goog.exportSymbol(
+  'ol.geom.MultiPolygon',
+  ol.geom.MultiPolygon);
+
+goog.exportProperty(
+  ol.geom.MultiPolygon.prototype,
+  'getPolygons',
+  ol.geom.MultiPolygon.prototype.getPolygons);
+
+goog.exportSymbol(
+  'ol.geom.Point',
+  ol.geom.Point);
+
+goog.exportProperty(
+  ol.geom.Point.prototype,
+  'getCoordinates',
+  ol.geom.Point.prototype.getCoordinates);
+
+goog.exportSymbol(
+  'ol.geom.Polygon',
+  ol.geom.Polygon);
+
+goog.exportProperty(
+  ol.geom.Polygon.prototype,
+  'getLinearRings',
+  ol.geom.Polygon.prototype.getLinearRings);


### PR DESCRIPTION
JSTS requires some symbols and properties from OpenLayers to work, i.e. the library uses objects and methods from the `ol.geom` namespace.  Nothing gets exported in the ngeo or gmf builds from ol.

This PR introduces a list of symbols and properties that are exported within a file, which gets included where JSTS is used.

Fixes #2066.