### PR TITLE
Fix translations

### DIFF
--- a/src/modules/import/importlocal.js
+++ b/src/modules/import/importlocal.js
@@ -6,14 +6,14 @@ goog.require('ngeo.fileService');
 /**
  * @constructor
  * @param {angular.$timeout} $timeout .
- * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
+ * @param {gettext} gettext .
  * @param {ngeo.File} ngeoFile .
  * @param {string|function(!angular.JQLite=, !angular.Attributes=)}
        ngeoImportLocalTemplateUrl Template URL for the directive.
  * @ngInject
  * @struct
  */
-exports = function($timeout, gettextCatalog, ngeoFile, ngeoImportLocalTemplateUrl) {
+exports = function($timeout, gettext, ngeoFile, ngeoImportLocalTemplateUrl) {
 
   let timeoutP;
 
@@ -38,7 +38,7 @@ exports = function($timeout, gettextCatalog, ngeoFile, ngeoImportLocalTemplateUr
 
 
       const initUserMsg = function() {
-        scope['userMessage'] = gettextCatalog.getString('Load local file');
+        scope['userMessage'] = gettext('Load local file');
         scope['progress'] = 0;
         scope['fileReader'] = null;
       };
@@ -100,16 +100,15 @@ exports = function($timeout, gettextCatalog, ngeoFile, ngeoImportLocalTemplateUr
           return;
         }
         scope['loading'] = true;
-        scope['userMessage'] = gettextCatalog.getString('Reading file');
+        scope['userMessage'] = gettext('Reading file');
         $timeout.cancel(timeoutP);
 
         ngeoFile.read(scope['file']).then((fileContent) => {
           scope['fileReader'] = null;
-          scope['userMessage'] = gettextCatalog.getString('Parsing file');
+          scope['userMessage'] = gettext('Parsing file');
           return scope['handleFileContent'](fileContent, scope.file);
-
         }).then((parsingResults) => {
-          scope['userMessage'] = gettextCatalog.getString('Parsing succeeded');
+          scope['userMessage'] = gettext('Parsing succeeded');
 
         }, (err) => {
           scope['userMessage'] = err.message;

--- a/src/modules/import/importonline.js
+++ b/src/modules/import/importonline.js
@@ -10,13 +10,12 @@ goog.require('ngeo.fileService');
  * @param {angular.$timeout} $timeout .
  * @param {ngeo.File} ngeoFile .
  * @param {gettext} gettext .
- * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @param {string|function(!angular.JQLite=, !angular.Attributes=)}
        ngeoImportOnlineTemplateUrl The template url.
  * @ngInject
  * @struct
  */
-exports = function($q, $timeout, ngeoFile, gettext, gettextCatalog, ngeoImportOnlineTemplateUrl) {
+exports = function($q, $timeout, ngeoFile, gettext, ngeoImportOnlineTemplateUrl) {
 
   let timeoutP;
 
@@ -137,7 +136,7 @@ exports = function($q, $timeout, ngeoFile, gettext, gettextCatalog, ngeoImportOn
 
         scope['canceler'] = $q.defer();
         scope['loading'] = true;
-        scope['userMessage'] = gettext('Dowloading file');
+        scope['userMessage'] = gettext('Downloading file');
         $timeout.cancel(timeoutP);
 
         // Angularjs doesn't handle onprogress event

--- a/src/modules/import/partials/import-local.html
+++ b/src/modules/import/partials/import-local.html
@@ -14,6 +14,6 @@
           ng-class="{'btn-danger': loading}"
           ng-disabled="!isValid(file) || (loading && !fileReader)"
           ng-click="loading ? cancel() : handleFile()">
-    <span>{{userMessage | translate }}</span>
+    <span>{{userMessage | translate}}</span>
   </button>
 </div>

--- a/src/modules/import/partials/import-online.html
+++ b/src/modules/import/partials/import-online.html
@@ -9,6 +9,6 @@
           ng-class="{'btn-danger': canceler}"
           ng-disabled="!fileUrl || !isValid(fileUrl) || (loading && !canceler)"
           ng-click="loading ? cancel() : handleFileUrl()">
-    {{userMessage | translate}}
+    <span>{{userMessage | translate}}</span>
   </button>
 </div>


### PR DESCRIPTION
This PR replace uses of `gettextCatalog` by `gettext` to fix the translation and also remove use of tranlsate filter when it's unneeded.