### PR TITLE
ObjectEditing - Ensure multi-geometry on INSERT

### DIFF
--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -936,7 +936,8 @@ gmf.ObjecteditingController.prototype.handleSketchFeaturesAdd_ = function(evt) {
     }
 
   } else if (this.process === gmf.ObjecteditingtoolsController.ProcessType.ADD) {
-    this.feature.setGeometry(sketchGeom.clone());
+    this.feature.setGeometry(
+      gmf.ObjecteditingController.toMultiGeometry_(sketchGeom.clone()));
   }
 
   this.sketchFeatures.clear();


### PR DESCRIPTION
This PR fixes the ObjectEditing directive when it attemps to insert a feature.  The geometry has to be MULTI.