### PR TITLE
Filter - Allow anonymous filtering

### DIFF
--- a/contribs/gmf/src/directives/filterselector.js
+++ b/contribs/gmf/src/directives/filterselector.js
@@ -40,8 +40,8 @@ gmf.FilterselectorController = class {
     this.gmfUser_ = gmfUser;
 
     $scope.$watch(
-      () => this.gmfUser_.username,
-      this.handleUsernameChange_.bind(this)
+      () => this.gmfUser_.functionalities,
+      this.handleGmfUserFunctionalitiesChange_.bind(this)
     );
 
     /**
@@ -95,9 +95,8 @@ gmf.FilterselectorController = class {
   /**
    * @private
    */
-  handleUsernameChange_() {
-    if (this.gmfUser_.username &&
-        this.gmfUser_.functionalities &&
+  handleGmfUserFunctionalitiesChange_() {
+    if (this.gmfUser_.functionalities &&
         this.gmfUser_.functionalities.filterable_layers
     ) {
       this.filtrableLayerNodeNames_ =


### PR DESCRIPTION
This PR allows the list of filtrable data sources to be filled upon loading the page and if we are not connected.  The 'anonymous' user can contain functionnalities, therefore can contain filtrable layers.

**Note**: This works, but only when loading the page.  If you log in with a user, then log out you're not as the 'anonymous' user thereafter and no filtrable layers are there.  If this is an issue, this should be addressed in an other PR as this is out of scope of the Filter project.