### PR TITLE
ObjectEditing - Fix list of copyable layers with undefined values

### DIFF
--- a/contribs/gmf/src/services/objecteditingquery.js
+++ b/contribs/gmf/src/services/objecteditingquery.js
@@ -214,13 +214,11 @@ gmf.ObjectEditingQuery.GetQueryableLayerNodesResponse;
 
 
 /**
- * @typedef {{
- *     ogcServer: (gmfThemes.GmfOgcServer),
- *     layerNode: (gmfThemes.GmfLayerWMS)
- * }}
+ * @constructor
+ * @struct
  * @export
  */
-gmf.ObjectEditingQuery.QueryableLayerInfo;
+gmf.ObjectEditingQuery.QueryableLayerInfo = function() {};
 
 
 /**

--- a/contribs/gmf/src/services/objecteditingquery.js
+++ b/contribs/gmf/src/services/objecteditingquery.js
@@ -220,3 +220,17 @@ gmf.ObjectEditingQuery.GetQueryableLayerNodesResponse;
  * }}
  */
 gmf.ObjectEditingQuery.QueryableLayerInfo;
+
+
+/**
+ * @type {gmfThemes.GmfOgcServer}
+ * @export
+ */
+gmf.ObjectEditingQuery.QueryableLayerInfo.prototype.ogcServer;
+
+
+/**
+ * @type {gmfThemes.GmfLayerWMS}
+ * @export
+ */
+gmf.ObjectEditingQuery.QueryableLayerInfo.prototype.layerNode;

--- a/contribs/gmf/src/services/objecteditingquery.js
+++ b/contribs/gmf/src/services/objecteditingquery.js
@@ -218,6 +218,7 @@ gmf.ObjectEditingQuery.GetQueryableLayerNodesResponse;
  *     ogcServer: (gmfThemes.GmfOgcServer),
  *     layerNode: (gmfThemes.GmfLayerWMS)
  * }}
+ * @export
  */
 gmf.ObjectEditingQuery.QueryableLayerInfo;
 


### PR DESCRIPTION
This PR fixes the list of copyables layers in the ObjectEditing tools that have 'undefined' values when using minimized code.

## Live demo

 * https://adube.github.io/ngeo/oe-layers-list-undefined/examples/contribs/gmf/objecteditinghub.html