### PR TITLE
Filter - Support date rule

### DIFF
--- a/contribs/gmf/examples/filterselector.html
+++ b/contribs/gmf/examples/filterselector.html
@@ -114,6 +114,11 @@
         color: #666666;
       }
 
+      ngeo-rule ngeo-date-picker {
+        display: block;
+        text-align: right;
+      }
+
 
     </style>
   </head>

--- a/src/directives/partials/rule.html
+++ b/src/directives/partials/rule.html
@@ -20,9 +20,25 @@
     <div ng-switch="::ruleCtrl.clone.type">
 
       <div
-          class="ngeo-rule-type-date"
+          class="ngeo-rule-type-date form-group"
+          ng-if="ruleCtrl.active"
           ng-switch-when="date|datetime"
-          ng-switch-when-separator="|">Date or datetime...</div>
+          ng-switch-when-separator="|">
+        <div ng-switch="ruleCtrl.clone.operator">
+          <div ng-switch-when="..">
+            <ngeo-date-picker
+                time="ruleCtrl.timeRangeMode"
+                on-date-selected="ruleCtrl.onDateRangeSelected(time)">
+            </ngeo-date-picker>
+          </div>
+          <div ng-switch-default>
+            <ngeo-date-picker
+                time="ruleCtrl.timeValueMode"
+                on-date-selected="ruleCtrl.onDateSelected(time)">
+            </ngeo-date-picker>
+          </div>
+        </div>
+      </div>
 
       <div
           class="checkbox ngeo-rule-type-select"
@@ -95,8 +111,22 @@
   </a>
 
   <div ng-switch="::ruleCtrl.rule.type">
-    <div ng-switch-when="date|datetime">
-      Datetime value...
+
+    <div
+        ng-switch-when="date|datetime"
+        ng-switch-when-separator="|">
+      <div ng-switch="ruleCtrl.rule.operator">
+        <div ng-switch-when="..">
+          <span translate>From </span>
+          <span>{{ ruleCtrl.timeToDate(ruleCtrl.rule.lowerBoundary) }}</span>
+          <span translate> to </span>
+          <span>{{ ruleCtrl.timeToDate(ruleCtrl.rule.upperBoundary) }}</span>
+        </div>
+        <div ng-switch-default>
+          <span>{{ ruleCtrl.rule.operator }}</span>
+          <span>{{ ruleCtrl.timeToDate(ruleCtrl.rule.expression) }}</span>
+        </div>
+      </div>
     </div>
 
     <div ng-switch-when="select">
@@ -118,5 +148,7 @@
           <span>{{ ruleCtrl.rule.expression }}</span>
         </div>
       </div>
+    </div>
+
   </div>
 </div>

--- a/src/directives/rule.js
+++ b/src/directives/rule.js
@@ -74,7 +74,7 @@ ngeo.RuleController = class {
 
     /**
      * @type {!ngeo.RuleHelper}
-      * @private
+     * @private
      */
     this.ngeoRuleHelper_ = ngeoRuleHelper;
 
@@ -117,7 +117,7 @@ ngeo.RuleController = class {
     /**
      * Time property used when the rule is of type 'date|datetime' and uses
      * a range of date.
-     * @type {ngeox.TimeProperty}
+     * @type {!ngeox.TimeProperty}
      * @export
      */
     this.timeRangeMode = {
@@ -133,7 +133,7 @@ ngeo.RuleController = class {
     /**
      * Time property used when the rule is of type 'date|datetime' and uses
      * a single date.
-     * @type {ngeox.TimeProperty}
+     * @type {!ngeox.TimeProperty}
      * @export
      */
     this.timeValueMode = {
@@ -153,7 +153,7 @@ ngeo.RuleController = class {
     this.toolActivate_ = new ngeo.ToolActivate(this, 'active');
 
     /**
-     * @type {Array.<function()>}
+     * @type {!Array.<Function>}
      * @private
      */
     this.unlisteners_ = [];
@@ -185,7 +185,7 @@ ngeo.RuleController = class {
       this.unlisteners_.push(this.scope_.$watch(
         () => this.clone.expression,
         (newVal) => {
-          const value = (newVal === null) ? this.createDate_() : newVal;
+          const value = newVal === null ? this.createDate_() : newVal;
           this.timeValueMode.minValue = value;
         }
       ));


### PR DESCRIPTION
This PR adds the support of filter rules using a date.  For that purpose, the `ngeo-date-picker` directive is used.

## About the datepicker

The datepicker can't have its values set other by itself.  That's contrary to the other types of rules, i.e. a text rule can have its value input to something, then the user clicks 'cancel' and the menu is closed and value reverted.  That can't happen with the date picker.  However, it's possible to create a date picker giving it initial values.  For that reason, the date picker directive is created every time the menu of a rule is opened and destroyed on close.  This allow the control of the value to set.

Also, please note the following important things:

 * when using a date range, the "upperValue" is equal to "today" by default.
 * when using a date rante, the "lowerValue" is equal to "a week ago" by default.

## Todo

 * [x] Wait for #2391 to be merged
 * [x] Adjust the "grey" value being displayed (currently, the milliseconds are shown)
 * [x] Review