### PR TITLE
Add ngeo-filter component and rule classes

### DIFF
--- a/contribs/gmf/examples/filterselector.html
+++ b/contribs/gmf/examples/filterselector.html
@@ -36,6 +36,29 @@
       .collapse {
         display: block;
       }
+
+
+      /* CSS for filter */
+      .ngeo-filter-condition-button,
+      .ngeo-filter-condition-button:hover,
+      .ngeo-filter-condition-button:focus {
+        text-decoration: none;
+      }
+
+      .ngeo-filter-condition-criteria-header {
+        color: #999999;
+        padding: 0.3rem 2rem;
+      }
+
+      .ngeo-filter-condition-criteria {
+        opacity: 0;
+      }
+
+      .ngeo-filter-condition-criteria-active {
+        opacity: 1;
+      }
+
+
     </style>
   </head>
   <body ng-controller="MainController as ctrl">

--- a/contribs/gmf/externs/gmf-themes.js
+++ b/contribs/gmf/externs/gmf-themes.js
@@ -386,6 +386,14 @@ gmfThemes.GmfMetaData.prototype.copyable;
 
 
 /**
+ * List of attribute names which should have rules already ready when using
+ * the filter tools.
+ * @type {Array.<string>|undefined}
+ */
+gmfThemes.GmfMetaData.prototype.DirectedFilterAttributes;
+
+
+/**
  * The disclaimer.
  * @type {string|undefined}
  */

--- a/contribs/gmf/src/directives/filterselector.js
+++ b/contribs/gmf/src/directives/filterselector.js
@@ -371,7 +371,6 @@ gmf.FilterselectorController = class {
 
   /**
    * @param {?gmf.DataSource} dataSource Newly selected data source object.
-   *     object.
    * @private
    */
   handleSelectedDataSourceChange_(dataSource) {

--- a/contribs/gmf/src/directives/filterselector.js
+++ b/contribs/gmf/src/directives/filterselector.js
@@ -5,7 +5,10 @@ goog.require('gmf');
 goog.require('gmf.Authentication');
 /** @suppress {extraRequire} */
 goog.require('gmf.DataSourcesHelper');
+/** @suppress {extraRequire} */
+goog.require('ngeo.filterComponent');
 goog.require('ngeo.Notification');
+goog.require('ngeo.RuleHelper');
 goog.require('ol.CollectionEventType');
 
 
@@ -18,13 +21,14 @@ gmf.FilterselectorController = class {
    *     helper service.
    * @param {gmfx.User} gmfUser User.
    * @param {ngeo.Notification} ngeoNotification Ngeo notification service.
+   * @param {!ngeo.RuleHelper} ngeoRuleHelper Ngeo rule helper service.
    * @private
    * @ngInject
    * @ngdoc controller
    * @ngname GmfFilterselectorController
    */
   constructor($scope, gettextCatalog, gmfDataSourcesHelper, gmfUser,
-      ngeoNotification
+      ngeoNotification, ngeoRuleHelper
   ) {
 
     // Binding properties
@@ -39,6 +43,9 @@ gmf.FilterselectorController = class {
       () => this.active,
       this.toggleDataSourceRegistration_.bind(this)
     );
+
+
+    // Injected properties
 
     /**
      * @type {angularGettext.Catalog}
@@ -69,8 +76,26 @@ gmf.FilterselectorController = class {
      */
     this.ngeoNotification_ = ngeoNotification;
 
+    /**
+     * @type {!ngeo.RuleHelper}
+     * @private
+     */
+    this.ngeoRuleHelper_ = ngeoRuleHelper;
+
 
     // Inner properties
+
+    /**
+     * @type {Array.<ngeo.rule.Rule>}
+     * @export
+     */
+    this.customRules = null;
+
+    /**
+     * @type {Array.<ngeo.rule.Rule>}
+     * @export
+     */
+    this.directedRules = null;
 
     /**
      * @type {Array.<gmf.DataSource>}
@@ -103,6 +128,12 @@ gmf.FilterselectorController = class {
      * @export
      */
     this.readyDataSource = null;
+
+    /**
+     * @type {!gmf.FilterselectorController.RuleCache}
+     * @private
+     */
+    this.ruleCache_ = {};
 
     /**
      * The data source that has been selected in the list and that requires
@@ -339,25 +370,90 @@ gmf.FilterselectorController = class {
   }
 
   /**
-   * @param {?gmf.DataSource} dataSource Ngeo data source object
+   * @param {?gmf.DataSource} dataSource Newly selected data source object.
+   *     object.
    * @private
    */
   handleSelectedDataSourceChange_(dataSource) {
 
+    this.customRules = null;
+    this.directedRules = null;
+    this.readyDataSource = null;
+
     // No need to do anything if no data source is selected
     if (!dataSource) {
-      this.readyDataSource = null;
       return;
     }
 
     this.gmfDataSourcesHelper_.prepareFiltrableDataSource(
       dataSource
     ).then((dataSource) => {
+
+      // Data source is ready. Get any existing rules or create new ones from
+      // the attributes
+      let item = this.getRuleCacheItem_(dataSource);
+      if (!item) {
+        item = {
+          customRules: [],
+          directedRules: []
+        };
+        this.setRuleCacheItem_(dataSource, item);
+        if (dataSource.gmfLayer.metadata &&
+            dataSource.gmfLayer.metadata.DirectedFilterAttributes &&
+            dataSource.gmfLayer.metadata.DirectedFilterAttributes.length
+        ) {
+          const directedAttributes =
+              dataSource.gmfLayer.metadata.DirectedFilterAttributes;
+          const attributes = goog.asserts.assert(dataSource.attributes);
+          for (const attribute of attributes) {
+            if (ol.array.includes(directedAttributes, attribute.name)) {
+              item.directedRules.push(
+                this.ngeoRuleHelper_.createRule(attribute)
+              );
+            }
+          }
+        }
+      }
+
+      this.customRules = item.customRules;
+      this.directedRules = item.directedRules;
       this.readyDataSource = dataSource;
     });
   }
 
+  /**
+   * @param {ngeo.DataSource} dataSource Data source.
+   * @return {?gmf.FilterselectorController.RuleCacheItem} Rule cache item.
+   * @private
+   */
+  getRuleCacheItem_(dataSource) {
+    return this.ruleCache_[dataSource.id] || null;
+  }
+
+  /**
+   * @param {ngeo.DataSource} dataSource Data source.
+   * @param {gmf.FilterselectorController.RuleCacheItem} item Rule cache item.
+   * @private
+   */
+  setRuleCacheItem_(dataSource, item) {
+    this.ruleCache_[dataSource.id] = item;
+  }
 };
+
+
+/**
+ * @typedef {Object.<number, !gmf.FilterselectorController.RuleCacheItem>}
+ */
+gmf.FilterselectorController.RuleCache;
+
+
+/**
+ * @typedef {{
+ *     customRules: (Array.<ngeo.rule.Rule>),
+ *     directedRules: (Array.<ngeo.rule.Rule>)
+ * }}
+ */
+gmf.FilterselectorController.RuleCacheItem;
 
 
 gmf.module.component('gmfFilterselector', {

--- a/contribs/gmf/src/directives/partials/filterselector.html
+++ b/contribs/gmf/src/directives/partials/filterselector.html
@@ -10,9 +10,10 @@
     <option value="" translate>-- Layer to filter --</option>
   </select>
 
-  <!-- This is where the ngeo.Filter directive will go... -->
-  <div ng-if="fsCtrl.readyDataSource">
-    {{ fsCtrl.readyDataSource.name }} is ready to be filtered!
-  </div>
-
+  <ngeo-filter
+      ng-if="fsCtrl.customRules && fsCtrl.directedRules && fsCtrl.readyDataSource"
+      custom-rules="fsCtrl.customRules"
+      datasource="fsCtrl.readyDataSource"
+      directed-rules="fsCtrl.directedRules">
+  </ngeo-filter>
 </div>

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -145,6 +145,22 @@ ngeox.DataSourceOptions.prototype.dimensions;
 
 
 /**
+ * The filter condition to apply to the filter rules (if any). Defaults to
+ * `ngeo.FilterCondition.AND`.
+ * @type {string|undefined}
+ */
+ngeox.DataSourceOptions.prototype.filterCondition;
+
+
+/**
+ * A list of filter rules to apply to this data source using the filter
+ * condition.
+ * @type {!Array.<!ngeo.rule.Rule>|undefined}
+ */
+ngeox.DataSourceOptions.prototype.filterRules;
+
+
+/**
  * The name of the geometry attribute.
  * @type {string|undefined}
  */
@@ -1778,6 +1794,167 @@ ngeox.number;
  * @typedef {function(number, string=, string=, number=): string}
  */
 ngeox.unitPrefix;
+
+
+/**
+ * Namespace.
+ * @type {Object}
+ */
+ngeox.rule;
+
+
+/**
+ * @record
+ * @struct
+ */
+ngeox.rule.RuleOptions = function() {};
+
+
+/**
+ * The expression of the rule. The expression and boundaries are mutually
+ * exclusives.
+ * @type {boolean|number|string|undefined}
+ */
+ngeox.rule.RuleOptions.prototype.expression;
+
+
+/**
+ * Whether the rule is a custom one or not. Defaults to `true`.
+ * @type {boolean|undefined}
+ */
+ngeox.rule.RuleOptions.prototype.isCustom;
+
+
+/**
+ * The lower boundary of the rule. The expression and boundaries are
+ * mutually exclusives.
+ * @type {number|string|undefined}
+ */
+ngeox.rule.RuleOptions.prototype.lowerBoundary;
+
+
+/**
+ * The human-readable name of the rule.
+ * @type {string}
+ */
+ngeox.rule.RuleOptions.prototype.name;
+
+
+/**
+ * The rule operator.
+ * @type {string|undefined}
+ */
+ngeox.rule.RuleOptions.prototype.operator;
+
+
+/**
+ * The rule operators.
+ * @type {Array.<string>|undefined}
+ */
+ngeox.rule.RuleOptions.prototype.operators;
+
+
+/**
+ * The property name (a.k.a. the attribute name).
+ * @type {string}
+ */
+ngeox.rule.RuleOptions.prototype.propertyName;
+
+
+/**
+ * The type of rule.
+ * @type {string|undefined}
+ */
+ngeox.rule.RuleOptions.prototype.type;
+
+
+/**
+ * The upper boundary of the rule. The expression and boundaries are
+ * mutually exclusives.
+ * @type {string|number|undefined}
+ */
+ngeox.rule.RuleOptions.prototype.upperBoundary;
+
+
+/**
+ * @record
+ * @struct
+ * @extends ngeox.rule.RuleOptions
+ */
+ngeox.rule.SelectOptions = function() {};
+
+
+/**
+ * List of choices available for selection.
+ * @type {Array.<string>}
+ */
+ngeox.rule.SelectOptions.prototype.choices;
+
+
+/**
+ * @record
+ * @struct
+ * @extends ngeox.rule.RuleOptions
+ */
+ngeox.rule.TextOptions = function() {};
+
+
+/**
+ * @record
+ * @struct
+ */
+ngeox.rule.RuleBaseValue = function() {};
+
+
+/**
+ * The operator of the rule value.
+ * @type {string}
+ */
+ngeox.rule.RuleBaseValue.prototype.operator;
+
+
+/**
+ * The property name of the rule value.
+ * @type {string}
+ */
+ngeox.rule.RuleBaseValue.prototype.propertyName;
+
+
+/**
+ * @record
+ * @struct
+ * @extends ngeox.rule.RuleBaseValue
+ */
+ngeox.rule.RuleSimpleValue = function() {};
+
+
+/**
+ * The expression of the rule value.
+ * @type {boolean|number|string}
+ */
+ngeox.rule.RuleSimpleValue.prototype.expression;
+
+
+/**
+ * @record
+ * @struct
+ * @extends ngeox.rule.RuleBaseValue
+ */
+ngeox.rule.RuleRangeValue = function() {};
+
+
+/**
+ * The lower boundary of the rule value.
+ * @type {number|string}
+ */
+ngeox.rule.RuleRangeValue.prototype.lowerBoundary;
+
+
+/**
+ * The upper boundary of the rule value.
+ * @type {number|string}
+ */
+ngeox.rule.RuleRangeValue.prototype.upperBoundary;
 
 
 /**

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -1,13 +1,6 @@
-// TODO == Dynamic Properties ==
-// TODO  - filterCondition (and, or, not)
-// TODO  - filterRules (array of rules)
-//
-// TODO == Static Properties ==
-// TODO  - filterRuleDefinitions
-// TODO  - group
-
 goog.provide('ngeo.DataSource');
 
+goog.require('ngeo');
 goog.require('ol.format.WFS');
 goog.require('ol.format.WMSGetFeatureInfo');
 
@@ -40,6 +33,21 @@ ngeo.DataSource = class {
      * @private
      */
     this.activeDimensions_ = options.activeDimensions || null;
+
+    /**
+     * The filter condition to apply to the filter rules (if any).
+     * @type {string}
+     * @private
+     */
+    this.filterCondition_ = options.filterCondition || ngeo.FilterCondition.AND;
+
+    /**
+     * A list of filter rules to apply to this data source using the filter
+     * condition.
+     * @type {?Array.<!ngeo.rule.Rule>}
+     * @private
+     */
+    this.filterRules_ = options.filterRules || null;
 
     /**
      * A data source is considered 'in range' when it is synchronized to
@@ -327,6 +335,38 @@ ngeo.DataSource = class {
    */
   set activeDimensions(activeDimensions) {
     this.activeDimensions_ = activeDimensions;
+  }
+
+  /**
+   * @return {string} Filter condition
+   * @export
+   */
+  get filterCondition() {
+    return this.filterCondition_;
+  }
+
+  /**
+   * @param {string} filterCondition Filter condition
+   * @export
+   */
+  set filterCondition(filterCondition) {
+    this.filterCondition_ = filterCondition;
+  }
+
+  /**
+   * @return {?Array.<!ngeo.rule.Rule>} Filter rules
+   * @export
+   */
+  get filterRules() {
+    return this.filterRules_;
+  }
+
+  /**
+   * @param {?Array.<!ngeo.rule.Rule>} filterRules Filter rules
+   * @export
+   */
+  set filterRules(filterRules) {
+    this.filterRules_ = filterRules;
   }
 
   /**

--- a/src/directives/filter.js
+++ b/src/directives/filter.js
@@ -1,0 +1,184 @@
+goog.provide('ngeo.filterComponent');
+
+goog.require('ngeo');
+goog.require('ngeo.RuleHelper');
+
+
+ngeo.FilterController = class {
+
+  /**
+   * @param {!angularGettext.Catalog} gettextCatalog Gettext service.
+   * @param {!ngeo.RuleHelper} ngeoRuleHelper Ngeo rule helper service.
+   * @private
+   * @ngInject
+   * @ngdoc controller
+   * @ngname NgeoFilterController
+   */
+  constructor(gettextCatalog, ngeoRuleHelper) {
+
+    // Binding properties
+
+    /**
+     * @type {Array.<!ngeo.rule.Rule>}
+     * @export
+     */
+    this.customRules;
+
+    /**
+     * @type {!ngeo.DataSource}
+     * @export
+     */
+    this.datasource;
+
+    /**
+     * @type {Array.<!ngeo.rule.Rule>}
+     * @export
+     */
+    this.directedRules;
+
+    // Injected properties
+
+    /**
+     * @type {!angularGettext.Catalog}
+     * @private
+     */
+    this.gettextCatalog_ = gettextCatalog;
+
+    /**
+     * @type {!ngeo.RuleHelper}
+     * @private
+     */
+    this.ngeoRuleHelper_ = ngeoRuleHelper;
+
+    // Inner properties
+
+    /**
+     * @type {Array.<!ngeo.FilterController.Condition>}
+     * @export
+     */
+    this.conditions = [
+      {
+        text: gettextCatalog.getString('All'),
+        value: ngeo.FilterCondition.AND
+      },
+      {
+        text: gettextCatalog.getString('At least one'),
+        value: ngeo.FilterCondition.OR
+      },
+      {
+        text: gettextCatalog.getString('None'),
+        value: ngeo.FilterCondition.NOT
+      }
+    ];
+
+    /**
+     * List of geometry attributes.
+     * @type {Array.<!ngeox.Attribute>}
+     * @export
+     */
+    this.geometryAttributes = [];
+
+    /**
+     * List of other attribute names.
+     * @type {Array.<!ngeox.Attribute>}
+     * @export
+     */
+    this.otherAttributes = [];
+  }
+
+
+  /**
+   * Called on initialization of the controller.
+   *
+   * Loop through the attributes of the data source and separated them in 2
+   * lists: geometry and the others. Then, apply the filters to the data source.
+   */
+  $onInit() {
+    const attributes = goog.asserts.assert(this.datasource.attributes);
+    for (const attribute of attributes) {
+      if (attribute.type === ngeo.AttributeType.GEOMETRY) {
+        this.geometryAttributes.push(attribute);
+      } else {
+        this.otherAttributes.push(attribute);
+      }
+    }
+
+    this.apply();
+  }
+
+
+  /**
+   * Called on destruction of the controller.
+   *
+   * Reset the `filterRules` of the data source back to `null`.
+   */
+  $onDestroy() {
+    if (this.datasource.filterRules !== null) {
+      this.datasource.filterRules = null;
+    }
+  }
+
+
+  /**
+   * Loop in all directed and custom rules. Apply the rules that have a proper
+   * value inside the data source, in the `filterRules` property.
+   * @export
+   */
+  apply() {
+    const filterRules = [];
+    const rules = [].concat(this.customRules, this.directedRules);
+    for (const rule of rules) {
+      if (rule.value) {
+        filterRules.push(rule);
+      }
+    }
+    this.datasource.filterRules = filterRules.length ? filterRules : null;
+  }
+
+
+  /**
+   * @param {!ngeox.Attribute} attribute Attribute to use to create the custom
+   * rule.
+   * @export
+   */
+  createAndAddCustomRule(attribute) {
+    this.customRules.push(
+      this.ngeoRuleHelper_.createRule(attribute, true)
+    );
+  }
+
+
+  /**
+   * @param {!ngeo.FilterController.Condition} condition Condition to set.
+   * @export
+   */
+  setCondition(condition) {
+    if (this.datasource.filterCondition !== condition.value) {
+      this.datasource.filterCondition = condition.value;
+    }
+  }
+
+};
+
+
+/**
+ * @typedef {{
+ *     text: (string),
+ *     value: (string)
+ * }}
+ */
+ngeo.FilterController.Condition;
+
+
+ngeo.module.component('ngeoFilter', {
+  bindings: {
+    customRules: '<',
+    // It's 'datasource' instead of 'dataSource', because that would require
+    // the attribute to be 'data-source', and Angular strips the 'data-'.
+    datasource: '<',
+    directedRules: '<'
+  },
+  controller: ngeo.FilterController,
+  controllerAs: 'filterCtrl',
+  templateUrl: () => `${ngeo.baseTemplateUrl}/filter.html`
+});

--- a/src/directives/partials/filter.html
+++ b/src/directives/partials/filter.html
@@ -1,0 +1,73 @@
+<div class="dropdown">
+  <a
+      class="btn btn-link dropdown-toggle ngeo-filter-condition-button"
+      type="button"
+      data-toggle="dropdown">
+    <span class="glyphicon glyphicon-cog"></span>
+    <span class="caret"></span>
+  </a>
+  <ul class="dropdown-menu">
+    <li
+        class="ngeo-filter-condition-criteria-header"
+        translate>Criteria taken into account</li>
+    <li ng-repeat="condition in ::filterCtrl.conditions">
+      <a
+          href
+          ng-click="filterCtrl.setCondition(condition)">
+          <span
+              ng-class="{'ngeo-filter-condition-criteria-active': condition.value == filterCtrl.datasource.filterCondition}"
+              class="glyphicon glyphicon-ok ngeo-filter-condition-criteria">
+          </span>
+          <span>{{::condition.text | translate}}</span>
+      </a>
+    </li>
+  </ul>
+</div>
+
+<div
+    ng-repeat="rule in filterCtrl.directedRules">
+  {{ rule.name }}
+</div>
+
+<hr ng-if="filterCtrl.directedRules.length" />
+
+<div
+    ng-repeat="rule in filterCtrl.customRules">
+  {{ rule.name }}
+</div>
+
+<div class="dropdown">
+  <a
+      class="btn btn-link dropdown-toggle"
+      type="button"
+      data-toggle="dropdown">
+    <span translate>+ Add a new criteria</span>
+    <span class="caret"></span>
+  </a>
+  <ul class="dropdown-menu">
+    <li ng-repeat="attribute in ::filterCtrl.geometryAttributes">
+      <a
+          href
+          ng-click="">
+          <span translate>Spatial filter</span>
+      </a>
+    </li>
+    <li role="presentation" class="divider"></li>
+    <li ng-repeat="attribute in ::filterCtrl.otherAttributes">
+      <a
+          href
+          ng-click="filterCtrl.createAndAddCustomRule(attribute)">
+          <span>{{::attribute.name | translate}}</span>
+      </a>
+    </li>
+  </ul>
+</div>
+
+<a
+    class="btn btn-link"
+    type="button"
+    data-toggle="dropdown"
+    ng-click="filterCtrl.apply()">
+  <span class="glyphicon glyphicon-ok"></span>
+  <span translate>Apply</span>
+</a>

--- a/src/ngeo.js
+++ b/src/ngeo.js
@@ -146,6 +146,29 @@ ngeo.FeatureProperties = {
  * @enum {string}
  * @export
  */
+ngeo.FilterCondition = {
+  /**
+   * @type {string}
+   * @export
+   */
+  AND: '&&',
+  /**
+   * @type {string}
+   * @export
+   */
+  NOT: '!',
+  /**
+   * @type {string}
+   * @export
+   */
+  OR: '||'
+};
+
+
+/**
+ * @enum {string}
+ * @export
+ */
 ngeo.GeometryType = {
   /**
    * @type {string}

--- a/src/rule/rule.js
+++ b/src/rule/rule.js
@@ -1,0 +1,271 @@
+goog.provide('ngeo.rule.Rule');
+
+goog.require('ngeo');
+
+
+ngeo.rule.Rule = class {
+
+  /**
+   * The abstract class for all filter rules.
+   *
+   * Rules are used to define filters that can be applied on data sources.
+   * A rule is usually a combination of 3 things:
+   *
+   * - a property name, for example 'city_name'
+   * - an operator, for example 'is equal to'
+   * - and an expression, for example 'Chicoutimi'.
+   *
+   * A rule is useful to hold those properties and change them on the fly.
+   * For example, chaning an operator from 'is equal to' to 'like'.
+   *
+   * Also, a rule is especially useful for its `value` getter, which returns
+   * the combination of properties described above or `null` if there are some
+   * missing.  The `value` getter can be watched and used when the value is
+   * not null.
+   *
+   * When the operator is `between`, the `lowerBoundary` and `upperBoundary`
+   * properties are used instead of `expression`.
+   *
+   * @struct
+   * @param {ngeox.rule.RuleOptions} options Options.
+   */
+  constructor(options) {
+
+    // === DYNAMIC properties (i.e. that can change / be watched ===
+
+    /**
+     * The expression of the rule. The expression and boundaries are mutually
+     * exclusives.
+     * @type {?boolean|number|string}
+     * @private
+     */
+    this.expression_ = options.expression !== undefined ?
+      options.expression : null;
+
+    /**
+     * The lower boundary of the rule. The expression and boundaries are
+     * mutually exclusives.
+     * @type {?number|string}
+     * @private
+     */
+    this.lowerBoundary_ = options. lowerBoundary !== undefined ?
+      options.lowerBoundary : null;
+
+    /**
+     * The rule operator.
+     * @type {?string}
+     * @private
+     */
+    this.operator_ = options.operator || null;
+
+    /**
+     * The upper boundary of the rule. The expression and boundaries are
+     * mutually exclusives.
+     * @type {?number|string}
+     * @private
+     */
+    this.upperBoundary_ = options. upperBoundary !== undefined ?
+      options.upperBoundary : null;
+
+
+    // === STATIC properties (i.e. that never change) ===
+
+    /**
+     * Whether the rule is a custom one or not.
+     * @type {boolean}
+     * @private
+     */
+    this.isCustom_ = options.isCustom !== false;
+
+    /**
+     * The human-readable name of the rule.
+     * @type {string}
+     * @private
+     */
+    this.name_ = options.name;
+
+    /**
+     * A list of rule operators.
+     * @type {?Array.<string>}
+     * @private
+     */
+    this.operators_ = options.operators || null;
+
+    /**
+     * The property name (a.k.a. the attribute name).
+     * @type {string}
+     * @private
+     */
+    this.propertyName_ = options.propertyName;
+
+    /**
+     * The type of rule.
+     * @type {string}
+     * @private
+     */
+    this.type_ = goog.asserts.assert(options.type);
+
+  }
+
+  // === Dynamic property getters/setters ===
+
+  /**
+   * @return {?boolean|number|string} Expression
+   * @export
+   */
+  get expression() {
+    return this.expression_;
+  }
+
+  /**
+   * @param {?boolean|number|string} expression Expression
+   * @export
+   */
+  set expression(expression) {
+    this.expression_ = expression;
+  }
+
+  /**
+   * @return {?number|string} Lower boundary
+   * @export
+   */
+  get lowerBoundary() {
+    return this.lowerBoundary_;
+  }
+
+  /**
+   * @param {?number|string} lowerBoundary Lower boundary
+   * @export
+   */
+  set lowerBoundary(lowerBoundary) {
+    this.lowerBoundary_ = lowerBoundary;
+  }
+
+  /**
+   * @return {?string} Operator
+   * @export
+   */
+  get operator() {
+    return this.operator_;
+  }
+
+  /**
+   * @param {?string} operator Operator
+   * @export
+   */
+  set operator(operator) {
+    this.operator_ = operator;
+  }
+
+  /**
+   * @return {?number|string} Upper boundary
+   * @export
+   */
+  get upperBoundary() {
+    return this.upperBoundary_;
+  }
+
+  /**
+   * @param {?number|string} upperBoundary Upper boundary
+   * @export
+   */
+  set upperBoundary(upperBoundary) {
+    this.upperBoundary_ = upperBoundary;
+  }
+
+  // === Static property getters/setters ===
+
+  /**
+   * @return {boolean} Is custom.
+   * @export
+   */
+  get isCustom() {
+    return this.isCustom_;
+  }
+
+  /**
+   * @return {string} name
+   * @export
+   */
+  get name() {
+    return this.name_;
+  }
+
+  /**
+   * @return {?Array.<string>} Operators
+   * @export
+   */
+  get operators() {
+    return this.operators_;
+  }
+
+  /**
+   * @return {string} Property name
+   * @export
+   */
+  get propertyName() {
+    return this.propertyName_;
+  }
+
+  /**
+   * @return {string} Type
+   * @export
+   */
+  get type() {
+    return this.type_;
+  }
+
+  // === Calculated property getters ===
+
+  /**
+   * @return {?ngeox.rule.RuleSimpleValue|ngeox.rule.RuleRangeValue} Value.
+   * @export
+   */
+  get value() {
+    let value = null;
+
+    const expression = this.expression;
+    const lowerBoundary = this.lowerBoundary;
+    const operator = this.operator;
+    const propertyName = this.propertyName;
+    const upperBoundary = this.upperBoundary;
+
+    if (operator) {
+      if (operator === ngeo.rule.Rule.OperatorType.BETWEEN) {
+        if (lowerBoundary !== null && upperBoundary !== null) {
+          value = {
+            operator,
+            lowerBoundary,
+            propertyName,
+            upperBoundary
+          };
+        }
+      } else {
+        if (expression !== null) {
+          value = {
+            expression,
+            operator,
+            propertyName
+          };
+        }
+      }
+    }
+
+    return value;
+  }
+
+};
+
+
+/**
+ * @enum {string}
+ */
+ngeo.rule.Rule.OperatorType = {
+  BETWEEN: '..',
+  EQUAL_TO: '=',
+  GREATER_THAN: '>',
+  GREATER_THAN_OR_EQUAL_TO: '>=',
+  LESSER_THAN: '',
+  LESSER_THAN_OR_EQUAL_TO: '<=',
+  LIKE: '~'
+};

--- a/src/rule/select.js
+++ b/src/rule/select.js
@@ -1,0 +1,42 @@
+goog.provide('ngeo.rule.Select');
+
+goog.require('ngeo.rule.Rule');
+
+
+ngeo.rule.Select = class extends ngeo.rule.Rule {
+
+  /**
+   * A select rule, which allows the selection of multiple values among a list
+   * of choices.
+   *
+   * @struct
+   * @param {ngeox.rule.SelectOptions} options Options.
+   */
+  constructor(options) {
+
+    options.operator = ngeo.rule.Rule.OperatorType.EQUAL_TO;
+    options.type = ngeo.AttributeType.SELECT;
+
+    super(options);
+
+    // === STATIC properties (i.e. that never change) ===
+
+    /**
+     * @type {Array.<string>}
+     * @private
+     */
+    this.choices_ = options.choices;
+
+  }
+
+  // === Static property getters/setters ===
+
+  /**
+   * @return {Array.<string>} Choices
+   * @export
+   */
+  get choices() {
+    return this.choices_;
+  }
+
+};

--- a/src/rule/text.js
+++ b/src/rule/text.js
@@ -1,0 +1,22 @@
+goog.provide('ngeo.rule.Text');
+
+goog.require('ngeo.rule.Rule');
+
+
+ngeo.rule.Text = class extends ngeo.rule.Rule {
+
+  /**
+   * A text rule, which always compares the value with the LIKE operator.
+   *
+   * @struct
+   * @param {ngeox.rule.TextOptions} options Options.
+   */
+  constructor(options) {
+
+    options.operator = ngeo.rule.Rule.OperatorType.LIKE;
+    options.type = ngeo.AttributeType.TEXT;
+
+    super(options);
+
+  }
+};

--- a/src/services/rulehelper.js
+++ b/src/services/rulehelper.js
@@ -1,0 +1,95 @@
+goog.provide('ngeo.RuleHelper');
+
+goog.require('ngeo');
+goog.require('ngeo.rule.Rule');
+goog.require('ngeo.rule.Select');
+goog.require('ngeo.rule.Text');
+
+
+ngeo.RuleHelper = class {
+
+  /**
+   * A service that provides utility methods to create `ngeo.rule.Rule`
+   * objects.
+   *
+   * @param {!angularGettext.Catalog} gettextCatalog Gettext service.
+   * @struct
+   * @ngdoc service
+   * @ngname ngeoRuleHelper
+   * @ngInject
+   */
+  constructor(gettextCatalog) {
+
+    /**
+     * @type {!angularGettext.Catalog}
+     * @private
+     */
+    this.gettextCatalog_ = gettextCatalog;
+  }
+
+  /**
+   * @param {!Array.<!ngeox.Attribute>} attributes Attributes.
+   * @param {boolean=} opt_isCustom Whether the created rules should be marked
+   *     as custom or not. Defaults to `false`.
+   * @return {Array.<!ngeo.rule.Rule>} Rules.
+   * @export
+   */
+  createRules(attributes, opt_isCustom) {
+    const rules = [];
+    for (const attribute of attributes) {
+      rules.push(this.createRule(attribute, opt_isCustom));
+    }
+    return rules;
+  }
+
+  /**
+   * @param {!ngeox.Attribute} attribute Attribute.
+   * @param {boolean=} opt_isCustom Whether the created rule should be marked
+   *     as custom or not. Defaults to `false`.
+   * @return {!ngeo.rule.Rule} Rule.
+   * @export
+   */
+  createRule(attribute, opt_isCustom) {
+
+    let rule;
+
+    /**
+     * @type {string}
+     */
+    const name = this.gettextCatalog_.getString(attribute.name);
+
+    // Todo: support geometry
+
+    switch (attribute.type) {
+      case ngeo.AttributeType.DATE:
+      case ngeo.AttributeType.DATETIME:
+        rule = new ngeo.rule.Rule({
+          name,
+          operator: ngeo.rule.Rule.OperatorType.BETWEEN,
+          propertyName: attribute.name,
+          type: attribute.type
+        });
+        break;
+      case ngeo.AttributeType.SELECT:
+        rule = new ngeo.rule.Select({
+          choices: goog.asserts.assert(attribute.choices),
+          name,
+          propertyName: attribute.name
+        });
+        break;
+      default:
+        rule = new ngeo.rule.Text({
+          name,
+          operator: ngeo.rule.Rule.OperatorType.LIKE,
+          propertyName: attribute.name
+        });
+        break;
+    }
+
+    return rule;
+  }
+
+};
+
+
+ngeo.module.service('ngeoRuleHelper', ngeo.RuleHelper);


### PR DESCRIPTION
This PR introduces:

 * the `ngeo-filter` directive (component), which is responsible of listing the rules to apply to a data source in order to do filtering on it.
 * the `ngeo.rule.*` classes, which are the objects that define a filter rule

Here are the things that won't be managed in the PR:

 * geometry rules
 * `ngeo-rule` directive (component) --> that's the next PR I'll be working on.

## Todo

 * [x] review