### PR TITLE
Support dimensions in data sources and querent service

### DIFF
--- a/contribs/gmf/src/services/datasourcesmanager.js
+++ b/contribs/gmf/src/services/datasourcesmanager.js
@@ -327,7 +327,11 @@ gmf.DataSourcesManager = class {
     const snappingToVertice = meta.snappingConfig ?
           meta.snappingConfig.vertex : undefined;
 
-    // (7) Common options
+    // (7) Dimensions
+    const dimensions = node.dimensions || firstLevelGroup.dimensions;
+    const activeDimensions = dimensions;
+
+    // (8) Common options
     const copyable = meta.copyable;
     const identifierAttribute = meta.identifierAttributeField;
     const name = gmfLayer.name;
@@ -335,7 +339,9 @@ gmf.DataSourcesManager = class {
 
     // Create the data source and add it to the cache
     cache[id] = new ngeo.DataSource({
+      activeDimensions,
       copyable,
+      dimensions,
       id,
       identifierAttribute,
       maxResolution,

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -100,7 +100,9 @@ ngeox.DataSourceLayer.prototype.queryable;
 /**
  * The options to create a ngeo.DataSource with.
  * @typedef {{
+ *     activeDimensions: (Object.<string, string>|undefined),
  *     copyable: (boolean|undefined),
+ *     dimensions: (Object.<string, string>|undefined),
  *     geometryName: (string|undefined),
  *     id: (number),
  *     idAttribute: (string|undefined),
@@ -132,11 +134,25 @@ ngeox.DataSourceOptions;
 
 
 /**
+ * The dimensions that are currently active on the data source.
+ * @type {Object.<string, string>|undefined}
+ */
+ngeox.DataSourceOptions.prototype.activeDimensions;
+
+
+/**
  * Whether the geometry from this data source can be copied to other data
  * sources or not. Defaults to `false`.
  * @type {boolean|undefined}
  */
 ngeox.DataSourceOptions.prototype.copyable;
+
+
+/**
+ * The dimensions this data source supports.
+ * @type {Object.<string, string>|undefined}
+ */
+ngeox.DataSourceOptions.prototype.dimensions;
 
 
 /**

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -1,7 +1,6 @@
 // TODO == Dynamic Properties ==
 // TODO  - filterCondition (and, or, not)
 // TODO  - filterRules (array of rules)
-// TODO  - inRange (boolean)
 //
 // TODO == Static Properties ==
 // TODO  - attributes
@@ -37,6 +36,13 @@ ngeo.DataSource = class {
     // === DYNAMIC properties (i.e. that can change / be watched ===
 
     /**
+     * The dimensions that are currently active on the data source.
+     * @type {?Object.<string, string>}
+     * @private
+     */
+    this.activeDimensions_ = options.activeDimensions || null;
+
+    /**
      * A data source is considered 'in range' when it is synchronized to
      * a map view and the resolution of that view is within the range of
      * the `maxResolution` and `minResolution`. These 2 properties are
@@ -68,6 +74,13 @@ ngeo.DataSource = class {
      * @private
      */
     this.copyable_ = options.copyable === true;
+
+    /**
+     * The dimensions this data source supports.
+     * @type {?Object.<string, string>}
+     * @private
+     */
+    this.dimensions_ = options.dimensions || null;
 
     /**
      * The name of the geometry attribute.
@@ -297,6 +310,22 @@ ngeo.DataSource = class {
   // === Dynamic property getters/setters ===
 
   /**
+   * @return {?Object.<string, string>} Active dimensions
+   * @export
+   */
+  get activeDimensions() {
+    return this.activeDimensions_;
+  }
+
+  /**
+   * @param {?Object.<string, string>} activeDimensions Active dimensions
+   * @export
+   */
+  set activeDimensions(activeDimensions) {
+    this.activeDimensions_ = activeDimensions;
+  }
+
+  /**
    * @return {boolean} In range
    * @export
    */
@@ -336,6 +365,14 @@ ngeo.DataSource = class {
    */
   get copyable() {
     return this.copyable_;
+  }
+
+  /**
+   * @return {?Object.<string, string>} Dimensions
+   * @export
+   */
+  get dimensions() {
+    return this.dimensions_;
   }
 
   /**

--- a/src/services/querent.js
+++ b/src/services/querent.js
@@ -2,6 +2,7 @@ goog.provide('ngeo.Querent');
 
 goog.require('ngeo');
 goog.require('ol.format.WFS');
+goog.require('ol.obj');
 goog.require('ol.source.ImageWMS');
 
 
@@ -409,6 +410,7 @@ ngeo.Querent = class {
       let url;
       let LAYERS = [];
       let INFO_FORMAT;
+      const params = {};
 
       // (3) Build query options
       for (const dataSource of dataSources) {
@@ -422,12 +424,21 @@ ngeo.Querent = class {
         // (b) Add queryable layer names in featureTypes array
         LAYERS = LAYERS.concat(
           dataSource.getInRangeOGCLayerNames(resolution, true));
+
+        // (c) Manage active dimensions. Add them directly to the query
+        //     parameters.
+        const dimensions = dataSource.activeDimensions;
+        if (dimensions) {
+          for (const dimensionKey in dimensions) {
+            params[dimensionKey] = dimensions[dimensionKey];
+          }
+        }
       }
 
-      const params = {
+      ol.obj.assign(params, {
         LAYERS,
         QUERY_LAYERS: LAYERS
-      };
+      });
       goog.asserts.assert(url);
       const wmsSource = new ol.source.ImageWMS({
         params,


### PR DESCRIPTION
**Work in progress**

This PR adds the `dimensions` to the data sources and use them in the `ngeo.Querent`.

There's nothing responsible of updating the `activeDimensions` (yet).

 * [x] wait for #2223 to be merged first
 * [x] wait for #2239 to be merged first
 * [x] wait for #2244 to be merged first
 * [x] review (see last commit)