### PR TITLE
Work-around for download on Safari

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -281,7 +281,6 @@
         module.constant('authenticationBaseUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi');
         module.constant('fulltextsearchUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/fulltextsearch?limit=30&partitionlimit=5&interface=desktop');
         module.constant('gmfRasterUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/raster');
-        module.constant('gmfProfileCsvUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/profile.csv');
         module.constant('gmfProfileJsonUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/profile.json');
         module.constant('gmfPrintUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/printproxy');
         module.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background&interface=desktop');

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -297,7 +297,6 @@
         module.constant('fulltextsearchUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/fulltextsearch?limit=30&partitionlimit=5&interface=desktop');
         module.constant('gmfRasterUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/raster');
         module.constant('gmfPrintUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/printproxy');
-        module.constant('gmfProfileCsvUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/profile.csv');
         module.constant('gmfProfileJsonUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/profile.json');
         module.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background&interface=desktop');
         module.constant('gmfLayersUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/layers/');

--- a/contribs/gmf/apps/oeedit/index.html
+++ b/contribs/gmf/apps/oeedit/index.html
@@ -209,7 +209,6 @@
         module.constant('authenticationBaseUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi');
         module.constant('fulltextsearchUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/fulltextsearch?limit=30&partitionlimit=5&interface=desktop');
         module.constant('gmfRasterUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/raster');
-        module.constant('gmfProfileCsvUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/profile.csv');
         module.constant('gmfProfileJsonUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/profile.json');
         module.constant('gmfPrintUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/printproxy');
         module.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background&interface=desktop');

--- a/contribs/gmf/apps/oeview/index.html
+++ b/contribs/gmf/apps/oeview/index.html
@@ -165,7 +165,6 @@
         module.constant('authenticationBaseUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi');
         module.constant('fulltextsearchUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/fulltextsearch?limit=30&partitionlimit=5&interface=desktop');
         module.constant('gmfRasterUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/raster');
-        module.constant('gmfProfileCsvUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/profile.csv');
         module.constant('gmfProfileJsonUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/profile.json');
         module.constant('gmfPrintUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/printproxy');
         module.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background&interface=desktop');

--- a/contribs/gmf/examples/profile.html
+++ b/contribs/gmf/examples/profile.html
@@ -89,6 +89,7 @@
     <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
     <script src="../../../node_modules/proj4/dist/proj4.js"></script>
     <script src="../../../node_modules/d3/d3.js"></script>
+    <script src="../../../node_modules/file-saver/FileSaver.min.js"></script>
     <script src="/@?main=profile.js"></script>
     <script src="default.js"></script>
     <script src="../../../utils/watchwatchers.js"></script>

--- a/contribs/gmf/examples/profile.js
+++ b/contribs/gmf/examples/profile.js
@@ -25,10 +25,6 @@ gmfapp.module.value(
     'gmfProfileJsonUrl',
     'https://geomapfish-demo.camptocamp.net/2.1/wsgi/profile.json');
 
-gmfapp.module.value(
-    'gmfProfileCsvUrl',
-    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/profile.csv');
-
 /**
  * @param {angular.Scope} $scope Angular scope.
  * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr Feature overlay

--- a/contribs/gmf/src/directives/profile.js
+++ b/contribs/gmf/src/directives/profile.js
@@ -2,7 +2,7 @@ goog.provide('gmf.ProfileController');
 goog.provide('gmf.profileDirective');
 
 goog.require('gmf');
-goog.require('ngeo.Download');
+goog.require('ngeo.CsvDownload');
 goog.require('ngeo.FeatureOverlayMgr');
 /** @suppress {extraRequire} */
 goog.require('ngeo.profileDirective');
@@ -33,7 +33,7 @@ ngeo.module.value('gmfProfileTemplateUrl',
  * LineString geometry to request the c2cgeoportal profile.json service. The
  * raster used in the request are the keys of the 'linesconfiguration' object.
  * The 'map' attribute is optional and are only used to display on the map the
- * informations that concerne the hovered point (in the profile and on the map)
+ * information that concern the hovered point (in the profile and on the map)
  * of the line.
  * This profile relies on the ngeo.profile (d3) and ngeo.ProfileDirective.
  *
@@ -102,8 +102,7 @@ gmf.module.directive('gmfProfile', gmf.profileDirective);
  * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr Feature overlay
  *     manager.
  * @param {string} gmfProfileJsonUrl URL of GMF service JSON profile.
- * @param {string} gmfProfileCsvUrl URL of GMF service CSV profile.
- * @param {ngeo.Download} ngeoDownload Download service.
+ * @param {ngeo.CsvDownload} ngeoCsvDownload CSV Download service.
  * @constructor
  * @export
  * @ngInject
@@ -112,7 +111,7 @@ gmf.module.directive('gmfProfile', gmf.profileDirective);
  */
 gmf.ProfileController = function($scope, $http, $element, $filter,
     gettextCatalog, ngeoFeatureOverlayMgr, gmfProfileJsonUrl,
-    gmfProfileCsvUrl, ngeoDownload) {
+    ngeoCsvDownload) {
 
   /**
    * @type {angular.Scope}
@@ -157,17 +156,10 @@ gmf.ProfileController = function($scope, $http, $element, $filter,
   this.gmfProfileJsonUrl_ = gmfProfileJsonUrl;
 
   /**
-   * @type {string}
+   * @type {ngeo.CsvDownload}
    * @private
    */
-  this.gmfProfileCsvUrl_ = gmfProfileCsvUrl;
-
-  /**
-   * Download service.
-   * @type {ngeo.Download}
-   * @private
-   */
-  this.ngeoDownload_ = ngeoDownload;
+  this.ngeoCsvDownload_ = ngeoCsvDownload;
 
   var map = null;
   var mapFn = this['getMapFn'];
@@ -678,48 +670,40 @@ gmf.ProfileController.prototype.downloadCsv = function() {
   if (this.profileData.length === 0) {
     return;
   }
-  var geom = {
-    'type': 'LineString',
-    'coordinates': this.line.getCoordinates()
-  };
 
-  var params = {
-    'layers': this.layersNames_.join(','),
-    'geom': JSON.stringify(geom),
-    'nbPoints': this.nbPoints_
-  };
+  /** @type {Array.<ngeox.GridColumnDef>} */
+  var headers = [];
+  var hasDistance = false;
+  var firstPoint = this.profileData[0];
+  if ('dist' in firstPoint) {
+    headers.push({name: 'distance'});
+    hasDistance = true;
+  }
+  var layers = [];
+  for (var layer in firstPoint['values']) {
+    headers.push({'name': layer});
+    layers.push(layer);
+  }
+  headers.push({name: 'x'});
+  headers.push({name: 'y'});
 
-  /** @type {Function} */ (this.$http_)({
-    url: this.gmfProfileCsvUrl_,
-    method: 'POST',
-    params: params,
-    paramSerializer: '$httpParamSerializerJQLike',
-    headers: {
-      'Content-Type': 'text/csv;'
+  var rows = this.profileData.map(function(point) {
+    var row = {};
+    if (hasDistance) {
+      row['distance'] = point['dist'];
     }
-  }).then(
-    this.getCsvSuccess_.bind(this),
-    this.getCsvError_.bind(this)
-  );
-};
 
+    layers.forEach(function(layer) {
+      row[layer] = point['values'][layer];
+    });
 
-/**
- * @param {!angular.$http.Response} resp Response.
- * @private
- */
-gmf.ProfileController.prototype.getCsvSuccess_ = function(resp) {
-  this.ngeoDownload_(resp.data, 'profile.csv', 'attachment/csv;charset=utf-8');
-};
+    row['x'] = point['x'];
+    row['y'] = point['y'];
 
+    return row;
+  });
 
-/**
- * @param {!angular.$http.Response} resp Response.
- * @private
- */
-gmf.ProfileController.prototype.getCsvError_ = function(resp) {
-  this.isErrored = true;
-  console.error('Can not get CSV profile.');
+  this.ngeoCsvDownload_.startDownload(rows, headers, 'profile.csv');
 };
 
 

--- a/contribs/gmf/test/spec/directives/profile.spec.js
+++ b/contribs/gmf/test/spec/directives/profile.spec.js
@@ -1,0 +1,122 @@
+goog.require('gmf.ProfileController');
+
+
+describe('gmf.GmfProfileController', function() {
+
+  var profileController;
+  var csvDownloadServiceMock;
+  var $scope;
+  var $rootScope;
+
+  beforeEach(function() {
+    module('ngeo', function($provide) {
+      $provide.value('gmfProfileJsonUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/profile.json');
+      csvDownloadServiceMock = {
+        startDownload: function(data, columnDefs, fileName) {}
+      };
+    });
+
+    inject(function($injector, _$controller_, _$rootScope_) {
+      var $controller = _$controller_;
+      $rootScope = _$rootScope_;
+      $scope = $rootScope.$new();
+      var data = {
+        getLinesConfigurationFn: function() {
+          return {
+            'aster': {
+              'color':'#0404A0'
+            },
+            'srtm': {
+              'color':'#04A004'
+            }
+          };
+        }
+      };
+      profileController = $controller(
+          'GmfProfileController', {
+            $scope: $scope,
+            ngeoCsvDownload: csvDownloadServiceMock,
+            $element: $('<div></div>')}, data);
+      $rootScope.$digest();
+    });
+  });
+
+  describe('#downloadCsv', function() {
+
+    it('does nothing when empty', function() {
+      profileController.profileData = [];
+      spyOn(csvDownloadServiceMock, 'startDownload');
+      profileController.downloadCsv();
+      expect(csvDownloadServiceMock.startDownload).not.toHaveBeenCalled();
+    });
+
+    it('generates rows and header correctly', function() {
+      profileController.profileData = [
+        {
+          x: 631943,
+          y: 189536,
+          dist: 0,
+          values: {
+            aster: 1094,
+            srtm: 1097
+          }
+        },
+        {
+          x: 631945,
+          y: 189537,
+          dist: 101,
+          values: {
+            aster: 900,
+            srtm: 905
+          }
+        },
+        {
+          x: 631947,
+          y: 189539,
+          dist: 204,
+          values: {
+            aster: 564,
+            srtm: 562
+          }
+        }
+      ];
+      spyOn(csvDownloadServiceMock, 'startDownload');
+      profileController.downloadCsv();
+
+      expect(csvDownloadServiceMock.startDownload).toHaveBeenCalled();
+
+      var callArgs = csvDownloadServiceMock.startDownload.calls.mostRecent().args;
+      expect(callArgs[0]).toEqual([
+        {
+          x: 631943,
+          y: 189536,
+          distance: 0,
+          aster: 1094,
+          srtm: 1097
+        },
+        {
+          x: 631945,
+          y: 189537,
+          distance: 101,
+          aster: 900,
+          srtm: 905
+        },
+        {
+          x: 631947,
+          y: 189539,
+          distance: 204,
+          aster: 564,
+          srtm: 562
+        }
+      ]);
+      expect(callArgs[1]).toEqual([
+        {name: 'distance'},
+        {name: 'aster'},
+        {name: 'srtm'},
+        {name: 'x'},
+        {name: 'y'}
+      ]);
+      expect(callArgs[2]).toEqual('profile.csv');
+    });
+  });
+});

--- a/src/services/download.js
+++ b/src/services/download.js
@@ -1,6 +1,7 @@
 goog.provide('ngeo.Download');
 
 goog.require('ngeo');
+goog.require('ngeo.utils');
 
 /**
  * @typedef {function(string, string, string=)}
@@ -23,9 +24,13 @@ ngeo.downloadFactory_ = function() {
    *    `text/plain;charset=utf-8` is used.
    */
   function download(content, fileName, opt_fileType) {
+    // Safari does not properly work with FileSaver. Using the the type 'text/plain'
+    // makes it a least possible to show the file content so that users can
+    // do a manual download with "Save as".
+    // See also: https://github.com/eligrey/FileSaver.js/issues/12
     /** @type{string} */
-    var fileType = (opt_fileType !== undefined) ? opt_fileType :
-        'text/plain;charset=utf-8';
+    var fileType = opt_fileType !== undefined && !ngeo.utils.isSafari() ?
+        opt_fileType : 'text/plain;charset=utf-8';
 
     var blob = new Blob([content], {type: fileType});
     saveAs(blob, fileName);

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,3 +30,11 @@ ngeo.utils.toMulti = function(geometry) {
   }
   return multiGeom;
 };
+
+/**
+ * Checks if on Safari.
+ * @return {boolean} True if on Safari.
+ */
+ngeo.utils.isSafari = function() {
+  return navigator.userAgent.indexOf('Safari') != -1 && navigator.userAgent.indexOf('Chrome') == -1;
+};


### PR DESCRIPTION
There are several issues with the file download on Safari, see https://github.com/eligrey/FileSaver.js/issues/12. The latest Safari Tech Preview fixes these issues, but as long as no official release is available, it would be good to have a work-around.

The first commit addresses the problem that Safari is not able to start a download for files with a mime-type other than `text/plain`. So, when using Safari, the mime-type is set to `text/plain` (instead of the mime-type for csv/kml/gpx). This will open the file in a new tab and the user can download with `File -> Save as`. Not optimal, but as least the user can get the data.

The second commit deals with the problem that on Safari a download can only be started within 1000ms in the event handler of a *trusted event* (an event generated by a user action, like clicking the export button). Currently, a request is made to get the profile as CSV and then when the request succeeds, the download is started. But this doesn't work for Safari, the file would be shown in the same tab.
Instead the CSV file is generated on the client-side with the already available data.

Closes https://github.com/camptocamp/ngeo/issues/2083