### PR TITLE
Add an utility method to convert geom to multi

### DIFF
--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -11,9 +11,8 @@ goog.require('ngeo.FeatureHelper');
 goog.require('ngeo.LayerHelper');
 goog.require('ngeo.ToolActivate');
 goog.require('ngeo.ToolActivateMgr');
+goog.require('ngeo.utils');
 goog.require('ol.Collection');
-goog.require('ol.geom.MultiLineString');
-goog.require('ol.geom.MultiPoint');
 goog.require('ol.geom.MultiPolygon');
 goog.require('ol.interaction.Modify');
 goog.require('ol.style.Circle');
@@ -689,9 +688,7 @@ gmf.ObjecteditingController.prototype.handleModifyInteractionModifyEnd_ = functi
   if (geometry instanceof ol.geom.MultiPolygon) {
     var jstsGeom = this.jstsOL3Parser_.read(geometry);
     var jstsBuffered = jstsGeom.buffer(0);
-    geometry = gmf.ObjecteditingController.toMultiGeometry_(
-      this.jstsOL3Parser_.write(jstsBuffered)
-    );
+    geometry = ngeo.utils.toMulti(this.jstsOL3Parser_.write(jstsBuffered));
     this.skipGeometryChange_ = true;
     this.feature.setGeometry(geometry.clone());
     this.skipGeometryChange_ = false;
@@ -928,8 +925,7 @@ gmf.ObjecteditingController.prototype.handleSketchFeaturesAdd_ = function(evt) {
 
     if (jstsProcessedGeom) {
       var processedGeom = this.jstsOL3Parser_.write(jstsProcessedGeom);
-      var multiGeom = gmf.ObjecteditingController.toMultiGeometry_(
-        processedGeom);
+      var multiGeom = ngeo.utils.toMulti(processedGeom);
       this.feature.setGeometry(multiGeom.clone());
     }
 
@@ -1016,31 +1012,6 @@ gmf.ObjecteditingController.cloneGeometry_ = function(geometry) {
     clone = geometry.clone();
   }
   return clone;
-};
-
-
-/**
- * Utility method that converts a simple geometry to its multi equivalent. If
- * the geometry itself is already multi, it is returned as-is.
- * @param {ol.geom.Geometry} geometry A geometry
- * @return {ol.geom.Geometry} A multi geometry
- * @private
- */
-gmf.ObjecteditingController.toMultiGeometry_ = function(geometry) {
-  var multiGeom;
-  if (geometry instanceof ol.geom.Point) {
-    multiGeom = new ol.geom.MultiPoint([]);
-    multiGeom.appendPoint(geometry);
-  } else if (geometry instanceof ol.geom.LineString) {
-    multiGeom = new ol.geom.MultiLineString([]);
-    multiGeom.appendLineString(geometry);
-  } else if (geometry instanceof ol.geom.Polygon) {
-    multiGeom = new ol.geom.MultiPolygon([]);
-    multiGeom.appendPolygon(geometry);
-  } else {
-    multiGeom = geometry;
-  }
-  return multiGeom;
 };
 
 

--- a/src/directives/createfeature.js
+++ b/src/directives/createfeature.js
@@ -7,6 +7,7 @@ goog.require('ngeo.EventHelper');
 goog.require('ngeo.filters');
 goog.require('ngeo.interaction.MeasureArea');
 goog.require('ngeo.interaction.MeasureLength');
+goog.require('ngeo.utils');
 goog.require('ol.Feature');
 goog.require('ol.geom.GeometryType');
 goog.require('ol.interaction.Draw');
@@ -232,9 +233,7 @@ ngeo.CreatefeatureController.prototype.handleDrawEnd_ = function(event) {
   var geometry = event.feature.getGeometry();
   var type = geometry.getType();
   if (this.geomType.indexOf('Multi') != type.indexOf('Multi')) {
-    var multiType = 'Multi' +
-        type.substring(type.lastIndexOf('.') + 1, type.length);
-    geometry = new ol.geom[multiType]([geometry.getCoordinates()]);
+    geometry = ngeo.utils.toMulti(geometry);
   }
   var feature = new ol.Feature(geometry);
   if (this.features instanceof ol.Collection) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,32 @@
+goog.provide('ngeo.utils');
+
+goog.require('ol.geom.LineString');
+goog.require('ol.geom.MultiPoint');
+goog.require('ol.geom.MultiLineString');
+goog.require('ol.geom.MultiPolygon');
+goog.require('ol.geom.Point');
+goog.require('ol.geom.Polygon');
+
+
+/**
+ * Utility method that converts a simple geometry to its multi equivalent. If
+ * the geometry itself is already multi, it is returned as-is.
+ * @param {ol.geom.Geometry} geometry A geometry
+ * @return {ol.geom.Geometry} A multi geometry
+ */
+ngeo.utils.toMulti = function(geometry) {
+  var multiGeom;
+  if (geometry instanceof ol.geom.Point) {
+    multiGeom = new ol.geom.MultiPoint([]);
+    multiGeom.appendPoint(geometry);
+  } else if (geometry instanceof ol.geom.LineString) {
+    multiGeom = new ol.geom.MultiLineString([]);
+    multiGeom.appendLineString(geometry);
+  } else if (geometry instanceof ol.geom.Polygon) {
+    multiGeom = new ol.geom.MultiPolygon([]);
+    multiGeom.appendPolygon(geometry);
+  } else {
+    multiGeom = geometry;
+  }
+  return multiGeom;
+};


### PR DESCRIPTION
Fixes #2125

Instead of fixing the closure compile issues due to the fact that `getCoordinates` is not available for `ol.geom.SimpleGeometry` in the code I recently added, I decided to use the utility used in the object editing functionality after moving into ngeo core code.

Please review.