### PR TITLE
Filter - Prepare data source for filtering

### DIFF
--- a/contribs/gmf/examples/filterselector.html
+++ b/contribs/gmf/examples/filterselector.html
@@ -31,6 +31,11 @@
         display: block;
         width: 30rem;
       }
+
+      /* Override to allow the layer tree to be fully visible */
+      .collapse {
+        display: block;
+      }
     </style>
   </head>
   <body ng-controller="MainController as ctrl">
@@ -101,7 +106,7 @@
     <script src="../../../utils/watchwatchers.js"></script>
     <script>
       var gmfModule = angular.module('gmf');
-      gmfModule.constant('defaultTheme', 'OSM');
+      gmfModule.constant('defaultTheme', 'Filters');
       gmfModule.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
     </script>
   </body>

--- a/contribs/gmf/examples/filterselector.js
+++ b/contribs/gmf/examples/filterselector.js
@@ -101,9 +101,9 @@ gmfapp.MainController = class {
 
     gmfThemes.getThemesObject().then((themes) => {
       if (themes) {
-        // Add 'Edit' theme, i.e. the one with id 64
+        // Set 'Filters' theme, i.e. the one with id 175
         for (let i = 0, ii = themes.length; i < ii; i++) {
-          if (themes[i].id === 64) {
+          if (themes[i].id === 175) {
             this.gmfTreeManager.setFirstLevelGroups(themes[i].children);
             break;
           }

--- a/contribs/gmf/externs/gmf-themes.js
+++ b/contribs/gmf/externs/gmf-themes.js
@@ -542,3 +542,35 @@ gmfThemes.GmfSnappingConfig.prototype.tolerance;
  * @type {boolean|undefined}
  */
 gmfThemes.GmfSnappingConfig.prototype.vertex;
+
+
+/**
+ * @record
+ * @struct
+ */
+gmfThemes.GmfLayerAttributeValuesResponse = function() {};
+
+
+/**
+ * @type {Array.<gmfThemes.GmfLayerAttributeValue>}
+ */
+gmfThemes.GmfLayerAttributeValuesResponse.prototype.items;
+
+
+/**
+ * @record
+ * @struct
+ */
+gmfThemes.GmfLayerAttributeValue = function() {};
+
+
+/**
+ * @type {string}
+ */
+gmfThemes.GmfLayerAttributeValue.prototype.label;
+
+
+/**
+ * @type {string}
+ */
+gmfThemes.GmfLayerAttributeValue.prototype.value;

--- a/contribs/gmf/externs/gmf-themes.js
+++ b/contribs/gmf/externs/gmf-themes.js
@@ -393,6 +393,13 @@ gmfThemes.GmfMetaData.prototype.disclaimer;
 
 
 /**
+ * List of attribute names which have enumerated attribute values.
+ * @type {Array.<string>|undefined}
+ */
+gmfThemes.GmfMetaData.prototype.EnumeratedAttributes;
+
+
+/**
  * The icon URL visible in the layer tree.
  * @type {string|undefined}
  */

--- a/contribs/gmf/options/gmfx.js
+++ b/contribs/gmf/options/gmfx.js
@@ -59,6 +59,24 @@ gmfx.Config;
 
 
 /**
+ * The options to create a `gmf.DataSource` with.
+ * @record
+ * @struct
+ * @extends gmfThemes.GmfBaseNode
+ */
+gmfx.DataSource;
+
+
+/**
+ * A reference to the GMF layer node that was used to create the data source.
+ * It may contains additionnal information, such as metadata, about the data
+ * source.
+ * @type {gmfThemes.GmfLayer}
+ */
+gmfx.DataSourceOptions.prototype.gmfLayer;
+
+
+/**
  * Configuration for a grid tab.
  * @typedef {{
  *     configuration: ngeo.GridConfig,

--- a/contribs/gmf/options/gmfx.js
+++ b/contribs/gmf/options/gmfx.js
@@ -62,9 +62,9 @@ gmfx.Config;
  * The options to create a `gmf.DataSource` with.
  * @record
  * @struct
- * @extends gmfThemes.GmfBaseNode
+ * @extends ngeox.DataSourceOptions
  */
-gmfx.DataSource;
+gmfx.DataSourceOptions;
 
 
 /**

--- a/contribs/gmf/src/datasource.js
+++ b/contribs/gmf/src/datasource.js
@@ -1,0 +1,40 @@
+goog.provide('gmf.DataSource');
+
+goog.require('ngeo.DataSource');
+
+
+gmf.DataSource = class extends ngeo.DataSource {
+
+  /**
+   * A `gmf.DataSource` extends a `ngeo.DataSource` and adds some properties
+   * that are proper to GMF only.
+   *
+   * @struct
+   * @extends {ngeo.DataSource}
+   * @param {gmfx.DataSourceOptions} options Options.
+   */
+  constructor(options) {
+
+    super(options);
+
+    // === STATIC properties (i.e. that never change) ===
+
+    /**
+     * @type {gmfThemes.GmfLayer}
+     * @private
+     */
+    this.gmfLayer_ = options.gmfLayer;
+
+  }
+
+  // === Static property getters/setters ===
+
+  /**
+   * @return {gmfThemes.GmfLayer} GMF layer
+   * @export
+   */
+  get gmfLayer() {
+    return this.gmfLayer_;
+  }
+
+};

--- a/contribs/gmf/src/datasource.js
+++ b/contribs/gmf/src/datasource.js
@@ -10,7 +10,6 @@ gmf.DataSource = class extends ngeo.DataSource {
    * that are proper to GMF only.
    *
    * @struct
-   * @extends {ngeo.DataSource}
    * @param {gmfx.DataSourceOptions} options Options.
    */
   constructor(options) {

--- a/contribs/gmf/src/directives/filterselector.js
+++ b/contribs/gmf/src/directives/filterselector.js
@@ -3,6 +3,9 @@ goog.provide('gmf.filterselectorComponent');
 goog.require('gmf');
 /** @suppress {extraRequire} */
 goog.require('gmf.Authentication');
+/** @suppress {extraRequire} */
+goog.require('gmf.DataSourcesHelper');
+goog.require('ngeo.Notification');
 goog.require('ol.CollectionEventType');
 
 
@@ -10,15 +13,19 @@ gmf.FilterselectorController = class {
 
   /**
    * @param {!angular.Scope} $scope Angular scope.
+   * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
+   * @param {gmf.DataSourcesHelper} gmfDataSourcesHelper Gmf data sources
+   *     helper service.
    * @param {gmfx.User} gmfUser User.
-   * @param {ngeo.DataSources} ngeoDataSources Ngeo collection of data sources
-   *     objects.
+   * @param {ngeo.Notification} ngeoNotification Ngeo notification service.
    * @private
    * @ngInject
    * @ngdoc controller
    * @ngname GmfFilterselectorController
    */
-  constructor($scope, gmfUser, ngeoDataSources) {
+  constructor($scope, gettextCatalog, gmfDataSourcesHelper, gmfUser,
+      ngeoNotification
+  ) {
 
     // Binding properties
 
@@ -34,6 +41,18 @@ gmf.FilterselectorController = class {
     );
 
     /**
+     * @type {angularGettext.Catalog}
+     * @private
+     */
+    this.gettextCatalog_ = gettextCatalog;
+
+    /**
+     * @type {gmf.DataSourcesHelper}
+     * @private
+     */
+    this.gmfDataSourcesHelper_ = gmfDataSourcesHelper;
+
+    /**
      * @type {gmfx.User}
      * @private
      */
@@ -45,15 +64,16 @@ gmf.FilterselectorController = class {
     );
 
     /**
-     * @type {ngeo.DataSources}
+     * @type {ngeo.Notification}
      * @private
      */
-    this.ngeoDataSources_ = ngeoDataSources;
+    this.ngeoNotification_ = ngeoNotification;
+
 
     // Inner properties
 
     /**
-     * @type {Array.<ngeo.DataSource>}
+     * @type {Array.<gmf.DataSource>}
      * @export
      */
     this.filtrableDataSources = [];
@@ -65,16 +85,37 @@ gmf.FilterselectorController = class {
     this.filtrableLayerNodeNames_ = null;
 
     /**
+     * @type {gmf.DataSources}
+     * @private
+     */
+    this.gmfDataSources_ = gmfDataSourcesHelper.collection;
+
+    /**
      * @type {Array.<ol.EventsKey>}
      * @private
      */
     this.listenerKeys_ = [];
 
     /**
-     * @type {?ngeo.DataSource}
+     * The data source ready to be filtered, after it has been selected and
+     * prepared.
+     * @type {?gmf.DataSource}
+     * @export
+     */
+    this.readyDataSource = null;
+
+    /**
+     * The data source that has been selected in the list and that requires
+     * to be ready before it can be filtered.
+     * @type {?gmf.DataSource}
      * @export
      */
     this.selectedDataSource = null;
+
+    $scope.$watch(
+      () => this.selectedDataSource,
+      this.handleSelectedDataSourceChange_.bind(this)
+    );
 
     /**
      * @type {boolean}
@@ -131,7 +172,7 @@ gmf.FilterselectorController = class {
       // Listen to data sources being added/removed
       keys.push(
         ol.events.listen(
-          this.ngeoDataSources_,
+          this.gmfDataSources_,
           ol.CollectionEventType.ADD,
           this.handleDataSourcesAdd_,
           this
@@ -139,7 +180,7 @@ gmf.FilterselectorController = class {
       );
       keys.push(
         ol.events.listen(
-          this.ngeoDataSources_,
+          this.gmfDataSources_,
           ol.CollectionEventType.REMOVE,
           this.handleDataSourcesRemove_,
           this
@@ -147,7 +188,7 @@ gmf.FilterselectorController = class {
       );
 
       // Manage the data sources that are already in the collection
-      this.ngeoDataSources_.forEach(this.registerDataSource_, this);
+      this.gmfDataSources_.forEach(this.registerDataSource_, this);
 
     } else {
       ol.Observable.unByKey(keys);
@@ -169,7 +210,7 @@ gmf.FilterselectorController = class {
    */
   handleDataSourcesAdd_(evt) {
     const dataSource = evt.element;
-    goog.asserts.assertInstanceof(dataSource, ngeo.DataSource);
+    goog.asserts.assertInstanceof(dataSource, gmf.DataSource);
     this.registerDataSource_(dataSource);
   }
 
@@ -184,18 +225,18 @@ gmf.FilterselectorController = class {
    */
   handleDataSourcesRemove_(evt) {
     const dataSource = evt.element;
-    goog.asserts.assertInstanceof(dataSource, ngeo.DataSource);
+    goog.asserts.assertInstanceof(dataSource, gmf.DataSource);
     this.unregisterDataSource_(dataSource);
   }
 
 
   /**
-   * @param {ngeo.DataSource} dataSource Data source
+   * @param {gmf.DataSource} dataSource Data source
    * @private
    */
   registerDataSource_(dataSource) {
-    // Do nothing if data source is not valid
-    if (!this.isValidDataSource_(dataSource)) {
+    // Do nothing if data source is not filtrable
+    if (!this.isDataSourceFiltrable_(dataSource)) {
       return;
     }
 
@@ -204,12 +245,12 @@ gmf.FilterselectorController = class {
 
 
   /**
-   * @param {ngeo.DataSource} dataSource Data source
+   * @param {gmf.DataSource} dataSource Data source
    * @private
    */
   unregisterDataSource_(dataSource) {
-    // Do nothing if data source is not valid
-    if (!this.isValidDataSource_(dataSource)) {
+    // Do nothing if data source is not filtrable
+    if (!this.isDataSourceFiltrable_(dataSource)) {
       return;
     }
 
@@ -221,14 +262,99 @@ gmf.FilterselectorController = class {
    * Determines whether the data source is valid for addition (or removal) to
    * the list of filtrable data sources or not.
    *
-   * @param {ngeo.DataSource} dataSource Ngeo data source object
+   * To be filtrable, the data source must:
+   *
+   *  1) have its name in the list of filtrable layer node names
+   *  2) support WFS
+   *  3) have only one ogcLayers defined
+   *  4) the ogcLayer must be queryable
+   *
+   * If 1) is true but not any of the others, then the server has not been
+   * configured properly. In this case, a warning notification can be shown.
+   *
+   * @param {gmf.DataSource} dataSource Ngeo data source object
+   * @param {boolean=} opt_notify Whether to show a warning notification or not
+   *     in case of a data source that has its name is in the list of
+   *     filtrable layer node names but it doesn't match the other requirements.
+   *     Defaults to `true.`
    * @return {boolean} Whether the data source is valid to add to the list or
    *     not.
    * @private
    */
-  isValidDataSource_(dataSource) {
+  isDataSourceFiltrable_(dataSource, opt_notify) {
+    let filtrable = true;
+    const gettext = this.gettextCatalog_;
+    const notify = opt_notify !== false;
     const names = goog.asserts.assert(this.filtrableLayerNodeNames_);
-    return ol.array.includes(names, dataSource.name);
+    const msgs = [];
+
+    // (1) The name of the DS must be in list of filtrable layer node names
+    if (ol.array.includes(names, dataSource.name)) {
+
+      // (2) The DS must support WFS
+      if (!dataSource.supportsWFS) {
+        msgs.push(gettext.getString(
+          'The data source doesn\'t support WFS, which is required ' +
+          'to fetch the attributes to build the filter rules.'
+        ));
+      }
+
+      // (3) The DS must have only one ogcLayer
+      if (!dataSource.ogcLayers || !dataSource.ogcLayers.length) {
+        msgs.push(gettext.getString(
+          'The data source must have only 1 ogcLayer defined.'
+        ));
+      } else if (!dataSource.ogcLayers[0].queryable) {
+        // (4) The ogcLayer must be queryable
+        msgs.push(gettext.getString(
+          'The ogcLayer within the data source must be queryable.'
+        ));
+      }
+
+      filtrable = !msgs.length;
+
+      // Notify if the name is in list of filtrable layer node names but
+      // there are missing requirements.
+      if (notify && !filtrable) {
+        const p1 = gettext.getString(
+          `The following data source is marked as being filtrable,
+          but is missing some requirements: `
+        );
+        const p2 = `${dataSource.name} (${dataSource.id}).`;
+        const p3 = gettext.getString(
+          `Please, contact your administrator about this.
+          Here are the reasons: `
+        );
+        msgs.unshift(`${p1} ${p2} ${p3}`);
+        this.ngeoNotification_.notify({
+          msg: msgs.join(' '),
+          type: ngeo.MessageType.WARNING
+        });
+      }
+    } else {
+      filtrable = false;
+    }
+
+    return filtrable;
+  }
+
+  /**
+   * @param {?gmf.DataSource} dataSource Ngeo data source object
+   * @private
+   */
+  handleSelectedDataSourceChange_(dataSource) {
+
+    // No need to do anything if no data source is selected
+    if (!dataSource) {
+      this.readyDataSource = null;
+      return;
+    }
+
+    this.gmfDataSourcesHelper_.prepareFiltrableDataSource(
+      dataSource
+    ).then((dataSource) => {
+      this.readyDataSource = dataSource;
+    });
   }
 
 };

--- a/contribs/gmf/src/directives/partials/filterselector.html
+++ b/contribs/gmf/src/directives/partials/filterselector.html
@@ -9,4 +9,10 @@
       ng-options="dataSource.name | translate for dataSource in fsCtrl.filtrableDataSources">
     <option value="" translate>-- Layer to filter --</option>
   </select>
+
+  <!-- This is where the ngeo.Filter directive will go... -->
+  <div ng-if="fsCtrl.readyDataSource">
+    {{ fsCtrl.readyDataSource.name }} is ready to be filtered!
+  </div>
+
 </div>

--- a/contribs/gmf/src/services/datasourcehelper.js
+++ b/contribs/gmf/src/services/datasourcehelper.js
@@ -1,0 +1,135 @@
+goog.provide('gmf.DataSourcesHelper');
+
+goog.require('gmf');
+goog.require('gmf.EnumerateAttribute');
+goog.require('ngeo.DataSourcesHelper');
+
+
+gmf.DataSourcesHelper = class {
+
+  /**
+   * A service that provides utility methods to manipulate or get data sources.
+   *
+   * @struct
+   * @param {angular.$q} $q The Angular $q service.
+   * @param {gmf.EnumerateAttribute} gmfEnumerateAttribute The Gmf enumerate
+   *     attribute service.
+   * @param {ngeo.DataSourcesHelper} ngeoDataSourcesHelper Ngeo data source
+   *     helper service.
+   * @ngdoc service
+   * @ngname gmfDataSourcesHelper
+   * @ngInject
+   */
+  constructor($q, gmfEnumerateAttribute, ngeoDataSourcesHelper) {
+
+    // === Injected properties ===
+
+    /**
+     * @type {angular.$q}
+     * @private
+     */
+    this.q_ = $q;
+
+    /**
+     * @type {gmf.EnumerateAttribute}
+     * @private
+     */
+    this.gmfEnumerateAttribute_ = gmfEnumerateAttribute;
+
+    /**
+     * @type {ngeo.DataSourcesHelper}
+     * @private
+     */
+    this.ngeoDataSourcesHelper_ = ngeoDataSourcesHelper;
+
+
+    // === Other properties ===
+
+    /**
+     * @type {gmf.DataSources}
+     * @protected
+     */
+    this.collection_;
+
+    /**
+     * @type {Object.<number, gmf.DataSource>}
+     * @protected
+     */
+    this.cache_;
+  }
+
+  /**
+   * @return {gmf.DataSources} Data sources collection.
+   * @export
+   */
+  get collection() {
+    return this.ngeoDataSourcesHelper_.collection;
+  }
+
+  /**
+   * Return a data source using its id.
+   * @param {number} id Data source id.
+   * @return {?gmf.DataSource} Data source.
+   * @export
+   */
+  getDataSource(id) {
+    return this.ngeoDataSourcesHelper_.getDataSource(id);
+  }
+
+  /**
+   * @param {gmf.DataSource} dataSource Filtrable data source.
+   * @return {angular.$q.Promise} Promise.
+   * @export
+   */
+  prepareFiltrableDataSource(dataSource) {
+
+    const prepareFiltrableDataSourceDefer = this.q_.defer();
+
+    // (1) Get the attributes. The first time, they will be asynchronously
+    //     obtained using a WFS DescribeFeatureType request.
+    this.ngeoDataSourcesHelper_.getDataSourceAttributes(
+      dataSource
+    ).then((attributes) => {
+      // (2) The attribute names that are in the `EnumeratedAttributes`
+      //     metadata are the ones that need to have their values fetched.
+      //     Do that once then set the type to SELECT and the choices.
+      const meta = dataSource.gmfLayer.metadata || {};
+      const enumAttributes = meta.EnumeratedAttributes;
+      if (enumAttributes && enumAttributes.length) {
+        const promises = [];
+        for (const attribute of attributes) {
+          if (ol.array.includes(enumAttributes, attribute.name) &&
+             attribute.type !== ngeo.AttributeType.SELECT &&
+             (!attribute.choices || !attribute.choices.length)) {
+            promises.push(
+              this.gmfEnumerateAttribute_.getAttributeValues(
+                dataSource, attribute.name
+              ).then((values) => {
+                const choices = values.map(choice => choice.value);
+                attribute.type = ngeo.AttributeType.SELECT;
+                attribute.choices = choices;
+              })
+            );
+          }
+        }
+        return this.q_.all(promises).then(
+          prepareFiltrableDataSourceDefer.resolve(dataSource)
+        );
+      } else {
+        prepareFiltrableDataSourceDefer.resolve(dataSource);
+      }
+    });
+
+    return prepareFiltrableDataSourceDefer.promise;
+  }
+
+};
+
+
+gmf.module.service('gmfDataSourcesHelper', gmf.DataSourcesHelper);
+
+
+/**
+ * @typedef {ol.Collection.<gmf.DataSource>}
+ */
+gmf.DataSources;

--- a/contribs/gmf/src/services/datasourcehelper.js
+++ b/contribs/gmf/src/services/datasourcehelper.js
@@ -63,7 +63,9 @@ gmf.DataSourcesHelper = class {
    * @export
    */
   get collection() {
-    return this.ngeoDataSourcesHelper_.collection;
+    return /** @type {gmf.DataSources} */ (
+      this.ngeoDataSourcesHelper_.collection
+    );
   }
 
   /**
@@ -73,7 +75,9 @@ gmf.DataSourcesHelper = class {
    * @export
    */
   getDataSource(id) {
-    return this.ngeoDataSourcesHelper_.getDataSource(id);
+    return /** @type {?gmf.DataSource} */ (
+      this.ngeoDataSourcesHelper_.getDataSource(id)
+    );
   }
 
   /**

--- a/contribs/gmf/src/services/datasourcesmanager.js
+++ b/contribs/gmf/src/services/datasourcesmanager.js
@@ -2,7 +2,7 @@ goog.provide('gmf.DataSourcesManager');
 
 goog.require('gmf');
 goog.require('gmf.TreeManager');
-goog.require('ngeo.DataSource');
+goog.require('gmf.DataSource');
 /** @suppress {extraRequire} */
 goog.require('ngeo.DataSources');
 goog.require('ol.array');
@@ -71,7 +71,7 @@ gmf.DataSourcesManager = class {
      * The collection of DataSources from ngeo, which gets updated by this
      * service. When the theme changes, first we remove all data sources, then
      * the 'active' data source are added here.
-     * @type {ol.Collection.<ngeo.DataSource>}
+     * @type {ngeo.DataSources}
      * @private
      */
     this.ngeoDataSources_ = ngeoDataSources;
@@ -336,10 +336,11 @@ gmf.DataSourcesManager = class {
     const visible = meta.isChecked === true;
 
     // Create the data source and add it to the cache
-    cache[id] = new ngeo.DataSource({
+    cache[id] = new gmf.DataSource({
       activeDimensions,
       copyable,
       dimensions,
+      gmfLayer,
       id,
       identifierAttribute,
       maxResolution,

--- a/contribs/gmf/src/services/enumerateattribute.js
+++ b/contribs/gmf/src/services/enumerateattribute.js
@@ -1,0 +1,73 @@
+goog.provide('gmf.EnumerateAttribute');
+
+goog.require('gmf');
+
+
+gmf.EnumerateAttribute = class {
+
+  /**
+   * The EnumerateAttribute is responsible of fetching all possible of a given
+   * attribute of a given data source (gmf layer).
+   *
+   * @struct
+   * @param {angular.$http} $http Angular $http service.
+   * @param {string} gmfLayersUrl Url to the GeoMapFish layers service.
+   * @ngInject
+   * @ngdoc service
+   * @ngname gmfEnumerateAttribute
+   */
+  constructor($http, gmfLayersUrl) {
+
+    // === Injected services ===
+
+    /**
+     * @type {angular.$http}
+     * @private
+     */
+    this.http_ = $http;
+
+    /**
+     * @type {string}
+     * @private
+     */
+    this.baseUrl_ = gmfLayersUrl;
+
+    /**
+     * @type {Object.<number, !angular.$q.Promise>}
+     * @private
+     */
+    this.promises_ = {};
+  }
+
+  /**
+   * @param {gmf.DataSource} dataSource Data source.
+   * @param {string} attribute Attribute name.
+   * @return {angular.$q.Promise} Promise.
+   */
+  getAttributeValues(dataSource, attribute) {
+    const id = dataSource.id;
+    const name = dataSource.name;
+    if (!this.promises_[id]) {
+      const url = `${this.baseUrl_}/${name}/values/${attribute}`;
+      this.promises_[id] = this.http_.get(url).then(
+        this.handleGetAttributeValues_.bind(this));
+    }
+    return this.promises_[id];
+  }
+
+  /**
+   * @param {angular.$http.Response} resp Ajax response.
+   * @return {Array.<gmfThemes.GmfLayerAttributeValue>} List of the attribute
+   *     values.
+   * @export
+   */
+  handleGetAttributeValues_(resp) {
+    const data = /** @type {gmfThemes.GmfLayerAttributeValuesResponse} */ (
+      resp.data);
+    return data.items;
+  }
+
+};
+
+
+gmf.module.service('gmfEnumerateAttribute', gmf.EnumerateAttribute);

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -12,23 +12,10 @@ let ngeox;
 
 
 /**
- * A feature attribute definition.
- * @typedef {{
- *     choices: (Array.<string>|undefined),
- *     geomType: (string|undefined),
- *     name: (string),
- *     required: (boolean|undefined),
- *     type: (string)
- * }}
+ * @record
+ * @struct
  */
-ngeox.Attribute;
-
-
-/**
- * The list of possible values for the attribute.
- * @type {Array.<string>|undefined}
- */
-ngeox.Attribute.prototype.choices;
+ngeox.AttributeBase = function() {};
 
 
 /**
@@ -36,7 +23,30 @@ ngeox.Attribute.prototype.choices;
  * geometry.
  * @type {string|undefined}
  */
-ngeox.Attribute.prototype.geomType;
+ngeox.AttributeBase.prototype.geomType;
+
+
+/**
+ * The attribute type, which determines how to render it.
+ * @type {string|undefined}
+ */
+ngeox.AttributeBase.prototype.type;
+
+
+/**
+ * A feature attribute definition.
+ * @record
+ * @struct
+ * @extends ngeox.AttributeBase
+ */
+ngeox.Attribute = function() {};
+
+
+/**
+ * The list of possible values for the attribute.
+ * @type {Array.<string>|undefined}
+ */
+ngeox.Attribute.prototype.choices;
 
 
 /**
@@ -154,7 +164,7 @@ ngeox.DataSourceOptions.prototype.id;
  * each record individually.
  * @type {string|undefined}
  */
-ngeox.DataSourceOptions.prototype.identifierAtttribute;
+ngeox.DataSourceOptions.prototype.identifierAttribute;
 
 
 /**
@@ -203,7 +213,7 @@ ngeox.DataSourceOptions.prototype.ogcImageType;
  * A list of layer definitions that are used by (WMS) and (WFS) queries.
  * These are **not** used by the (WMTS) queries (the wmtsLayers is used
  * by WMTS queries).
- * @type {Array.<ngeox.DataSourceLayer>|undefined}
+ * @type {Array.<!ngeox.DataSourceLayer>|undefined}
  */
 ngeox.DataSourceOptions.prototype.ogcLayers;
 

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -98,39 +98,11 @@ ngeox.DataSourceLayer.prototype.queryable;
 
 
 /**
- * The options to create a ngeo.DataSource with.
- * @typedef {{
- *     activeDimensions: (Object.<string, string>|undefined),
- *     copyable: (boolean|undefined),
- *     dimensions: (Object.<string, string>|undefined),
- *     geometryName: (string|undefined),
- *     id: (number),
- *     idAttribute: (string|undefined),
- *     inRange: (boolean|undefined),
- *     maxResolution: (number|undefined),
- *     minResolution: (number|undefined),
- *     name: (string),
- *     ogcImageType: (string|undefined),
- *     ogcLayers: (!Array.<!ngeox.DataSourceLayer>|undefined),
- *     ogcServerType: (string|undefined),
- *     ogcType: (string|undefined),
- *     snappable: (boolean|undefined),
- *     snappingTolerance: (number|undefined),
- *     snappingToEdges: (boolean|undefined),
- *     snappingToVertice: (boolean|undefined),
- *     visible: (boolean|undefined),
- *     wfsFeatureNS: (string|undefined),
- *     wfsFeaturePrefix: (string|undefined),
- *     wfsOutputFormat: (string|undefined),
- *     wfsUrl: (string|undefined),
- *     wmsInfoFormat: (string|undefined),
- *     wmsIsSingleTile: (boolean|undefined),
- *     wmsUrl: (string|undefined),
- *     wmtsLayer: (string|undefined),
- *     wmtsUrl: (string|undefined)
- * }}
+ * The options to create a `ngeo.DataSource` with.
+ * @record
+ * @struct
  */
-ngeox.DataSourceOptions;
+ngeox.DataSourceOptions = function() {};
 
 
 /**
@@ -138,6 +110,13 @@ ngeox.DataSourceOptions;
  * @type {Object.<string, string>|undefined}
  */
 ngeox.DataSourceOptions.prototype.activeDimensions;
+
+
+/**
+ * The attributes of the data source.
+ * @type {Array.<ngeox.Attribute>|undefined}
+ */
+ngeox.DataSourceOptions.prototype.attributes;
 
 
 /**

--- a/src/attribute.js
+++ b/src/attribute.js
@@ -1,0 +1,32 @@
+goog.provide('ngeo.Attribute');
+
+
+/**
+ * Set the `type` and `geomType` properties of an attribute if the given
+ * type is a geometry one.
+ *
+ * @param {ngeox.Attribute} attribute Attribute.
+ * @param {string} type Type.
+ * @return {boolean} Whether both attribute type and geomType were set.
+ */
+ngeo.Attribute.setAttributeGeometryType = function(attribute, type) {
+  const geomRegex =
+    /gml:((Multi)?(Point|Line|Polygon|Curve|Surface|Geometry)).*/;
+  if (geomRegex.exec(type)) {
+    attribute.type = ngeo.AttributeType.GEOMETRY;
+    if (/^gml:Point/.exec(type)) {
+      attribute.geomType = ol.geom.GeometryType.POINT;
+    } else if (/^gml:LineString/.exec(type)) {
+      attribute.geomType = ol.geom.GeometryType.LINE_STRING;
+    } else if (/^gml:Polygon/.exec(type)) {
+      attribute.geomType = ol.geom.GeometryType.POLYGON;
+    } else if (/^gml:MultiPoint/.exec(type)) {
+      attribute.geomType = ol.geom.GeometryType.MULTI_POINT;
+    } else if (/^gml:MultiLineString/.exec(type)) {
+      attribute.geomType = ol.geom.GeometryType.MULTI_LINE_STRING;
+    } else if (/^gml:MultiPolygon/.exec(type)) {
+      attribute.geomType = ol.geom.GeometryType.MULTI_POLYGON;
+    }
+  }
+  return !!attribute.type && !!attribute.geomType;
+};

--- a/src/attribute.js
+++ b/src/attribute.js
@@ -5,11 +5,11 @@ goog.provide('ngeo.Attribute');
  * Set the `type` and `geomType` properties of an attribute if the given
  * type is a geometry one.
  *
- * @param {ngeox.Attribute} attribute Attribute.
+ * @param {ngeox.AttributeBase} attribute Attribute.
  * @param {string} type Type.
  * @return {boolean} Whether both attribute type and geomType were set.
  */
-ngeo.Attribute.setAttributeGeometryType = function(attribute, type) {
+ngeo.Attribute.setGeometryType = function(attribute, type) {
   const geomRegex =
     /gml:((Multi)?(Point|Line|Polygon|Curve|Surface|Geometry)).*/;
   if (geomRegex.exec(type)) {

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -3,7 +3,6 @@
 // TODO  - filterRules (array of rules)
 //
 // TODO == Static Properties ==
-// TODO  - attributes
 // TODO  - filterRuleDefinitions
 // TODO  - group
 
@@ -145,10 +144,10 @@ ngeo.DataSource = class {
      * A list of layer definitions that are used by (WMS) and (WFS) queries.
      * These are **not** used by the (WMTS) queries (the wmtsLayers is used
      * by WMTS queries).
-     * @type {!Array.<!ngeox.DataSourceLayer>|undefined}
+     * @type {?Array.<!ngeox.DataSourceLayer>}
      * @private
      */
-    this.ogcLayers_ = options.ogcLayers;
+    this.ogcLayers_ = options.ogcLayers || null;
 
     /**
      * The type of OGC server making the requests.
@@ -365,7 +364,7 @@ ngeo.DataSource = class {
   // === Static property getters/setters ===
 
   /**
-   * @return {Array.<ngeox.Attribute>} Attributes
+   * @return {?Array.<ngeox.Attribute>} Attributes
    * @export
    */
   get attributes() {
@@ -373,7 +372,7 @@ ngeo.DataSource = class {
   }
 
   /**
-   * @param {Array.<ngeox.Attribute>} attributes Attributes
+   * @param {?Array.<ngeox.Attribute>} attributes Attributes
    * @export
    */
   set attributes(attributes) {
@@ -453,7 +452,7 @@ ngeo.DataSource = class {
   }
 
   /**
-   * @return {!Array.<!ngeox.DataSourceLayer>|undefined} OGC layers
+   * @return {?Array.<!ngeox.DataSourceLayer>} OGC layers
    * @export
    */
   get ogcLayers() {
@@ -651,11 +650,11 @@ ngeo.DataSource = class {
    * @export
    */
   get supportsAttributes() {
-    return !!this.attributes || (
+    return this.attributes !== null || (
       this.supportsWFS &&
-      !!this.ogcLayers &&
+      this.ogcLayers !== null &&
       this.ogcLayers.length === 1 &&
-      this.ogcLayers[0].queryable
+      this.ogcLayers[0].queryable === true
     );
   }
 

--- a/src/ngeo.js
+++ b/src/ngeo.js
@@ -55,6 +55,34 @@ ngeo.baseModuleTemplateUrl = 'ngeomodule';
  * @enum {string}
  * @export
  */
+ngeo.AttributeType = {
+  /**
+   * @type {string}
+   */
+  DATE: 'date',
+  /**
+   * @type {string}
+   */
+  DATETIME: 'datetime',
+  /**
+   * @type {string}
+   */
+  GEOMETRY: 'geometry',
+  /**
+   * @type {string}
+   */
+  SELECT: 'select',
+  /**
+   * @type {string}
+   */
+  TEXT: 'text'
+};
+
+
+/**
+ * @enum {string}
+ * @export
+ */
 ngeo.FeatureProperties = {
   /**
    * @type {string}

--- a/src/ol-ext/format/wfsattribute.js
+++ b/src/ol-ext/format/wfsattribute.js
@@ -40,7 +40,7 @@ ngeo.format.WFSAttribute = class {
 
     const type = goog.asserts.assertString(object['type']);
 
-    if (!ngeo.Attribute.setAttributeGeometryType(attribute, type)) {
+    if (!ngeo.Attribute.setGeometryType(attribute, type)) {
       if (type === 'gml:TimeInstantType') {
         attribute.type = ngeo.AttributeType.DATETIME;
       } else {

--- a/src/ol-ext/format/wfsattribute.js
+++ b/src/ol-ext/format/wfsattribute.js
@@ -1,0 +1,54 @@
+goog.provide('ngeo.format.WFSAttribute');
+
+goog.require('ngeo.Attribute');
+
+
+ngeo.format.WFSAttribute = class {
+
+
+  /**
+   * A format that reads the complexType from a WFS DescribeFeatureType
+   * response for a single set of attributes and return an array of
+   * `ngeox.Attribute`.
+   */
+
+
+  /**
+   * @param {Array.<Object>} complexTypeElements Complex type element
+   * @return {Array.<ngeox.Attribute>} Attributes
+   * @export
+   */
+  read(complexTypeElements) {
+    return complexTypeElements.map(this.readFromComplexTypeElement_);
+  }
+
+
+  /**
+   * @param {Object} object Complex type element
+   * @return {ngeox.Attribute} Attribute
+   * @private
+   */
+  readFromComplexTypeElement_(object) {
+
+    const name = goog.asserts.assertString(object['name']);
+    const required = object['minOccurs'] != '0';
+
+    const attribute = {
+      name,
+      required
+    };
+
+    const type = goog.asserts.assertString(object['type']);
+
+    if (!ngeo.Attribute.setAttributeGeometryType(attribute, type)) {
+      if (type === 'gml:TimeInstantType') {
+        attribute.type = ngeo.AttributeType.DATETIME;
+      } else {
+        attribute.type = ngeo.AttributeType.TEXT;
+      }
+    }
+
+    return attribute;
+  }
+
+};

--- a/src/ol-ext/format/xsdattribute.js
+++ b/src/ol-ext/format/xsdattribute.js
@@ -86,7 +86,7 @@ ngeo.format.XSDAttribute.prototype.readFromNode = function(node) {
 ngeo.format.XSDAttribute.prototype.readFromElementNode_ = function(node) {
 
   const name = node.getAttribute('name');
-  goog.asserts.assert(name, 'name should be defined in element node.');
+  goog.asserts.assertString(name, 'name should be defined in element node.');
 
   const nillable = node.getAttribute('nillable');
   const required = !(nillable === true || nillable === 'true');
@@ -98,7 +98,7 @@ ngeo.format.XSDAttribute.prototype.readFromElementNode_ = function(node) {
 
   const type = node.getAttribute('type');
   if (type) {
-    if (!ngeo.Attribute.setAttributeGeometryType(attribute, type)) {
+    if (!ngeo.Attribute.setGeometryType(attribute, type)) {
       if (type === 'xsd:string') {
         attribute.type = ngeo.AttributeType.TEXT;
       } else if (type === 'xsd:date') {

--- a/src/ol-ext/format/xsdattribute.js
+++ b/src/ol-ext/format/xsdattribute.js
@@ -1,5 +1,7 @@
 goog.provide('ngeo.format.XSDAttribute');
 
+goog.require('ngeo');
+goog.require('ngeo.Attribute');
 goog.require('ol.format.XML');
 
 
@@ -96,31 +98,16 @@ ngeo.format.XSDAttribute.prototype.readFromElementNode_ = function(node) {
 
   const type = node.getAttribute('type');
   if (type) {
-    const geomRegex =
-      /gml:((Multi)?(Point|Line|Polygon|Curve|Surface|Geometry)).*/;
-    if (geomRegex.exec(type)) {
-      attribute.type = ngeo.format.XSDAttributeType.GEOMETRY;
-      if (/^gml:Point/.exec(type)) {
-        attribute.geomType = ol.geom.GeometryType.POINT;
-      } else if (/^gml:LineString/.exec(type)) {
-        attribute.geomType = ol.geom.GeometryType.LINE_STRING;
-      } else if (/^gml:Polygon/.exec(type)) {
-        attribute.geomType = ol.geom.GeometryType.POLYGON;
-      } else if (/^gml:MultiPoint/.exec(type)) {
-        attribute.geomType = ol.geom.GeometryType.MULTI_POINT;
-      } else if (/^gml:MultiLineString/.exec(type)) {
-        attribute.geomType = ol.geom.GeometryType.MULTI_LINE_STRING;
-      } else if (/^gml:MultiPolygon/.exec(type)) {
-        attribute.geomType = ol.geom.GeometryType.MULTI_POLYGON;
+    if (!ngeo.Attribute.setAttributeGeometryType(attribute, type)) {
+      if (type === 'xsd:string') {
+        attribute.type = ngeo.AttributeType.TEXT;
+      } else if (type === 'xsd:date') {
+        attribute.type = ngeo.AttributeType.DATE;
+      } else if (type === 'xsd:dateTime') {
+        attribute.type = ngeo.AttributeType.DATETIME;
+      } else {
+        return null;
       }
-    } else if (type === 'xsd:string') {
-      attribute.type = ngeo.format.XSDAttributeType.TEXT;
-    } else if (type === 'xsd:date') {
-      attribute.type = ngeo.format.XSDAttributeType.DATE;
-    } else if (type === 'xsd:dateTime') {
-      attribute.type = ngeo.format.XSDAttributeType.DATETIME;
-    } else {
-      return null;
     }
   } else {
     let enumerations = node.getElementsByTagName('enumeration');
@@ -128,7 +115,7 @@ ngeo.format.XSDAttribute.prototype.readFromElementNode_ = function(node) {
       enumerations = node.getElementsByTagName('xsd:enumeration');
     }
     if (enumerations.length) {
-      attribute.type = ngeo.format.XSDAttributeType.SELECT;
+      attribute.type = ngeo.AttributeType.SELECT;
       const choices = [];
       for (let i = 0, ii = enumerations.length; i < ii; i++) {
         choices.push(enumerations[i].getAttribute('value'));
@@ -154,37 +141,10 @@ ngeo.format.XSDAttribute.prototype.readFromElementNode_ = function(node) {
 ngeo.format.XSDAttribute.getGeometryAttribute = function(attributes) {
   let geomAttribute = null;
   for (let i = 0, ii = attributes.length; i < ii; i++) {
-    if (attributes[i].type === ngeo.format.XSDAttributeType.GEOMETRY) {
+    if (attributes[i].type === ngeo.AttributeType.GEOMETRY) {
       geomAttribute = attributes[i];
       break;
     }
   }
   return geomAttribute;
-};
-
-
-/**
- * @enum {string}
- */
-ngeo.format.XSDAttributeType = {
-  /**
-   * @type {string}
-   */
-  DATE: 'date',
-  /**
-   * @type {string}
-   */
-  DATETIME: 'datetime',
-  /**
-   * @type {string}
-   */
-  GEOMETRY: 'geometry',
-  /**
-   * @type {string}
-   */
-  SELECT: 'select',
-  /**
-   * @type {string}
-   */
-  TEXT: 'text'
 };

--- a/src/ol-ext/wfsdescribefeaturetype.js
+++ b/src/ol-ext/wfsdescribefeaturetype.js
@@ -50,11 +50,22 @@ ol.format.WFSDescribeFeatureType.prototype.readFromDocument = function(doc) {
  */
 ol.format.WFSDescribeFeatureType.prototype.readFromNode = function(node) {
   let result = {};
-  result = ol.xml.pushParseAndPop(result, ol.format.WFSDescribeFeatureType.PARSERS_, node, []);
+  result = ol.xml.pushParseAndPop(
+    result,
+    ol.format.WFSDescribeFeatureType.PARSERS_,
+    node,
+    []
+  );
   return result;
 };
 
 
+/**
+ * @private
+ * @param {Node} node Node.
+ * @param {Array.<*>} objectStack Object stack.
+ * @return {Object} Attributes.
+ */
 ol.format.WFSDescribeFeatureType.readElement_ = function(node, objectStack) {
   const attributes = {};
   for (let i = 0, len = node.attributes.length; i < len; i++) {
@@ -69,24 +80,77 @@ ol.format.WFSDescribeFeatureType.readElement_ = function(node, objectStack) {
 };
 
 
+/**
+ * @private
+ * @param {Node} node Node.
+ * @param {Array.<*>} objectStack Object stack.
+ * @return {T} Object.
+ * @template T
+ */
 ol.format.WFSDescribeFeatureType.readComplexType_ = function(node, objectStack) {
   const name = node.getAttribute('name');
-  const object = ol.xml.pushParseAndPop({'name': name}, ol.format.WFSDescribeFeatureType.COMPLEX_TYPE_PARSERS_, node, objectStack);
+  const object = ol.xml.pushParseAndPop(
+    {'name': name},
+    ol.format.WFSDescribeFeatureType.COMPLEX_TYPE_PARSERS_,
+    node, objectStack
+  );
   // flatten
-  object['complexContent'] = object['complexContent']['extension']['sequence']['element'];
+  object['complexContent'] =
+    object['complexContent']['extension']['sequence']['element'];
   return object;
 };
 
-ol.format.WFSDescribeFeatureType.readComplexContent_ = function(node, objectStack) {
-  return ol.xml.pushParseAndPop({}, ol.format.WFSDescribeFeatureType.COMPLEX_CONTENT_PARSERS_, node, objectStack);
+
+/**
+ * @private
+ * @param {Node} node Node.
+ * @param {Array.<*>} objectStack Object stack.
+ * @return {T} Object.
+ * @template T
+ */
+ol.format.WFSDescribeFeatureType.readComplexContent_ = function(
+  node, objectStack
+) {
+  return ol.xml.pushParseAndPop(
+    {},
+    ol.format.WFSDescribeFeatureType.COMPLEX_CONTENT_PARSERS_,
+    node,
+    objectStack
+  );
 };
 
+
+/**
+ * @private
+ * @param {Node} node Node.
+ * @param {Array.<*>} objectStack Object stack.
+ * @return {T} Object.
+ * @template T
+ */
 ol.format.WFSDescribeFeatureType.readExtension_ = function(node, objectStack) {
-  return ol.xml.pushParseAndPop({}, ol.format.WFSDescribeFeatureType.EXTENSION_PARSERS_, node, objectStack);
+  return ol.xml.pushParseAndPop(
+    {},
+    ol.format.WFSDescribeFeatureType.EXTENSION_PARSERS_,
+    node,
+    objectStack
+  );
 };
 
+
+/**
+ * @private
+ * @param {Node} node Node.
+ * @param {Array.<*>} objectStack Object stack.
+ * @return {T} Object.
+ * @template T
+ */
 ol.format.WFSDescribeFeatureType.readSequence_ = function(node, objectStack) {
-  return ol.xml.pushParseAndPop({}, ol.format.WFSDescribeFeatureType.SEQUENCE_PARSERS_, node, objectStack);
+  return ol.xml.pushParseAndPop(
+    {},
+    ol.format.WFSDescribeFeatureType.SEQUENCE_PARSERS_,
+    node,
+    objectStack
+  );
 };
 
 
@@ -108,8 +172,12 @@ ol.format.WFSDescribeFeatureType.NAMESPACE_URIS_ = [
  */
 ol.format.WFSDescribeFeatureType.PARSERS_ = ol.xml.makeStructureNS(
     ol.format.WFSDescribeFeatureType.NAMESPACE_URIS_, {
-      'element': ol.xml.makeObjectPropertyPusher(ol.format.WFSDescribeFeatureType.readElement_),
-      'complexType': ol.xml.makeObjectPropertyPusher(ol.format.WFSDescribeFeatureType.readComplexType_)
+      'element': ol.xml.makeObjectPropertyPusher(
+        ol.format.WFSDescribeFeatureType.readElement_
+      ),
+      'complexType': ol.xml.makeObjectPropertyPusher(
+        ol.format.WFSDescribeFeatureType.readComplexType_
+      )
     });
 
 
@@ -120,7 +188,9 @@ ol.format.WFSDescribeFeatureType.PARSERS_ = ol.xml.makeStructureNS(
  */
 ol.format.WFSDescribeFeatureType.COMPLEX_TYPE_PARSERS_ = ol.xml.makeStructureNS(
     ol.format.WFSDescribeFeatureType.NAMESPACE_URIS_, {
-      'complexContent': ol.xml.makeObjectPropertySetter(ol.format.WFSDescribeFeatureType.readComplexContent_)
+      'complexContent': ol.xml.makeObjectPropertySetter(
+        ol.format.WFSDescribeFeatureType.readComplexContent_
+      )
     });
 
 
@@ -131,7 +201,9 @@ ol.format.WFSDescribeFeatureType.COMPLEX_TYPE_PARSERS_ = ol.xml.makeStructureNS(
  */
 ol.format.WFSDescribeFeatureType.COMPLEX_CONTENT_PARSERS_ = ol.xml.makeStructureNS(
     ol.format.WFSDescribeFeatureType.NAMESPACE_URIS_, {
-      'extension': ol.xml.makeObjectPropertySetter(ol.format.WFSDescribeFeatureType.readExtension_)
+      'extension': ol.xml.makeObjectPropertySetter(
+        ol.format.WFSDescribeFeatureType.readExtension_
+      )
     });
 
 
@@ -142,7 +214,9 @@ ol.format.WFSDescribeFeatureType.COMPLEX_CONTENT_PARSERS_ = ol.xml.makeStructure
  */
 ol.format.WFSDescribeFeatureType.EXTENSION_PARSERS_ = ol.xml.makeStructureNS(
     ol.format.WFSDescribeFeatureType.NAMESPACE_URIS_, {
-      'sequence': ol.xml.makeObjectPropertySetter(ol.format.WFSDescribeFeatureType.readSequence_)
+      'sequence': ol.xml.makeObjectPropertySetter(
+        ol.format.WFSDescribeFeatureType.readSequence_
+      )
     });
 
 
@@ -153,5 +227,7 @@ ol.format.WFSDescribeFeatureType.EXTENSION_PARSERS_ = ol.xml.makeStructureNS(
  */
 ol.format.WFSDescribeFeatureType.SEQUENCE_PARSERS_ = ol.xml.makeStructureNS(
     ol.format.WFSDescribeFeatureType.NAMESPACE_URIS_, {
-      'element': ol.xml.makeObjectPropertyPusher(ol.format.WFSDescribeFeatureType.readElement_)
+      'element': ol.xml.makeObjectPropertyPusher(
+        ol.format.WFSDescribeFeatureType.readElement_
+      )
     });

--- a/src/ol-ext/wfsdescribefeaturetype.js
+++ b/src/ol-ext/wfsdescribefeaturetype.js
@@ -167,7 +167,7 @@ ol.format.WFSDescribeFeatureType.NAMESPACE_URIS_ = [
 
 /**
  * @const
- * @type {!Object.<string, !Object.<string, ol.XmlParser>>}
+ * @type {Object.<string, !Object.<string, ol.XmlParser>>}
  * @private
  */
 ol.format.WFSDescribeFeatureType.PARSERS_ = ol.xml.makeStructureNS(
@@ -183,7 +183,7 @@ ol.format.WFSDescribeFeatureType.PARSERS_ = ol.xml.makeStructureNS(
 
 /**
  * @const
- * @type {!Object.<string, !Object.<string, ol.XmlParser>>}
+ * @type {Object.<string, !Object.<string, ol.XmlParser>>}
  * @private
  */
 ol.format.WFSDescribeFeatureType.COMPLEX_TYPE_PARSERS_ = ol.xml.makeStructureNS(
@@ -196,7 +196,7 @@ ol.format.WFSDescribeFeatureType.COMPLEX_TYPE_PARSERS_ = ol.xml.makeStructureNS(
 
 /**
  * @const
- * @type {!Object.<string, !Object.<string, ol.XmlParser>>}
+ * @type {Object.<string, !Object.<string, ol.XmlParser>>}
  * @private
  */
 ol.format.WFSDescribeFeatureType.COMPLEX_CONTENT_PARSERS_ = ol.xml.makeStructureNS(
@@ -209,7 +209,7 @@ ol.format.WFSDescribeFeatureType.COMPLEX_CONTENT_PARSERS_ = ol.xml.makeStructure
 
 /**
  * @const
- * @type {!Object.<string, !Object.<string, ol.XmlParser>>}
+ * @type {Object.<string, !Object.<string, ol.XmlParser>>}
  * @private
  */
 ol.format.WFSDescribeFeatureType.EXTENSION_PARSERS_ = ol.xml.makeStructureNS(
@@ -222,7 +222,7 @@ ol.format.WFSDescribeFeatureType.EXTENSION_PARSERS_ = ol.xml.makeStructureNS(
 
 /**
  * @const
- * @type {!Object.<string, !Object.<string, ol.XmlParser>>}
+ * @type {Object.<string, !Object.<string, ol.XmlParser>>}
  * @private
  */
 ol.format.WFSDescribeFeatureType.SEQUENCE_PARSERS_ = ol.xml.makeStructureNS(

--- a/src/ol-ext/wfsdescribefeaturetype.js
+++ b/src/ol-ext/wfsdescribefeaturetype.js
@@ -64,7 +64,7 @@ ol.format.WFSDescribeFeatureType.prototype.readFromNode = function(node) {
  * @private
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {Object} Attributes.
+ * @return {!Object.<string, string>} Attributes.
  */
 ol.format.WFSDescribeFeatureType.readElement_ = function(node, objectStack) {
   const attributes = {};
@@ -84,8 +84,7 @@ ol.format.WFSDescribeFeatureType.readElement_ = function(node, objectStack) {
  * @private
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {T} Object.
- * @template T
+ * @return {!Object.<string, string>} Object.
  */
 ol.format.WFSDescribeFeatureType.readComplexType_ = function(node, objectStack) {
   const name = node.getAttribute('name');
@@ -105,8 +104,7 @@ ol.format.WFSDescribeFeatureType.readComplexType_ = function(node, objectStack) 
  * @private
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {T} Object.
- * @template T
+ * @return {!Object.<string, string>} Object.
  */
 ol.format.WFSDescribeFeatureType.readComplexContent_ = function(
   node, objectStack
@@ -124,8 +122,7 @@ ol.format.WFSDescribeFeatureType.readComplexContent_ = function(
  * @private
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {T} Object.
- * @template T
+ * @return {!Object.<string, string>} Object.
  */
 ol.format.WFSDescribeFeatureType.readExtension_ = function(node, objectStack) {
   return ol.xml.pushParseAndPop(
@@ -141,8 +138,7 @@ ol.format.WFSDescribeFeatureType.readExtension_ = function(node, objectStack) {
  * @private
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {T} Object.
- * @template T
+ * @return {!Object.<string, string>} Object.
  */
 ol.format.WFSDescribeFeatureType.readSequence_ = function(node, objectStack) {
   return ol.xml.pushParseAndPop(
@@ -167,10 +163,10 @@ ol.format.WFSDescribeFeatureType.NAMESPACE_URIS_ = [
 
 /**
  * @const
- * @type {Object.<string, !Object.<string, ol.XmlParser>>}
+ * @type {!Object.<string, !Object.<string, !ol.XmlParser>>}
  * @private
  */
-ol.format.WFSDescribeFeatureType.PARSERS_ = ol.xml.makeStructureNS(
+ol.format.WFSDescribeFeatureType.PARSERS_ = goog.asserts.assert(ol.xml.makeStructureNS(
     ol.format.WFSDescribeFeatureType.NAMESPACE_URIS_, {
       'element': ol.xml.makeObjectPropertyPusher(
         ol.format.WFSDescribeFeatureType.readElement_
@@ -178,56 +174,56 @@ ol.format.WFSDescribeFeatureType.PARSERS_ = ol.xml.makeStructureNS(
       'complexType': ol.xml.makeObjectPropertyPusher(
         ol.format.WFSDescribeFeatureType.readComplexType_
       )
-    });
+    }));
 
 
 /**
  * @const
- * @type {Object.<string, !Object.<string, ol.XmlParser>>}
+ * @type {!Object.<string, !Object.<string, !ol.XmlParser>>}
  * @private
  */
-ol.format.WFSDescribeFeatureType.COMPLEX_TYPE_PARSERS_ = ol.xml.makeStructureNS(
+ol.format.WFSDescribeFeatureType.COMPLEX_TYPE_PARSERS_ = goog.asserts.assert(ol.xml.makeStructureNS(
     ol.format.WFSDescribeFeatureType.NAMESPACE_URIS_, {
       'complexContent': ol.xml.makeObjectPropertySetter(
         ol.format.WFSDescribeFeatureType.readComplexContent_
       )
-    });
+    }));
 
 
 /**
  * @const
- * @type {Object.<string, !Object.<string, ol.XmlParser>>}
+ * @type {!Object.<string, !Object.<string, !ol.XmlParser>>}
  * @private
  */
-ol.format.WFSDescribeFeatureType.COMPLEX_CONTENT_PARSERS_ = ol.xml.makeStructureNS(
+ol.format.WFSDescribeFeatureType.COMPLEX_CONTENT_PARSERS_ = goog.asserts.assert(ol.xml.makeStructureNS(
     ol.format.WFSDescribeFeatureType.NAMESPACE_URIS_, {
       'extension': ol.xml.makeObjectPropertySetter(
         ol.format.WFSDescribeFeatureType.readExtension_
       )
-    });
+    }));
 
 
 /**
  * @const
- * @type {Object.<string, !Object.<string, ol.XmlParser>>}
+ * @type {!Object.<string, !Object.<string, !ol.XmlParser>>}
  * @private
  */
-ol.format.WFSDescribeFeatureType.EXTENSION_PARSERS_ = ol.xml.makeStructureNS(
+ol.format.WFSDescribeFeatureType.EXTENSION_PARSERS_ = goog.asserts.assert(ol.xml.makeStructureNS(
     ol.format.WFSDescribeFeatureType.NAMESPACE_URIS_, {
       'sequence': ol.xml.makeObjectPropertySetter(
         ol.format.WFSDescribeFeatureType.readSequence_
       )
-    });
+    }));
 
 
 /**
  * @const
- * @type {Object.<string, !Object.<string, ol.XmlParser>>}
+ * @type {!Object.<string, !Object.<string, !ol.XmlParser>>}
  * @private
  */
-ol.format.WFSDescribeFeatureType.SEQUENCE_PARSERS_ = ol.xml.makeStructureNS(
+ol.format.WFSDescribeFeatureType.SEQUENCE_PARSERS_ = goog.asserts.assert(ol.xml.makeStructureNS(
     ol.format.WFSDescribeFeatureType.NAMESPACE_URIS_, {
       'element': ol.xml.makeObjectPropertyPusher(
         ol.format.WFSDescribeFeatureType.readElement_
       )
-    });
+    }));

--- a/src/services/datasourceshelper.js
+++ b/src/services/datasourceshelper.js
@@ -89,8 +89,13 @@ ngeo.DataSourcesHelper = class {
 
   /**
    * Get the attributes of a data source. If they are not set, they are obtained
-   * from the querent service and set first.
-   * @param {gmf.DataSource} dataSource Filtrable data source.
+   * from the querent service using a WFS DescribeFeatureType request, then set
+   * in the data source.
+   *
+   * Please, note that in order to be dynamically set, the data source must
+   * only have 1 ogcLayer set and be queryable.
+   *
+   * @param {ngeo.DataSource} dataSource Filtrable data source.
    * @return {angular.$q.Promise} Promise.
    * @export
    */

--- a/src/services/querent.js
+++ b/src/services/querent.js
@@ -2,6 +2,7 @@ goog.provide('ngeo.Querent');
 
 goog.require('ngeo');
 goog.require('ol.format.WFS');
+goog.require('ol.format.WFSDescribeFeatureType');
 goog.require('ol.obj');
 goog.require('ol.source.ImageWMS');
 
@@ -135,6 +136,34 @@ ngeo.Querent = class {
     }
 
     return queryableDataSources;
+  }
+
+  /**
+   * @param {ngeo.DataSource} dataSource Data source.
+   * @return {angular.$q.Promise} Promise.
+   * @export
+   */
+  wfsDescribeFeatureType(dataSource) {
+
+    goog.asserts.assert(
+      dataSource.supportsAttributes,
+      `The data source must support WFS, have a single OGCLayer that
+      is queryable in order to issue WFS DescribeFeatureType requests`
+    );
+
+    const ogcLayerNames = dataSource.getOGCLayerNames();
+
+    const url = ol.uri.appendParams(dataSource.wfsUrl, {
+      'REQUEST': 'DescribeFeatureType',
+      'SERVICE': 'WFS',
+      'VERSION': '2.0.0',
+      'TYPENAME': ogcLayerNames
+    });
+
+    return this.http_.get(url).then((response) => {
+      const format = new ol.format.WFSDescribeFeatureType();
+      return format.read(response.data);
+    });
   }
 
 

--- a/src/services/querent.js
+++ b/src/services/querent.js
@@ -153,12 +153,15 @@ ngeo.Querent = class {
 
     const ogcLayerNames = dataSource.getOGCLayerNames();
 
-    const url = ol.uri.appendParams(dataSource.wfsUrl, {
-      'REQUEST': 'DescribeFeatureType',
-      'SERVICE': 'WFS',
-      'VERSION': '2.0.0',
-      'TYPENAME': ogcLayerNames
-    });
+    const url = ol.uri.appendParams(
+      goog.asserts.assertString(dataSource.wfsUrl),
+      {
+        'REQUEST': 'DescribeFeatureType',
+        'SERVICE': 'WFS',
+        'VERSION': '2.0.0',
+        'TYPENAME': ogcLayerNames
+      }
+    );
 
     return this.http_.get(url).then((response) => {
       const format = new ol.format.WFSDescribeFeatureType();


### PR DESCRIPTION
This PR ensures that a data source is ready for filtering when being selected in the `gmf.FilterSelector` directive.

It features:

 * the addition of the `gmf.DataSource` to allow the gmfThemes.Layer to be referenced in the data source and access some meta data
 * the addition of a `gmf.DataSourcesHelper` service to be able to asynchronously fetch:
  * the attributes (using the ngeo.Querent service and a WFS DescribeFeatureType request)
  * the values of an attribute listed in the `EnumeratedAttribute` metadata

Once ready, the data source is set in a `readyDataSource` property in the `gmf.FilterSelector`.  The next step will be to sync that data source with the upcoming `ngeo.Filter` directive.