### PR TITLE
Use the accuracy circle to recenter the view

### DIFF
--- a/contribs/gmf/src/controllers/abstractmobile.js
+++ b/contribs/gmf/src/controllers/abstractmobile.js
@@ -102,7 +102,7 @@ gmf.AbstractMobileController = function(config, $scope, $injector) {
   this.mobileGeolocationOptions = {
     positionFeatureStyle: positionFeatureStyle,
     accuracyFeatureStyle: accuracyFeatureStyle,
-    zoom: config.geolocationZoom || 9
+    zoom: config.geolocationZoom
   };
 
   var viewConfig = {

--- a/src/directives/mobilegeolocation.js
+++ b/src/directives/mobilegeolocation.js
@@ -269,9 +269,13 @@ ngeo.MobileGeolocationController.prototype.setPosition_ = function(event) {
 
   if (this.follow_) {
     this.viewChangedByMe_ = true;
-    this.map_.getView().setCenter(position);
     if (this.zoom_ !== undefined) {
+      this.map_.getView().setCenter(position);
       this.map_.getView().setZoom(this.zoom_);
+    } else {
+      var polygon = /** @type {!ol.geom.Polygon} */ (this.geolocation_.getAccuracyGeometry());
+      var size = /** @type {!ol.Size} */ (this.map_.getSize());
+      this.map_.getView().fit(polygon, size);
     }
     this.viewChangedByMe_ = false;
   }


### PR DESCRIPTION
If no zoom level is provided in th configuration, use the accuracy circle.


fixes #2388 