### PR TITLE
Filter query count first

### DIFF
--- a/contribs/gmf/examples/displayquerygrid.html
+++ b/contribs/gmf/examples/displayquerygrid.html
@@ -196,8 +196,12 @@
   <body ng-controller="MainController as ctrl">
 
     <gmf-map gmf-map-map="ctrl.map"
-        ngeo-map-query="" ngeo-map-query-map="::ctrl.map"
-        ngeo-map-query-active="ctrl.queryActive">
+        ngeo-map-query=""
+        ngeo-map-query-map="::ctrl.map"
+        ngeo-map-query-active="ctrl.queryActive"
+        ngeo-bbox-query=""
+        ngeo-bbox-query-map="::ctrl.map"
+        ngeo-bbox-query-active="ctrl.queryActive">
     </gmf-map>
 
     <div id="tree-container">

--- a/contribs/gmf/examples/displayquerygrid.js
+++ b/contribs/gmf/examples/displayquerygrid.js
@@ -11,6 +11,8 @@ goog.require('gmf.mapDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.proj.EPSG21781');
 /** @suppress {extraRequire} */
+goog.require('ngeo.bboxQueryDirective');
+/** @suppress {extraRequire} */
 goog.require('ngeo.btnDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.gridDirective');
@@ -31,7 +33,8 @@ gmfapp.module = angular.module('gmfapp', ['gmf']);
 
 
 gmfapp.module.constant('ngeoQueryOptions', {
-  'limit': 20
+  'limit': 20,
+  'queryCountFirst': true
 });
 
 

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -458,7 +458,7 @@ ngeox.QuerentResult;
  * @typedef {{
  *     features: (Array.<ol.Feature>),
  *     tooManyFeatures: (boolean|undefined),
- *     totalFeatureCount: (number|undefined),
+ *     totalFeatureCount: (number|undefined)
  * }}
  */
 ngeox.QuerentResultItem;

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -343,7 +343,8 @@ ngeox.DataSourceOptions.prototype.wmtsUrl;
  *     limit: (number|undefined),
  *     map: (ol.Map),
  *     queryableDataSources: (ngeox.QueryableDataSources|undefined),
- *     tolerancePx: (number|undefined)
+ *     tolerancePx: (number|undefined),
+ *     wfsCount: (boolean|undefined)
  * }}
  */
 ngeox.IssueGetFeaturesOptions;
@@ -407,6 +408,16 @@ ngeox.IssueGetFeaturesOptions.prototype.tolerancePx;
 
 
 /**
+ * When set, before making WFS GetFeature requests to fetch features,
+ * WFS GetFeature requests with `resultType = 'hits'` are made first. If
+ * the number of records for the request would exceed the limit, then
+ * no features are returned.
+ * @type {boolean|undefined}
+ */
+ngeox.IssueGetFeaturesOptions.prototype.wfsCount;
+
+
+/**
  * A hash that contains 2 lists of queryable data sources: `wfs` and `wms`.
  * The same data source can only be in one of the two lists. The `wfs` list
  * has priority, i.e. if the data source supports WFS, it's put in the
@@ -432,6 +443,47 @@ ngeox.QueryableDataSources.prototype.wfs;
  * @type {Array.<ngeo.DataSource>}
  */
 ngeox.QueryableDataSources.prototype.wms;
+
+
+/**
+ * Hash of features by data source ids.
+ * @typedef {!Object.<number, !Array.<!ol.Feature>>}
+ */
+ngeox.QuerentResult;
+
+
+/**
+ * The definition of a result item returned by the querent service.
+ *
+ * @typedef {{
+ *     features: (Array.<ol.Feature>),
+ *     tooManyFeatures: (boolean|undefined),
+ *     totalFeatureCount: (number|undefined),
+ * }}
+ */
+ngeox.QuerentResultItem;
+
+
+/**
+ * The list of features that were returned by the query.
+ * @type {Array.<ol.Feature>}
+ */
+ngeox.QuerentResultItem.prototype.features;
+
+
+/**
+ * Set if the query would have returned to many features. When set, no features
+ * are returned.
+ * @type {boolean|undefined}
+ */
+ngeox.QuerentResultItem.prototype.tooManyFeatures;
+
+
+/**
+ * The total number of features that would have been returned by the query.
+ * @type {number|undefined}
+ */
+ngeox.QuerentResultItem.prototype.totalFeatureCount;
 
 
 /**


### PR DESCRIPTION
This PR introduces the concept of doing "count" requests before WFS GetFeature requests, as supported in the current query service.

The `ngeo.Querent` is responsible of doing the requests.  The `ngeo.MapQuerent` reads what's returned and use it in the result.

## Todo

 * [x] wait for #2223 to be merged first
 * [x] wait for #2239 to be merged first
 * [ ] review (see last commits (those that have 'count'))
 * [ ] fix issues reported by Travis