### PR TITLE
Fix layertree parent state

### DIFF
--- a/contribs/gmf/src/services/syncLayertreeMap.js
+++ b/contribs/gmf/src/services/syncLayertreeMap.js
@@ -257,7 +257,7 @@ gmf.SyncLayertreeMap.prototype.createLeafInAMixedGroup_ = function(treeCtrl, map
 /**
  * Update a WMS layer with the given treeCtrl node information. Assumes that
  * the first parent with ogcServer information is linked to the layer to update
- * and that this treeCtrl nod is a leafNode.
+ * and that this treeCtrl node is a leafNode.
  * @param {ngeo.LayertreeController} treeCtrl ngeo layertree controller.
  * @param {ol.Map} map A map that contains the layer to update.
  * @private
@@ -273,6 +273,8 @@ gmf.SyncLayertreeMap.prototype.initGmfLayerInANotMixedGroup_ = function(treeCtrl
   if (leafNode.metadata.isChecked) {
     treeCtrl.setState('on', false);
     this.updateLayerState_(layer, firstLevelGroup);
+  } else {
+    treeCtrl.parent.refreshState();
   }
 };
 


### PR DESCRIPTION
When the first child is checked and there exist another child which
is not checked, the parent was incorrectly checked instead of being
indeterminate.

To avoid this, the parent state is always refreshed.

The root cause is that state management is done too early, when the
layertree controller hierarchy is instanciated.

A more involved fix would be to:
- stop initializing layertrees in their constructors;
- have layertrees register a ready listener on the root layertree;
- have the root layertree triggers an onReady event in its postLink
  function.