### PR TITLE
Add support for multi geometries

### DIFF
--- a/contribs/gmf/src/directives/partials/editfeature.html
+++ b/contribs/gmf/src/directives/partials/editfeature.html
@@ -18,11 +18,23 @@
           <span class="gmf-icon gmf-icon-point"></span>
           {{'Draw new point' | translate}}
         </span>
+        <span ng-switch-when="MultiPoint">
+          <span class="gmf-icon gmf-icon-point"></span>
+          {{'Draw new point' | translate}}
+        </span>
         <span ng-switch-when="LineString">
           <span class="gmf-icon gmf-icon-line"></span>
           {{'Draw new linestring' | translate}}
         </span>
+        <span ng-switch-when="MultiLineString">
+          <span class="gmf-icon gmf-icon-line"></span>
+          {{'Draw new linestring' | translate}}
+        </span>
         <span ng-switch-when="Polygon">
+          <span class="gmf-icon gmf-icon-polygon"></span>
+          {{'Draw new polygon' | translate}}
+        </span>
+        <span ng-switch-when="MultiPolygon">
           <span class="gmf-icon gmf-icon-polygon"></span>
           {{'Draw new polygon' | translate}}
         </span>

--- a/src/directives/createfeature.js
+++ b/src/directives/createfeature.js
@@ -228,7 +228,15 @@ ngeo.CreatefeatureController = function(gettext, $compile, $filter, $scope,
  * @export
  */
 ngeo.CreatefeatureController.prototype.handleDrawEnd_ = function(event) {
-  var feature = new ol.Feature(event.feature.getGeometry());
+  // convert to multi if geomType is multi and feature is not
+  var geometry = event.feature.getGeometry();
+  var type = geometry.getType();
+  if (this.geomType.indexOf('Multi') != type.indexOf('Multi')) {
+    var multiType = 'Multi' +
+        type.substring(type.lastIndexOf('.') + 1, type.length);
+    geometry = new ol.geom[multiType]([geometry.getCoordinates()]);
+  }
+  var feature = new ol.Feature(geometry);
   if (this.features instanceof ol.Collection) {
     this.features.push(feature);
   } else {


### PR DESCRIPTION
This fixes #2084.

The idea is to ensure that the drawn geometry is multi if the geometry type (as defined in the .xsd) is multi as well.