### PR TITLE
Add Bloodhound service for GeoAdmin location search

### DIFF
--- a/buildtools/mako_build.json
+++ b/buildtools/mako_build.json
@@ -54,6 +54,7 @@ _ngeo_folder = '' if ngeo_folder is UNDEFINED else ngeo_folder
       "${_ngeo_folder}externs/angular-dynamic-locale.js",
       "${_ngeo_folder}externs/file-saver.js",
       "${_ngeo_folder}externs/jsts.js",
+      "${_ngeo_folder}externs/geo-admin-api.js",
       ".build/externs/angular-1.5.js",
       ".build/externs/angular-1.5-q_templated.js",
       ".build/externs/angular-1.5-http-promise_templated.js",

--- a/examples/locationsearch.html
+++ b/examples/locationsearch.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>Location-search example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+    <style>
+      #map {
+        width: 600px;
+        height: 400px;
+      }
+      /* CSS stolen from https://github.com/bassjobsen/typeahead.js-bootstrap-css/ */
+      span.twitter-typeahead .tt-menu {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        z-index: 1000;
+        display: none;
+        float: left;
+        min-width: 160px;
+        padding: 5px 0;
+        margin: 2px 0 0;
+        list-style: none;
+        font-size: 14px;
+        text-align: left;
+        background-color: #ffffff;
+        border: 1px solid #cccccc;
+        border: 1px solid rgba(0, 0, 0, 0.15);
+        border-radius: 4px;
+        -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+        box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+        background-clip: padding-box;
+      }
+      span.twitter-typeahead .tt-suggestion {
+        display: block;
+        padding: 3px 20px;
+        margin-bottom: 0px;
+        clear: both;
+        font-weight: normal;
+        line-height: 1.42857143;
+        color: #333333;
+        white-space: nowrap;
+      }
+      span.twitter-typeahead .tt-suggestion.tt-cursor,
+      span.twitter-typeahead .tt-suggestion:hover,
+      span.twitter-typeahead .tt-suggestion:focus {
+        color: #ffffff;
+        text-decoration: none;
+        outline: 0;
+        background-color: #428bca;
+      }
+      span.twitter-typeahead .tt-suggestion button {
+        background: none;
+        border: 0;
+        float: right;
+      }
+      span.twitter-typeahead {
+        width: 100%;
+      }
+      .input-group span.twitter-typeahead {
+        display: block !important;
+      }
+      .input-group span.twitter-typeahead .tt-menu {
+        top: 32px !important;
+      }
+      .input-group.input-group-lg span.twitter-typeahead .tt-menu {
+        top: 44px !important;
+      }
+      .input-group.input-group-sm span.twitter-typeahead .tt-menu {
+        top: 28px !important;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <div class="container-fluid">
+      <div id="map" ngeo-map="ctrl.map"></div>
+      <p>Search for 'lausanne' for example…<p>
+      <app-location-search app-search-map="ctrl.map"></app-location-search>
+      <p id="desc">This example shows how to use the <code><a href="../apidoc/ngeo.searchDirective.html" title="Read our documentation">ngeo-search</a></code> directive
+      together with the <a href="http://api3.geo.admin.ch/services/sdiservices.html#search">GeoAdmin Location Search API</a>.
+    </div>
+    <script src="../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../node_modules/angular/angular.js"></script>
+    <script src="../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="../node_modules/angular-ui-date/dist/date.js"></script>
+    <script src="../node_modules/angular-float-thead/angular-floatThead.js"></script>
+    <script src="../node_modules/floatthead/dist/jquery.floatThead.min.js"></script>
+    <script src="../node_modules/corejs-typeahead/dist/typeahead.bundle.js"></script>
+    <script src="../node_modules/proj4/dist/proj4.js"></script>
+    <script src="/@?main=locationsearch.js"></script>
+    <script src="default.js"></script>
+    <script src="../utils/watchwatchers.js"></script>
+  </body>
+</html>

--- a/examples/locationsearch.js
+++ b/examples/locationsearch.js
@@ -134,13 +134,11 @@ app.SearchController.prototype.createAndInitBloodhound_ = function(ngeoCreateLoc
  * @private
  */
 app.SearchController.select_ = function(event, suggestion, dataset) {
-  var map = /** @type {ol.Map} */ (this.map);
   var feature = /** @type {ol.Feature} */ (suggestion);
-  var bbox = /** @type {ol.Extent} */
-      (feature.get('bbox'));
-  var mapSize = /** @type {ol.Size} */ (map.getSize());
-  map.getView().fit(bbox, mapSize,
-      /** @type {olx.view.FitOptions} */ ({maxZoom: 16}));
+  var bbox = /** @type {ol.Extent} */ (feature.get('bbox'));
+  var mapSize = this.map.getSize();
+  goog.asserts.assert(mapSize !== undefined);
+  this.map.getView().fit(bbox, mapSize, {maxZoom: 16});
 };
 
 

--- a/examples/locationsearch.js
+++ b/examples/locationsearch.js
@@ -1,0 +1,174 @@
+goog.provide('app.locationsearch');
+
+/** @suppress {extraRequire} */
+goog.require('ngeo.mapDirective');
+goog.require('ngeo');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+/** @suppress {extraRequire} */
+goog.require('ngeo.search.createLocationSearchBloodhound');
+goog.require('goog.asserts');
+
+
+/** @type {!angular.Module} **/
+app.module = angular.module('app', [ngeo.module.name]);
+
+
+/**
+ * @return {angular.Directive} Directive Definition Object.
+ * @ngInject
+ */
+app.locationSearchDirective = function() {
+  return {
+    restrict: 'E',
+    scope: {
+      'map': '=appSearchMap'
+    },
+    controller: 'AppSearchController as ctrl',
+    bindToController: true,
+    template:
+        '<input type="text" placeholder="Search…" ' +
+        'ngeo-search="ctrl.options" ' +
+        'ngeo-search-datasets="ctrl.datasets" ' +
+        'ngeo-search-listeners="ctrl.listeners">'
+  };
+};
+
+
+app.module.directive('appLocationSearch', app.locationSearchDirective);
+
+
+/**
+ * @constructor
+ * @param {ngeo.search.CreateLocationSearchBloodhound} ngeoCreateLocationSearchBloodhound Bloodhound service.
+ * @ngInject
+ */
+app.SearchController = function(ngeoCreateLocationSearchBloodhound) {
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
+
+  var limit = 10;
+  /** @type {Bloodhound} */
+  var bloodhoundEngine = this.createAndInitBloodhound_(
+      ngeoCreateLocationSearchBloodhound, limit);
+
+  /**
+   * @type {TypeaheadOptions}
+   * @export
+   */
+  this.options = /** @type {TypeaheadOptions} */ ({
+    highlight: true,
+    hint: undefined,
+    minLength: undefined
+  });
+
+  /**
+   * @type {Array.<TypeaheadDataset>}
+   * @export
+   */
+  this.datasets = [{
+    source: bloodhoundEngine.ttAdapter(),
+    limit: limit,
+    display: function(suggestion) {
+      var feature = /** @type {ol.Feature} */ (suggestion);
+      return feature.get('label_no_html');
+    },
+    templates: {
+      header: function() {
+        return '<div class="ngeo-header">Locations</div>';
+      },
+      suggestion: function(suggestion) {
+        var feature = /** @type {ol.Feature} */ (suggestion);
+        return '<p>' + feature.get('label') + '</p>';
+      }
+    }
+  }];
+
+  /**
+   * @type {ngeox.SearchDirectiveListeners}
+   * @export
+   */
+  this.listeners = /** @type {ngeox.SearchDirectiveListeners} */ ({
+    select: app.SearchController.select_.bind(this)
+  });
+
+};
+
+
+/**
+ * @param {ngeo.search.CreateLocationSearchBloodhound} ngeoCreateLocationSearchBloodhound Bloodhound service.
+ * @param {number} limit Limit.
+ * @return {Bloodhound} The bloodhound engine.
+ * @private
+ */
+app.SearchController.prototype.createAndInitBloodhound_ = function(ngeoCreateLocationSearchBloodhound, limit) {
+  var proj = ol.proj.get('EPSG:3857');
+  goog.asserts.assert(proj !== null);
+  var bloodhound = ngeoCreateLocationSearchBloodhound({
+    targetProjection: proj,
+    limit: limit,
+    origins: 'gazetteer',
+    prepare: function(query, settings) {
+      // in a real application the interface language could be used here
+      var lang = 'fr';
+      settings.url += '&lang=' + lang;
+      return settings;
+    }
+  });
+  bloodhound.initialize();
+  return bloodhound;
+};
+
+
+/**
+ * @param {jQuery.Event} event Event.
+ * @param {Object} suggestion Suggestion.
+ * @param {TypeaheadDataset} dataset Dataset.
+ * @this {app.SearchController}
+ * @private
+ */
+app.SearchController.select_ = function(event, suggestion, dataset) {
+  var map = /** @type {ol.Map} */ (this.map);
+  var feature = /** @type {ol.Feature} */ (suggestion);
+  var bbox = /** @type {ol.Extent} */
+      (feature.get('bbox'));
+  var mapSize = /** @type {ol.Size} */ (map.getSize());
+  map.getView().fit(bbox, mapSize,
+      /** @type {olx.view.FitOptions} */ ({maxZoom: 16}));
+};
+
+
+app.module.controller('AppSearchController', app.SearchController);
+
+
+/**
+ * @constructor
+ * @ngInject
+ */
+app.MainController = function() {
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map = new ol.Map({
+    layers: [
+      new ol.layer.Tile({
+        source: new ol.source.OSM()
+      })
+    ],
+    view: new ol.View({
+      center: [0, 0],
+      zoom: 4
+    })
+  });
+
+};
+
+
+app.module.controller('MainController', app.MainController);

--- a/examples/search.js
+++ b/examples/search.js
@@ -12,6 +12,7 @@ goog.require('ol.layer.Vector');
 goog.require('ol.proj');
 goog.require('ol.source.OSM');
 goog.require('ol.source.Vector');
+goog.require('goog.asserts');
 
 
 /** @type {!angular.Module} **/
@@ -171,16 +172,15 @@ app.SearchController.prototype.createAndInitBloodhound_ = function(ngeoSearchCre
  * @private
  */
 app.SearchController.select_ = function(event, suggestion, dataset) {
-  var map = /** @type {ol.Map} */ (this.map);
   var feature = /** @type {ol.Feature} */ (suggestion);
   var featureGeometry = /** @type {ol.geom.SimpleGeometry} */
       (feature.getGeometry());
-  var mapSize = /** @type {ol.Size} */ (map.getSize());
+  var mapSize = this.map.getSize();
+  goog.asserts.assert(mapSize !== undefined);
   var source = this.vectorLayer_.getSource();
   source.clear(true);
   source.addFeature(feature);
-  map.getView().fit(featureGeometry, mapSize,
-      /** @type {olx.view.FitOptions} */ ({maxZoom: 16}));
+  this.map.getView().fit(featureGeometry, mapSize, {maxZoom: 16});
 };
 
 

--- a/externs/geo-admin-api.js
+++ b/externs/geo-admin-api.js
@@ -1,0 +1,51 @@
+/**
+ * Externs for the GeoAdmin API.
+ * See: http://api3.geo.admin.ch/services/sdiservices.html
+ * @externs
+ */
+
+
+/**
+ * @private
+ * @type {Object}
+ */
+var geoAdminx;
+
+
+/**
+ * Response returned by the Location Search API.
+ * See: http://api3.geo.admin.ch/services/sdiservices.html#id26
+ * @typedef {{
+ *     results: Array.<geoAdminx.SearchLocationResult>
+ * }}
+ */
+geoAdminx.SearchLocationResponse;
+
+
+/**
+ * @typedef {{
+ *     weight: number,
+ *     attrs: geoAdminx.SearchLocationResultAttrs
+ * }}
+ */
+geoAdminx.SearchLocationResult;
+
+
+/**
+ * @typedef {{
+ *     label: string,
+ *     lon: number,
+ *     lat: number,
+ *     detail: string,
+ *     x: number,
+ *     y: number,
+ *     geom_st_box2d: string,
+ *     origin: string,
+ *     geom_quadindex: string,
+ *     layerBodId: (string|undefined),
+ *     featureId: (string|undefined),
+ *     rank: number,
+ *     num: number
+ * }}
+ */
+geoAdminx.SearchLocationResultAttrs;

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -1429,3 +1429,67 @@ ngeox.source.SwisstopoOptions.prototype.format;
  * @type {string}
  */
 ngeox.source.SwisstopoOptions.prototype.timestamp;
+
+
+/**
+ * Namespace.
+ * @type {Object}
+ */
+ngeox.search;
+
+
+/**
+ * @typedef {{
+ *    limit: (number|undefined),
+ *    origins: (string|undefined),
+ *    targetProjection: (!ol.proj.Projection|undefined),
+ *    options: (!BloodhoundOptions|undefined),
+ *    remoteOptions: (!BloodhoundRemoteOptions|undefined),
+ *    prepare: ((function(string, jQueryAjaxSettings):jQueryAjaxSettings)|undefined)
+ * }}
+ */
+ngeox.search.LocationSearchOptions;
+
+
+/**
+ * The maximum number of results to retrieve per request (max. and default limit=50).
+ * @type {number|undefined}
+ */
+ngeox.search.LocationSearchOptions.prototype.limit;
+
+
+/**
+ * A comma separated list of origins.
+ * Possible origins are: zipcode,gg25,district,kantone,gazetteer,address,parcel
+ * Per default all origins are used.
+ * @type {string|undefined}
+ */
+ngeox.search.LocationSearchOptions.prototype.origins;
+
+
+/**
+ * Target projection.
+ * @type {!ol.proj.Projection|undefined}
+ */
+ngeox.search.LocationSearchOptions.prototype.targetProjection;
+
+
+/**
+ * Optional Bloodhound options. If `undefined`, the default Bloodhound config will be used.
+ * @type {!BloodhoundOptions|undefined}
+ */
+ngeox.search.LocationSearchOptions.prototype.options;
+
+
+/**
+ * Optional Bloodhound remote options. Only used if `remote` is not defined in `options`.
+ * @type {!BloodhoundRemoteOptions|undefined}
+ */
+ngeox.search.LocationSearchOptions.prototype.remoteOptions;
+
+
+/**
+ * Optional function to prepare the request.
+ * @type {(function(string, jQueryAjaxSettings):jQueryAjaxSettings)|undefined}
+ */
+ngeox.search.LocationSearchOptions.prototype.prepare;

--- a/src/modules/search/creategeojsonbloodhound.js
+++ b/src/modules/search/creategeojsonbloodhound.js
@@ -8,7 +8,7 @@ goog.require('ol.obj');
 
 /**
  * Provides a function that creates a Bloodhound engine
- * expecting GeoJSON responses from the search web service, and creating
+ * expecting GeoJSON responses from the search web service, which creates
  * `ol.Feature` objects as suggestions.
  *
  * Example:

--- a/src/modules/search/createlocationsearchbloodhound.js
+++ b/src/modules/search/createlocationsearchbloodhound.js
@@ -1,0 +1,154 @@
+/**
+ * @module ngeo location search namespace
+ */
+goog.provide('ngeo.search.createLocationSearchBloodhound');
+
+goog.require('ol.obj');
+goog.require('ol.proj');
+/** @suppress {extraRequire} */
+goog.require('ngeo.proj.EPSG21781');
+goog.require('ol.geom.Point');
+goog.require('ol.Feature');
+
+/**
+ * Provides a function that creates a Bloodhound engine
+ * for the GeoAdmin Location Search API, which creates `ol.Feature` objects
+ * as suggestions.
+ *
+ * See: http://api3.geo.admin.ch/services/sdiservices.html#search
+ *
+ * Example:
+ *
+ *     var bloodhound = ngeoCreateLocationSearchBloodhound({
+ *       targetProjection: ol.proj.get('EPSG:3857'),
+ *       limit: 10
+ *     });
+ *     bloodhound.initialize();
+ *
+ * @typedef {function(ngeox.search.LocationSearchOptions=):Bloodhound}
+ * @ngdoc service
+ * @ngname search.createLocationSearchBloodhound
+ */
+ngeo.search.CreateLocationSearchBloodhound;
+
+
+/**
+ * @param {ngeox.search.LocationSearchOptions=} opt_options Options.
+ * @return {Bloodhound} The Bloodhound object.
+ */
+ngeo.search.createLocationSearchBloodhound = function(opt_options) {
+  var options = opt_options || {};
+
+  var sourceProjection = ol.proj.get('EPSG:21781');
+  var targetProjection = options.targetProjection;
+
+  /**
+   * @param {string} bbox Bbox string.
+   * @return {?ol.Extent} Parsed extent.
+   */
+  var parseBbox = function(bbox) {
+    var regex = /BOX\((.*?) (.*?),(.*?) (.*?)\)/g;
+    var match = regex.exec(bbox);
+    if (match !== null) {
+      return [
+        parseFloat(match[1]),
+        parseFloat(match[2]),
+        parseFloat(match[3]),
+        parseFloat(match[4])
+      ];
+    } else {
+      return null;
+    }
+  };
+
+  var removeHtmlTags = function(label) {
+    return label.replace(/<\/?[ib]>/g, '');
+  };
+
+  var extractName = function(label) {
+    var regex = /<b>(.*?)<\/b>/g;
+    var match = regex.exec(label);
+    if (match !== null) {
+      return match[1];
+    } else {
+      return label;
+    }
+  };
+
+  var bloodhoundOptions = /** @type {BloodhoundOptions} */ ({
+    remote: {
+      url: 'https://api3.geo.admin.ch/rest/services/api/SearchServer?type=locations&searchText=%QUERY',
+      prepare: function(query, settings) {
+        settings.url = settings.url.replace('%QUERY', query);
+        if (options.limit !== undefined) {
+          settings.url += '&limit=' + options.limit;
+        }
+        if (options.origins !== undefined) {
+          settings.url += '&origins=' + options.origins;
+        }
+
+        return (options.prepare !== undefined) ?
+            options.prepare(query, settings) : settings;
+      },
+      transform: function(/** @type{geoAdminx.SearchLocationResponse} */ parsedResponse) {
+        var features = parsedResponse.results.map(function(/** @type{geoAdminx.SearchLocationResult} */ result) {
+          var attrs = result.attrs;
+
+          // note that x and y are switched!
+          var point = new ol.geom.Point([attrs.y, attrs.x]);
+          var bbox = parseBbox(attrs.geom_st_box2d);
+          if (targetProjection !== undefined) {
+            point.transform(sourceProjection, targetProjection);
+            if (bbox !== null) {
+              bbox = ol.proj.transformExtent(bbox, sourceProjection, targetProjection);
+            }
+          }
+
+          attrs['geometry'] = point;
+          attrs['bbox'] = bbox;
+
+          // create a label without HTML tags
+          var label = attrs.label;
+          attrs['label_no_html'] = removeHtmlTags(label);
+          attrs['label_simple'] = extractName(label);
+
+          var feature = new ol.Feature(attrs);
+          feature.setId(attrs.featureId);
+
+          return feature;
+        });
+
+        return features;
+      }
+    },
+    // datumTokenizer is required by the Bloodhound constructor but it
+    // is not used when only a remote is passsed to Bloodhound.
+    datumTokenizer: ol.nullFunction,
+    queryTokenizer: Bloodhound.tokenizers.whitespace
+  });
+
+  // the options objects are cloned to avoid updating the passed object
+  var bhOptions = ol.obj.assign({}, options.options || {});
+  var remoteOptions = ol.obj.assign({}, options.remoteOptions || {});
+
+  if (bhOptions.remote) {
+    // move the remote options to opt_remoteOptions
+    ol.obj.assign(remoteOptions, bhOptions.remote);
+    delete bhOptions.remote;
+  }
+
+  ol.obj.assign(bloodhoundOptions, bhOptions);
+  ol.obj.assign(bloodhoundOptions.remote, remoteOptions);
+
+  return new Bloodhound(bloodhoundOptions);
+};
+
+
+/**
+ * @type {!angular.Module}
+ */
+ngeo.search.createLocationSearchBloodhound.module = angular.module('ngeoCreateLocationSearchBloodhound', []);
+
+ngeo.search.createLocationSearchBloodhound.module.value(
+  'ngeoCreateLocationSearchBloodhound',
+  ngeo.search.createLocationSearchBloodhound);

--- a/src/modules/search/searchmodule.js
+++ b/src/modules/search/searchmodule.js
@@ -5,6 +5,7 @@ goog.provide('ngeo.search.searchModule');
 
 goog.require('ngeo.search.searchDirective');
 goog.require('ngeo.search.createGeoJSONBloodhound');
+goog.require('ngeo.search.createLocationSearchBloodhound');
 
 
 /**
@@ -12,5 +13,6 @@ goog.require('ngeo.search.createGeoJSONBloodhound');
  */
 ngeo.search.searchModule.module = angular.module('ngeoSearchModule', [
   ngeo.search.searchDirective.module.name,
-  ngeo.search.createGeoJSONBloodhound.module.name
+  ngeo.search.createGeoJSONBloodhound.module.name,
+  ngeo.search.createLocationSearchBloodhound.module.name
 ]);

--- a/test/spec/beforeeach.js
+++ b/test/spec/beforeeach.js
@@ -1,3 +1,42 @@
+/*eslint valid-jsdoc: 0 */
 beforeEach(function() {
   module('ngeo');
+
+  jasmine.addMatchers({
+    /**
+     * A matcher similar to `expect(...).toBeCloseTo(...)` to check that
+     * numbers in two arrays are almost equal.
+     */
+    arrayToBeCloseTo: function(util, customEqualityTesters) {
+      return {
+        compare: function(actual, expected, precision) {
+          if (precision !== 0) {
+            precision = precision || 2;
+          }
+
+          if (expected === undefined) {
+            expected = [];
+          }
+
+          var result = {pass: true};
+
+          var len1 = actual.length;
+          if (len1 !== expected.length) {
+            result.pass = false;
+          } else {
+            for (var i = 0; i < len1; i++) {
+              if (!(Math.abs(actual[i] - expected[i]) < (Math.pow(10, -precision) / 2))) {
+                result.pass = false;
+                break;
+              }
+            }
+          }
+
+          result.message =  'expected ' + actual + ' to sort of equal ' + expected;
+
+          return result;
+        }
+      };
+    }
+  });
 });

--- a/test/spec/data/geoAdminLocationSearch.js
+++ b/test/spec/data/geoAdminLocationSearch.js
@@ -1,0 +1,96 @@
+/*eslint no-unused-vars: ["error", { "varsIgnorePattern": "geoAdminLocationSearch" }] */
+goog.provide('ngeo.test.data.geoAdminLocationSearch');
+
+var geoAdminLocationSearch = {
+  'results': [{
+    'id': 1883,
+    'weight': 9,
+    'attrs': {
+      'origin': 'gg25',
+      'geom_quadindex': '02',
+      'layerBodId': 'ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill',
+      'featureId': '5586',
+      'lon': 6.695578575134277,
+      'detail': 'lausanne vd',
+      'rank': 2,
+      'geom_st_box2d': 'BOX(534438.41 150654.78125,544978.329999998 161554.030000001)',
+      'lat': 46.553794860839844,
+      'num': 1,
+      'y': 543016.4375,
+      'x': 156104.765625,
+      'label': '<i>Populated Place</i> <b>Lausanne</b> (VD) - Lausanne'
+    }
+  }, {
+    'id': 1878,
+    'weight': 6,
+    'attrs': {
+      'origin': 'gg25',
+      'geom_quadindex': '0212222',
+      'layerBodId': 'ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill',
+      'featureId': '5581',
+      'lon': 6.686537265777588,
+      'detail': 'belmont-sur-lausanne vd',
+      'rank': 2,
+      'geom_st_box2d': 'BOX(541059.5 151614.48,544169.140000001 154495.620000001)',
+      'lat': 46.526302337646484,
+      'num': 1,
+      'y': 542293.75,
+      'x': 153055.0625,
+      'label': '<b>Belmont-sur-Lausanne (VD)</b>'
+    }
+  }, {
+    'id': 1879,
+    'weight': 6,
+    'attrs': {
+      'origin': 'gg25',
+      'geom_quadindex': '0203331',
+      'layerBodId': 'ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill',
+      'featureId': '5582',
+      'lon': 6.599144458770752,
+      'detail': 'cheseaux-sur-lausanne vd',
+      'rank': 2,
+      'geom_st_box2d': 'BOX(533834.153749999 158224.57,537011.092500001 160929.420000002)',
+      'lat': 46.584373474121094,
+      'num': 1,
+      'y': 535657.75,
+      'x': 159578.53125,
+      'label': '<b>Cheseaux-sur-Lausanne (VD)</b>'
+    }
+  }, {
+    'id': 1890,
+    'weight': 6,
+    'attrs': {
+      'origin': 'gg25',
+      'geom_quadindex': '020333',
+      'layerBodId': 'ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill',
+      'featureId': '5592',
+      'lon': 6.608593940734863,
+      'detail': 'romanel-sur-lausanne vd',
+      'rank': 2,
+      'geom_st_box2d': 'BOX(535327.260000002 155630.510000002,537220.43 157952.949999999)',
+      'lat': 46.55949401855469,
+      'num': 1,
+      'y': 536352.75,
+      'x': 156805.0625,
+      'label': '<b>Romanel-sur-Lausanne (VD)</b>'
+    }
+  }, {
+    'id': 1885,
+    'weight': 6,
+    'attrs': {
+      'origin': 'gg25',
+      'geom_quadindex': '02',
+      'layerBodId': 'ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill',
+      'featureId': '5587',
+      'lon': 6.639688968658447,
+      'detail': 'le mont-sur-lausanne vd',
+      'rank': 2,
+      'geom_st_box2d': 'BOX(536937.07 154491.710000001,540385.440000001 158954.309999999)',
+      'lat': 46.55897521972656,
+      'num': 1,
+      'y': 538736.375,
+      'x': 156722.671875,
+      'label': '<b>Le Mont-sur-Lausanne (VD)</b>'
+    }
+  }]
+};

--- a/test/spec/modules/search/createlocationsearchbloodhound.spec.js
+++ b/test/spec/modules/search/createlocationsearchbloodhound.spec.js
@@ -1,0 +1,36 @@
+/* global geoAdminLocationSearch */
+goog.require('ngeo.search.createLocationSearchBloodhound');
+goog.require('ngeo.test.data.geoAdminLocationSearch');
+
+describe('ngeo.search.createLocationSearchBloodhound', function() {
+
+  var ngeoCreateLocationSearchBloodhound;
+
+  beforeEach(function() {
+    inject(function($injector) {
+      ngeoCreateLocationSearchBloodhound = $injector.get('ngeoCreateLocationSearchBloodhound');
+    });
+  });
+
+  it('Parses the features correctly', function() {
+    var bloodhound = ngeoCreateLocationSearchBloodhound({
+      targetProjection: ol.proj.get('EPSG:3857'),
+      limit: 5
+    });
+    var transform = bloodhound.remote.transform;
+
+    var features = transform(geoAdminLocationSearch);
+    expect(features.length).toBe(5);
+
+    var feature = features[0];
+    expect(feature.getId(), '5586');
+    expect(feature.get('label')).toBe('<i>Populated Place</i> <b>Lausanne</b> (VD) - Lausanne');
+    expect(feature.get('label_no_html')).toBe('Populated Place Lausanne (VD) - Lausanne');
+    expect(feature.get('label_simple')).toBe('Lausanne');
+
+    expect(feature.getGeometry().getCoordinates()).arrayToBeCloseTo(
+        [745348.9689, 5869543.2550]);
+    expect(feature.get('bbox')).arrayToBeCloseTo(
+        [732811.7205, 5861483.7511, 748269.0879, 5877508.3355]);
+  });
+});


### PR DESCRIPTION
This PR proposes to add a service for the [GeoAdmin location search](http://api3.geo.admin.ch/services/sdiservices.html#search) which creates a Bloodhound object that parses the response from the location service and creates features (similar to the `createGeoJSONBloodhound` service).