### PR TITLE
Add static function to open popup

### DIFF
--- a/contribs/gmf/less/fullscreenpopup.less
+++ b/contribs/gmf/less/fullscreenpopup.less
@@ -9,7 +9,10 @@
     height: calc(~"100vh -" 2 * @app-margin);
     max-height: calc(~"100vh -" 2 * @app-margin);
     margin: @app-margin;
-    border-radius: 0;
+    /* Like bootstrap modal border-radius */
+    border-radius: 6px;
+    /* Under bootstrap modal */
+    z-index: 1040;
   }
   .popover-title {
     background-color: @nav-bg;
@@ -22,17 +25,14 @@
     }
   }
   .popover-content {
-    /*
-     * popup's height - popover-title's height
-     * should be computed using bootstrap variables
-     */
     max-height: 90vh;
+    height: 90vh;
     -webkit-overflow-scrolling: touch;
   }
 }
 
 @media (min-width: @screen-sm-min) {
-  @fullscreenpopup-tablet-width: 8 * @map-tools-size;
+  @fullscreenpopup-tablet-width: 12 * @map-tools-size;
   [ngeo-popup] {
     &.popover {
       top: @app-margin + @map-tools-size;
@@ -45,11 +45,8 @@
     }
     .popover-content {
       overflow: auto;
-      /*
-       * popup's height - popover-title's height
-       * should be computed using bootstrap variables
-       */
       max-height: @fullscreenpopup-tablet-width;
+      height: @fullscreenpopup-tablet-width - @app-margin;
     }
   }
 }

--- a/contribs/gmf/options/gmfx.js
+++ b/contribs/gmf/options/gmfx.js
@@ -598,3 +598,18 @@ gmfx.ThemesOptions;
  * @type {boolean|undefined}
  */
 gmfx.ThemesOptions.prototype.addBlankBackgroundLayer;
+
+
+/**
+ * Static function to create a popup with an iframe.
+ * @param {string} url an url.
+ * @param {string} title (text).
+ */
+gmfx.OpenIframePopup;
+
+/**
+ * Static function to create a popup with html content.
+ * @param {string} content (text or html).
+ * @param {string} title (text).
+ */
+gmfx.OpenTextPopup;

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -443,6 +443,44 @@ gmf.AbstractController = function(config, $scope, $injector) {
       this.hasEditableLayers = hasEditableLayers;
     }.bind(this));
   };
+
+  /**
+   * Ngeo create popup factory
+   * @type {ngeo.CreatePopup}
+   */
+  var ngeoCreatePopup = $injector.get('ngeoCreatePopup');
+
+  // Static "not used" functions should be in the window because otherwise
+  // closure remove them. "export" tag doens't work on static function below,
+  // we "export" them as externs in the gmfx options file.
+  var gmfx = window.gmfx || {};
+  window.gmfx = gmfx;
+
+  /**
+   * Static function to create a popup with an iframe.
+   * @param {string} url an url.
+   * @param {string} title (text).
+   */
+  gmfx.OpenIframePopup = function(url, title) {
+    var popup = ngeoCreatePopup();
+    popup.setTitle('' + title);
+    popup.setUrl('' + url);
+    popup.setAutoDestroy(true);
+    popup.setOpen(true);
+  };
+
+  /**
+   * Static function to create a popup with html content.
+   * @param {string} content (text or html).
+   * @param {string} title (text).
+   */
+  gmfx.OpenTextPopup = function(content, title) {
+    var popup = ngeoCreatePopup();
+    popup.setTitle('' + title);
+    popup.setContent('' + content, true);
+    popup.setAutoDestroy(true);
+    popup.setOpen(true);
+  };
 };
 
 


### PR DESCRIPTION
Fix: #2195 

Example: https://testgmf.sig.cloud.camptocamp.net/bge (theme OSM .> layer OSM open -> select a dot -> click on the "Open" link -> the popup open (with some css errors (out of ngeo project)))

Add static functions `gmf.OpenTextPopup` and `gmf.OpenIframePopup`
\+ add some imporvement in the (unused) css for fullscreenpopup