### PR TITLE
Fix colorpicker colors array input binding.

### DIFF
--- a/src/directives/colorpicker.js
+++ b/src/directives/colorpicker.js
@@ -77,7 +77,7 @@ ngeo.ColorpickerController = function($scope, $element, $attrs) {
    * @type {Array.<Array.<string>>}
    * @export
    */
-  this.colors = defaultColors;
+  this.colors = this.colors || defaultColors;
 
   /**
    * The selected color


### PR DESCRIPTION
The `colorPicker` directive didn't take the input colors array.