### PR TITLE
ObjectEditing - Show 'Cut from' label when tool is active

### DIFF
--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -193,6 +193,18 @@ gmf.ObjecteditingController = function($scope, $timeout, gettextCatalog,
   this.queryableLayerListShown = false;
 
   /**
+   * @type {boolean}
+   * @export
+   */
+  this.copyFromActive = false;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.deleteFromActive = false;
+
+  /**
    * @type {ngeo.LayerHelper}
    * @private
    */

--- a/contribs/gmf/src/directives/objecteditingtools.js
+++ b/contribs/gmf/src/directives/objecteditingtools.js
@@ -31,6 +31,8 @@ gmf.module.value('gmfObjectEditingToolsOptions', {});
  *
  *     <gmf-objecteditingtools
  *         gmf-objecteditingtools-active="ctrl.objectEditingActive"
+ *         gmf-objecteditingtools-copyfromactive="ctrl.objectEditingCopyFromActive"
+ *         gmf-objecteditingtools-deletefromactive="ctrl.objectEditingDeleteFromActive"
  *         gmf-objecteditingtools-feature="ctrl.objectEditingFeature"
  *         gmf-objecteditingtools-geomtype="ctrl.objectEditingGeomType"
  *         gmf-objecteditingtools-map="::ctrl.map"
@@ -42,6 +44,10 @@ gmf.module.value('gmfObjectEditingToolsOptions', {});
  *
  * @htmlAttribute {boolean} gmf-objecteditingtools-active Whether the
  *     directive is active or not.
+ * @htmlAttribute {boolean} gmf-objecteditingtools-copyfromactive Whether the
+ *     'Copy from' tool is active or not.
+ * @htmlAttribute {boolean} gmf-objecteditingtools-deletefromactive Whether the
+ *     'Delete from' tool is active or not.
  * @htmlAttribute {ol.Feature} gmf-objecteditingtools-feature The feature to
  *     edit.
  * @htmlAttribute {string} gmf-objecteditingtools-geomtype The geometry type.
@@ -64,6 +70,8 @@ gmf.objecteditingtoolsDirective = function() {
     controller: 'GmfObjecteditingtoolsController',
     scope: {
       'active': '=gmfObjecteditingtoolsActive',
+      'copyFromActive': '=gmfObjecteditingtoolsCopyfromactive',
+      'deleteFromActive': '=gmfObjecteditingtoolsDeletefromactive',
       'feature': '<gmfObjecteditingtoolsFeature',
       'geomType': '<gmfObjecteditingtoolsGeomtype',
       'map': '<gmfObjecteditingtoolsMap',
@@ -103,6 +111,18 @@ gmf.ObjecteditingtoolsController = function($injector, $scope,
    * @export
    */
   this.active;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.copyFromActive;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.deleteFromActive;
 
   /**
    * @type {ol.Feature}
@@ -224,20 +244,8 @@ gmf.ObjecteditingtoolsController = function($injector, $scope,
   this.registerTool_('drawTriangleActive',
     gmf.ObjecteditingtoolsController.ProcessType.ADD);
 
-  /**
-   * @type {boolean}
-   * @export
-   */
-  this.copyFromActive = false;
-
   this.registerTool_('copyFromActive',
     gmf.ObjecteditingtoolsController.ProcessType.ADD, true);
-
-  /**
-   * @type {boolean}
-   * @export
-   */
-  this.deleteFromActive = false;
 
   this.registerTool_('deleteFromActive',
     gmf.ObjecteditingtoolsController.ProcessType.DELETE, true);

--- a/contribs/gmf/src/directives/partials/objectediting.html
+++ b/contribs/gmf/src/directives/partials/objectediting.html
@@ -1,5 +1,7 @@
 <gmf-objecteditingtools
   gmf-objecteditingtools-active="oeCtrl.toolsActive"
+  gmf-objecteditingtools-copyfromactive="oeCtrl.copyFromActive"
+  gmf-objecteditingtools-deletefromactive="oeCtrl.deleteFromActive"
   gmf-objecteditingtools-feature="oeCtrl.feature"
   gmf-objecteditingtools-geomtype="::oeCtrl.geomType"
   gmf-objecteditingtools-map="::oeCtrl.map"
@@ -12,7 +14,12 @@
 <div
   class="form-group"
   ng-show="oeCtrl.queryableLayerListShown">
-  <label class="control-label">{{'Copy from:' | translate}}</label>
+  <label
+    ng-show="oeCtrl.copyFromActive === true"
+    class="control-label">{{'Copy from:' | translate}}</label>
+  <label
+    ng-show="oeCtrl.deleteFromActive === true"
+    class="control-label">{{'Cut from:' | translate}}</label>
   <select
     class="form-control"
     ng-model="oeCtrl.selectedQueryableLayerInfo"

--- a/contribs/gmf/src/directives/partials/objecteditingtools.html
+++ b/contribs/gmf/src/directives/partials/objecteditingtools.html
@@ -118,7 +118,7 @@
     class="btn btn-sm btn-default gmf-objecteditinggetwmsfeature-delete"
     ng-class="{active: oetCtrl.deleteFromActive}"
     ng-model="oetCtrl.deleteFromActive"
-    title="{{'Delete from external WMS feature' | translate}}">
+    title="{{'Cut from external WMS feature' | translate}}">
     <span
       class="fa fa-scissors gmf-icon-oe-deletefrom">
     </span>


### PR DESCRIPTION
This PR fixes the label of the ObjectEditing 'Delete From' tool, a.k.a 'Cut From'.  The label `Copy from` was previously shown by both 'Copy From' and 'Delete From' tools.