### PR TITLE
Replace the 'query' service for the 'querent' and 'mapquerent'

### DIFF
--- a/contribs/gmf/examples/displayquerygrid.js
+++ b/contribs/gmf/examples/displayquerygrid.js
@@ -1,6 +1,6 @@
 goog.provide('gmfapp.displayquerygrid');
 
-goog.require('gmf.QueryManager');
+goog.require('gmf.DataSourcesManager');
 goog.require('gmf.Themes');
 /** @suppress {extraRequire} */
 goog.require('gmf.displayquerygridDirective');
@@ -84,12 +84,13 @@ gmfapp.module.controller('gmfappQueryresultController', gmfapp.QueryresultContro
 /**
  * @constructor
  * @param {gmf.Themes} gmfThemes The gmf themes service.
- * @param {gmf.QueryManager} gmfQueryManager The gmf query manager service.
+ * @param {gmf.DataSourcesManager} gmfDataSourcesManager The gmf data sources
+ *     manager service.
  * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *   overlay manager service.
  * @ngInject
  */
-gmfapp.MainController = function(gmfThemes, gmfQueryManager,
+gmfapp.MainController = function(gmfThemes, gmfDataSourcesManager,
     ngeoFeatureOverlayMgr) {
 
   gmfThemes.loadThemes();

--- a/contribs/gmf/examples/displayquerywindow.html
+++ b/contribs/gmf/examples/displayquerywindow.html
@@ -301,15 +301,15 @@
 
     <p id="desc">
       This example shows how to use the <code>ngeo-map-query</code>
-      directive in combination with the <code>gmf.QueryManager</code>.
-      The QueryManager fetches the themes returned by the theme service and
-      adds one source to the query service per layer definition found. In this
-      example, the layer tree is responsible of creating the layer. You can
-      switch theme and turn on/off layers to see the impact it has on results
-      returned by the query service.
-      To display results, this example use the <code>gmf-displayquerywindow
-      </code> component. Here, this last directive uses a custom style to
-      display all selected features.</p>
+      directive in combination with the <code>gmf.DataSourcesManager</code>.
+      The DataSourcesManager fetches the themes returned by the theme
+      service and adds one DataSource, which is used by the querent service
+      per layer definition found. In this example, the layer tree is
+      responsible of creating the layer. You can switch theme and turn
+      on/off layers to see the impact it has on results returned by the
+      query service.  To display results, this example use the
+      <code>gmf-displayquerywindow </code> component. Here, this last
+      directive uses a custom style to display all selected features.
     </p>
 
     <input type="checkbox"

--- a/contribs/gmf/examples/displayquerywindow.js
+++ b/contribs/gmf/examples/displayquerywindow.js
@@ -1,6 +1,6 @@
 goog.provide('gmfapp.displayquerywindow');
 
-goog.require('gmf.QueryManager');
+goog.require('gmf.DataSourcesManager');
 goog.require('gmf.Themes');
 /** @suppress {extraRequire} */
 goog.require('gmf.displayquerywindowDirective');
@@ -81,12 +81,13 @@ gmfapp.module.controller('AppQueryresultController', gmfapp.QueryresultControlle
 /**
  * @constructor
  * @param {gmf.Themes} gmfThemes The gmf themes service.
- * @param {gmf.QueryManager} gmfQueryManager The gmf query manager service.
+ * @param {gmf.DataSourcesManager} gmfDataSourcesManager The gmf data sources
+ *     manager service.
  * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *   overlay manager service.
  * @ngInject
  */
-gmfapp.MainController = function(gmfThemes, gmfQueryManager,
+gmfapp.MainController = function(gmfThemes, gmfDataSourcesManager,
     ngeoFeatureOverlayMgr) {
 
   gmfThemes.loadThemes();

--- a/contribs/gmf/examples/filterselector.html
+++ b/contribs/gmf/examples/filterselector.html
@@ -31,11 +31,24 @@
     </style>
   </head>
   <body ng-controller="MainController as ctrl">
-    <gmf-map gmf-map-map="ctrl.map"></gmf-map>
+    <gmf-map
+      gmf-map-map="ctrl.map"
+      ngeo-map-query=""
+      ngeo-map-query-map="::ctrl.map"
+      ngeo-map-query-active="ctrl.queryActive"
+      ngeo-bbox-query=""
+      ngeo-bbox-query-map="::ctrl.map"
+      ngeo-bbox-query-active="ctrl.queryActive">
+    </gmf-map>
 
     <p id="desc">
       This example shows how to use the <code>gmf-filterselector</code>
       directive to apply filters on the layers on the map.
+    </p>
+
+    <p>
+      You can also issue queries on the map by clicking on it or use the
+      <code>Ctrl</code> key to draw boxes on the map.
     </p>
 
     <gmf-layertree

--- a/contribs/gmf/examples/filterselector.js
+++ b/contribs/gmf/examples/filterselector.js
@@ -12,6 +12,10 @@ goog.require('gmf.filterselectorComponent');
 goog.require('gmf.layertreeDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.mapDirective');
+/** @suppress {extraRequire} */
+goog.require('ngeo.bboxQueryDirective');
+/** @suppress {extraRequire} */
+goog.require('ngeo.mapQueryDirective');
 goog.require('ngeo.ToolActivate');
 goog.require('ngeo.ToolActivateMgr');
 /** @suppress {extraRequire} */
@@ -126,6 +130,12 @@ gmfapp.MainController = class {
       this, 'dummyActive');
     ngeoToolActivateMgr.registerTool(
       'mapTools', dummyToolActivate, false);
+
+    /**
+     * @type {boolean}
+     * @export
+     */
+    this.queryActive = true;
 
     // initialize tooltips
     $('[data-toggle="tooltip"]').tooltip({

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -240,7 +240,7 @@ gmf.AbstractController = function(config, $scope, $injector) {
   this.printActive = false;
 
   /**
-   * @type {ngeo.Querent}
+   * @type {ngeo.MapQuerent}
    * @private
    */
   this.ngeoMapQuerent_ = $injector.get('ngeoMapQuerent');

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -6,7 +6,7 @@ goog.require('gmf.authenticationDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.backgroundlayerselectorDirective');
 /** @suppress {extraRequire} */
-goog.require('gmf.QueryManager');
+goog.require('gmf.DataSourcesManager');
 /** @suppress {extraRequire} */
 goog.require('gmf.TreeManager');
 /** @suppress {extraRequire} */
@@ -31,7 +31,8 @@ goog.require('ngeo.filters');
 goog.require('ngeo.mapQueryDirective');
 goog.require('ngeo.FeatureOverlayMgr');
 goog.require('ngeo.GetBrowserLanguage');
-goog.require('ngeo.Query');
+/** @suppress {extraRequire} */
+goog.require('ngeo.MapQuerent');
 goog.require('ngeo.StateManager');
 goog.require('ngeo.ToolActivate');
 goog.require('ngeo.ToolActivateMgr');
@@ -158,8 +159,12 @@ gmf.AbstractController = function(config, $scope, $injector) {
   // watch any change on dimensions object to refresh the url
   permalink.setDimensions(this.dimensions);
 
-  const queryManager = $injector.get('gmfQueryManager');
-  queryManager.setDimensions(this.dimensions);
+  // FIXME - manage dimensions ...
+  //const queryManager = $injector.get('gmfQueryManager');
+  //queryManager.setDimensions(this.dimensions);
+
+  // Injecting the gmfDataSourcesManager service creates the data sources
+  $injector.get('gmfDataSourcesManager');
 
   if ($injector.has('gmfDefaultDimensions')) {
     // Set defaults
@@ -235,17 +240,17 @@ gmf.AbstractController = function(config, $scope, $injector) {
   this.printActive = false;
 
   /**
-   * @type {ngeo.Query}
+   * @type {ngeo.Querent}
    * @private
    */
-  this.ngeoQuery_ = $injector.get('ngeoQuery');
+  this.ngeoMapQuerent_ = $injector.get('ngeoMapQuerent');
 
   // Don't deactivate ngeoQuery on print activation
   $scope.$watch(() => this.printPanelActive, (newVal) => {
     // Clear queries if another panel is open but not if user go back to the
     // map form the print.
     if (!newVal && !this.queryActive) {
-      this.ngeoQuery_.clear();
+      this.ngeoMapQuerent_.clear();
     }
     this.queryAutoClear = !newVal;
     this.printActive = newVal;

--- a/contribs/gmf/src/directives/displayquerygrid.js
+++ b/contribs/gmf/src/directives/displayquerygrid.js
@@ -8,6 +8,8 @@ goog.require('ngeo.GridConfig');
 goog.require('ngeo.gridDirective');
 goog.require('ngeo.FeatureOverlay');
 goog.require('ngeo.FeatureOverlayMgr');
+/** @suppress {extraRequire} - required for `ngeoQueryResult` */
+goog.require('ngeo.MapQuerent');
 goog.require('ol.Collection');
 goog.require('ol.style.Circle');
 goog.require('ol.style.Fill');
@@ -93,13 +95,13 @@ gmf.module.directive('gmfDisplayquerygrid', gmf.displayquerygridDirective);
 /**
  * Controller for the query grid.
  *
+ * @param {angular.$injector} $injector Main injector.
  * @param {!angular.Scope} $scope Angular scope.
  * @param {ngeox.QueryResult} ngeoQueryResult ngeo query result.
  * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *     overlay manager service.
  * @param {angular.$timeout} $timeout Angular timeout service.
  * @param {ngeo.CsvDownload} ngeoCsvDownload CSV download service.
- * @param {ngeo.Query} ngeoQuery Query service.
  * @param {angular.JQLite} $element Element.
  * @constructor
  * @export
@@ -107,8 +109,12 @@ gmf.module.directive('gmfDisplayquerygrid', gmf.displayquerygridDirective);
  * @ngdoc Controller
  * @ngname GmfDisplayquerygridController
  */
-gmf.DisplayquerygridController = function($scope, ngeoQueryResult,
-    ngeoFeatureOverlayMgr, $timeout, ngeoCsvDownload, ngeoQuery, $element) {
+gmf.DisplayquerygridController = function($injector, $scope, ngeoQueryResult,
+    ngeoFeatureOverlayMgr, $timeout, ngeoCsvDownload, $element) {
+
+  const queryOptions = /** @type {ngeox.QueryOptions} */ (
+      $injector.has('ngeoQueryOptions') ?
+      $injector.get('ngeoQueryOptions') : {});
 
   /**
    * @type {!angular.Scope}
@@ -144,7 +150,7 @@ gmf.DisplayquerygridController = function($scope, ngeoQueryResult,
    * @type {number}
    * @export
    */
-  this.maxResults = ngeoQuery.getLimit();
+  this.maxResults = queryOptions.limit !== undefined ? queryOptions.limit : 50;
 
   /**
    * @type {boolean}

--- a/contribs/gmf/src/directives/displayquerywindow.js
+++ b/contribs/gmf/src/directives/displayquerywindow.js
@@ -4,6 +4,8 @@ goog.provide('gmf.displayquerywindowDirective');
 goog.require('gmf');
 goog.require('ngeo.FeatureOverlay');
 goog.require('ngeo.FeatureOverlayMgr');
+/** @suppress {extraRequire} - required for `ngeoQueryResult` */
+goog.require('ngeo.MapQuerent');
 goog.require('ol.Collection');
 goog.require('ol.style.Circle');
 goog.require('ol.style.Fill');

--- a/contribs/gmf/src/services/objecteditingquery.js
+++ b/contribs/gmf/src/services/objecteditingquery.js
@@ -2,6 +2,7 @@ goog.provide('gmf.ObjectEditingQuery');
 
 goog.require('gmf');
 goog.require('gmf.Themes');
+goog.require('ngeo.DataSource');
 goog.require('ol.format.WMSGetFeatureInfo');
 goog.require('ol.source.ImageWMS');
 
@@ -168,7 +169,7 @@ gmf.ObjectEditingQuery.prototype.getFeatureInfo = function(
   const view = map.getView();
   const projCode = view.getProjection().getCode();
   const resolution = /** @type {number} */(view.getResolution());
-  const infoFormat = ngeo.QueryInfoFormatType.GML;
+  const infoFormat = ngeo.DataSource.WMSInfoFormat.GML;
   const layerNode = layerInfo.layerNode;
   const layersParam = layerNode.layers.split(',');
   const ogcServer = layerInfo.ogcServer;

--- a/examples/bboxquery.js
+++ b/examples/bboxquery.js
@@ -2,7 +2,8 @@ goog.provide('app.bboxquery');
 
 /** @suppress {extraRequire} */
 goog.require('ngeo.proj.EPSG21781');
-goog.require('ngeo.Query');
+goog.require('ngeo.DataSource');
+goog.require('ngeo.DataSources');
 /** @suppress {extraRequire} */
 goog.require('ngeo.btnDirective');
 /** @suppress {extraRequire} */
@@ -66,11 +67,12 @@ app.module.controller('AppQueryresultController', app.QueryresultController);
 
 /**
  * @param {angular.Scope} $scope Scope.
- * @param {ngeo.Query} ngeoQuery The ngeo query service
+ * @param {ngeo.DataSources} ngeoDataSources Ngeo collection of data sources
+ *     objects.
  * @constructor
  * @ngInject
  */
-app.MainController = function($scope, ngeoQuery) {
+app.MainController = function($scope, ngeoDataSources) {
 
   /**
    * @type {boolean}
@@ -78,32 +80,38 @@ app.MainController = function($scope, ngeoQuery) {
    */
   this.queryActive = true;
 
-  const busStopSourceId = 'bus_stop';
+  ngeoDataSources.push(new ngeo.DataSource({
+    id: 1,
+    name: 'bus_stop',
+    visible: true,
+    wfsUrl: 'https://geomapfish-demo.camptocamp.net/1.6/wsgi/mapserv_proxy',
+    ogcLayers: [{
+      name: 'bus_stop',
+      queryable: true
+    }]
+  }));
   const busStopLayer = new ol.layer.Image({
-    'querySourceId': busStopSourceId,
     'source': new ol.source.ImageWMS({
       'url': 'https://geomapfish-demo.camptocamp.net/1.6/wsgi/mapserv_proxy',
       params: {'LAYERS': 'bus_stop'}
     })
   });
-  ngeoQuery.addSource({
-    'id': busStopSourceId,
-    'layer': busStopLayer,
-    'wfsQuery': true
-  });
 
-  const informationSourceId = 'information';
+  ngeoDataSources.push(new ngeo.DataSource({
+    id: 2,
+    name: 'information',
+    visible: true,
+    wfsUrl: 'https://geomapfish-demo.camptocamp.net/1.6/wsgi/mapserv_proxy',
+    ogcLayers: [{
+      name: 'information',
+      queryable: true
+    }]
+  }));
   const informationLayer = new ol.layer.Image({
-    'querySourceId': informationSourceId,
     'source': new ol.source.ImageWMS({
       'url': 'https://geomapfish-demo.camptocamp.net/1.6/wsgi/mapserv_proxy',
       params: {'LAYERS': 'information'}
     })
-  });
-  ngeoQuery.addSource({
-    'id': informationSourceId,
-    'layer': informationLayer,
-    'wfsQuery': true
   });
 
   /**

--- a/examples/mapquery.js
+++ b/examples/mapquery.js
@@ -2,7 +2,8 @@ goog.provide('app.mapquery');
 
 /** @suppress {extraRequire} */
 goog.require('ngeo.proj.EPSG21781');
-goog.require('ngeo.Query');
+goog.require('ngeo.DataSource');
+goog.require('ngeo.DataSources');
 goog.require('ngeo.ToolActivate');
 goog.require('ngeo.ToolActivateMgr');
 /** @suppress {extraRequire} */
@@ -68,13 +69,14 @@ app.module.controller('AppQueryresultController', app.QueryresultController);
 
 /**
  * @param {angular.Scope} $scope Scope.
- * @param {ngeo.Query} ngeoQuery The ngeo query service
+ * @param {ngeo.DataSources} ngeoDataSources Ngeo collection of data sources
+ *     objects.
  * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr The ngeo ToolActivate
  *     manager.
  * @constructor
  * @ngInject
  */
-app.MainController = function($scope, ngeoQuery, ngeoToolActivateMgr) {
+app.MainController = function($scope, ngeoDataSources, ngeoToolActivateMgr) {
 
   /**
    * @type {boolean}
@@ -88,30 +90,38 @@ app.MainController = function($scope, ngeoQuery, ngeoToolActivateMgr) {
    */
   this.queryActive = true;
 
-  const busStopSourceId = 'bus_stop';
+  ngeoDataSources.push(new ngeo.DataSource({
+    id: 1,
+    name: 'bus_stop',
+    visible: true,
+    wmsUrl: 'https://geomapfish-demo.camptocamp.net/1.6/wsgi/mapserv_proxy',
+    ogcLayers: [{
+      name: 'bus_stop',
+      queryable: true
+    }]
+  }));
   const busStopLayer = new ol.layer.Image({
-    'querySourceIds': [busStopSourceId],
     'source': new ol.source.ImageWMS({
       'url': 'https://geomapfish-demo.camptocamp.net/1.6/wsgi/mapserv_proxy',
       params: {'LAYERS': 'bus_stop'}
     })
   });
-  ngeoQuery.addSource({
-    'id': busStopSourceId,
-    'layer': busStopLayer
-  });
 
-  const informationSourceId = 'information';
+  ngeoDataSources.push(new ngeo.DataSource({
+    id: 2,
+    name: 'information',
+    visible: true,
+    wmsUrl: 'https://geomapfish-demo.camptocamp.net/1.6/wsgi/mapserv_proxy',
+    ogcLayers: [{
+      name: 'information',
+      queryable: true
+    }]
+  }));
   const informationLayer = new ol.layer.Image({
-    'querySourceIds': [informationSourceId],
     'source': new ol.source.ImageWMS({
       'url': 'https://geomapfish-demo.camptocamp.net/1.6/wsgi/mapserv_proxy',
       params: {'LAYERS': 'information'}
     })
-  });
-  ngeoQuery.addSource({
-    'id': informationSourceId,
-    'layer': informationLayer
   });
 
   /**

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -101,6 +101,7 @@ ngeox.DataSourceLayer.prototype.queryable;
  * The options to create a ngeo.DataSource with.
  * @typedef {{
  *     copyable: (boolean|undefined),
+ *     geometryName: (string|undefined),
  *     id: (number),
  *     idAttribute: (string|undefined),
  *     inRange: (boolean|undefined),
@@ -110,13 +111,17 @@ ngeox.DataSourceLayer.prototype.queryable;
  *     ogcImageType: (string|undefined),
  *     ogcLayers: (!Array.<!ngeox.DataSourceLayer>|undefined),
  *     ogcServerType: (string|undefined),
- *     ogcType: (string),
+ *     ogcType: (string|undefined),
  *     snappable: (boolean|undefined),
  *     snappingTolerance: (number|undefined),
  *     snappingToEdges: (boolean|undefined),
  *     snappingToVertice: (boolean|undefined),
  *     visible: (boolean|undefined),
+ *     wfsFeatureNS: (string|undefined),
+ *     wfsFeaturePrefix: (string|undefined),
+ *     wfsOutputFormat: (string|undefined),
  *     wfsUrl: (string|undefined),
+ *     wmsInfoFormat: (string|undefined),
  *     wmsIsSingleTile: (boolean|undefined),
  *     wmsUrl: (string|undefined),
  *     wmtsLayer: (string|undefined),
@@ -132,6 +137,13 @@ ngeox.DataSourceOptions;
  * @type {boolean|undefined}
  */
 ngeox.DataSourceOptions.prototype.copyable;
+
+
+/**
+ * The name of the geometry attribute.
+ * @type {string|undefined}
+ */
+ngeox.DataSourceOptions.prototype.geometryName;
 
 
 /**
@@ -258,10 +270,38 @@ ngeox.DataSourceOptions.prototype.visible;
 
 
 /**
+ * The feature namespace to use with WFS requests.
+ * @type {string|undefined}
+ */
+ngeox.DataSourceOptions.prototype.wfsFeatureNS;
+
+
+/**
+ * The feature prefix to use with WFS requests.
+ * @type {string|undefined}
+ */
+ngeox.DataSourceOptions.prototype.wfsFeaturePrefix;
+
+
+/**
+ * The OutputFormat to use with WFS requests.
+ * @type {string|undefined}
+ */
+ngeox.DataSourceOptions.prototype.wfsOutputFormat;
+
+
+/**
  * The url to use for (WFS) requests.
  * @type {string|undefined}
  */
 ngeox.DataSourceOptions.prototype.wfsUrl;
+
+
+/**
+ * The InfoFormat to use with WMS requests.
+ * @type {string|undefined}
+ */
+ngeox.DataSourceOptions.prototype.wmsInfoFormat;
 
 
 /**
@@ -291,6 +331,107 @@ ngeox.DataSourceOptions.prototype.wmtsLayer;
  * @type {string|undefined}
  */
 ngeox.DataSourceOptions.prototype.wmtsUrl;
+
+
+/**
+ * The options to use when sending GetFeature/GetFeatureInfo requests using
+ * the querent or map query service.
+ * @typedef {{
+ *     coordinate: (ol.Coordinate|undefined),
+ *     dataSources: (Array.<ngeo.DataSource>|undefined),
+ *     extent: (ol.Extent|undefined),
+ *     limit: (number|undefined),
+ *     map: (ol.Map),
+ *     queryableDataSources: (ngeox.QueryableDataSources|undefined),
+ *     tolerancePx: (number|undefined)
+ * }}
+ */
+ngeox.IssueGetFeaturesOptions;
+
+
+/**
+ * The coordinate to issue the requests with, which can end up with either
+ * WMS or WFS requests.
+ * @type {ol.Coordinate|undefined}
+ */
+ngeox.IssueGetFeaturesOptions.prototype.coordinate;
+
+
+/**
+ * List of data sources to query. Only those that meet the requirements will
+ * actually be queried. The querent service requires either the `dataSources`
+ * or `queryableDataSources` property to be set.
+ * @type {Array.<ngeo.DataSource>|undefined}
+ */
+ngeox.IssueGetFeaturesOptions.prototype.dataSources;
+
+
+/**
+ * The extent to issue the requests with, which can end up with WFS requests
+ * only.
+ * @type {ol.Extent|undefined}
+ */
+ngeox.IssueGetFeaturesOptions.prototype.extent;
+
+
+/**
+ * The maximum number of features to get per request.
+ * @type {number|undefined}
+ */
+ngeox.IssueGetFeaturesOptions.prototype.limit;
+
+
+/**
+ * The ol3 map object. Used to fill some parameters of the queries, such as
+ * 'srs' and filter the queryable layers within the data sources.
+ * @type {ol.Map}
+ */
+ngeox.IssueGetFeaturesOptions.prototype.map;
+
+
+/**
+ * A hash of queryable data sources, which must meet all requirements. The
+ * querent service requires either the `dataSources` or `queryableDataSources`
+ * property to be set.
+ * @type {ngeox.QueryableDataSources|undefined}
+ */
+ngeox.IssueGetFeaturesOptions.prototype.queryableDataSources;
+
+
+/**
+ * A tolerance value in pixels used to create an extent from a coordinate
+ * to issue WFS requests.
+ * @type {number|undefined}
+ */
+ngeox.IssueGetFeaturesOptions.prototype.tolerancePx;
+
+
+/**
+ * A hash that contains 2 lists of queryable data sources: `wfs` and `wms`.
+ * The same data source can only be in one of the two lists. The `wfs` list
+ * has priority, i.e. if the data source supports WFS, it's put in the
+ * `wfs` list.
+ *
+ * @typedef {{
+ *     wfs: (!Array.<!ngeo.DataSource>),
+ *     wms: (!Array.<!ngeo.DataSource>)
+ * }}
+ */
+ngeox.QueryableDataSources;
+
+
+/**
+ * List of queryable data sources that support WFS.
+ * @type {Array.<ngeo.DataSource>}
+ */
+ngeox.QueryableDataSources.prototype.wfs;
+
+
+/**
+ * List of queryable data sources that support WMS.
+ * @type {Array.<ngeo.DataSource>}
+ */
+ngeox.QueryableDataSources.prototype.wms;
 
 
 /**
@@ -489,7 +630,7 @@ ngeox.PopupOptions.prototype.width;
 /**
  * Results of the query source.
  * @typedef {{
- *     sources: (Array.<ngeox.QueryResultSource>),
+ *     sources: (!Array.<ngeox.QueryResultSource>),
  *     total: (number),
  *     pending: (boolean)
  * }}
@@ -499,7 +640,7 @@ ngeox.QueryResult;
 
 /**
  * Results for each query source.
- * @type {Array.<ngeox.QueryResultSource>}
+ * @type {!Array.<ngeox.QueryResultSource>}
  */
 ngeox.QueryResult.prototype.sources;
 

--- a/src/directives/bboxquery.js
+++ b/src/directives/bboxquery.js
@@ -1,7 +1,7 @@
 goog.provide('ngeo.bboxQueryDirective');
 
 goog.require('ngeo');
-goog.require('ngeo.Query');
+goog.require('ngeo.MapQuerent');
 goog.require('ol.interaction.DragBox');
 
 
@@ -27,13 +27,13 @@ goog.require('ol.interaction.DragBox');
  *
  * See the live example: [../examples/bboxquery.html](../examples/bboxquery.html)
  *
- * @param {ngeo.Query} ngeoQuery The ngeo Query service.
+ * @param {ngeo.MapQuerent} ngeoMapQuerent The ngeo map querent service.
  * @return {angular.Directive} The Directive Definition Object.
  * @ngInject
  * @ngdoc directive
  * @ngname ngeoBboxQuery
  */
-ngeo.bboxQueryDirective = function(ngeoQuery) {
+ngeo.bboxQueryDirective = function(ngeoMapQuerent) {
   return {
     restrict: 'A',
     scope: false,
@@ -54,7 +54,10 @@ ngeo.bboxQueryDirective = function(ngeoQuery) {
        */
       const handleBoxEnd = function(evt) {
         const extent = interaction.getGeometry().getExtent();
-        ngeoQuery.issue(map, extent);
+        ngeoMapQuerent.issue({
+          extent,
+          map
+        });
       };
       interaction.on('boxend', handleBoxEnd);
 
@@ -68,7 +71,7 @@ ngeo.bboxQueryDirective = function(ngeoQuery) {
               // deactivate
               map.removeInteraction(interaction);
               if (scope.$eval(attrs['ngeoBboxQueryAutoclear']) !== false) {
-                ngeoQuery.clear();
+                ngeoMapQuerent.clear();
               }
             }
           }

--- a/src/directives/mapquery.js
+++ b/src/directives/mapquery.js
@@ -1,7 +1,7 @@
 goog.provide('ngeo.mapQueryDirective');
 
 goog.require('ngeo');
-goog.require('ngeo.Query');
+goog.require('ngeo.MapQuerent');
 
 
 /**
@@ -26,13 +26,13 @@ goog.require('ngeo.Query');
  *
  * See our live example: [../examples/mapquery.html](../examples/mapquery.html)
  *
- * @param {ngeo.Query} ngeoQuery The ngeo Query service.
+ * @param {ngeo.MapQuerent} ngeoMapQuerent The ngeo map querent service.
  * @return {angular.Directive} The Directive Definition Object.
  * @ngInject
  * @ngdoc directive
  * @ngname ngeoMapQuery
  */
-ngeo.mapQueryDirective = function(ngeoQuery) {
+ngeo.mapQueryDirective = function(ngeoMapQuerent) {
   return {
     restrict: 'A',
     scope: false,
@@ -46,7 +46,11 @@ ngeo.mapQueryDirective = function(ngeoQuery) {
        * @param {ol.MapBrowserEvent} evt The map browser event being fired.
        */
       const handleMapClick_ = function(evt) {
-        ngeoQuery.issue(map, evt.coordinate);
+        const coordinate = evt.coordinate;
+        ngeoMapQuerent.issue({
+          coordinate,
+          map
+        });
       };
 
       /**
@@ -67,7 +71,7 @@ ngeo.mapQueryDirective = function(ngeoQuery) {
           clickEventKey_ = null;
         }
         if (scope.$eval(attrs['ngeoMapQueryAutoclear']) !== false) {
-          ngeoQuery.clear();
+          ngeoMapQuerent.clear();
         }
       };
 

--- a/src/services/datasourceshelper.js
+++ b/src/services/datasourceshelper.js
@@ -1,0 +1,95 @@
+goog.provide('ngeo.DataSourcesHelper');
+
+goog.require('ngeo');
+goog.require('ngeo.DataSource');
+goog.require('ngeo.DataSources');
+
+
+ngeo.DataSourcesHelper = class {
+
+  /**
+   * A service that provides utility methods to manipulate or get data sources.
+   *
+   * @struct
+   * @param {ngeo.DataSources} ngeoDataSources Ngeo collection of data source
+   *     objects.
+   * @ngdoc service
+   * @ngname ngeoDataSourcesHelper
+   * @ngInject
+   */
+  constructor(ngeoDataSources) {
+
+    /**
+     * @type {ngeo.DataSources}
+     * @private
+     */
+    this.collection_ = ngeoDataSources;
+
+    /**
+     * @type {Object.<number, ngeo.DataSource>}
+     * @private
+     */
+    this.cache_ = {};
+
+    // Events
+
+    ol.events.listen(
+      ngeoDataSources,
+      ol.Collection.EventType.ADD,
+      this.handleDataSourcesAdd_,
+      this
+    );
+    ol.events.listen(
+      ngeoDataSources,
+      ol.Collection.EventType.REMOVE,
+      this.handleDataSourcesRemove_,
+      this
+    );
+  }
+
+  /**
+   * @return {ngeo.DataSources} Data sources collection.
+   * @export
+   */
+  get collection() {
+    return this.collection_;
+  }
+
+  /**
+   * Return a data source using its id.
+   * @param {number} id Data source id.
+   * @return {?ngeo.DataSource} Data source.
+   * @export
+   */
+  getDataSource(id) {
+    return this.cache_[id] || null;
+  }
+
+  /**
+   * Called when a new data source is added to the ngeo collection. Add it
+   * to the cache.
+   * @param {ol.Collection.Event} evt Event
+   * @private
+   */
+  handleDataSourcesAdd_(evt) {
+    const dataSource = goog.asserts.assertInstanceof(
+      evt.element, ngeo.DataSource);
+    this.cache_[dataSource.id] = dataSource;
+  }
+
+  /**
+   * Called when a data source is removed from the ngeo collection. Remove it
+   * from the cache.
+   * @param {ol.Collection.Event} evt Event
+   * @private
+   */
+  handleDataSourcesRemove_(evt) {
+    const dataSource = goog.asserts.assertInstanceof(
+      evt.element, ngeo.DataSource);
+    delete this.cache_[dataSource.id];
+  }
+
+};
+
+
+ngeo.module.service('ngeoDataSourcesHelper', ngeo.DataSourcesHelper);

--- a/src/services/mapquerent.js
+++ b/src/services/mapquerent.js
@@ -1,0 +1,180 @@
+goog.provide('ngeo.MapQuerent');
+
+goog.require('ngeo');
+goog.require('ngeo.Querent');
+goog.require('ngeo.DataSourcesHelper');
+
+
+/**
+ * The `ngeoQueryResult` is the value service where the features of the query
+ * result are added.
+ */
+ngeo.module.value('ngeoQueryResult', /** @type {ngeox.QueryResult} */ ({
+  sources: [],
+  total: 0,
+  pending: false
+}));
+
+
+ngeo.MapQuerent = class {
+
+  /**
+   * The ngeo Map Querent is the service bound to a map that issues
+   * queries using the Querent service. The result is stored inside this
+   * service.
+   *
+   * NOTE: This will replace the ngeo.Query service.
+   *
+   * @struct
+   * @param {angular.$injector} $injector Main injector.
+   * @param {ngeo.DataSources} ngeoDataSources Ngeo collection of data source
+   *     objects.
+   * @param {ngeo.DataSourcesHelper} ngeoDataSourcesHelper Ngeo data sources
+   *     helper service.
+   * @param {ngeo.Querent} ngeoQuerent The ngeo querent service.
+   * @param {ngeox.QueryResult} ngeoQueryResult The ngeo query result service.
+   * @ngdoc service
+   * @ngname ngeoQuerent
+   * @ngInject
+   */
+  constructor($injector, ngeoDataSources, ngeoDataSourcesHelper, ngeoQuerent,
+      ngeoQueryResult) {
+
+    const options = /** @type {ngeox.QueryOptions} */ (
+      $injector.has('ngeoQueryOptions') ?
+      $injector.get('ngeoQueryOptions') : {});
+
+    /**
+     * @type {ngeo.DataSources}
+     * @private
+     */
+    this.ngeoDataSources_ = ngeoDataSources;
+
+    /**
+     * @type {ngeo.DataSourcesHelper}
+     * @private
+     */
+    this.ngeoDataSourcesHelper_ = ngeoDataSourcesHelper;
+
+    /**
+     * @type {ngeo.Querent}
+     * @private
+     */
+    this.ngeoQuerent_ = ngeoQuerent;
+
+    /**
+     * @type {ngeox.QueryResult}
+     * @private
+     */
+    this.result_ = ngeoQueryResult;
+
+    /**
+     * @type {number}
+     * @private
+     */
+    this.limit_ = options.limit !== undefined ? options.limit : 50;
+
+    /**
+     * FIXME
+     * @type {boolean}
+     * @private
+     */
+    this.queryCountFirst_ = options.queryCountFirst !== undefined ?
+      options.queryCountFirst : false;
+
+    /**
+     * @type {number}
+     * @private
+     */
+    this.tolerancePx_ = options.tolerance !== undefined ?
+      options.tolerance : 3;
+
+    /**
+     * A hash of data source names classified by ids.
+     * @type {Object.<number, string>}
+     * @private
+     */
+    this.dataSourceNames_ = {};
+  }
+
+  /**
+   * @param {ngeox.IssueGetFeaturesOptions} options Options.
+   * @export
+   */
+  issue(options) {
+    // (1) Clear previous result
+    this.clear();
+
+    // (2) Get queryable data sources
+    const queryableDataSources = this.ngeoQuerent_.getQueryableDataSources(
+      this.ngeoDataSources_.getArray(),
+      options.map
+    );
+
+    // (3) Update query options, update the pending property and issue the
+    //     request.
+    ol.obj.assign(options, {
+      queryableDataSources,
+      limit: this.limit_,
+      tolerancePx: this.tolerancePx_
+    });
+    this.result_.pending = true;
+    this.ngeoQuerent_.issue(options).then(this.handleResult_.bind(this));
+  }
+
+  /**
+   * Clear result, i.e. clear all 'result source' from their features and other
+   * information.
+   * @export
+   */
+  clear() {
+    this.result_.total = 0;
+    for (const source of this.result_.sources) {
+      source.features.length = 0;
+      source.pending = false;
+      source.queried = false;
+      source.tooManyResults = false;
+      source.totalFeatureCount = undefined;
+    }
+    this.result_.sources.length = 0; // Clear previous result sources
+    this.result_.pending = false;
+  }
+
+  /**
+   * Called after a request to the querent service. Update the result.
+   *
+   * @param {!Object.<number, !Array.<!ol.Feature>>} response Response
+   * @private
+   */
+  handleResult_(response) {
+    let total = 0;
+
+    // (1) Update result sources, i.e. add them
+    for (const idStr in response) {
+      const id = Number(idStr);
+      const dataSource = this.ngeoDataSourcesHelper_.getDataSource(id);
+      const label = dataSource.name;
+      goog.asserts.assert(dataSource);
+
+      const features = response[id];
+      goog.asserts.assert(features);
+      this.result_.sources.push({
+        features,
+        id,
+        label,
+        pending: false,
+        queried: true,
+        tooManyResults: false
+      });
+      total += features.length;
+    }
+
+    // (2) Update total & pending
+    this.result_.total = total;
+    this.result_.pending = false;
+  }
+
+};
+
+
+ngeo.module.service('ngeoMapQuerent', ngeo.MapQuerent);

--- a/src/services/querent.js
+++ b/src/services/querent.js
@@ -1,0 +1,509 @@
+goog.provide('ngeo.Querent');
+
+goog.require('ngeo');
+goog.require('ol.format.WFS');
+goog.require('ol.source.ImageWMS');
+
+
+ngeo.Querent = class {
+
+  /**
+   * The ngeo Querent is a service that issues all sorts of queries using
+   * ngeo data sources. It does not store the result. Instead, it returns it
+   * using promises. Any component that inject this service can use it to
+   * make it issue its own queries and do whatever it wants with the result.
+   *
+   * @struct
+   * @param {angular.$http} $http Angular $http service.
+   * @param {angular.$q} $q The Angular $q service.
+   * @ngdoc service
+   * @ngname ngeoQuerent
+   * @ngInject
+   */
+  constructor($http, $q) {
+
+    // === Injected properties ===
+
+    /**
+     * @type {angular.$http}
+     * @private
+     */
+    this.http_ = $http;
+
+    /**
+     * @type {angular.$q}
+     * @private
+     */
+    this.q_ = $q;
+
+
+    // === Other properties ===
+
+    /**
+     * Promises that can be resolved to cancel started requests.
+     * @type {!Array.<angular.$q.Deferred>}
+     * @private
+     */
+    this.requestCancelers_ = [];
+  }
+
+
+  // === PUBLIC methods ===
+
+  /**
+   * Issue WMS GetFeatureInfo and/or WFS GetFeature requests using the given
+   * data sources, map and optional filters.
+   *
+   * @param {ngeox.IssueGetFeaturesOptions} options Options.
+   * @return {angular.$q.Promise} Promise.
+   * @export
+   */
+  issue(options) {
+
+    const promises = [];
+    const map = options.map;
+
+    // (1) Cancel requests that are still running
+    this.cancelStillRunningRequests_();
+
+    // (2) Get queryable data sources
+    let queryableDataSources;
+    if (options.queryableDataSources) {
+      queryableDataSources = options.queryableDataSources;
+    } else {
+      const dataSources = options.dataSources;
+      goog.asserts.assert(dataSources, 'DataSources should be set');
+      queryableDataSources = this.getQueryableDataSources(dataSources, map);
+    }
+
+    // (3) Combine data sources that support WFS and issue WFS queries.
+    //     The 'bbox' ('extent' option) is not required for WFS requests to
+    //     be issued.
+    const combinedWFSDataSources = this.getCombinableWFSDataSources_(
+      queryableDataSources.wfs);
+    promises.push(this.issueCombinedWFS_(combinedWFSDataSources, options));
+
+    // (4) Combine data sources that support WMS and issue WMS queries.
+    //     Only occurs if the `coordinate` option is set, because it's required
+    //     by WMS GetFeatureInfo requests.
+    const coordinate = options.coordinate;
+    if (coordinate) {
+      const combinedWMSDataSources = this.getCombinableWMSDataSources_(
+        queryableDataSources.wms);
+      promises.push(this.issueCombinedWMS_(combinedWMSDataSources, options));
+    }
+
+    return this.q_.all(promises).then(
+      this.handleCombinedQueryResult_.bind(this)
+    );
+  }
+
+  /**
+   * Browse a given list of data sources. Return 2 lists of data sources that
+   * are queryable, the first one being those that support WFS and the other
+   * WMS only. This means that WFS is always favored first, then WMS.
+   *
+   * The map view resolution determines if the inner ogc layers are in range.
+   *
+   * @param {!Array.<!ngeo.DataSource>} dataSources Data sources
+   * @param {ol.Map} map Map.
+   * @return {!ngeox.QueryableDataSources} Queryable data sources.
+   * @export
+   */
+  getQueryableDataSources(dataSources, map) {
+
+    const queryableDataSources = {
+      wfs: [],
+      wms: []
+    };
+    const resolution = goog.asserts.assertNumber(map.getView().getResolution());
+
+    for (const dataSource of dataSources) {
+
+      // (1) Skip data source that can't be queried
+      if (!this.isDataSourceQueryable_(dataSource, resolution)) {
+        continue;
+      }
+
+      // (2) Split data sources
+      if (dataSource.supportsWFS) {
+        queryableDataSources.wfs.push(dataSource);
+      } else {
+        queryableDataSources.wms.push(dataSource);
+      }
+    }
+
+    return queryableDataSources;
+  }
+
+
+  // === PRIVATE methods ===
+
+  /**
+   * Handles the response of multiple promises that did either
+   * WMS GetFeatureInfo or WFS GetFeature requests, in which the result is
+   * a hash with key being the data source id and value the array of features.
+   *
+   * The response object itself is an array, one item being one result per
+   * promise. The idea is to return a single hash by combining the result
+   * objects.
+   *
+   * The keys are always unique, i.e. there can be multiple result objects for
+   * the same data source id.
+   *
+   * @param {!Array.<!Object.<number, !Array.<!ol.Feature>>>} response Response.
+   * @return {!Object.<number, !Array.<!ol.Feature>>} Hash of features by
+   *     data source ids.
+   * @private
+   */
+  handleCombinedQueryResult_(response) {
+    const combinedHash = {};
+    for (const hash of response) {
+      for (const dataSourceIdStr in hash) {
+        const dataSourceId = Number(dataSourceIdStr);
+        combinedHash[dataSourceId] = hash[dataSourceId];
+      }
+    }
+    return combinedHash;
+  }
+
+
+  /**
+   * Handles the result of a single WMS GetFeatureInfo or WFS GetFeature
+   * request. Read features from the response and return them.
+   *
+   * @param {!Array.<!ngeo.DataSource>} dataSources List of queryable data
+   *     sources that were used to do the query.
+   * @param {boolean} wfs Whether the query was WFS or WMS.
+   * @param {!angular.$http.Response} response Response.
+   * @return {Object.<number, Array.<ol.Feature>>} Hash of features by
+   *     data source ids.
+   * @private
+   */
+  handleQueryResult_(dataSources, wfs, response) {
+
+    const hash = {};
+
+    for (const dataSource of dataSources) {
+      let features;
+      if (wfs) {
+        features = dataSource.wfsFormat.readFeatures(response.data);
+      } else {
+        features = dataSource.wmsFormat.readFeatures(response.data);
+      }
+      const dataSourceId = dataSource.id;
+      this.setUniqueIds_(features, dataSource.id);
+      hash[dataSourceId] = features;
+    }
+
+    return hash;
+  }
+
+  /**
+   * Issue WFS GetFeature requests using the given combined data sources, map
+   * and optional filters.
+   *
+   * @param {!ngeo.Querent.CombinedDataSources} combinedDataSources Combined
+   *     data sources.
+   * @param {ngeox.IssueGetFeaturesOptions} options Options.
+   * @return {angular.$q.Promise} Promise.
+   * @private
+   */
+  issueCombinedWFS_(combinedDataSources, options) {
+
+    const promises = [];
+
+    const maxFeatures = options.limit;
+    const map = options.map;
+    const view = map.getView();
+    const resolution = goog.asserts.assertNumber(view.getResolution());
+    const projection = view.getProjection();
+    const srsName = projection.getCode();
+
+    // (1) Extent (bbox), which is optional, i.e. its value can stay undefined
+    let bbox;
+    const coordinate = options.coordinate;
+    if (coordinate) {
+      const tolerancePx = options.tolerancePx;
+      goog.asserts.assert(tolerancePx);
+      const tolerance = tolerancePx * resolution;
+      bbox = ol.extent.buffer(
+        ol.extent.createOrUpdateFromCoordinate(coordinate),
+        tolerance
+      );
+    } else {
+      bbox = options.extent;
+    }
+
+    // (2) Launch one request per combinaison of data sources
+    const wfsFormat = new ol.format.WFS();
+    const xmlSerializer = new XMLSerializer();
+    for (const dataSources of combinedDataSources) {
+
+      let getFeatureOptions;
+      let featureNS;
+      let featureTypes = [];
+      let url;
+
+      // (3) Build query options
+      for (const dataSource of dataSources) {
+
+        // (a) Create common options, if not done yet
+        if (!getFeatureOptions) {
+          featureNS = dataSource.wfsFeatureNS;
+          const featurePrefix = dataSource.wfsFeaturePrefix;
+          const geometryName = dataSource.geometryName;
+          const outputFormat = dataSource.wfsOutputFormat;
+
+          getFeatureOptions = {
+            bbox,
+            featureNS,
+            featurePrefix,
+            geometryName,
+            maxFeatures,
+            outputFormat,
+            srsName
+          };
+
+          url = dataSource.wfsUrl;
+        }
+
+        // (b) Add queryable layer names in featureTypes array
+        featureTypes = featureTypes.concat(
+          dataSource.getInRangeOGCLayerNames(resolution, true));
+      }
+
+      goog.asserts.assert(getFeatureOptions);
+      getFeatureOptions.featureTypes = featureTypes;
+      goog.asserts.assert(url);
+
+      // (4) Build query then launch
+      const featureRequestXml = wfsFormat.writeGetFeature(getFeatureOptions);
+      const featureRequest = xmlSerializer.serializeToString(featureRequestXml);
+
+      const canceler = this.registerCanceler_();
+      promises.push(
+        this.http_.post(
+          url,
+          featureRequest,
+          {
+            timeout: canceler.promise
+          }
+        ).then(
+          this.handleQueryResult_.bind(this, dataSources, true)
+        )
+      );
+    }
+
+    return this.q_.all(promises).then(
+      this.handleCombinedQueryResult_.bind(this)
+    );
+  }
+
+  /**
+   * Issue WMS GetFeatureInfo requests using the given combined data sources,
+   * map and optional filters.
+   *
+   * @param {!ngeo.Querent.CombinedDataSources} combinedDataSources Combined
+   *     data sources.
+   * @param {ngeox.IssueGetFeaturesOptions} options Options.
+   * @return {angular.$q.Promise} Promise.
+   * @private
+   */
+  issueCombinedWMS_(combinedDataSources, options) {
+
+    const promises = [];
+
+    const FEATURE_COUNT = options.limit;
+    const map = options.map;
+    const view = map.getView();
+    const resolution = goog.asserts.assertNumber(view.getResolution());
+    const projection = view.getProjection();
+    const projCode = projection.getCode();
+
+    // (1) Coordinate, which is required to issue WMS GetFeatureInfo requests
+    const coordinate = options.coordinate;
+    goog.asserts.assert(coordinate);
+
+    // (2) Launch one request per combinaison of data sources
+    for (const dataSources of combinedDataSources) {
+
+      let url;
+      let LAYERS = [];
+      let INFO_FORMAT;
+
+      // (3) Build query options
+      for (const dataSource of dataSources) {
+
+        // (a) Create common options, if not done yet
+        if (!INFO_FORMAT) {
+          INFO_FORMAT = dataSource.wmsInfoFormat;
+          url = dataSource.wmsUrl;
+        }
+
+        // (b) Add queryable layer names in featureTypes array
+        LAYERS = LAYERS.concat(
+          dataSource.getInRangeOGCLayerNames(resolution, true));
+      }
+
+      const params = {
+        LAYERS,
+        QUERY_LAYERS: LAYERS
+      };
+      goog.asserts.assert(url);
+      const wmsSource = new ol.source.ImageWMS({
+        params,
+        url
+      });
+
+      // (4) Build query url, then launch
+      const wmsGetFeatureInfoUrl = goog.asserts.assertString(
+        wmsSource.getGetFeatureInfoUrl(
+          coordinate, resolution, projCode, {
+            FEATURE_COUNT,
+            INFO_FORMAT
+          }
+        )
+      );
+
+      const canceler = this.registerCanceler_();
+      promises.push(
+        this.http_.get(
+          wmsGetFeatureInfoUrl,
+          {
+            timeout: canceler.promise
+          }
+        ).then(
+          this.handleQueryResult_.bind(this, dataSources, false)
+        )
+      );
+    }
+
+    return this.q_.all(promises).then(
+      this.handleCombinedQueryResult_.bind(this)
+    );
+  }
+
+  /**
+   * @param {!Array.<ngeo.DataSource>} dataSources List of queryable data
+   *     sources that supports WFS.
+   * @return {ngeo.Querent.CombinedDataSources} Combined lists of data sources.
+   * @private
+   */
+  getCombinableWFSDataSources_(dataSources) {
+    const combinableDataSources = [];
+    const notCombinableDataSources = [];
+
+    for (const dataSource of dataSources) {
+      if (dataSource.combinableForWFS) {
+        let combined = false;
+        for (const combinableDataSource of combinableDataSources) {
+          if (dataSource.combinableWithDataSourceForWFS(combinableDataSource[0])) {
+            combinableDataSource.push(dataSource);
+            combined = true;
+          }
+        }
+        if (!combined) {
+          combinableDataSources.push([dataSource]);
+        }
+      } else {
+        notCombinableDataSources.push([dataSource]);
+      }
+    }
+
+    return combinableDataSources.concat(notCombinableDataSources);
+  }
+
+  /**
+   * @param {!Array.<ngeo.DataSource>} dataSources List of queryable data
+   *     sources that supports WMS.
+   * @return {ngeo.Querent.CombinedDataSources} Combined lists of data sources.
+   * @private
+   */
+  getCombinableWMSDataSources_(dataSources) {
+    const combinableDataSources = [];
+    const notCombinableDataSources = [];
+
+    for (const dataSource of dataSources) {
+      if (dataSource.combinableForWMS) {
+        let combined = false;
+        for (const combinableDataSource of combinableDataSources) {
+          if (dataSource.combinableWithDataSourceForWMS(combinableDataSource[0])) {
+            combinableDataSource.push(dataSource);
+            combined = true;
+          }
+        }
+        if (!combined) {
+          combinableDataSources.push([dataSource]);
+        }
+      } else {
+        notCombinableDataSources.push([dataSource]);
+      }
+    }
+
+    return combinableDataSources.concat(notCombinableDataSources);
+  }
+
+  /**
+   * Checks if a data source can be queried, which requires it to be:
+   * - visible
+   * - in range
+   * - queryable (using the native getter)
+   * - have at least one OGC layer in range of current map view resolution.
+   *
+   * @param {ngeo.DataSource} ds Data source
+   * @param {number} res Resolution.
+   * @return {boolean} Whether the data source is queryable
+   * @private
+   */
+  isDataSourceQueryable_(ds, res) {
+    return ds.visible && ds.inRange && ds.queryable &&
+      ds.isAnyOGCLayerInRange(res, true);
+  }
+
+  /**
+   * Make sure that feature ids are unique, because the same features might
+   * be returned for different layers.
+   * @param {Array.<ol.Feature>} features Features
+   * @param {number} dataSourceId Data source id.
+   * @private
+   */
+  setUniqueIds_(features, dataSourceId) {
+    features.forEach((feature) => {
+      if (feature.getId() !== undefined) {
+        const id = `${dataSourceId}_${feature.getId()}`;
+        feature.setId(id);
+      }
+    });
+  }
+
+  /**
+   * @return {angular.$q.Deferred} A deferred that can be resolved to cancel a
+   *    HTTP request.
+   * @private
+   */
+  registerCanceler_() {
+    const canceler = this.q_.defer();
+    this.requestCancelers_.push(canceler);
+    return canceler;
+  }
+
+  /**
+   * @private
+   */
+  cancelStillRunningRequests_() {
+    for (const canceler of this.requestCancelers_) {
+      canceler.resolve();
+    }
+    this.requestCancelers_.length = 0;
+  }
+};
+
+
+/**
+ * @typedef {!Array.<!Array.<!ngeo.DataSource>>}
+ */
+ngeo.Querent.CombinedDataSources;
+
+
+ngeo.module.service('ngeoQuerent', ngeo.Querent);

--- a/src/services/query.js
+++ b/src/services/query.js
@@ -1,3 +1,5 @@
+// DEPRECATED
+
 goog.provide('ngeo.Query');
 
 goog.require('ngeo');
@@ -36,15 +38,16 @@ ngeo.QueryCacheItem;
 ngeo.QueryableSources;
 
 
+// Moved to mapquerent.js
 /**
  * The `ngeoQueryResult` is the value service where the features of the query
  * result are added.
  */
-ngeo.module.value('ngeoQueryResult', /** @type {ngeox.QueryResult} */ ({
-  sources: [],
-  total: 0,
-  pending: false
-}));
+//ngeo.module.value('ngeoQueryResult', /** @type {ngeox.QueryResult} */ ({
+//  sources: [],
+//  total: 0,
+//  pending: false
+//}));
 
 
 /**

--- a/src/services/wfspermalink.js
+++ b/src/services/wfspermalink.js
@@ -2,7 +2,7 @@ goog.provide('ngeo.WfsPermalink');
 
 goog.require('ngeo');
 /** @suppress {extraRequire} - required for `ngeoQueryResult` */
-goog.require('ngeo.Query');
+goog.require('ngeo.MapQuerent');
 goog.require('ol.format.WFS');
 
 


### PR DESCRIPTION
**Work in progress**

This PR introduces replacement for the `ngeo.Query` service.  Their replacements are:

 * `ngeo.Querent` - a service that issues WMS GetFeatureInfo and/or WFS GetFeature queries through promises. It doesn't store the result.  It uses a list of `ngeo.DataSource` as point of entry to do its requests.  It supports combining requests when data sources use the same url.

 * `ngeo.MapQuerent` - the direct equivalent of the `ngeo.Query` service, but it uses the `ngeo.Querent` to issue queries.

All directives, services, examples and app controllers are updated in this PR to use these new components instead of the `ngeo.Query`.

The structure of the `ngeo.QueryResult` is the same as before.  It is defined in the `ngeo.MapQuerent` service. The only difference is that the sources are removed on each new query.  Before, they were created when sources were created.  This change doesn't affect how they are used in the end.

## Not included in this PR

The following features are not included in this PR.  They should come in in further PRs:

 * support of 'dimensions'
 * support WFS resultType = hits.
 * remove the query.js file

## Todo

 * [x] Wait for #2221 to be merged
 * [x] Wait for #2223 to be merged
 * [x] Review (you can look at the code in the last commit only)