### PR TITLE
Remove duplication in angular-gettext externs

### DIFF
--- a/externs/angular-gettext.js
+++ b/externs/angular-gettext.js
@@ -5,7 +5,7 @@
 
 
 /**
- * @typedef {function(string):string}
+ * @typedef {function(string): string}
  */
 var gettext;
 
@@ -17,31 +17,21 @@ var angularGettext = {};
 
 
 /**
- * @typedef {{
- *   currentLanguage: string,
- *   debug: boolean,
- *   getPlural: function(number, string, string, Object.<string, string>=):string,
- *   getStringForm: function(string, number):string,
- *   getString: function(string, Object.<string, string>=),
- *   loadRemote: function(string),
- *   setCurrentLanguage: function(string),
- *   setStrings: function(string, Object.<string, string>),
- *   strings: Object.<string, string>
- *   }}
+ * @interface
  */
-angularGettext.Catalog;
+angularGettext.Catalog = function() {};
 
 
 /**
  * @type {string}
  */
-angularGettext.Catalog.currentLanguage;
+angularGettext.Catalog.prototype.currentLanguage;
 
 
 /**
  * @type {boolean}
  */
-angularGettext.Catalog.debug;
+angularGettext.Catalog.prototype.debug;
 
 
 /**
@@ -51,7 +41,7 @@ angularGettext.Catalog.debug;
  * @param {Object.<string, string>=} opt_context
  * @return {string}
  */
-angularGettext.Catalog.getPlural = function(n, string, stringPlural, opt_context) {};
+angularGettext.Catalog.prototype.getPlural = function(n, string, stringPlural, opt_context) {};
 
 
 /**
@@ -59,7 +49,7 @@ angularGettext.Catalog.getPlural = function(n, string, stringPlural, opt_context
  * @param {number} n
  * @return {string}
  */
-angularGettext.Catalog.getStringForm = function(string, n) {};
+angularGettext.Catalog.prototype.getStringForm = function(string, n) {};
 
 
 /**
@@ -68,34 +58,35 @@ angularGettext.Catalog.getStringForm = function(string, n) {};
  * @param {Object.<string, string>=} opt_context
  * @return {string}
  */
-angularGettext.Catalog.getString = function(string, opt_scope, opt_context) {};
+angularGettext.Catalog.prototype.getString = function(string, opt_scope, opt_context) {};
 
 
 /**
  * @param {string} url
  */
-angularGettext.Catalog.loadRemote = function(url) {};
+angularGettext.Catalog.prototype.loadRemote = function(url) {};
 
 
 /**
  * @param {string} lang
  */
-angularGettext.Catalog.setCurrentLanguage = function(lang) {};
+angularGettext.Catalog.prototype.setCurrentLanguage = function(lang) {};
+
 
 /**
  * @return {string} lang
  */
-angularGettext.Catalog.getCurrentLanguage = function() {};
+angularGettext.Catalog.prototype.getCurrentLanguage = function() {};
 
 
 /**
  * @param {string} language
  * @param {Object.<string, string>} strings
  */
-angularGettext.Catalog.setStrings = function(language, strings) {};
+angularGettext.Catalog.prototype.setStrings = function(language, strings) {};
 
 
 /**
  * @type {Object.<string, string>}
  */
-angularGettext.Catalog.strings;
+angularGettext.Catalog.prototype.strings;


### PR DESCRIPTION
Fix inconsistencies:
- getCurrentLanguage was missing in @typedef
- getString had 2 conflicting definitions

Amendment of #2088