### PR TITLE
Better management of print field values

### DIFF
--- a/contribs/gmf/examples/print.html
+++ b/contribs/gmf/examples/print.html
@@ -194,7 +194,8 @@
           </div>
           <gmf-print
             gmf-print-map="ctrl.map"
-            gmf-print-active="printActive">
+            gmf-print-active="printActive"
+            gmf-print-fieldvalues="ctrl.defaulPrintFieldstValues">
           </gmf-print>
         </div>
       </div>

--- a/contribs/gmf/examples/print.js
+++ b/contribs/gmf/examples/print.js
@@ -65,6 +65,15 @@ gmfapp.MainController = function(gmfThemes, ngeoFeatureOverlayMgr) {
   });
 
   /**
+   * @type {Object.<string, string|number|boolean>}
+   * export
+   */
+  this.defaulPrintFieldstValues = {
+    'comments': 'Default comments example',
+    'legend': true
+  };
+
+  /**
    * @type {Array.<Object>|undefined}
    * export
    */

--- a/contribs/gmf/src/directives/print.js
+++ b/contribs/gmf/src/directives/print.js
@@ -90,7 +90,7 @@ gmf.module.value('gmfPrintTemplateUrl',
  *     gmf-print-fieldvalues optional. Key, value object to define default
  *     value in each of your print panel field. The key refers to the
  *     property's name of the field.
- *     Example: {'comments': 'demo', 'legend': false}. Don't work for the dpi
+ *     Example: {'comments': 'demo', 'legend': false}. Doesn't work for the dpi
  *     and the scale. Server's values are used in priorty.
  * @param {string|function(!angular.JQLite=, !angular.Attributes=)}
  *     gmfPrintTemplateUrl Template url for the directive.
@@ -490,10 +490,10 @@ gmf.PrintController.prototype.updateFields_ = function() {
   this.updateCustomFields_();
 
   var legend = this.isAttributeInCurrentLayout_('legend');
-  var customLegendField = this.fieldValues_['legend'] !== undefined ?
-      false : true; // default is true, so if it's defined it's to get false.
-  this.fields.legend = legend !== null ?
-      this.fields.legend || customLegendField : undefined;
+  if (this.fields.legend === undefined) {
+    this.fields.legend = !!(legend !== undefined ?
+        legend : this.fieldValues_['legend']);
+  }
 
   this.fields.scales = clientInfo['scales'] || [];
   this.fields.dpis = clientInfo['dpiSuggestions'] || [];
@@ -533,7 +533,9 @@ gmf.PrintController.prototype.updateCustomFields_ = function() {
   this.layout_.attributes.forEach(function(attribute) {
     if (!attribute['clientParams']) {
       name = '' + attribute.name;
-      value = attribute.default || this.fieldValues_[name];
+      var defaultValue = attribute.default;
+      value = (defaultValue !== undefined && defaultValue !== '') ?
+          defaultValue : this.fieldValues_[name];
 
       // Try to use existing form field type
       rawType = '' + attribute.type;
@@ -546,6 +548,8 @@ gmf.PrintController.prototype.updateCustomFields_ = function() {
           break;
         case 'Number':
           type = 'number';
+          value = parseFloat(value);
+          value = isNaN(value) ? 0 : value;
           break;
         default:
           type = rawType;


### PR DESCRIPTION
Fix #2141 + example of the attribute `gmf-print-fieldvalues` (in the example page)

Example: https://ger-benjamin.github.io/ngeo/print_values/examples/contribs/gmf/apps/desktop_alt/