### PR TITLE
ObjectEditing - Fix save requests after insert

### DIFF
--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -527,13 +527,22 @@ gmf.ObjecteditingController.prototype.handleDeleteFeature_ = function(resp) {
  * @private
  */
 gmf.ObjecteditingController.prototype.handleEditFeature_ = function(resp) {
+  // (1) Update the id
+  var features = new ol.format.GeoJSON().readFeatures(resp.data);
+  if (features.length) {
+    this.feature.setId(features[0].getId());
+  }
+  // (2) Reset geometry changes
   this.resetGeometryChanges_();
+  // (3) Update state
   if (this.feature.getGeometry()) {
     this.state_ = gmf.ObjecteditingController.State.UPDATE;
   } else {
     this.state_ = gmf.ObjecteditingController.State.INSERT;
   }
+  // (4) No longer pending
   this.pending = false;
+  // (5) Refresh WMS layer
   this.refreshWMSLayer_();
 };
 

--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -14,6 +14,7 @@ goog.require('ngeo.LayerHelper');
 goog.require('ngeo.ToolActivate');
 goog.require('ngeo.ToolActivateMgr');
 goog.require('ol.Collection');
+goog.require('ol.format.GeoJSON');
 goog.require('ol.geom.MultiLineString');
 goog.require('ol.geom.MultiPoint');
 goog.require('ol.geom.MultiPolygon');


### PR DESCRIPTION
After inserting a new feature in the ObjectEditing tool, the id returned in the JSON was not stored in the existing feature.  Therefore, further actions were not working because they require the id.

This fixes this issue.