### PR TITLE
Filter - Create rule component, support 'text' and 'select' types

### DIFF
--- a/contribs/gmf/examples/filterselector.html
+++ b/contribs/gmf/examples/filterselector.html
@@ -63,9 +63,14 @@
         opacity: 1;
       }
 
+      .ngeo-filter-rule-custom-rm-btn {
+        float: right;
+        margin: 0.4rem 0;
+      }
+
       ngeo-rule {
         display: block;
-        margin: 1rem 0;
+        margin: 1rem 2.5rem 1rem 0;
       }
 
       ngeo-rule .dropdown > a.btn {

--- a/contribs/gmf/examples/filterselector.html
+++ b/contribs/gmf/examples/filterselector.html
@@ -39,6 +39,11 @@
 
 
       /* CSS for filter */
+
+      .gmf-filterselector-separator {
+        margin: 1.5rem 0 0.5rem 0;
+      }
+
       .ngeo-filter-condition-button,
       .ngeo-filter-condition-button:hover,
       .ngeo-filter-condition-button:focus {
@@ -56,6 +61,48 @@
 
       .ngeo-filter-condition-criteria-active {
         opacity: 1;
+      }
+
+      ngeo-rule {
+        display: block;
+        margin: 1rem 0;
+      }
+
+      ngeo-rule .dropdown > a.btn {
+        display: block;
+        text-align: left;
+      }
+
+      ngeo-rule .dropdown > a.btn > span.caret {
+        float: right;
+        margin: 0.8rem 0 0 0;
+      }
+
+      ngeo-rule .dropdown-menu {
+        padding: 1rem;
+      }
+
+      .ngeo-rule-btns {
+        float: right;
+      }
+
+      .ngeo-rule-type-select label {
+        width: 13.5rem;
+      }
+
+      .ngeo-rule-value {
+        color: #999999;
+        margin: 0.5rem;
+      }
+
+      .ngeo-rule-value a.btn {
+        color: #999999;
+        float: right;
+      }
+
+      .ngeo-rule-value a.btn:hover,
+      .ngeo-rule-value a.btn:focus {
+        color: #666666;
       }
 
 
@@ -106,7 +153,9 @@
 
       <gmf-filterselector
           ng-show="ctrl.filterSelectorActive === true"
-          active="ctrl.filterSelectorActive">
+          active="ctrl.filterSelectorActive"
+          map="ctrl.map"
+          tool-group="ctrl.toolGroup">
       </gmf-filterselector>
     </div>
 

--- a/contribs/gmf/examples/filterselector.js
+++ b/contribs/gmf/examples/filterselector.js
@@ -112,6 +112,12 @@ gmfapp.MainController = class {
     });
 
     /**
+     * @type {string}
+     * @export
+     */
+    this.toolGroup = 'mapTools';
+
+    /**
      * @type {boolean}
      * @export
      */
@@ -120,7 +126,7 @@ gmfapp.MainController = class {
     const filterSelectorToolActivate = new ngeo.ToolActivate(
       this, 'filterSelectorActive');
     ngeoToolActivateMgr.registerTool(
-      'mapTools', filterSelectorToolActivate, true);
+      'dummyTools', filterSelectorToolActivate, true);
 
     /**
      * @type {boolean}
@@ -131,13 +137,18 @@ gmfapp.MainController = class {
     const dummyToolActivate = new ngeo.ToolActivate(
       this, 'dummyActive');
     ngeoToolActivateMgr.registerTool(
-      'mapTools', dummyToolActivate, false);
+      'dummyTools', dummyToolActivate, false);
 
     /**
      * @type {boolean}
      * @export
      */
     this.queryActive = true;
+
+    const queryToolActivate = new ngeo.ToolActivate(
+      this, 'queryActive');
+    ngeoToolActivateMgr.registerTool(
+      this.toolGroup, queryToolActivate, true);
 
     // initialize tooltips
     $('[data-toggle="tooltip"]').tooltip({

--- a/contribs/gmf/externs/gmf-themes.js
+++ b/contribs/gmf/externs/gmf-themes.js
@@ -390,7 +390,7 @@ gmfThemes.GmfMetaData.prototype.copyable;
  * the filter tools.
  * @type {Array.<string>|undefined}
  */
-gmfThemes.GmfMetaData.prototype.DirectedFilterAttributes;
+gmfThemes.GmfMetaData.prototype.directedFilterAttributes;
 
 
 /**
@@ -404,7 +404,7 @@ gmfThemes.GmfMetaData.prototype.disclaimer;
  * List of attribute names which have enumerated attribute values.
  * @type {Array.<string>|undefined}
  */
-gmfThemes.GmfMetaData.prototype.EnumeratedAttributes;
+gmfThemes.GmfMetaData.prototype.enumeratedAttributes;
 
 
 /**

--- a/contribs/gmf/src/directives/filterselector.js
+++ b/contribs/gmf/src/directives/filterselector.js
@@ -44,6 +44,18 @@ gmf.FilterselectorController = class {
       this.toggleDataSourceRegistration_.bind(this)
     );
 
+    /**
+     * @type {!ol.Map}
+     * @export
+     */
+    this.map;
+
+    /**
+     * @type {string}
+     * @export
+     */
+    this.toolGroup;
+
 
     // Injected properties
 
@@ -398,11 +410,11 @@ gmf.FilterselectorController = class {
         };
         this.setRuleCacheItem_(dataSource, item);
         if (dataSource.gmfLayer.metadata &&
-            dataSource.gmfLayer.metadata.DirectedFilterAttributes &&
-            dataSource.gmfLayer.metadata.DirectedFilterAttributes.length
+            dataSource.gmfLayer.metadata.directedFilterAttributes &&
+            dataSource.gmfLayer.metadata.directedFilterAttributes.length
         ) {
           const directedAttributes =
-              dataSource.gmfLayer.metadata.DirectedFilterAttributes;
+              dataSource.gmfLayer.metadata.directedFilterAttributes;
           const attributes = goog.asserts.assert(dataSource.attributes);
           for (const attribute of attributes) {
             if (ol.array.includes(directedAttributes, attribute.name)) {
@@ -457,7 +469,9 @@ gmf.FilterselectorController.RuleCacheItem;
 
 gmf.module.component('gmfFilterselector', {
   bindings: {
-    active: '<'
+    active: '<',
+    map: '<',
+    toolGroup: '<'
   },
   controller: gmf.FilterselectorController,
   controllerAs: 'fsCtrl',

--- a/contribs/gmf/src/directives/filterselector.js
+++ b/contribs/gmf/src/directives/filterselector.js
@@ -180,11 +180,9 @@ gmf.FilterselectorController = class {
    * @private
    */
   handleGmfUserFunctionalitiesChange_() {
-    if (this.gmfUser_.functionalities &&
-        this.gmfUser_.functionalities.filterable_layers
-    ) {
-      this.filtrableLayerNodeNames_ =
-        this.gmfUser_.functionalities.filterable_layers;
+    const usrFunc = this.gmfUser_.functionalities;
+    if (usrFunc && usrFunc['filterable_layers']) {
+      this.filtrableLayerNodeNames_ = usrFunc['filterable_layers'];
     } else {
       this.filtrableLayerNodeNames_ = null;
     }

--- a/contribs/gmf/src/directives/partials/filterselector.html
+++ b/contribs/gmf/src/directives/partials/filterselector.html
@@ -10,10 +10,14 @@
     <option value="" translate>-- Layer to filter --</option>
   </select>
 
-  <ngeo-filter
-      ng-if="fsCtrl.customRules && fsCtrl.directedRules && fsCtrl.readyDataSource"
-      custom-rules="fsCtrl.customRules"
-      datasource="fsCtrl.readyDataSource"
-      directed-rules="fsCtrl.directedRules">
-  </ngeo-filter>
+  <div ng-if="fsCtrl.customRules && fsCtrl.directedRules && fsCtrl.readyDataSource">
+    <hr class="gmf-filterselector-separator" />
+    <ngeo-filter
+        custom-rules="fsCtrl.customRules"
+        datasource="fsCtrl.readyDataSource"
+        directed-rules="fsCtrl.directedRules"
+        map="fsCtrl.map"
+        tool-group="fsCtrl.toolGroup">
+    </ngeo-filter>
+  </div>
 </div>

--- a/contribs/gmf/src/services/datasourcehelper.js
+++ b/contribs/gmf/src/services/datasourcehelper.js
@@ -94,11 +94,11 @@ gmf.DataSourcesHelper = class {
     this.ngeoDataSourcesHelper_.getDataSourceAttributes(
       dataSource
     ).then((attributes) => {
-      // (2) The attribute names that are in the `EnumeratedAttributes`
+      // (2) The attribute names that are in the `enumeratedAttributes`
       //     metadata are the ones that need to have their values fetched.
       //     Do that once then set the type to SELECT and the choices.
       const meta = dataSource.gmfLayer.metadata || {};
-      const enumAttributes = meta.EnumeratedAttributes;
+      const enumAttributes = meta.enumeratedAttributes;
       if (enumAttributes && enumAttributes.length) {
         const promises = [];
         for (const attribute of attributes) {

--- a/src/directives/filter.js
+++ b/src/directives/filter.js
@@ -193,6 +193,14 @@ ngeo.FilterController = class {
     }
   }
 
+  /**
+   * @param {!ngeo.rule.Rule} rule Custom rule to remove.
+   * @export
+   */
+  removeCustomRule(rule) {
+    ol.array.remove(this.customRules, rule);
+  }
+
 };
 
 

--- a/src/directives/filter.js
+++ b/src/directives/filter.js
@@ -1,6 +1,8 @@
 goog.provide('ngeo.filterComponent');
 
 goog.require('ngeo');
+/** @suppress {extraRequire} */
+goog.require('ngeo.ruleComponent');
 goog.require('ngeo.RuleHelper');
 
 
@@ -8,13 +10,14 @@ ngeo.FilterController = class {
 
   /**
    * @param {!angularGettext.Catalog} gettextCatalog Gettext service.
+   * @param {!angular.$timeout} $timeout Angular timeout service.
    * @param {!ngeo.RuleHelper} ngeoRuleHelper Ngeo rule helper service.
    * @private
    * @ngInject
    * @ngdoc controller
    * @ngname NgeoFilterController
    */
-  constructor(gettextCatalog, ngeoRuleHelper) {
+  constructor(gettextCatalog, $timeout, ngeoRuleHelper) {
 
     // Binding properties
 
@@ -36,6 +39,18 @@ ngeo.FilterController = class {
      */
     this.directedRules;
 
+    /**
+     * @type {!ol.Map}
+     * @export
+     */
+    this.map;
+
+    /**
+     * @type {string}
+     * @export
+     */
+    this.toolGroup;
+
     // Injected properties
 
     /**
@@ -43,6 +58,12 @@ ngeo.FilterController = class {
      * @private
      */
     this.gettextCatalog_ = gettextCatalog;
+
+    /**
+     * @type {!angular.$timeout}
+     * @private
+     */
+    this.timeout_ = $timeout;
 
     /**
      * @type {!ngeo.RuleHelper}
@@ -79,6 +100,16 @@ ngeo.FilterController = class {
     this.geometryAttributes = [];
 
     /**
+     * Flag that is set after initialization of the filter directive. Before
+     * the initialization is completed, rules are created with the `active`
+     * property set to `false`. After that, newly created rules are created
+     * with the `active` property set to `true`.
+     * @type {boolean}
+     * @export
+     */
+    this.initialized = false;
+
+    /**
      * List of other attribute names.
      * @type {Array.<!ngeox.Attribute>}
      * @export
@@ -104,6 +135,10 @@ ngeo.FilterController = class {
     }
 
     this.apply();
+
+    this.timeout_(() => {
+      this.initialized = true;
+    });
   }
 
 
@@ -176,7 +211,9 @@ ngeo.module.component('ngeoFilter', {
     // It's 'datasource' instead of 'dataSource', because that would require
     // the attribute to be 'data-source', and Angular strips the 'data-'.
     datasource: '<',
-    directedRules: '<'
+    directedRules: '<',
+    map: '<',
+    toolGroup: '<'
   },
   controller: ngeo.FilterController,
   controllerAs: 'filterCtrl',

--- a/src/directives/partials/filter.html
+++ b/src/directives/partials/filter.html
@@ -24,17 +24,23 @@
   </ul>
 </div>
 
-<div
-    ng-repeat="rule in filterCtrl.directedRules">
-  {{ rule.name }}
-</div>
+<ngeo-rule
+    ng-repeat="rule in filterCtrl.directedRules"
+    active="::filterCtrl.initialized"
+    map="filterCtrl.map"
+    rule="rule"
+    tool-group="filterCtrl.toolGroup">
+</ngeo-rule>
 
 <hr ng-if="filterCtrl.directedRules.length" />
 
-<div
-    ng-repeat="rule in filterCtrl.customRules">
-  {{ rule.name }}
-</div>
+<ngeo-rule
+    ng-repeat="rule in filterCtrl.customRules"
+    active="::filterCtrl.initialized"
+    map="filterCtrl.map"
+    rule="rule"
+    tool-group="filterCtrl.toolGroup">
+</ngeo-rule>
 
 <div class="dropdown">
   <a

--- a/src/directives/partials/filter.html
+++ b/src/directives/partials/filter.html
@@ -27,6 +27,7 @@
 <ngeo-rule
     ng-repeat="rule in filterCtrl.directedRules"
     active="::filterCtrl.initialized"
+      class="ngeo-filter-rule-directed"
     map="filterCtrl.map"
     rule="rule"
     tool-group="filterCtrl.toolGroup">
@@ -34,13 +35,21 @@
 
 <hr ng-if="filterCtrl.directedRules.length" />
 
-<ngeo-rule
-    ng-repeat="rule in filterCtrl.customRules"
-    active="::filterCtrl.initialized"
-    map="filterCtrl.map"
-    rule="rule"
-    tool-group="filterCtrl.toolGroup">
-</ngeo-rule>
+<div ng-repeat="rule in filterCtrl.customRules">
+  <a
+      class="btn btn-xs btn-link ngeo-filter-rule-custom-rm-btn"
+      ng-click="filterCtrl.removeCustomRule(rule)"
+      href>
+    <span class="glyphicon glyphicon-remove"></span>
+  </a>
+  <ngeo-rule
+      active="::filterCtrl.initialized"
+      class="ngeo-filter-rule-custom"
+      map="filterCtrl.map"
+      rule="rule"
+      tool-group="filterCtrl.toolGroup">
+  </ngeo-rule>
+</div>
 
 <div class="dropdown">
   <a

--- a/src/directives/partials/rule.html
+++ b/src/directives/partials/rule.html
@@ -1,0 +1,89 @@
+<div
+    class="dropdown"
+    ng-class="{open: ruleCtrl.active}">
+  <a
+      class="btn btn-default btn-sm dropdown-toggle"
+      type="button"
+      ng-click="ruleCtrl.toggle()">
+    <span translate>{{ ::ruleCtrl.clone.name }}</span>
+    <span class="caret"></span>
+  </a>
+  <div
+      class="dropdown-menu form-group"
+      ng-switch="::ruleCtrl.clone.type">
+
+    <div
+        class="ngeo-rule-type-date"
+        ng-switch-when="date|datetime"
+        ng-switch-when-separator="|">Date or datetime...</div>
+
+    <div
+        class="checkbox ngeo-rule-type-select"
+        ng-switch-when="select">
+        <a
+            ng-click="ruleCtrl.selectAllChoices()"
+            href>{{ All | translate}}
+        </a>
+        <label
+            class="form-group ol-unselectable"
+            ng-repeat="choice in ::ruleCtrl.clone.choices">
+          <input
+              ng-checked="ruleCtrl.clone.expression && ruleCtrl.clone.expression.split(',').indexOf(choice) > -1"
+              ng-click="ruleCtrl.toggleChoiceSelection(choice)"
+              type="checkbox"
+              value="choice" />
+          <span>{{ choice | translate }}</span>
+        </label>
+
+    </div>
+
+    <div
+        class="form-group ngeo-rule-type-text"
+        ng-switch-default>
+      <input
+          type="text"
+          class="form-control input-sm"
+          ng-model="ruleCtrl.clone.expression"/>
+    </div>
+
+    <div class="ngeo-rule-btns">
+      <button
+          class="btn btn-xs btn-default"
+          ng-click="ruleCtrl.apply()"
+          type="button">{{'Apply' | translate}}</button>
+      <button
+          class="btn btn-xs btn-default"
+          ng-click="ruleCtrl.cancel()"
+          type="button">{{'Cancel' | translate}}</button>
+    </div>
+
+  </div>
+</div>
+
+
+<div
+    class="ngeo-rule-value"
+    ng-if="ruleCtrl.rule.value !== null">
+
+  <a
+      class="btn btn-xs btn-link"
+      ng-click="ruleCtrl.reset()"
+      href>
+    <span class="glyphicon glyphicon-remove"></span>
+  </a>
+
+  <div ng-switch="::ruleCtrl.rule.type">
+    <div ng-switch-when="date|datetime">
+      Datetime value...
+    </div>
+
+    <div ng-switch-when="select">
+      <span ng-repeat="choice in ruleCtrl.rule.expression.split(',')">
+        {{ choice | translate }}{{ $last ? '' : ', ' }}
+      </span>
+    </div>
+
+    <div ng-switch-default>{{ ruleCtrl.rule.expression }}</div>
+
+  </div>
+</div>

--- a/src/directives/rule.js
+++ b/src/directives/rule.js
@@ -1,0 +1,201 @@
+goog.provide('ngeo.ruleComponent');
+
+goog.require('ngeo');
+goog.require('ngeo.RuleHelper');
+goog.require('ngeo.ToolActivate');
+goog.require('ngeo.ToolActivateMgr');
+goog.require('ngeo.rule.Select');
+
+
+ngeo.RuleController = class {
+
+  /**
+   * @param {!angular.$timeout} $timeout Angular timeout service.
+   * @param {!ngeo.RuleHelper} ngeoRuleHelper Ngeo rule helper service.
+   * @param {!ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate
+   *     manager service.
+   * @private
+   * @ngInject
+   * @ngdoc controller
+   * @ngname NgeoRuleController
+   */
+  constructor($timeout, ngeoRuleHelper, ngeoToolActivateMgr) {
+
+    // Binding properties
+
+    /**
+     * Determines whether the component is active or not. When active, the
+     * dropdown menu is shown and the tool activate manager activates it
+     * as a tool.
+     * @type {boolean}
+     * @export
+     */
+    this.active;
+
+    /**
+     * @type {!ol.Map}
+     * @export
+     */
+    this.map;
+
+    /**
+     * The original rule.
+     * @type {!ngeo.rule.Rule}
+     * @export
+     */
+    this.rule;
+
+    /**
+     * @type {string}
+     * @export
+     */
+    this.toolGroup;
+
+    // Injected properties
+
+    /**
+     * @type {!angular.$timeout}
+     * @private
+     */
+    this.timeout_ = $timeout;
+
+    /**
+     * @type {!ngeo.RuleHelper}
+     * @private
+     */
+    this.ngeoRuleHelper_ = ngeoRuleHelper;
+
+    /**
+     * @type {!ngeo.ToolActivateMgr}
+     * @private
+     */
+    this.ngeoToolActivateMgr_ = ngeoToolActivateMgr;
+
+    // Inner properties
+
+    /**
+     * The cloned rule. Changes in the UI are applied to the clone 'on-the-fly'.
+     * Changes in the clone are applied back in the original rule when the
+     * apply button is clicked.
+     * @type {!ngeo.rule.Rule}
+     * @export
+     */
+    this.clone;
+
+    /**
+     * @type {!ngeo.ToolActivate}
+     * @private
+     */
+    this.toolActivate_ = new ngeo.ToolActivate(this, 'active');
+
+  }
+
+  /**
+   * Called on initialization of the controller.
+   *
+   * Clone the rule to be able to work with the clone directly.
+   */
+  $onInit() {
+    this.clone = this.ngeoRuleHelper_.cloneRule(this.rule);
+
+    this.ngeoToolActivateMgr_.registerTool(
+      this.toolGroup, this.toolActivate_);
+
+    // In order to let the tool activate manager do its magic, the setting of
+    // of the `active` property must be reset to true if it's true upon
+    // initialization.
+    if (this.active) {
+      this.active = false;
+      this.timeout_(() => {
+        this.active = true;
+      });
+    }
+  }
+
+  /**
+   * Called on destruction of the controller.
+   */
+  $onDestroy() {
+    this.active = false;
+    this.ngeoToolActivateMgr_.unregisterTool(
+      this.toolGroup, this.toolActivate_);
+  }
+
+  /**
+   * @export
+   */
+  toggle() {
+    if (this.active) {
+      this.cancel();
+    } else {
+      this.active = true;
+    }
+  }
+
+  /**
+   * Apply the changes that were made in the original rule.
+   * @export
+   */
+  apply() {
+    this.ngeoRuleHelper_.extendRule(this.clone, this.rule);
+    this.active = false;
+  }
+
+  /**
+   * Revert the changes that were made in the clone rule.
+   * @export
+   */
+  cancel() {
+    this.ngeoRuleHelper_.extendRule(this.rule, this.clone);
+    this.active = false;
+  }
+
+  /**
+   * Reset both original and clone rules.
+   * @export
+   */
+  reset() {
+    this.clone.reset();
+    this.rule.reset();
+  }
+
+  /**
+   * Called when a choice is clicked, when using a `ngeo.rule.Select` rule type.
+   * Add/remove the choice to/from the `expression` of the rule.
+   * @param {string|number} choice Choice that has been clicked.
+   * @export
+   */
+  toggleChoiceSelection(choice) {
+    const rule = goog.asserts.assertInstanceof(this.clone, ngeo.rule.Select);
+    const choices = rule.expression ? rule.expression.split(',') : [];
+    const idx = choices.indexOf(choice);
+    if (idx > -1) {
+      choices.splice(idx, 1);
+    } else {
+      choices.push(choice);
+    }
+    rule.expression = choices.length ? choices.join(',') : null;
+  }
+
+};
+
+
+/**
+ * The rule component is bound to a `ngeo.rule.Rule` object and shows UI
+ * components to be able to edit its properties, such as: operator, expression,
+ * etc. The actual properties depend on the type of rule.
+ *
+ * Also, changes are not made on-the-fly. A button must be clicked for the
+ * changes to be applied to the rule.
+ */
+ngeo.module.component('ngeoRule', {
+  bindings: {
+    active: '<',
+    map: '<',
+    rule: '<',
+    toolGroup: '<'
+  },
+  controller: ngeo.RuleController,
+  controllerAs: 'ruleCtrl',
+  templateUrl: () => `${ngeo.baseTemplateUrl}/rule.html`
+});

--- a/src/rule/rule.js
+++ b/src/rule/rule.js
@@ -257,19 +257,19 @@ ngeo.rule.Rule = class {
   // === Other utility methods ===
 
   /**
-   * Reset the following properties to `null`: expression, lowerProperty,
-   * upperProperty.
+   * Reset the following properties to `null`: expression, lowerBoundary,
+   * upperBoundary.
    * @export
    */
   reset() {
     if (this.expression !== null) {
       this.expression = null;
     }
-    if (this.lowerProperty !== null) {
-      this.lowerProperty = null;
+    if (this.lowerBoundary !== null) {
+      this.lowerBoundary = null;
     }
-    if (this.upperProperty !== null) {
-      this.upperProperty = null;
+    if (this.upperBoundary !== null) {
+      this.upperBoundary = null;
     }
   }
 

--- a/src/rule/rule.js
+++ b/src/rule/rule.js
@@ -254,6 +254,25 @@ ngeo.rule.Rule = class {
     return value;
   }
 
+  // === Other utility methods ===
+
+  /**
+   * Reset the following properties to `null`: expression, lowerProperty,
+   * upperProperty.
+   * @export
+   */
+  reset() {
+    if (this.expression !== null) {
+      this.expression = null;
+    }
+    if (this.lowerProperty !== null) {
+      this.lowerProperty = null;
+    }
+    if (this.upperProperty !== null) {
+      this.upperProperty = null;
+    }
+  }
+
 };
 
 

--- a/src/services/datasourceshelper.js
+++ b/src/services/datasourceshelper.js
@@ -119,7 +119,7 @@ ngeo.DataSourcesHelper = class {
         goog.asserts.assert(
           featureType.complexType[0].name === element.type);
 
-        const complexContent = featureType.complexType[0].complexContent;
+        const complexContent = featureType['complexType'][0]['complexContent'];
         const attributes = new ngeo.format.WFSAttribute().read(complexContent);
 
         // Set the attributes in the data source

--- a/src/services/rulehelper.js
+++ b/src/services/rulehelper.js
@@ -100,16 +100,28 @@ ngeo.RuleHelper = class {
 
     let clone;
 
+    const expression = rule.expression !== null ? rule.expression : undefined;
+    const isCustom = rule.isCustom;
+    const lowerBoundary = rule.lowerBoundary !== null ? rule.lowerBoundary :
+          undefined;
+    const name = rule.name;
+    const operator = rule.operator !== null ? rule.operator : undefined;
+    const operators = rule.operators ? rule.operators.slice(0) : undefined;
+    const propertyName = rule.propertyName;
+    const type = rule.type !== null ? rule.type : undefined;
+    const upperBoundary = rule.upperBoundary !== null ? rule.upperBoundary :
+          undefined;
+
     const options = {
-      expression: rule.expression,
-      isCustom: rule.isCustom,
-      lowerBoundary: rule.lowerBoundary,
-      name: rule.name,
-      operator: rule.operator,
-      operators: rule.operators ? rule.operators.slice(0) : null,
-      propertyName: rule.propertyName,
-      type: rule.type,
-      upperBoundary: rule.upperBoundary
+      expression,
+      isCustom,
+      lowerBoundary,
+      name,
+      operator,
+      operators,
+      propertyName,
+      type,
+      upperBoundary
     };
 
     if (rule instanceof ngeo.rule.Select) {

--- a/src/services/rulehelper.js
+++ b/src/services/rulehelper.js
@@ -89,6 +89,70 @@ ngeo.RuleHelper = class {
     return rule;
   }
 
+  /**
+   * Create a new `ngeo.rule.Rule` object using an other given rule.
+   *
+   * @param {!ngeo.rule.Rule} rule Original rule to clone.
+   * @return {!ngeo.rule.Rule} A clone rule.
+   * @export
+   */
+  cloneRule(rule) {
+
+    let clone;
+
+    const options = {
+      expression: rule.expression,
+      isCustom: rule.isCustom,
+      lowerBoundary: rule.lowerBoundary,
+      name: rule.name,
+      operator: rule.operator,
+      operators: rule.operators ? rule.operators.slice(0) : null,
+      propertyName: rule.propertyName,
+      type: rule.type,
+      upperBoundary: rule.upperBoundary
+    };
+
+    if (rule instanceof ngeo.rule.Select) {
+      options.choices = rule.choices.slice(0);
+      clone = new ngeo.rule.Select(options);
+    } else if (rule instanceof ngeo.rule.Text) {
+      clone = new ngeo.rule.Text(options);
+    } else {
+      clone = new ngeo.rule.Rule(options);
+    }
+
+    return clone;
+  }
+
+  /**
+   * Extend the dynamic properties from a source rule to destination rule.
+   * The source rule remains unchanged, while the destination rule changes.
+   *
+   * @param {!ngeo.rule.Rule} sourceRule Source rule to collect the dynamic
+   *     properties from.
+   * @param {!ngeo.rule.Rule} destRule Destination rule where the dynamic
+   *     properties are set.
+   * @export
+   */
+  extendRule(sourceRule, destRule) {
+
+    if (destRule.expression !== sourceRule.expression) {
+      destRule.expression = sourceRule.expression;
+    }
+
+    if (destRule.lowerBoundary !== sourceRule.lowerBoundary) {
+      destRule.lowerBoundary = sourceRule.lowerBoundary;
+    }
+
+    if (destRule.operator !== sourceRule.operator) {
+      destRule.operator = sourceRule.operator;
+    }
+
+    if (destRule.upperBoundary !== sourceRule.upperBoundary) {
+      destRule.upperBoundary = sourceRule.upperBoundary;
+    }
+  }
+
 };
 
 


### PR DESCRIPTION
This PR introduces the `ngeo-rule` component, which is used to set the value of a rule.  It is used by the `ngeo-filter` directive.

This PR includes:

 * support of `text` rule type
 * support of `select` rule type
 * rename metadata `EnumeratedAttributes` to `enumeratedAttributes`
 * rename metadata `DirectedFilterAttributes` to `directedFilterAttributes`
 * support of removing custom rules

This PR doesn't include:

 * support of `date` rule type (will come in the next PR)
 * support of `geometry` rule type

Please note that I decided to go with always using "apply" and "cancel" buttons  and prevent the closing of the drop-down menu with click outs.  I did this to allow the `active` property of the `ngeo-rule` component to be toggled on while the drop-down menu is shown, which is also linked to a tool activate object (using the tool activate manager).  This allows the deactivation of the query tool while the menu is shown.  This will be especially useful when we introduce the vector features with the geometry filters.

## Todo

 * [ ] Review