### PR TITLE
Filter - Add list of filtrable data sources to filterselector directive

### DIFF
--- a/contribs/gmf/src/directives/filterselector.js
+++ b/contribs/gmf/src/directives/filterselector.js
@@ -2,17 +2,20 @@ goog.provide('gmf.FilterselectorController');
 goog.provide('gmf.filterselectorComponent');
 
 goog.require('gmf');
+goog.require('ol.CollectionEventType');
 
 
 gmf.FilterselectorController = class {
 
   /**
    * @param {!angular.Scope} $scope Angular scope.
+   * @param {ngeo.DataSources} ngeoDataSources Ngeo collection of data sources
+   *     objects.
    * @ngInject
    * @ngdoc controller
    * @ngname GmfFilterselectorController
    */
-  constructor($scope) {
+  constructor($scope, ngeoDataSources) {
 
     // Binding properties
 
@@ -26,6 +29,32 @@ gmf.FilterselectorController = class {
       () => this.active,
       this.handleActiveChange_.bind(this)
     );
+
+    /**
+     * @type {ngeo.DataSources}
+     * @private
+     */
+    this.ngeoDataSources_ = ngeoDataSources;
+
+    // Inner properties
+
+    /**
+     * @type {Array.<ngeo.DataSource>}
+     * @export
+     */
+    this.filtrableDataSources = [];
+
+    /**
+     * @type {Array.<ol.EventsKey>}
+     * @private
+     */
+    this.listenerKeys_ = [];
+
+    /**
+     * @type {?ngeo.DataSource}
+     * @export
+     */
+    this.selectedDataSource = null;
   }
 
   /**
@@ -36,7 +65,100 @@ gmf.FilterselectorController = class {
    */
   handleActiveChange_(active) {
     // Work in progress...
+
+    const keys = this.listenerKeys_;
+
+    if (active) {
+
+      // Listen to data sources being added/removed
+      keys.push(
+        ol.events.listen(
+          this.ngeoDataSources_,
+          ol.CollectionEventType.ADD,
+          this.handleDataSourcesAdd_,
+          this
+        )
+      );
+      keys.push(
+        ol.events.listen(
+          this.ngeoDataSources_,
+          ol.CollectionEventType.REMOVE,
+          this.handleDataSourceRemove_,
+          this
+        )
+      );
+
+      // Manage the data sources that are already in the collection
+      this.ngeoDataSources_.forEach(this.handleDataSourcesAdd_, this);
+
+    } else {
+      ol.Observable.unByKey(keys);
+      keys.length = 0;
+
+      // Remove data sources that are in the collection
+      this.filtrableDataSources.length = 0;
+    }
+
   }
+
+
+  /**
+   * Called when a data source is added to the collection of ngeo data sources.
+   * If the data source is 'valid', add it to the list of filtrable data
+   * sources.
+   *
+   * @param {ol.Collection.Event} evt Collection event.
+   * @private
+   */
+  handleDataSourcesAdd_(evt) {
+    const dataSource = evt.element;
+    goog.asserts.assertInstanceof(dataSource, ngeo.DataSource);
+
+    // Do nothing if data source is not valid
+    if (!this.isValidDataSource_(dataSource)) {
+      return;
+    }
+
+    this.filtrableDataSources.push(dataSource);
+  }
+
+
+  /**
+   * Called when a data source is added to the collection of ngeo data sources.
+   * If the data source is 'valid', add it to the list of filtrable data
+   * sources.
+   *
+   * @param {ol.Collection.Event} evt Collection event.
+   * @private
+   */
+  handleDataSourcesRemove_(evt) {
+    const dataSource = evt.element;
+    goog.asserts.assertInstanceof(dataSource, ngeo.DataSource);
+
+    // Do nothing if data source is not valid
+    if (!this.isValidDataSource_(dataSource)) {
+      return;
+    }
+
+    ol.array.remove(this.filtrableDataSources, dataSource);
+  }
+
+
+  /**
+   * Determines whether the data source is valid for addition (or removal) to
+   * the list of filtrable data sources or not.
+   *
+   * @param {ngeo.DataSource} dataSource Ngeo data source object
+   * @return {boolean} Whether the data source is valid to add to the list or
+   *     not.
+   * @private
+   */
+  isValidDataSource_(dataSource) {
+    // FIXME - use 'filtrable' instead.
+    return dataSource.queryable;
+  }
+
+
 };
 
 

--- a/contribs/gmf/src/directives/filterselector.js
+++ b/contribs/gmf/src/directives/filterselector.js
@@ -64,7 +64,6 @@ gmf.FilterselectorController = class {
    * @private
    */
   handleActiveChange_(active) {
-    // Work in progress...
 
     const keys = this.listenerKeys_;
 

--- a/contribs/gmf/src/directives/partials/filterselector.html
+++ b/contribs/gmf/src/directives/partials/filterselector.html
@@ -1,1 +1,12 @@
-<div>gmf.Filterselector</div>
+<div
+    class="form-group"
+    ng-switch="fsCtrl.filtrableDataSources.length">
+  <span ng-switch-when="0" translate>No filtrable layer available!</span>
+  <select
+      class="form-control"
+      ng-switch-default
+      ng-model="fsCtrl.selectedDataSource"
+      ng-options="dataSource.name | translate for dataSource in fsCtrl.filtrableDataSources">
+    <option value="" translate>-- Layer to filter --</option>
+  </select>
+</div>


### PR DESCRIPTION
This PR introduces a dropdown list of "filtrable" data sources within the `ngeo.FilterSelector` directive (component).

Important note: the GMF server is not yet ready and doesn't have any information about the filtrable layers yet.  For now, the queryable data sources are used instead.  I can't go much further for now...