### PR TITLE
Filter - Add ngeo.DataSource & gmf.FilterSelector example and directive

### DIFF
--- a/contribs/gmf/examples/filterselector.html
+++ b/contribs/gmf/examples/filterselector.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html ng-app='gmfapp'>
+  <head>
+    <title>GeoMapFish Filter selector example</title>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <meta name="mobile-web-app-capable" content="yes">
+    <link rel="stylesheet" href="../../../node_modules/openlayers/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+    <link rel="stylesheet" href="../../../node_modules/font-awesome/css/font-awesome.css" type="text/css">
+    <link rel="stylesheet" href="../../../third-party/jquery-ui/jquery-ui.min.css">
+    <style>
+      body {
+        padding: 1rem;
+      }
+      .panel {
+        display: block;
+        float: left;
+        margin: 0 1rem 0 0;
+        width: 35rem;
+      }
+      gmf-map > div {
+        width: 60rem;
+        height: 40rem;
+      }
+      gmf-filterselector {
+        display: block;
+        width: 30rem;
+      }
+    </style>
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <gmf-map gmf-map-map="ctrl.map"></gmf-map>
+
+    <p id="desc">
+      This example shows how to use the <code>gmf-filterselector</code>
+      directive to apply filters on the layers on the map.
+    </p>
+
+    <gmf-layertree
+        class="panel panel-default panel-body"
+        gmf-layertree-map="::ctrl.map">
+    </gmf-layertree>
+
+    <div class="panel panel-default panel-body">
+    <input type="checkbox"
+       id="checkbox-filterselector"
+       ng-model="ctrl.filterSelectorActive" />
+    <label for="checkbox-filterselector"> FilterSelector</label>
+
+    <input type="checkbox"
+       id="checkbox-dummy"
+       ng-model="ctrl.dummyActive" />
+    <label for="checkbox-dummy"> Dummy tool</label>
+    </div>
+
+    <gmf-filterselector
+        class="panel panel-default panel-body"
+        ng-show="ctrl.filterSelectorActive === true"
+        active="ctrl.filterSelectorActive">
+    </gmf-filterselector>
+
+    </div>
+
+    <script src="../../../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../../../third-party/jquery-ui/jquery-ui.min.js"></script>
+    <script src="../../../node_modules/angular/angular.js"></script>
+    <script src="../../../node_modules/angular-animate/angular-animate.js"></script>
+    <script src="../../../node_modules/angular-sanitize/angular-sanitize.js"></script>
+    <script src="../../../node_modules/angular-touch/angular-touch.js"></script>
+    <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../../../node_modules/angular-gettext/dist/angular-gettext.js"></script>
+    <script src="../../../node_modules/proj4/dist/proj4.js"></script>
+    <script src="../../../node_modules/angular-ui-date/dist/date.js"></script>
+    <script src="../../../node_modules/angular-float-thead/angular-floatThead.js"></script>
+    <script src="../../../node_modules/floatthead/dist/jquery.floatThead.min.js"></script>
+    <script src="../../../node_modules/angular-ui-slider/src/slider.js"></script>
+    <script src="../../../node_modules/angular-dynamic-locale/dist/tmhDynamicLocale.js"></script>
+    <script src="/@?main=filterselector.js"></script>
+    <script src="default.js"></script>
+    <script src="../../../utils/watchwatchers.js"></script>
+    <script>
+      var gmfModule = angular.module('gmf');
+      gmfModule.constant('defaultTheme', 'Edit');
+      gmfModule.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
+    </script>
+  </body>
+</html>

--- a/contribs/gmf/examples/filterselector.js
+++ b/contribs/gmf/examples/filterselector.js
@@ -1,0 +1,165 @@
+// Todo - use the 'Filter' theme instead if the 'Edit' theme
+
+goog.provide('gmfapp.filterselector');
+
+goog.require('gmf.Themes');
+goog.require('gmf.TreeManager');
+/** @suppress {extraRequire} */
+goog.require('gmf.DataSourcesManager');
+/** @suppress {extraRequire} */
+goog.require('gmf.filterselectorComponent');
+/** @suppress {extraRequire} */
+goog.require('gmf.layertreeDirective');
+/** @suppress {extraRequire} */
+goog.require('gmf.mapDirective');
+goog.require('ngeo.DataSource');
+goog.require('ngeo.DataSources');
+goog.require('ngeo.ToolActivate');
+goog.require('ngeo.ToolActivateMgr');
+/** @suppress {extraRequire} */
+goog.require('ngeo.proj.EPSG21781');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+
+
+/** @type {!angular.Module} **/
+gmfapp.module = angular.module('gmfapp', ['gmf']);
+
+
+gmfapp.module.value('gmfTreeUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
+
+
+gmfapp.module.value(
+    'authenticationBaseUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi');
+
+
+gmfapp.module.value('gmfTreeUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background');
+
+
+gmfapp.module.value('gmfLayersUrl',
+    'https://geomapfish-demo.camptocamp.net/2.1/wsgi/layers/');
+
+
+gmfapp.MainController = class {
+
+  /**
+   * @param {!angular.Scope} $scope Angular scope.
+   * @param {gmf.DataSourcesManager} gmfDataSourcesManager The gmf data sources
+   *     manager service.
+   * @param {gmf.Themes} gmfThemes The gmf themes service.
+   * @param {gmf.TreeManager} gmfTreeManager gmf Tree Manager service.
+   * @param {ol.Collection.<ngeo.DataSource>} ngeoDataSources Ngeo collection
+   *     of data sources objects.
+   * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
+   *     service.
+   * @ngInject
+   */
+  constructor($scope, gmfDataSourcesManager, gmfThemes, gmfTreeManager,
+      ngeoDataSources, ngeoToolActivateMgr
+  ) {
+
+    /**
+     * @type {!angular.Scope}
+     * @private
+     */
+    this.scope_ = $scope;
+
+    gmfThemes.loadThemes();
+
+    /**
+     * @type {gmf.TreeManager}
+     * @export
+     */
+    this.gmfTreeManager = gmfTreeManager;
+
+    ngeoDataSources.on('add', this.handleDataSourcesAdd_, this);
+    ngeoDataSources.on('remove', this.handleDataSourcesRemove_, this);
+
+    /**
+     * @type {ol.Map}
+     * @export
+     */
+    this.map = new ol.Map({
+      layers: [
+        new ol.layer.Tile({
+          source: new ol.source.OSM()
+        })
+      ],
+      view: new ol.View({
+        projection: 'EPSG:21781',
+        resolutions: [200, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5],
+        center: [537635, 152640],
+        zoom: 2
+      })
+    });
+
+    gmfThemes.getThemesObject().then((themes) => {
+      if (themes) {
+        // Add 'Edit' theme, i.e. the one with id 73
+        for (let i = 0, ii = themes.length; i < ii; i++) {
+          if (themes[i].id === 73) {
+            this.gmfTreeManager.setFirstLevelGroups(themes[i].children);
+            break;
+          }
+        }
+      }
+    });
+
+    /**
+     * @type {boolean}
+     * @export
+     */
+    this.filterSelectorActive = true;
+
+    const filterSelectorToolActivate = new ngeo.ToolActivate(
+      this, 'filterSelectorActive');
+    ngeoToolActivateMgr.registerTool(
+      'mapTools', filterSelectorToolActivate, true);
+
+    /**
+     * @type {boolean}
+     * @export
+     */
+    this.dummyActive = false;
+
+    const dummyToolActivate = new ngeo.ToolActivate(
+      this, 'dummyActive');
+    ngeoToolActivateMgr.registerTool(
+      'mapTools', dummyToolActivate, false);
+
+    // initialize tooltips
+    $('[data-toggle="tooltip"]').tooltip({
+      container: 'body',
+      trigger: 'hover'
+    });
+
+  }
+
+  /**
+   * @param {ol.Collection.Event} evt Event.
+   * @private
+   */
+  handleDataSourcesAdd_(evt) {
+    const dataSource = /** @type {ngeo.dataSource} */ (evt.element);
+    console.log(`DataSource added: ${dataSource.id} - ${dataSource.name}`);
+    console.log(dataSource);
+  }
+
+  /**
+   * @param {ol.Collection.Event} evt Event.
+   * @private
+   */
+  handleDataSourcesRemove_(evt) {
+    const dataSource = /** @type {ngeo.dataSource} */ (evt.element);
+    console.log(`DataSource removed: ${dataSource.id} - ${dataSource.name}`);
+    console.log(dataSource);
+  }
+};
+
+
+gmfapp.module.controller('MainController', gmfapp.MainController);

--- a/contribs/gmf/examples/filterselector.js
+++ b/contribs/gmf/examples/filterselector.js
@@ -12,8 +12,6 @@ goog.require('gmf.filterselectorComponent');
 goog.require('gmf.layertreeDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.mapDirective');
-goog.require('ngeo.DataSource');
-goog.require('ngeo.DataSources');
 goog.require('ngeo.ToolActivate');
 goog.require('ngeo.ToolActivateMgr');
 /** @suppress {extraRequire} */

--- a/contribs/gmf/examples/filterselector.js
+++ b/contribs/gmf/examples/filterselector.js
@@ -75,9 +75,6 @@ gmfapp.MainController = class {
      */
     this.gmfTreeManager = gmfTreeManager;
 
-    ngeoDataSources.on('add', this.handleDataSourcesAdd_, this);
-    ngeoDataSources.on('remove', this.handleDataSourcesRemove_, this);
-
     /**
      * @type {ol.Map}
      * @export
@@ -136,26 +133,6 @@ gmfapp.MainController = class {
       trigger: 'hover'
     });
 
-  }
-
-  /**
-   * @param {ol.Collection.Event} evt Event.
-   * @private
-   */
-  handleDataSourcesAdd_(evt) {
-    const dataSource = /** @type {ngeo.dataSource} */ (evt.element);
-    console.log(`DataSource added: ${dataSource.id} - ${dataSource.name}`);
-    console.log(dataSource);
-  }
-
-  /**
-   * @param {ol.Collection.Event} evt Event.
-   * @private
-   */
-  handleDataSourcesRemove_(evt) {
-    const dataSource = /** @type {ngeo.dataSource} */ (evt.element);
-    console.log(`DataSource removed: ${dataSource.id} - ${dataSource.name}`);
-    console.log(dataSource);
   }
 };
 

--- a/contribs/gmf/src/directives/filterselector.js
+++ b/contribs/gmf/src/directives/filterselector.js
@@ -1,0 +1,50 @@
+goog.provide('gmf.FilterselectorController');
+goog.provide('gmf.filterselectorComponent');
+
+goog.require('gmf');
+
+
+gmf.FilterselectorController = class {
+
+  /**
+   * @param {!angular.Scope} $scope Angular scope.
+   * @ngInject
+   * @ngdoc controller
+   * @ngname GmfFilterselectorController
+   */
+  constructor($scope) {
+
+    // Binding properties
+
+    /**
+     * @type {boolean}
+     * @export
+     */
+    this.active;
+
+    $scope.$watch(
+      () => this.active,
+      this.handleActiveChange_.bind(this)
+    );
+  }
+
+  /**
+   * Called when the active property of the this directive changes. Manage
+   * the activation/deactivation accordingly.
+   * @param {boolean} active Whether the directive is active or not.
+   * @private
+   */
+  handleActiveChange_(active) {
+    // Work in progress...
+  }
+};
+
+
+gmf.module.component('gmfFilterselector', {
+  bindings: {
+    active: '<'
+  },
+  controller: gmf.FilterselectorController,
+  controllerAs: 'fsCtrl',
+  templateUrl: () => `${gmf.baseTemplateUrl}/filterselector.html`
+});

--- a/contribs/gmf/src/directives/partials/filterselector.html
+++ b/contribs/gmf/src/directives/partials/filterselector.html
@@ -1,0 +1,1 @@
+<div>gmf.Filterselector</div>

--- a/contribs/gmf/src/services/datasourcesmanager.js
+++ b/contribs/gmf/src/services/datasourcesmanager.js
@@ -5,6 +5,7 @@ goog.provide('gmf.DataSourcesManager');
 goog.require('gmf');
 goog.require('gmf.TreeManager');
 goog.require('ngeo.DataSource');
+/** @suppress {extraRequire} */
 goog.require('ngeo.DataSources');
 goog.require('ol.obj');
 

--- a/contribs/gmf/src/services/datasourcesmanager.js
+++ b/contribs/gmf/src/services/datasourcesmanager.js
@@ -1,0 +1,419 @@
+// TODO - Do not always remove all data sources from the ngeo collection
+
+goog.provide('gmf.DataSourcesManager');
+
+goog.require('gmf');
+goog.require('gmf.TreeManager');
+goog.require('ngeo.DataSource');
+goog.require('ngeo.DataSources');
+goog.require('ol.obj');
+
+
+gmf.DataSourcesManager = class {
+
+  /**
+   * The GeoMapFish DataSources Manager is responsible of listenening to the
+   * c2cgeoportal's themes to create instances of `ngeo.DataSource` objects with
+   * the layer definitions found and push them in the `ngeo.DataSources`
+   * collection.
+   *
+   * When changing theme, these data sources are cleared then re-created.
+   *
+   * @struct
+   * @param {angular.$q} $q Angular q service
+   * @param {!angular.Scope} $rootScope Angular rootScope.
+   * @param {angular.$timeout} $timeout Angular timeout service.
+   * @param {gmf.Themes} gmfThemes The gmf Themes service.
+   * @param {gmf.TreeManager} gmfTreeManager The gmf TreeManager service.
+   * @param {ol.Collection.<ngeo.DataSource>} ngeoDataSources Ngeo collection
+   *     of data sources objects.
+   * @ngInject
+   * @ngdoc service
+   * @ngname gmfDataSourcesManager
+   */
+  constructor($q, $rootScope, $timeout, gmfThemes, gmfTreeManager,
+      ngeoDataSources
+  ) {
+
+    // === Injected properties ===
+
+    /**
+     * @type {angular.$q}
+     * @private
+     */
+    this.q_ = $q;
+
+    /**
+     * @type {!angular.Scope}
+     * @private
+     */
+    this.rootScope_ = $rootScope;
+
+    /**
+     * @type {angular.$timeout}
+     * @private
+     */
+    this.timeout_ = $timeout;
+
+    /**
+     * @type {gmf.Themes}
+     * @private
+     */
+    this.gmfThemes_ = gmfThemes;
+
+    /**
+     * @type {gmf.TreeManager}
+     * @private
+     */
+    this.gmfTreeManager_ = gmfTreeManager;
+
+    /**
+     * The collection of DataSources from ngeo, which gets updated by this
+     * service. When the theme changes, first we remove all data sources, then
+     * the 'active' data source are added here.
+     * @type {ol.Collection.<ngeo.DataSource>}
+     * @private
+     */
+    this.ngeoDataSources_ = ngeoDataSources;
+
+
+    // === Inner properties ===
+
+    /**
+     * While loading a new theme, this is where all of the created data sources
+     * are put using the id as key for easier find in the future.
+     * @type {Object.<number, ngeo.DataSource>}
+     * @private
+     */
+    this.dataSourcesCache_ = {};
+
+    /**
+     * The cache of layertree leaf controller, i.e. those that are added to
+     * the tree manager. When treeCtrl is added in this cache, it's given
+     * a reference to its according data source.
+     * @type {gmf.DataSourcesManager.TreeCtrlCache}
+     * @private
+     */
+    this.treeCtrlCache_ = {};
+
+    /**
+     * The function to call to unregister the `watchCollection` event on
+     * the root layer tree controller children.
+     * @type {?Function}
+     * @private
+     */
+    this.treeCtrlsUnregister_ = null;
+
+    // === Events ===
+
+    ol.events.listen(this.gmfThemes_, gmf.ThemesEventType.CHANGE,
+        this.handleThemesChange_, this);
+  }
+
+  /**
+   * Called when the themes change. Remove any existing data sources first,
+   * then create and add data sources from the loaded themes.
+   * @private
+   */
+  handleThemesChange_() {
+    // (1) Clear
+    this.clearDataSources_();
+    if (this.treeCtrlsUnregister_) {
+      this.treeCtrlsUnregister_();
+    }
+
+    // (2) Re-create data sources and event listeners
+    this.gmfThemes_.getOgcServersObject().then((ogcServers) => {
+      const promiseThemes = this.gmfThemes_.getThemesObject().then((themes) => {
+        // Create a DataSources for each theme
+        for (const theme of themes) {
+          for (const child of theme.children) {
+            goog.asserts.assert(child);
+            this.createDataSource_(child, child, ogcServers);
+          }
+        }
+      });
+
+      const promiseBgLayers = this.gmfThemes_.getBackgroundLayersObject().then((backgroundLayers) => {
+        // Create a DataSource for each background layer
+        for (const backgroundLayer of backgroundLayers) {
+          this.createDataSource_(null, backgroundLayer, ogcServers);
+        }
+      });
+
+      // Then add the data sources that are active in the ngeo collection
+      this.q_.all([promiseThemes, promiseBgLayers]).then(() => {
+        this.treeCtrlsUnregister_ = this.rootScope_.$watchCollection(() => {
+          if (this.gmfTreeManager_.rootCtrl) {
+            return this.gmfTreeManager_.rootCtrl.children;
+          }
+        }, (value) => {
+          // Timeout required, because the collection event is fired before
+          // the leaf nodes are created and they are the ones we're looking
+          // for here.
+          this.timeout_(() => {
+            if (value) {
+              this.clearTreeCtrlCache_();
+              this.gmfTreeManager_.rootCtrl.traverseDepthFirst(
+                this.addTreeCtrlToCache_.bind(this)
+              );
+            }
+          });
+        });
+      });
+    });
+  }
+
+  /**
+   * Remove all data sources from the ngeo collection and from the cache.
+   * @private
+   */
+  clearDataSources_() {
+    this.ngeoDataSources_.clear();
+    ol.obj.clear(this.dataSourcesCache_);
+  }
+
+  /**
+   * Create a data source using the information on the node, group node
+   * and OGC servers. If the node has children, then we loop in those to get
+   * leaf nodes. Only leaf nodes end up creating a data source. If a data
+   * source with the same id already exists, then the node is skipped.
+   *
+   * Once a data source is created, it is added to the data sources cache.
+   *
+   * @param {gmfThemes.GmfGroup} firstLevelGroup The first level group node.
+   * @param {!gmfThemes.GmfGroup|!gmfThemes.GmfLayer} node The node, which
+   *     may have children or not.
+   * @param {!gmfThemes.GmfOgcServers} ogcServers OGC servers.
+   * @private
+   */
+  createDataSource_(firstLevelGroup, node, ogcServers) {
+
+    const children = node.children;
+
+    // (1) Group node (node that has children). Loop in the children
+    //     individually and create a data source for each one of them. The
+    //     group node itself is **skipped**.
+    if (children) {
+      for (const child of children) {
+        goog.asserts.assert(child);
+        this.createDataSource_(firstLevelGroup, child, ogcServers);
+      }
+      return;
+    }
+
+    // From there on, the node is a layer node.
+    const gmfLayer = /** @type gmfThemes.GmfLayer */ (node);
+
+    // (2) Skip layer node if a data source with the same id exists
+    const cache = this.dataSourcesCache_;
+    const id = gmfLayer.id;
+    if (cache[id]) {
+      return;
+    }
+
+    // From there on, a data source will be created
+    const meta = gmfLayer.metadata;
+    const ogcType = gmfLayer.type;
+    let maxResolution;
+    let minResolution;
+    let ogcLayers;
+    let ogcServer;
+    let wmtsLayer;
+    let wmtsUrl;
+
+    if (ogcType === gmf.Themes.NodeType.WMTS) {
+      // (3) Manage WMTS
+
+      // Common options for WMTS
+      wmtsLayer = gmfLayer.layer;
+      wmtsUrl = gmfLayer.url;
+      maxResolution = meta.maxResolution;
+      minResolution = meta.minResolution;
+
+      // OGC Layers
+      const layers = meta.queryLayers || meta.wmsLayers;
+      if (layers) {
+        ogcLayers = layers.split(',').map((layer) => {
+          return {
+            maxResolution,
+            minResolution,
+            name: layer,
+            queryable: true
+          };
+        });
+      }
+
+      // OGC Server
+      if (meta.ogcServer && ogcServers[meta.ogcServer]) {
+        ogcServer = ogcServers[meta.ogcServer];
+      }
+    } else if (ogcType === gmf.Themes.NodeType.WMS) {
+      // (4) Manage WMS
+      const gmfLayerWMS = /** @type {gmfThemes.GmfLayerWMS} */ (gmfLayer);
+
+      // Common options for WMS
+      maxResolution = gmfLayerWMS.maxResolutionHint;
+      minResolution = gmfLayerWMS.minResolutionHint;
+
+      // OGC Layers
+      ogcLayers = gmfLayerWMS.childLayers.map((childLayer) => {
+        return {
+          maxResolution: childLayer.maxResolutionHint,
+          minResolution: childLayer.minResolutionHint,
+          name: childLayer.name,
+          queryable: childLayer.queryable
+        };
+      });
+
+      // OGC Server
+      if (firstLevelGroup && firstLevelGroup.mixed) {
+        goog.asserts.assert(gmfLayerWMS.ogcServer);
+        ogcServer = ogcServers[/** @type string */ (gmfLayerWMS.ogcServer)];
+      } else {
+        goog.asserts.assert(firstLevelGroup.ogcServer);
+        ogcServer = ogcServers[/** @type string */ (firstLevelGroup.ogcServer)];
+      }
+    }
+
+    // (5) ogcServer
+    const ogcServerType = ogcServer ? ogcServer.type : undefined;
+    const wmsIsSingleTile = ogcServer ? ogcServer.isSingleTile : undefined;
+    const wfsUrl = ogcServer && ogcServer.wfsSupport ?
+          ogcServer.urlWfs : undefined;
+    const wmsUrl = ogcServer ? ogcServer.url : undefined;
+
+    // (6) Snapping
+    const snappable = !!meta.snappingConfig;
+    const snappingTolerance = meta.snappingConfig ?
+          meta.snappingConfig.tolerance : undefined;
+    const snappingToEdges = meta.snappingConfig ?
+          meta.snappingConfig.edge : undefined;
+    const snappingToVertice = meta.snappingConfig ?
+          meta.snappingConfig.vertex : undefined;
+
+    // (7) Common options
+    const copyable = meta.copyable;
+    const identifierAttribute = meta.identifierAttributeField;
+    const name = gmfLayer.name;
+    const ogcImageType = gmfLayer.imageType;
+    const visible = meta.isChecked === true;
+
+    // Create the data source and add it to the cache
+    cache[id] = new ngeo.DataSource({
+      copyable,
+      id,
+      identifierAttribute,
+      maxResolution,
+      minResolution,
+      name,
+      ogcImageType,
+      ogcLayers,
+      ogcServerType,
+      ogcType,
+      snappable,
+      snappingTolerance,
+      snappingToEdges,
+      snappingToVertice,
+      visible,
+      wfsUrl,
+      wmsIsSingleTile,
+      wmsUrl,
+      wmtsLayer,
+      wmtsUrl
+    });
+  }
+
+  /**
+   * If the given Layertree controller is a 'leaf', add it to the cache.
+   * Also, set its according data source. Finally, add the data source to
+   * the ngeo collection.
+   *
+   * @param {ngeo.LayertreeController} treeCtrl Layertree controller to add
+   * @private
+   */
+  addTreeCtrlToCache_(treeCtrl) {
+
+    // Skip any Layertree controller that has a node that is not a leaf
+    const node = /** @type {gmfThemes.GmfGroup|gmfThemes.GmfLayer} */ (
+      treeCtrl.node);
+    if (node.children) {
+      return;
+    }
+
+    const id = node.id;
+    const dataSource = this.dataSourcesCache_[id];
+    if (dataSource) {
+      treeCtrl.setDataSource(dataSource);
+    }
+
+    const stateWatcherUnregister = this.rootScope_.$watch(
+      () => treeCtrl.getState(),
+      this.handleTreeCtrlStateChange_.bind(this, treeCtrl)
+    );
+
+    this.treeCtrlCache_[id] = {
+      stateWatcherUnregister,
+      treeCtrl
+    };
+
+    this.ngeoDataSources_.push(dataSource);
+  }
+
+  /**
+   * Clears the layer tree controller cache. At the same time, each item gets
+   * its data source reference unset and state watcher unregistered.
+   *
+   * The data source gets also removed from the ngeo data sources collection.
+   * @private
+   */
+  clearTreeCtrlCache_() {
+    for (const id in this.treeCtrlCache_) {
+      const item = this.treeCtrlCache_[id];
+      const dataSource = item.treeCtrl.getDataSource();
+      goog.asserts.assert(dataSource, 'DataSource should be set');
+      this.ngeoDataSources_.remove(dataSource);
+      item.treeCtrl.setDataSource(null);
+      item.stateWatcherUnregister();
+    }
+    ol.obj.clear(this.treeCtrlCache_);
+  }
+
+  /**
+   * Called when the state of a 'leaf' layertree controller changes.
+   * Update the `visible` property of the data source according to the
+   * state of the layertree controller.
+   *
+   * Note: The possible states can only be 'on' or 'off', because the
+   * layertree controller being a 'leaf'.
+   *
+   * @param {ngeo.LayertreeController} treeCtrl The layer tree controller
+   * @param {?string} newVal New state value
+   * @private
+   */
+  handleTreeCtrlStateChange_(treeCtrl, newVal) {
+    const dataSource = treeCtrl.getDataSource();
+    goog.asserts.assert(dataSource, 'DataSource should be set');
+    const visible = newVal === 'on';
+    dataSource.visible = visible;
+  }
+
+};
+
+
+/**
+ * @typedef {Object<number, gmf.DataSourcesManager.TreeCtrlCacheItem>}
+ */
+gmf.DataSourcesManager.TreeCtrlCache;
+
+
+/**
+ * @typedef {{
+ *     stateWatcherUnregister: (Function),
+ *     treeCtrl: (ngeo.LayertreeController)
+ * }}
+ */
+gmf.DataSourcesManager.TreeCtrlCacheItem;
+
+
+gmf.module.service('gmfDataSourcesManager', gmf.DataSourcesManager);

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -62,6 +62,223 @@ ngeox.Attribute.prototype.type;
 
 
 /**
+ * The definition of a single layer (WMS) and/or featureType (WFS).
+ * @record
+ * @struct
+ */
+ngeox.DataSourceLayer = function() {};
+
+
+/**
+ * The maximum resolution the layer should be rendered (when visible).
+ * @type {number|undefined}
+ */
+ngeox.DataSourceLayer.prototype.maxResolution;
+
+
+/**
+ * The minimum resolution the layer should be rendered (when visible).
+ * @type {number|undefined}
+ */
+ngeox.DataSourceLayer.prototype.minResolution;
+
+
+/**
+ * The layer name (WMS) and/or feature type name (WFS)
+ * @type {string}
+ */
+ngeox.DataSourceLayer.prototype.name;
+
+
+/**
+ * Whether the the layer is queryable or not. Defaults to `false`.
+ * @type {boolean|undefined}
+ */
+ngeox.DataSourceLayer.prototype.queryable;
+
+
+/**
+ * The options to create a ngeo.DataSource with.
+ * @typedef {{
+ *     copyable: (boolean|undefined),
+ *     id: (number),
+ *     idAttribute: (string|undefined),
+ *     maxResolution: (number|undefined),
+ *     minResolution: (number|undefined),
+ *     name: (string),
+ *     ogcImageType: (string|undefined),
+ *     ogcLayers: (Array.<ngeox.DataSourceLayer>|undefined),
+ *     ogcServerType: (string|undefined),
+ *     ogcType: (string|undefined),
+ *     snappable: (boolean|undefined),
+ *     snappingTolerance: (number|undefined),
+ *     snappingToEdges: (boolean|undefined),
+ *     snappingToVertice: (boolean|undefined),
+ *     visible: (boolean|undefined),
+ *     wfsUrl: (string|undefined),
+ *     wmsIsSingleTile: (boolean|undefined),
+ *     wmsUrl: (string|undefined),
+ *     wmtsLayer: (string|undefined),
+ *     wmtsUrl: (string|undefined)
+ * }}
+ */
+ngeox.DataSourceOptions;
+
+
+/**
+ * Whether the geometry from this data source can be copied to other data
+ * sources or not. Defaults to `false`.
+ * @type {boolean|undefined}
+ */
+ngeox.DataSourceOptions.prototype.copyable;
+
+
+/**
+ * (Required) The data source id.
+ * @type {number}
+ */
+ngeox.DataSourceOptions.prototype.id;
+
+
+/**
+ * The name of an attribute among the attributes of the data source.
+ * The value of that attribute, in records, can be used to identify
+ * each record individually.
+ * @type {string|undefined}
+ */
+ngeox.DataSourceOptions.prototype.identifierAtttribute;
+
+
+/**
+ * Maximum resolution where the data source can be displayed or queried.
+ * @type {number|undefined}
+ */
+ngeox.DataSourceOptions.prototype.maxResolution;
+
+
+/**
+ * Minimum resolution where the data source can be displayed or queried.
+ * @type {number|undefined}
+ */
+ngeox.DataSourceOptions.prototype.minResolution;
+
+
+/**
+ * (Required) A human-readable name for the data source.
+ * @type {string}
+ */
+ngeox.DataSourceOptions.prototype.name;
+
+
+/**
+ * The type of images to fetch by queries by the (WMS) or (WMTS) .
+ * @type {string|undefined}
+ */
+ngeox.DataSourceOptions.prototype.ogcImageType;
+
+
+/**
+ * A list of layer definitions that are used by (WMS) and (WFS) queries.
+ * These are **not** used by the (WMTS) queries (the wmtsLayers is used
+ * by WMTS queries).
+ * @type {Array.<ngeox.DataSourceLayer>|undefined}
+ */
+ngeox.DataSourceOptions.prototype.ogcLayers;
+
+
+/**
+ * The type of OGC server.
+ * @type {string|undefined}
+ */
+ngeox.DataSourceOptions.prototype.ogcServerType;
+
+
+/**
+ * The type data source. Can be: 'WMS' or 'WMTS'.
+ * @type {string|undefined}
+ */
+ngeox.DataSourceOptions.prototype.ogcType;
+
+
+/**
+ * Whether the geometry from this data source can be used to snap the geometry
+ * of features from other data sources that are being edited. Defaults to
+ * `false`.
+ * @type {boolean|undefined}
+ */
+ngeox.DataSourceOptions.prototype.snappable;
+
+
+/**
+ * Determines whether external features can be snapped to the edges of
+ * features from this data source or not. Defaults to `true`. Requires
+ * `snappable` to be set.
+ * @type {boolean|undefined}
+ */
+ngeox.DataSourceOptions.prototype.snappingToEdges;
+
+
+/**
+ * Determines whether external features can be snapped to the vertice of
+ * features from this data source or not. Defaults to `true`. Requires
+ * `snappable` to be set.
+ * @type {boolean|undefined}
+ */
+ngeox.DataSourceOptions.prototype.snappingToVertice;
+
+
+/**
+ * The tolerance in pixels the snapping should occur. Defaults to `10`.
+ * @type {number|undefined}
+ */
+ngeox.DataSourceOptions.prototype.snappingTolerance;
+
+
+/**
+ * Whether the data source is visible or not, i.e. whether its is ON or OFF.
+ * Defaults to `false`.
+ * @type {boolean|undefined}
+ */
+ngeox.DataSourceOptions.prototype.visible;
+
+
+/**
+ * The url to use for (WFS) requests.
+ * @type {string|undefined}
+ */
+ngeox.DataSourceOptions.prototype.wfsUrl;
+
+
+/**
+ * Whether the (WMS) images returned by this data source should be single tiles
+ * or not. Defaults to `false`.
+ * @type {boolean|undefined}
+ */
+ngeox.DataSourceOptions.prototype.wmsIsSingleTile;
+
+
+/**
+ * The url to use for (WMS) requests.
+ * @type {string|undefined}
+ */
+ngeox.DataSourceOptions.prototype.wmsUrl;
+
+
+/**
+ * The layer name to use for the (WMTS) requests.
+ * @type {string|undefined}
+ */
+ngeox.DataSourceOptions.prototype.wmtsLayer;
+
+
+/**
+ * The url to use for (WMTS) requests.
+ * @type {string|undefined}
+ */
+ngeox.DataSourceOptions.prototype.wmtsUrl;
+
+
+/**
  * @interface
  */
 ngeox.MenuEvent = function() {};

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -1,0 +1,428 @@
+// TODO == Dynamic Properties ==
+// TODO  - filterCondition (and, or, not)
+// TODO  - filterRules (array of rules)
+// TODO  - inRange (boolean)
+//
+// TODO == Static Properties ==
+// TODO  - attributes
+// TODO  - filterRuleDefinitions
+// TODO  - group
+
+goog.provide('ngeo.DataSource');
+
+
+ngeo.DataSource = class {
+
+  /**
+   * A `ngeo.DataSource` represents a single source of data, which can combine
+   * different type of servers to display or fetch the data. It can serve
+   * as a point of entry to get all the information about a single data
+   * source.
+   *
+   * You can use the information in a data source to do all sorts of things:
+   *  - create `ol.layer.Layer` objects using the WMS, WMTS or even WFS
+   *    information
+   *  - issue WMS/WFS queries
+   *  - know whether the data is visible or not
+   *  - apply filter rules on it
+   *
+   * @struct
+   * @param {ngeox.DataSourceOptions} options Options.
+   */
+  constructor(options) {
+
+    // === DYNAMIC properties (i.e. that can change / be watched ===
+
+    /**
+     * Whether the data source is visible or not, i.e. whether its is ON or OFF.
+     * Defaults to `false`.
+     * @type {boolean}
+     * @private
+     */
+    this.visible_ = options.visible === true;
+
+
+    // === STATIC properties (i.e. that never change) ===
+
+    /**
+     * Whether the geometry from this data source can be copied to other data
+     * sources or not. Defaults to `false`.
+     * @type {boolean}
+     * @private
+     */
+    this.copyable_ = options.copyable === true;
+
+    /**
+     * (Required) The data source id.
+     * @type {number}
+     * @private
+     */
+    this.id_ = options.id;
+
+    /**
+     * The name of an attribute among the attributes of the data source.
+     * The value of that attribute, in records, can be used to identify
+     * each record individually.
+     * @type {?string}
+     * @private
+     */
+    this.identifierAttribute_ = options.identifierAttribute || null;
+
+    /**
+     * Maximum resolution where the data source can be displayed or queried.
+     * @type {?number}
+     * @private
+     */
+    this.maxResolution_ = options.maxResolution !== undefined ?
+      options.maxResolution : null;
+
+    /**
+     * Minimum resolution where the data source can be displayed or queried.
+     * @type {?number}
+     * @private
+     */
+    this.minResolution_ = options.minResolution !== undefined ?
+      options.minResolution : null;
+
+    /**
+     * (Required) A human-readable name for the data source.
+     * @type {string}
+     * @private
+     */
+    this.name_ = options.name;
+
+    /**
+     * The type of images to fetch by queries by the (WMS) or (WMTS) .
+     * @type {string}
+     * @private
+     */
+    this.ogcImageType_ = options.ogcImageType || 'image/png';
+
+    /**
+     * A list of layer definitions that are used by (WMS) and (WFS) queries.
+     * These are **not** used by the (WMTS) queries (the wmtsLayers is used
+     * by WMTS queries).
+     * @type {?Array.<ngeox.DataSourceLayer>}
+     * @private
+     */
+    this.ogcLayers_ = options.ogcLayers || null;
+
+    /**
+     * The type of OGC server making the requests.
+     * @type {string}
+     * @private
+     */
+    this.ogcServerType_ = options.ogcServerType ||
+      ngeo.DataSource.OGCServerType.MAPSERVER;
+
+    /**
+     * The type data source. Can be: 'WMS' or 'WMTS'.
+     * @type {?string}
+     * @private
+     */
+    this.ogcType_ = options.ogcType || null;
+
+    /**
+     * Whether the geometry from this data source can be used to snap the
+     * geometry of features from other data sources that are being edited.
+     * Defaults to `false`.
+     * @type {boolean}
+     * @private
+     */
+    this.snappable_ = options.snappable === true;
+
+    /**
+     * Determines whether external features can be snapped to the edges of
+     * features from this data source or not. Defaults to `true`. Requires
+     * `snappable` to be set.
+     * @type {boolean}
+     * @private
+     */
+    this.snappingToEdges_ = options.snappingToEdges !== false;
+
+    /**
+     * Determines whether external features can be snapped to the vertice of
+     * features from this data source or not. Defaults to `true`. Requires
+     * `snappable` to be set.
+     * @type {boolean}
+     * @private
+     */
+    this.snappingToVertice_ = options.snappingToVertice !== false;
+
+    /**
+     * The tolerance in pixels the snapping should occur. Defaults to `10`.
+     * @type {number}
+     * @private
+     */
+    this.snappingTolerance_ = options.snappingTolerance !== undefined ?
+      options.snappingTolerance : 10;
+
+    /**
+     * The url to use for (WFS) requests.
+     * @type {?string}
+     * @private
+     */
+    this.wfsUrl_ = options.wfsUrl || null;
+
+    /**
+     * Whether the (WMS) images returned by this data source
+     * should be single tiles or not.
+     * @type {boolean}
+     * @private
+     */
+    this.wmsIsSingleTile_ = options.wmsIsSingleTile === true;
+
+    /**
+     * The url to use for (WMS) requests.
+     * @type {?string}
+     * @private
+     */
+    this.wmsUrl_ = options.wmsUrl || null;
+
+    /**
+     * The layer name to use for the (WMTS) requests.
+     * @type {?string}
+     * @private
+     */
+    this.wmtsLayer_ = options.wmtsLayer || null;
+
+    /**
+     * The url to use for (WMTS) requests.
+     * @type {?string}
+     * @private
+     */
+    this.wmtsUrl_ = options.wmtsUrl || null;
+  }
+
+  // === Dynamic property getters/setters ===
+
+  /**
+   * @return {boolean} Visible
+   * @export
+   */
+  get visible() {
+    return this.visible_;
+  }
+
+  /**
+   * @param {boolean} visible Visible
+   * @export
+   */
+  set visible(visible) {
+    this.visible_ = visible;
+  }
+
+  // === Static property getters/setters ===
+
+  /**
+   * @return {boolean} Copyable
+   * @export
+   */
+  get copyable() {
+    return this.copyable_;
+  }
+
+  /**
+   * @return {number} Id
+   * @export
+   */
+  get id() {
+    return this.id_;
+  }
+
+  /**
+   * @return {?string} Identifier attribute
+   * @export
+   */
+  get identifierAttribute() {
+    return this.identifierAttribute_;
+  }
+
+  /**
+   * @return {?number} Maximum resolution
+   * @export
+   */
+  get maxResolution() {
+    return this.maxResolution_;
+  }
+
+  /**
+   * @return {?number} Minimum resolution
+   * @export
+   */
+  get minResolution() {
+    return this.minResolution_;
+  }
+
+  /**
+   * @return {string} Name
+   * @export
+   */
+  get name() {
+    return this.name_;
+  }
+
+  /**
+   * @return {string} OGC image type
+   * @export
+   */
+  get ogcImageType() {
+    return this.ogcImageType_;
+  }
+
+  /**
+   * @return {?Array.<ngeox.DataSourceLayer>} OGC layers
+   * @export
+   */
+  get ogcLayers() {
+    return this.ogcLayers_;
+  }
+
+  /**
+   * @return {string} OGC server type
+   * @export
+   */
+  get ogcServerType() {
+    return this.ogcServerType_;
+  }
+
+  /**
+   * @return {string} OGC type
+   * @export
+   */
+  get ogcType() {
+    return this.ogcType_;
+  }
+
+  /**
+   * @return {boolean} Snappable
+   * @export
+   */
+  get snappable() {
+    return this.snappable_;
+  }
+
+  /**
+   * @return {boolean} Snapping to edges
+   * @export
+   */
+  get snappingToEdges() {
+    return this.snappingToEdges_;
+  }
+
+  /**
+   * @return {boolean} Snapping to vertices
+   * @export
+   */
+  get snappingToVertice() {
+    return this.snappingToVertice_;
+  }
+
+  /**
+   * @return {number} Snapping tolerance
+   * @export
+   */
+  get snappingTolerance() {
+    return this.snappingTolerance_;
+  }
+
+  /**
+   * @export
+   * @return {?string} WFS url
+   */
+  get wfsUrl() {
+    return this.wfsUrl_;
+  }
+
+  /**
+   * @return {boolean} WMS is single tile
+   * @export
+   */
+  get wmsIsSingleTile() {
+    return this.wmsIsSingleTile_;
+  }
+
+  /**
+   * @return {?string} WMS url
+   * @export
+   */
+  get wmsUrl() {
+    return this.wmsUrl_;
+  }
+
+  /**
+   * @return {?string} WMTS layer
+   * @export
+   */
+  get wmtsLayer() {
+    return this.wmtsLayer_;
+  }
+
+  /**
+   * @return {?string} WMTS url
+   * @export
+   */
+  get wmtsUrl() {
+    return this.wmtsUrl_;
+  }
+
+  // === Calculated property getters ===
+
+  /**
+   * Whether the data source is queryable or not. To be queryable, it requires
+   * the support of WFS or WMS and at least one ogc layer to be querable.
+   * @return {boolean} Whether the data source is queryable or not.
+   * @export
+   */
+  get isQueryable() {
+    let isQueryable = false;
+    const supportsOGCQueries = this.supportsWMS || this.supportsWFS;
+    if (supportsOGCQueries && this.ogcLayers) {
+      for (const ogcLayer of this.ogcLayers) {
+        if (ogcLayer.queryable === true) {
+          isQueryable = true;
+          break;
+        }
+      }
+    }
+    return isQueryable;
+  }
+
+  /**
+   * @return {boolean} Whether the data source supports making WFS requests
+   *     or not.
+   * @export
+   */
+  get supportsWFS() {
+    return this.wfsUrl !== null;
+  }
+
+  /**
+   * @return {boolean} Whether the data source supports making WMS requests
+   *     or not.
+   * @export
+   */
+  get supportsWMS() {
+    return this.wmsUrl !== null;
+  }
+
+  /**
+   * @return {boolean} Whether the data source supports making WTMS requests
+   *     or not.
+   * @export
+   */
+  get supportsWMTS() {
+    return this.wmtsUrl !== null;
+  }
+};
+
+
+/**
+ * Available OGC server types.
+ * @enum {string}
+ */
+ngeo.DataSource.OGCServerType = {
+  GEOSERVER: 'geoserver',
+  MAPSERVER: 'mapserver',
+  QGIS: 'qgis'
+};

--- a/src/directives/layertree.js
+++ b/src/directives/layertree.js
@@ -250,6 +250,12 @@ ngeo.LayertreeController = function($scope, $rootScope, $attrs, ngeoDecorateLaye
   this.layer = isRoot ? null : /** @type {ol.layer.Layer} */
       ($scope.$eval(nodelayerExpr, {'treeCtrl': this}));
 
+  /**
+   * @type {?ngeo.DataSource}
+   * @private
+   */
+  this.dataSource_ = null;
+
   if (this.layer) {
     ngeoDecorateLayerLoading(this.layer, $scope);
     ngeoDecorateLayer(this.layer);
@@ -396,6 +402,25 @@ ngeo.LayertreeController.prototype.getSetActive = function(val) {
   } else {
     return map.getLayers().getArray().indexOf(layer) >= 0;
   }
+};
+
+
+/**
+ * @return {?ngeo.DataSource} dataSource The data source bound to this layer
+ *     tree controller.
+ * @export
+ */
+ngeo.LayertreeController.prototype.getDataSource = function() {
+  return this.dataSource_;
+};
+
+
+/**
+ * @param {?ngeo.DataSource} dataSource Data source or null.
+ * @export
+ */
+ngeo.LayertreeController.prototype.setDataSource = function(dataSource) {
+  this.dataSource_ = dataSource;
 };
 
 

--- a/src/services/datasources.js
+++ b/src/services/datasources.js
@@ -1,0 +1,7 @@
+goog.provide('ngeo.DataSources');
+goog.require('ngeo');
+
+goog.require('ol.Collection');
+
+
+ngeo.module.value('ngeoDataSources', new ol.Collection());


### PR DESCRIPTION
This PR introduces the `ngeo.DataSource` object, which will be used as base for anything that wants to get information about specific data sources, such as: which ones are queryable, how can they be queried, etc.

This PR introduces the `gmf.DataSourcesManager` service, which is hooked to the theme and treeManager services in order to create and add the `ngeo.DataSource` objects from the themes.  The treeManager is used to synchronize the `visible` property, i.e. when the treeCtrl state becomes "on", the visibility of the data source is set.

Finally, this PR introduces an example in which the manager is injected for the data sources to be created.  It also includes the `gmf.FilterSelector` directive, which doesn't currently do anything.  It will do something in further pull requests.

## Todo

 * [x] Review