### PR TITLE
Use gmfUser to populate filtrable data sources in gmf.FilterSelector

### DIFF
--- a/contribs/gmf/examples/filterselector.html
+++ b/contribs/gmf/examples/filterselector.html
@@ -12,17 +12,20 @@
     <link rel="stylesheet" href="../../../third-party/jquery-ui/jquery-ui.min.css">
     <style>
       body {
-        padding: 1rem;
+        padding: 0;
       }
       .panel {
         display: block;
-        float: left;
-        margin: 0 1rem 0 0;
         width: 35rem;
       }
       gmf-map > div {
-        width: 60rem;
+        width: 71rem;
         height: 40rem;
+      }
+      gmf-map > div,
+      .panel {
+        float: left;
+        margin: 0.5rem;
       }
       gmf-filterselector {
         display: block;
@@ -41,39 +44,42 @@
       ngeo-bbox-query-active="ctrl.queryActive">
     </gmf-map>
 
-    <p id="desc">
-      This example shows how to use the <code>gmf-filterselector</code>
-      directive to apply filters on the layers on the map.
-    </p>
-
-    <p>
-      You can also issue queries on the map by clicking on it or use the
-      <code>Ctrl</code> key to draw boxes on the map.
-    </p>
-
     <gmf-layertree
         class="panel panel-default panel-body"
         gmf-layertree-map="::ctrl.map">
     </gmf-layertree>
 
-    <div class="panel panel-default panel-body">
-    <input type="checkbox"
-       id="checkbox-filterselector"
-       ng-model="ctrl.filterSelectorActive" />
-    <label for="checkbox-filterselector"> FilterSelector</label>
+    <gmf-authentication
+        class="panel panel-default panel-body">
+    </gmf-authentication>
 
-    <input type="checkbox"
-       id="checkbox-dummy"
-       ng-model="ctrl.dummyActive" />
-    <label for="checkbox-dummy"> Dummy tool</label>
+    <div class="panel panel-default panel-body">
+      <p id="desc">
+        This example shows how to use the <code>gmf-filterselector</code>
+        directive to apply filters on the layers on the map.
+      </p>
+      <p>
+        You can also issue queries on the map by clicking on it or use the
+        <code>Ctrl</code> key to draw boxes on the map.
+      </p>
     </div>
 
-    <gmf-filterselector
-        class="panel panel-default panel-body"
-        ng-show="ctrl.filterSelectorActive === true"
-        active="ctrl.filterSelectorActive">
-    </gmf-filterselector>
+    <div class="panel panel-default panel-body">
+      <input
+          type="checkbox"
+          id="checkbox-filterselector"
+          ng-model="ctrl.filterSelectorActive" />
+      <label for="checkbox-filterselector"> FilterSelector</label>
 
+      <input type="checkbox"
+             id="checkbox-dummy"
+             ng-model="ctrl.dummyActive" />
+      <label for="checkbox-dummy"> Dummy tool</label>
+
+      <gmf-filterselector
+          ng-show="ctrl.filterSelectorActive === true"
+          active="ctrl.filterSelectorActive">
+      </gmf-filterselector>
     </div>
 
     <script src="../../../node_modules/jquery/dist/jquery.js"></script>
@@ -95,7 +101,7 @@
     <script src="../../../utils/watchwatchers.js"></script>
     <script>
       var gmfModule = angular.module('gmf');
-      gmfModule.constant('defaultTheme', 'Edit');
+      gmfModule.constant('defaultTheme', 'OSM');
       gmfModule.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
     </script>
   </body>

--- a/contribs/gmf/examples/filterselector.js
+++ b/contribs/gmf/examples/filterselector.js
@@ -57,14 +57,13 @@ gmfapp.MainController = class {
    *     manager service.
    * @param {gmf.Themes} gmfThemes The gmf themes service.
    * @param {gmf.TreeManager} gmfTreeManager gmf Tree Manager service.
-   * @param {gmfx.User} gmfUser User.
    * @param {ngeo.DataSources} ngeoDataSources Ngeo collection of data sources
    *     objects.
    * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
    *     service.
    * @ngInject
    */
-  constructor($scope, gmfDataSourcesManager, gmfThemes, gmfTreeManager, gmfUser,
+  constructor($scope, gmfDataSourcesManager, gmfThemes, gmfTreeManager,
       ngeoDataSources, ngeoToolActivateMgr
   ) {
 
@@ -81,12 +80,6 @@ gmfapp.MainController = class {
      * @export
      */
     this.gmfTreeManager = gmfTreeManager;
-
-    /**
-     * @type {gmfx.User}
-     * @export
-     */
-    this.gmfUser = gmfUser;
 
     /**
      * @type {ol.Map}

--- a/contribs/gmf/examples/filterselector.js
+++ b/contribs/gmf/examples/filterselector.js
@@ -2,6 +2,8 @@
 
 goog.provide('gmfapp.filterselector');
 
+/** @suppress {extraRequire} */
+goog.require('gmf.authenticationDirective');
 goog.require('gmf.Themes');
 goog.require('gmf.TreeManager');
 /** @suppress {extraRequire} */
@@ -55,13 +57,14 @@ gmfapp.MainController = class {
    *     manager service.
    * @param {gmf.Themes} gmfThemes The gmf themes service.
    * @param {gmf.TreeManager} gmfTreeManager gmf Tree Manager service.
+   * @param {gmfx.User} gmfUser User.
    * @param {ngeo.DataSources} ngeoDataSources Ngeo collection of data sources
    *     objects.
    * @param {ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate manager
    *     service.
    * @ngInject
    */
-  constructor($scope, gmfDataSourcesManager, gmfThemes, gmfTreeManager,
+  constructor($scope, gmfDataSourcesManager, gmfThemes, gmfTreeManager, gmfUser,
       ngeoDataSources, ngeoToolActivateMgr
   ) {
 
@@ -78,6 +81,12 @@ gmfapp.MainController = class {
      * @export
      */
     this.gmfTreeManager = gmfTreeManager;
+
+    /**
+     * @type {gmfx.User}
+     * @export
+     */
+    this.gmfUser = gmfUser;
 
     /**
      * @type {ol.Map}
@@ -99,9 +108,9 @@ gmfapp.MainController = class {
 
     gmfThemes.getThemesObject().then((themes) => {
       if (themes) {
-        // Add 'Edit' theme, i.e. the one with id 73
+        // Add 'Edit' theme, i.e. the one with id 64
         for (let i = 0, ii = themes.length; i < ii; i++) {
-          if (themes[i].id === 73) {
+          if (themes[i].id === 64) {
             this.gmfTreeManager.setFirstLevelGroups(themes[i].children);
             break;
           }

--- a/contribs/gmf/options/gmfx.js
+++ b/contribs/gmf/options/gmfx.js
@@ -476,6 +476,14 @@ gmfx.AuthenticationFunctionalities.prototype.default_basemap;
  */
 gmfx.AuthenticationFunctionalities.prototype.default_theme;
 
+
+/**
+ * A list of layer names that can be filtered.
+ * @type {Array.<string>|undefined}
+ */
+gmfx.AuthenticationFunctionalities.prototype.filtrable_layers;
+
+
 /**
  * Availables locations.
  * @type {Array.<string>}

--- a/contribs/gmf/options/gmfx.js
+++ b/contribs/gmf/options/gmfx.js
@@ -457,6 +457,7 @@ gmfx.ServiceUrls.prototype.exportgpxkml;
  * @typedef {{
  *     default_basemap: Array.<string>,
  *     default_theme: Array.<string>,
+ *     filtrable_layers: (Array.<string>|undefined),
  *     location: Array.<string>
  * }}
  */


### PR DESCRIPTION
This PR is the follow-up of #2283.  It ensures that the data sources that are filtrables are added in the `gmf.FilterSelector` directive (component).  For that, the `gmf.User` service is used, from where the `filtrable_layers` are obtained in the `functionnalities`.  In other words, you need to be logged in to use the filter tool.

Once the tool is activated AND the list of filtrable layers are available, that's where the data sources are registered and added to the list.

## Todo

 * [x] Wait for #2283 to be merged, then rebase
 * [x] Review
