### PR TITLE
Filter - Add and synchronize ngeo.DataSource inRange property

### DIFF
--- a/contribs/gmf/examples/filterselector.js
+++ b/contribs/gmf/examples/filterselector.js
@@ -51,8 +51,8 @@ gmfapp.MainController = class {
    *     manager service.
    * @param {gmf.Themes} gmfThemes The gmf themes service.
    * @param {gmf.TreeManager} gmfTreeManager gmf Tree Manager service.
-   * @param {ol.Collection.<ngeo.DataSource>} ngeoDataSources Ngeo collection
-   *     of data sources objects.
+   * @param {ngeo.DataSources} ngeoDataSources Ngeo collection of data sources
+   *     objects.
    * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
    *     service.
    * @ngInject

--- a/contribs/gmf/src/services/datasourcesmanager.js
+++ b/contribs/gmf/src/services/datasourcesmanager.js
@@ -27,8 +27,8 @@ gmf.DataSourcesManager = class {
    * @param {angular.$timeout} $timeout Angular timeout service.
    * @param {gmf.Themes} gmfThemes The gmf Themes service.
    * @param {gmf.TreeManager} gmfTreeManager The gmf TreeManager service.
-   * @param {ol.Collection.<ngeo.DataSource>} ngeoDataSources Ngeo collection
-   *     of data sources objects.
+   * @param {ngeo.DataSources} ngeoDataSources Ngeo collection of data sources
+   *     objects.
    * @ngInject
    * @ngdoc service
    * @ngname gmfDataSourcesManager

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -103,6 +103,7 @@ ngeox.DataSourceLayer.prototype.queryable;
  *     copyable: (boolean|undefined),
  *     id: (number),
  *     idAttribute: (string|undefined),
+ *     inRange: (boolean|undefined),
  *     maxResolution: (number|undefined),
  *     minResolution: (number|undefined),
  *     name: (string),
@@ -147,6 +148,20 @@ ngeox.DataSourceOptions.prototype.id;
  * @type {string|undefined}
  */
 ngeox.DataSourceOptions.prototype.identifierAtttribute;
+
+
+/**
+ * A data source is considered 'in range' when it is synchronized to
+ * a map view and the resolution of that view is within the range of
+ * the `maxResolution` and `minResolution`. These 2 properties are
+ * required for the `inRange` property to be dynamic, otherwise its
+ * value is always `true` by default.
+ *
+ * The synchronization is made in the `ngeo.syncDataSourcesMap` service.
+ *
+ * @type {boolean|undefined}
+ */
+ngeox.DataSourceOptions.prototype.inRange;
 
 
 /**

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -34,6 +34,20 @@ ngeo.DataSource = class {
     // === DYNAMIC properties (i.e. that can change / be watched ===
 
     /**
+     * A data source is considered 'in range' when it is synchronized to
+     * a map view and the resolution of that view is within the range of
+     * the `maxResolution` and `minResolution`. These 2 properties are
+     * required for the `inRange` property to be dynamic, otherwise its
+     * value is always `true` by default.
+     *
+     * The synchronization is made in the `ngeo.syncDataSourcesMap` service.
+     *
+     * @type {boolean}
+     * @private
+     */
+    this.inRange_ = options.inRange !== false;
+
+    /**
      * Whether the data source is visible or not, i.e. whether its is ON or OFF.
      * Defaults to `false`.
      * @type {boolean}
@@ -195,6 +209,22 @@ ngeo.DataSource = class {
   }
 
   // === Dynamic property getters/setters ===
+
+  /**
+   * @return {boolean} In range
+   * @export
+   */
+  get inRange() {
+    return this.inRange_;
+  }
+
+  /**
+   * @param {boolean} inRange In range
+   * @export
+   */
+  set inRange(inRange) {
+    this.inRange_ = inRange;
+  }
 
   /**
    * @return {boolean} Visible
@@ -386,6 +416,15 @@ ngeo.DataSource = class {
       }
     }
     return isQueryable;
+  }
+
+  /**
+   * @return {boolean} Whether the data source supports a dynamic `inRange`
+   *     property or not, i.e. whether it can be calculated.
+   * @export
+   */
+  get supportsDynamicInRange() {
+    return this.maxResolution !== null || this.minResolution !== null;
   }
 
   /**

--- a/src/directives/map.js
+++ b/src/directives/map.js
@@ -2,6 +2,7 @@ goog.provide('ngeo.mapDirective');
 
 goog.require('goog.asserts');
 goog.require('ngeo');
+goog.require('ngeo.SyncDataSourcesMap');
 goog.require('ol.Map');
 
 
@@ -18,12 +19,14 @@ goog.require('ol.Map');
  * [../examples/simple.html](../examples/simple.html)
  *
  * @htmlAttribute {ol.Map} ngeo-map The map.
+ * @param {ngeo.SyncDataSourcesMap} ngeoSyncDataSourcesMap Ngeo sync
+ *     data sources map service.
  * @return {angular.Directive} Directive Definition Object.
  * @ngInject
  * @ngdoc directive
  * @ngname ngeoMap
  */
-ngeo.mapDirective = function() {
+ngeo.mapDirective = function(ngeoSyncDataSourcesMap) {
   return {
     restrict: 'A',
     /**
@@ -39,6 +42,8 @@ ngeo.mapDirective = function() {
       goog.asserts.assertInstanceof(map, ol.Map);
 
       map.setTarget(element[0]);
+
+      ngeoSyncDataSourcesMap.map = map;
     }
   };
 };

--- a/src/services/datasources.js
+++ b/src/services/datasources.js
@@ -5,3 +5,9 @@ goog.require('ol.Collection');
 
 
 ngeo.module.value('ngeoDataSources', new ol.Collection());
+
+
+/**
+ * @typedef {ol.Collection.<ngeo.DataSource>}
+ */
+ngeo.DataSources;

--- a/src/services/syncDataSourcesMap.js
+++ b/src/services/syncDataSourcesMap.js
@@ -1,10 +1,12 @@
 goog.provide('ngeo.SyncDataSourcesMap');
 
 goog.require('ngeo');
+goog.require('ngeo.DataSource');
 /** @suppress {extraRequire} */
 goog.require('ngeo.DataSources');
 goog.require('ol.Collection');
 goog.require('ol.Observable');
+goog.require('ol.View');
 
 
 ngeo.SyncDataSourcesMap = class {
@@ -111,7 +113,7 @@ ngeo.SyncDataSourcesMap = class {
    * @private
    */
   handleViewResolutionChange_(evt) {
-    const view = /** @type {ol.View} */ (evt.target);
+    const view = goog.asserts.assetInstanceof(evt.target, ol.View);
     this.syncDataSourcesToResolution_(view.getResolution());
   }
 
@@ -156,7 +158,8 @@ ngeo.SyncDataSourcesMap = class {
    * @private
    */
   handleDataSourcesAdd_(evt) {
-    const dataSource = /** @type {ngeo.DataSource} */ (evt.element);
+    const dataSource = goog.asserts.assetInstanceof(
+      evt.element, ngeo.DataSource);
     if (this.map_) {
       this.syncDataSourceToResolution_(
         dataSource,

--- a/src/services/syncDataSourcesMap.js
+++ b/src/services/syncDataSourcesMap.js
@@ -113,7 +113,7 @@ ngeo.SyncDataSourcesMap = class {
    * @private
    */
   handleViewResolutionChange_(evt) {
-    const view = goog.asserts.assetInstanceof(evt.target, ol.View);
+    const view = goog.asserts.assertInstanceof(evt.target, ol.View);
     this.syncDataSourcesToResolution_(view.getResolution());
   }
 
@@ -158,7 +158,7 @@ ngeo.SyncDataSourcesMap = class {
    * @private
    */
   handleDataSourcesAdd_(evt) {
-    const dataSource = goog.asserts.assetInstanceof(
+    const dataSource = goog.asserts.assertInstanceof(
       evt.element, ngeo.DataSource);
     if (this.map_) {
       this.syncDataSourceToResolution_(

--- a/src/services/syncDataSourcesMap.js
+++ b/src/services/syncDataSourcesMap.js
@@ -1,0 +1,171 @@
+goog.provide('ngeo.SyncDataSourcesMap');
+
+goog.require('ngeo');
+/** @suppress {extraRequire} */
+goog.require('ngeo.DataSources');
+goog.require('ol.Collection');
+goog.require('ol.Observable');
+
+
+ngeo.SyncDataSourcesMap = class {
+
+  /**
+   * This service is responsible of the synchronization between the ngeo
+   * collection of data sources and a specific map. It listens to events
+   * that come directly or indirectly from the map and update the inner
+   * properties of the data sources.
+   *
+   * The following data sources properties are synchronized here:
+   *
+   * - inRange: The map view 'change:resolution' event is listened and the
+   *   property is updated depending on the current resolution.
+   *
+   * @param {ngeo.DataSources} ngeoDataSources Ngeo collection of data sources
+   *     objects.
+   *
+   * @struct
+   * @ngdoc service
+   * @ngname ngeoSyncDataSourcesMap
+   * @ngInject
+   */
+  constructor(ngeoDataSources) {
+
+    /**
+     * @type {ngeo.DataSources}
+     * @private
+     */
+    this.ngeoDataSources_ = ngeoDataSources;
+
+    /**
+     * @type {ol.Map}
+     * @private
+     */
+    this.map_ = null;
+
+    /**
+     * @type {Array.<ol.EventsKey>}
+     * @private
+     */
+    this.listenerKeys_ = [];
+
+    ol.events.listen(
+      this.ngeoDataSources_,
+      ol.Collection.EventType.ADD,
+      this.handleDataSourcesAdd_,
+      this
+    );
+  }
+
+  /**
+   * Set a map to this service. Null can be given to unset the map.
+   * @param {?ol.Map} map Map.
+   */
+  set map(map) {
+    if (this.map_) {
+      this.unbindMap_(this.map_);
+    }
+
+    this.map_ = map;
+
+    if (map) {
+      this.bindMap_(map);
+    }
+  }
+
+  /**
+   * Bind a map to this service.
+   * @param {ol.Map} map Map.
+   * @private
+   */
+  bindMap_(map) {
+
+    // (1) Event listeners
+    const view = map.getView();
+    this.listenerKeys_.push(
+      ol.events.listen(
+        view,
+        ol.Object.getChangeEventType(ol.View.Property.RESOLUTION),
+        this.handleViewResolutionChange_,
+        this
+      )
+    );
+
+    // (2) Sync resolution with existing data sources
+    this.syncDataSourcesToResolution_(view.getResolution());
+  }
+
+  /**
+   * Unbind a map to this service.
+   * @param {ol.Map} map Map.
+   * @private
+   */
+  unbindMap_(map) {
+    ol.Observable.unByKey(this.listenerKeys_);
+    this.listenerKeys_ = 0;
+  }
+
+  /**
+   * Called when the resolution of the map view changes. Synchronize the
+   * datasources to current resolution of the view.
+   * @param {ol.ObjectEvent} evt Event.
+   * @private
+   */
+  handleViewResolutionChange_(evt) {
+    const view = /** @type {ol.View} */ (evt.target);
+    this.syncDataSourcesToResolution_(view.getResolution());
+  }
+
+  /**
+   * Synchronize all datasources in the ngeo collection with a given resolution.
+   * @param {number} resolution Resolution
+   * @private
+   */
+  syncDataSourcesToResolution_(resolution) {
+    this.ngeoDataSources_.forEach((dataSource) => {
+      this.syncDataSourceToResolution_(dataSource, resolution);
+    });
+  }
+
+  /**
+   * Synchronize a data source `inRange` property with a given resolution.
+   * @param {ngeo.DataSource} dataSource Data source
+   * @param {number} resolution Resolution
+   * @private
+   */
+  syncDataSourceToResolution_(dataSource, resolution) {
+    // No need to do anything if the data source doesn't support dynamic
+    // setting of inRange
+    if (!dataSource.supportsDynamicInRange) {
+      return;
+    }
+
+    const maxResolution = dataSource.maxResolution;
+    const minResolution = dataSource.minResolution;
+
+    const inMinRange = minResolution === null || resolution >= minResolution;
+    const inMaxRange = maxResolution === null || resolution <= maxResolution;
+    const inRange = inMinRange && inMaxRange;
+
+    dataSource.inRange = inRange;
+  }
+
+  /**
+   * Called when a new data source is added to the ngeo collection. If there's
+   * map bound, update its `inRange` right away.
+   * @param {ol.Collection.Event} evt Event
+   * @private
+   */
+  handleDataSourcesAdd_(evt) {
+    const dataSource = /** @type {ngeo.DataSource} */ (evt.element);
+    if (this.map_) {
+      this.syncDataSourceToResolution_(
+        dataSource,
+        this.map_.getView().getResolution()
+      );
+    }
+  }
+
+};
+
+
+ngeo.module.service('ngeoSyncDataSourcesMap', ngeo.SyncDataSourcesMap);


### PR DESCRIPTION
This PR introduces the `ìnRange` dynamic property within the `ngeo.DataSource` object.

It is a dynamic property, i.e. its value can change and be watched.

The value is calculated every time the map view resolution changes and uses the `maxResolution` and `minResolution` properties.  This is not directly managed within the `ngeo.DataSource` object, but inside a `ngeo.SyncDataSourcesMap` service in order to listen only once for each change of resolution.  That service is injected in the `ngeo.Map` directive.

## Todo

 * [x] Wait for #2221 to be merged
 * [ ] Review ~~(you can look at the code in the last commit only)~~