### PR TITLE
Add viewport meta in desktop and desktop_alt

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>{{'Desktop Application'|translate}}</title>
     <meta charset="utf-8">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
     <link rel="shortcut icon" href="image/favicon.ico"/>
     <link rel="stylesheet" href="../../build/desktop.css">
   </head>

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>{{'Alternative Desktop Application'|translate}}</title>
     <meta charset="utf-8">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
     <link rel="shortcut icon" href="image/favicon.ico"/>
     <link rel="stylesheet" href="../../build/desktop_alt.css">
   </head>


### PR DESCRIPTION
See #2082 

Improve touch support in desktop and desktop_alt

demo: https://camptocamp.github.io/ngeo/desktop_viewport/examples/contribs/gmf/apps/desktop