### PR TITLE
Don't use controllerAs in examples

### DIFF
--- a/contribs/gmf/examples/displayquerygrid.js
+++ b/contribs/gmf/examples/displayquerygrid.js
@@ -52,8 +52,7 @@ gmfapp.queryresultDirective = function() {
   return {
     restrict: 'E',
     scope: {},
-    controller: 'gmfappQueryresultController',
-    controllerAs: 'qrCtrl',
+    controller: 'gmfappQueryresultController as qrCtrl',
     bindToController: true,
     templateUrl: 'partials/queryresult.html'
   };

--- a/contribs/gmf/examples/displayquerywindow.js
+++ b/contribs/gmf/examples/displayquerywindow.js
@@ -49,8 +49,7 @@ gmfapp.queryresultDirective = function() {
   return {
     restrict: 'E',
     scope: {},
-    controller: 'AppQueryresultController',
-    controllerAs: 'qrCtrl',
+    controller: 'AppQueryresultController as qrCtrl',
     bindToController: true,
     templateUrl: 'partials/queryresult.html'
   };

--- a/examples/backgroundlayer.js
+++ b/examples/backgroundlayer.js
@@ -37,9 +37,8 @@ app.backgroundlayerDirective = function() {
       'map': '=appBackgroundlayerMap'
     },
     templateUrl: 'partials/backgroundlayer.html',
-    controllerAs: 'ctrl',
     bindToController: true,
-    controller: 'AppBackgroundlayerController'
+    controller: 'AppBackgroundlayerController as ctrl'
   };
 };
 

--- a/examples/backgroundlayerdropdown.js
+++ b/examples/backgroundlayerdropdown.js
@@ -32,9 +32,8 @@ app.backgroundlayerDirective = function() {
       'map': '=appBackgroundlayerMap'
     },
     templateUrl: 'partials/backgroundlayerdropdown.html',
-    controllerAs: 'ctrl',
     bindToController: true,
-    controller: 'AppBackgroundlayerController'
+    controller: 'AppBackgroundlayerController as ctrl'
   };
 };
 

--- a/examples/bboxquery.js
+++ b/examples/bboxquery.js
@@ -36,8 +36,7 @@ app.queryresultDirective = function() {
   return {
     restrict: 'E',
     scope: {},
-    controller: 'AppQueryresultController',
-    controllerAs: 'qrCtrl',
+    controller: 'AppQueryresultController as qrCtrl',
     bindToController: true,
     templateUrl: 'partials/queryresult.html'
   };

--- a/examples/colorpicker.js
+++ b/examples/colorpicker.js
@@ -22,9 +22,8 @@ app.colorpickerDirective = function() {
     restrict: 'E',
     scope: true,
     template: '<div ngeo-colorpicker="ctrl.colors" ngeo-colorpicker-color="mainCtrl.color"></div>',
-    controllerAs: 'ctrl',
     bindToController: true,
-    controller: 'AppColorpickerController'
+    controller: 'AppColorpickerController as ctrl'
   };
 };
 

--- a/examples/layertree.js
+++ b/examples/layertree.js
@@ -35,8 +35,7 @@ app.layertreeDirective = function() {
     scope: {
       'map': '=appLayertreeMap'
     },
-    controller: 'AppLayertreeController',
-    controllerAs: 'ctrl',
+    controller: 'AppLayertreeController as ctrl',
     bindToController: true,
     // use "::ctrl.tree" for the "tree" expression as we know the
     // layer tree won't change

--- a/examples/mapquery.js
+++ b/examples/mapquery.js
@@ -38,8 +38,7 @@ app.queryresultDirective = function() {
   return {
     restrict: 'E',
     scope: {},
-    controller: 'AppQueryresultController',
-    controllerAs: 'qrCtrl',
+    controller: 'AppQueryresultController as qrCtrl',
     bindToController: true,
     templateUrl: 'partials/queryresult.html'
   };

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -40,8 +40,7 @@ app.measuretoolsDirective = function() {
       'map': '=appMeasuretoolsMap',
       'lang': '=appMeasuretoolsLang'
     },
-    controller: 'AppMeasuretoolsController',
-    controllerAs: 'ctrl',
+    controller: 'AppMeasuretoolsController as ctrl',
     bindToController: true,
     templateUrl: 'partials/measuretools.html'
   };

--- a/examples/permalink.js
+++ b/examples/permalink.js
@@ -38,8 +38,7 @@ app.mapDirective = function() {
     scope: {
       'map': '=appMap'
     },
-    controller: 'AppMapController',
-    controllerAs: 'ctrl',
+    controller: 'AppMapController as ctrl',
     bindToController: true,
     template: '<div ngeo-map=ctrl.map></div>'
   };
@@ -114,8 +113,7 @@ app.drawDirective = function() {
       'map': '=appDrawMap',
       'layer': '=appDrawLayer'
     },
-    controller: 'AppDrawController',
-    controllerAs: 'ctrl',
+    controller: 'AppDrawController as ctrl',
     bindToController: true,
     template:
         '<label>Enable drawing:' +

--- a/examples/scaleselector.js
+++ b/examples/scaleselector.js
@@ -33,9 +33,8 @@ app.scaleselectorDirective = function() {
     template: '<div ngeo-scaleselector="ctrl.scales" ' +
         'ngeo-scaleselector-map="ctrl.map" ' +
         'ngeo-scaleselector-options="ctrl.options"></div>',
-    controllerAs: 'ctrl',
     bindToController: true,
-    controller: 'AppScaleselectorController'
+    controller: 'AppScaleselectorController as ctrl'
   };
 };
 

--- a/examples/search.js
+++ b/examples/search.js
@@ -28,9 +28,8 @@ app.searchDirective = function() {
     scope: {
       'map': '=appSearchMap'
     },
-    controller: 'AppSearchController',
+    controller: 'AppSearchController as ctrl',
     bindToController: true,
-    controllerAs: 'ctrl',
     template:
         '<input type="text" placeholder="search…" ' +
         'ngeo-search="ctrl.options" ' +


### PR DESCRIPTION
Simplify the examples by using:
```
controller: 'fooController as ctrl'
```
Instead of:
```
controller: 'fooController',
controllerAs: 'ctrl'
```