### PR TITLE
Filter - Support spatial rule

### DIFF
--- a/contribs/gmf/examples/filterselector.html
+++ b/contribs/gmf/examples/filterselector.html
@@ -37,6 +37,57 @@
         display: block;
       }
 
+      /* drawfeature */
+
+      .gmf-icon-circle:before {
+        content: "Circle";
+      }
+      .gmf-icon-line:after {
+        content: 'Line';
+      }
+      .gmf-icon-point:after {
+        content: 'Point';
+      }
+      .gmf-icon-polygon:after {
+        content: 'Polygon';
+      }
+      .gmf-icon-rectangle:after {
+        content: 'Rectangle';
+      }
+      .gmf-icon-text:after {
+        content: 'Text';
+      }
+
+      .tooltip {
+        position: relative;
+        background: rgba(0, 0, 0, 0.5);
+        border-radius: 4px;
+        color: white;
+        padding: 4px 8px;
+        opacity: 0.7;
+        white-space: nowrap;
+      }
+      .ngeo-tooltip-measure {
+        opacity: 1;
+        font-weight: bold;
+      }
+      .ngeo-tooltip-static {
+        display: none;
+      }
+      .ngeo-tooltip-measure:before,
+      .ngeo-tooltip-static:before {
+        border-top: 6px solid rgba(0, 0, 0, 0.5);
+        border-right: 6px solid transparent;
+        border-left: 6px solid transparent;
+        content: "";
+        position: absolute;
+        bottom: -6px;
+        margin-left: -7px;
+        left: 50%;
+      }
+      .ngeo-tooltip-static:before {
+        border-top-color: #ffcc33;
+      }
 
       /* CSS for filter */
 
@@ -117,6 +168,12 @@
       ngeo-rule ngeo-date-picker {
         display: block;
         text-align: right;
+      }
+
+      .ngeo-rule-type-geometry-instructions {
+        font-size: 9pt;
+        font-style: italic;
+        margin: 0.5rem;
       }
 
 

--- a/contribs/gmf/src/directives/filterselector.js
+++ b/contribs/gmf/src/directives/filterselector.js
@@ -21,6 +21,8 @@ gmf.FilterselectorController = class {
    *     helper service.
    * @param {gmfx.User} gmfUser User.
    * @param {ngeo.Notification} ngeoNotification Ngeo notification service.
+   * @param {!ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr Ngeo FeatureOverlay
+   *     manager
    * @param {!ngeo.RuleHelper} ngeoRuleHelper Ngeo rule helper service.
    * @private
    * @ngInject
@@ -28,7 +30,7 @@ gmf.FilterselectorController = class {
    * @ngname GmfFilterselectorController
    */
   constructor($scope, gettextCatalog, gmfDataSourcesHelper, gmfUser,
-      ngeoNotification, ngeoRuleHelper
+      ngeoNotification, ngeoFeatureOverlayMgr, ngeoRuleHelper
   ) {
 
     // Binding properties
@@ -87,6 +89,14 @@ gmf.FilterselectorController = class {
      * @private
      */
     this.ngeoNotification_ = ngeoNotification;
+
+    /**
+     * @type {!ngeo.FeatureOverlay}
+     * @export
+     */
+    this.featureOverlay = goog.asserts.assert(
+      ngeoFeatureOverlayMgr.getFeatureOverlay()
+    );
 
     /**
      * @type {!ngeo.RuleHelper}

--- a/contribs/gmf/src/directives/partials/filterselector.html
+++ b/contribs/gmf/src/directives/partials/filterselector.html
@@ -16,6 +16,7 @@
         custom-rules="fsCtrl.customRules"
         datasource="fsCtrl.readyDataSource"
         directed-rules="fsCtrl.directedRules"
+        feature-overlay="fsCtrl.featureOverlay"
         map="fsCtrl.map"
         tool-group="fsCtrl.toolGroup">
     </ngeo-filter>

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -1811,6 +1811,14 @@ ngeox.rule.RuleOptions = function() {};
 
 
 /**
+ * Whether the rule is active or not. Used by the `ngeo-rule` component.
+ * Defaults to `false`.
+ * @type {boolean|undefined}
+ */
+ngeox.rule.RuleOptions.prototype.active;
+
+
+/**
  * The expression of the rule. The expression and boundaries are mutually
  * exclusives.
  * @type {boolean|number|string|undefined}

--- a/src/directives/drawfeature.js
+++ b/src/directives/drawfeature.js
@@ -81,6 +81,9 @@ goog.require('ol.Feature');
  *
  * @htmlAttribute {boolean} ngeo-drawfeature-active Whether the directive is
  *     active or not.
+ * @htmlAttribute {!ol.Collection=} ngeo-drawfeature-features The features
+ *     collection in which to push the drawn features. If none is provided,
+ *     then the `ngeoFeatures` collection is used.
  * @htmlAttribute {ol.Map} ngeo-drawfeature-map The map.
  * @return {angular.Directive} The directive specs.
  * @ngInject
@@ -93,6 +96,7 @@ ngeo.drawfeatureDirective = function() {
     scope: true,
     bindToController: {
       'active': '=ngeoDrawfeatureActive',
+      'features': '=?ngeoDrawfeatureFeatures',
       'map': '=ngeoDrawfeatureMap'
     }
   };
@@ -122,12 +126,6 @@ ngeo.DrawfeatureController = function($scope, $compile, $sce, gettext,
     gettextCatalog, ngeoDecorateInteraction, ngeoFeatureHelper, ngeoFeatures) {
 
   /**
-   * @type {ol.Map}
-   * @export
-   */
-  this.map;
-
-  /**
    * @type {boolean}
    * @export
    */
@@ -136,6 +134,20 @@ ngeo.DrawfeatureController = function($scope, $compile, $sce, gettext,
   if (this.active === undefined) {
     this.active = false;
   }
+
+  /**
+   * Alternate collection of features in which to push the drawn features.
+   * If not defined, then `ngeoFeatures` is used instead.
+   * @type {!ol.Collection.<!ol.Feature>|undefined}
+   * @export
+   */
+  this.features;
+
+  /**
+   * @type {ol.Map}
+   * @export
+   */
+  this.map;
 
   /**
    * @type {angularGettext.Catalog}
@@ -159,7 +171,7 @@ ngeo.DrawfeatureController = function($scope, $compile, $sce, gettext,
    * @type {ol.Collection.<ol.Feature>}
    * @private
    */
-  this.features_ = ngeoFeatures;
+  this.ngeoFeatures_ = ngeoFeatures;
 
   /**
    * @type {Array.<ol.interaction.Interaction>}
@@ -255,6 +267,9 @@ ngeo.DrawfeatureController.prototype.handleActiveChange = function(event) {
  * @export
  */
 ngeo.DrawfeatureController.prototype.handleDrawEnd = function(type, event) {
+
+  const features = this.features || this.ngeoFeatures_;
+
   const feature = new ol.Feature(event.feature.getGeometry());
 
   const prop = ngeo.FeatureProperties;
@@ -280,7 +295,7 @@ ngeo.DrawfeatureController.prototype.handleDrawEnd = function(type, event) {
    * @type {string}
    */
   const name = this.gettextCatalog_.getString(type);
-  feature.set(prop.NAME, `${name} ${this.features_.getLength() + 1}`);
+  feature.set(prop.NAME, `${name} ${features.getLength() + 1}`);
 
   /**
    * @type {string}
@@ -298,7 +313,7 @@ ngeo.DrawfeatureController.prototype.handleDrawEnd = function(type, event) {
   this.featureHelper_.setStyle(feature);
 
   // push in collection
-  this.features_.push(feature);
+  features.push(feature);
 };
 
 ngeo.module.controller('ngeoDrawfeatureController', ngeo.DrawfeatureController);

--- a/src/directives/partials/filter.html
+++ b/src/directives/partials/filter.html
@@ -26,8 +26,8 @@
 
 <ngeo-rule
     ng-repeat="rule in filterCtrl.directedRules"
-    active="::filterCtrl.initialized"
-      class="ngeo-filter-rule-directed"
+    feature-overlay="::filterCtrl.featureOverlay"
+    class="ngeo-filter-rule-directed"
     map="filterCtrl.map"
     rule="rule"
     tool-group="filterCtrl.toolGroup">
@@ -43,7 +43,7 @@
     <span class="glyphicon glyphicon-remove"></span>
   </a>
   <ngeo-rule
-      active="::filterCtrl.initialized"
+      feature-overlay="::filterCtrl.featureOverlay"
       class="ngeo-filter-rule-custom"
       map="filterCtrl.map"
       rule="rule"
@@ -63,7 +63,7 @@
     <li ng-repeat="attribute in ::filterCtrl.geometryAttributes">
       <a
           href
-          ng-click="">
+          ng-click="filterCtrl.createAndAddCustomRule(attribute)">
           <span translate>Spatial filter</span>
       </a>
     </li>

--- a/src/directives/partials/rule.html
+++ b/src/directives/partials/rule.html
@@ -1,6 +1,6 @@
 <div
     class="dropdown"
-    ng-class="{open: ruleCtrl.active}">
+    ng-class="{open: ruleCtrl.rule.active}">
   <a
       class="btn btn-default btn-sm dropdown-toggle"
       type="button"
@@ -12,6 +12,7 @@
 
     <select
         class="form-control input-sm ngeo-rule-operators-list"
+        ng-disabled="ruleCtrl.drawActive"
         ng-if="::ruleCtrl.clone.operators"
         ng-model="ruleCtrl.clone.operator"
         ng-options="ruleCtrl.operators[operator] | translate for operator in ::ruleCtrl.clone.operators track by operator">
@@ -21,7 +22,7 @@
 
       <div
           class="ngeo-rule-type-date form-group"
-          ng-if="ruleCtrl.active"
+          ng-if="ruleCtrl.rule.active"
           ng-switch-when="date|datetime"
           ng-switch-when-separator="|">
         <div ng-switch="ruleCtrl.clone.operator">
@@ -41,6 +42,119 @@
       </div>
 
       <div
+          class="ngeo-rule-type-geometry form-group"
+          ng-switch-when="geometry">
+        <div ng-switch="ruleCtrl.geomType">
+          <span
+              class="gmf-icon gmf-icon-point"
+              ng-switch-when="Point">
+          </span>
+          <span
+              class="gmf-icon gmf-icon-line"
+              ng-switch-when="LineString">
+          </span>
+          <span
+              class="gmf-icon gmf-icon-polygon"
+              ng-switch-when="Polygon">
+          </span>
+          <span
+              class="gmf-icon gmf-icon-circle"
+              ng-switch-when="Circle">
+          </span>
+          <span
+              class="gmf-icon gmf-icon-rectangle"
+              ng-switch-when="Rectangle">
+          </span>
+        </div>
+        <ngeo-drawfeature
+            ngeo-drawfeature-active="ruleCtrl.drawActive"
+            ngeo-drawfeature-features="ruleCtrl.drawnFeatures"
+            ngeo-drawfeature-map="ruleCtrl.map">
+          <div
+              ngeo-btn-group
+              class="btn-group">
+              <a
+                data-toggle="tooltip"
+                title="{{'Draw a point on the map' | translate}}"
+                href
+                ngeo-btn
+                ngeo-drawpoint
+                class="btn btn-xs btn-default ngeo-drawfeature-point"
+                ng-show="['intersects', 'within'].indexOf(ruleCtrl.clone.operator) !== -1"
+                ng-class="{active: dfCtrl.drawPoint.active}"
+                ng-model="dfCtrl.drawPoint.active">
+                <span class="gmf-icon gmf-icon-point"></span>
+              </a>
+              <a
+                data-toggle="tooltip"
+                title="{{'Draw a line on the map' | translate}}"
+                href
+                ngeo-btn
+                ngeo-measurelength
+                class="btn btn-xs btn-default ngeo-drawfeature-linestring"
+                ng-show="['intersects', 'within'].indexOf(ruleCtrl.clone.operator) !== -1"
+                ng-class="{active: dfCtrl.measureLength.active}"
+                ng-model="dfCtrl.measureLength.active">
+                <span class="gmf-icon gmf-icon-line"></span>
+              </a>
+              <a
+                data-toggle="tooltip"
+                title="{{'Draw a polygon on the map' | translate}}"
+                href
+                ngeo-btn
+                ngeo-measurearea
+                class="btn btn-xs btn-default ngeo-drawfeature-polygon"
+                ng-class="{active: dfCtrl.measureArea.active}"
+                ng-model="dfCtrl.measureArea.active">
+                <span class="gmf-icon gmf-icon-polygon"></span>
+              </a>
+              <a
+                data-toggle="tooltip"
+                title="{{'Draw a circle on the map' | translate}}"
+                href
+                ngeo-btn
+                ngeo-measureazimut
+                class="btn btn-xs btn-default ngeo-drawfeature-circle"
+                ng-class="{active: dfCtrl.measureAzimut.active}"
+                ng-model="dfCtrl.measureAzimut.active">
+                <span class="gmf-icon gmf-icon-circle"></span>
+              </a>
+              <a
+                data-toggle="tooltip"
+                title="{{'Draw a rectangle on the map' | translate}}"
+                href
+                ngeo-btn
+                ngeo-drawrectangle
+                class="btn btn-xs btn-default ngeo-drawfeature-rectangle"
+                ng-class="{active: dfCtrl.drawRectangle.active}"
+                ng-model="dfCtrl.drawRectangle.active">
+                <span class="gmf-icon gmf-icon-rectangle"></span>
+              </a>
+          </div>
+
+          <div
+              class="ngeo-rule-type-geometry-instructions"
+              ng-if="ruleCtrl.drawActive">
+            <span ng-if="dfCtrl.drawPoint.active">
+              {{ 'Draw a point on the map.' | translate }}
+            </span>
+            <span ng-if="dfCtrl.measureLength.active">
+              {{ 'Draw a line string on the map.' | translate }}
+            </span>
+            <span ng-if="dfCtrl.measureArea.active">
+              {{ 'Draw a polygon on the map.' | translate }}
+            </span>
+            <span ng-if="dfCtrl.measureAzimut.active">
+              {{ 'Draw a circle on the map.' | translate }}
+            </span>
+            <span ng-if="dfCtrl.drawRectangle.active">
+              {{ 'Draw a rectangle on the map.' | translate }}
+            </span>
+          </div>
+        </ngeo-drawfeature>
+      </div>
+
+      <div
           class="checkbox ngeo-rule-type-select"
           ng-switch-when="select">
         <a
@@ -51,7 +165,7 @@
             class="form-group ol-unselectable"
             ng-repeat="choice in ::ruleCtrl.clone.choices">
           <input
-              ng-checked="ruleCtrl.clone.expression && ruleCtrl.clone.expression.split(',').indexOf(choice) > -1"
+              ng-checked="ruleCtrl.clone.getExpression() && ruleCtrl.clone.getExpression().split(',').indexOf(choice) > -1"
               ng-click="ruleCtrl.toggleChoiceSelection(choice)"
               type="checkbox"
               value="choice" />
@@ -124,13 +238,39 @@
         </div>
         <div ng-switch-default>
           <span>{{ ruleCtrl.rule.operator }}</span>
-          <span>{{ ruleCtrl.timeToDate(ruleCtrl.rule.expression) }}</span>
+          <span>{{ ruleCtrl.timeToDate(ruleCtrl.rule.getExpression()) }}</span>
         </div>
       </div>
     </div>
 
+    <div ng-switch-when="geometry">
+      <span>{{ ruleCtrl.operators[ruleCtrl.rule.operator] }}</span>
+      <span ng-switch="ruleCtrl.getRuleGeometryType()">
+        <span
+            class="gmf-icon gmf-icon-point"
+            ng-switch-when="Point">
+        </span>
+        <span
+            class="gmf-icon gmf-icon-line"
+            ng-switch-when="LineString">
+        </span>
+        <span
+            class="gmf-icon gmf-icon-polygon"
+            ng-switch-when="Polygon">
+        </span>
+        <span
+            class="gmf-icon gmf-icon-circle"
+            ng-switch-when="Circle">
+        </span>
+        <span
+            class="gmf-icon gmf-icon-rectangle"
+            ng-switch-when="Rectangle">
+        </span>
+      </span>
+    </div>
+
     <div ng-switch-when="select">
-      <span ng-repeat="choice in ruleCtrl.rule.expression.split(',')">
+      <span ng-repeat="choice in ruleCtrl.rule.getExpression().split(',')">
         {{ choice | translate }}{{ $last ? '' : ', ' }}
       </span>
     </div>
@@ -145,7 +285,7 @@
         </div>
         <div ng-switch-default>
           <span>{{ ruleCtrl.rule.operator }}</span>
-          <span>{{ ruleCtrl.rule.expression }}</span>
+          <span>{{ ruleCtrl.rule.getExpression() }}</span>
         </div>
       </div>
     </div>

--- a/src/rule/geometry.js
+++ b/src/rule/geometry.js
@@ -1,0 +1,192 @@
+goog.provide('ngeo.rule.Geometry');
+
+goog.require('ngeo.rule.Rule');
+goog.require('ol.Feature');
+goog.require('ol.format.GeoJSON');
+
+
+ngeo.rule.Geometry = class extends ngeo.rule.Rule {
+
+  /**
+   * A rule bound to the geometry of a `ol.Feature` object. Changes made
+   * to the geometry are applied to the `expression` property of the rule.
+   *
+   * @struct
+   * @param {!ngeox.rule.RuleOptions} options Options.
+   */
+  constructor(options) {
+
+    options.type = ngeo.AttributeType.GEOMETRY;
+
+    super(options);
+
+    // === STATIC properties ===
+
+    /**
+     * @type {!ol.Feature}
+     * @private
+     */
+    this.feature_ = new ol.Feature();
+
+    /**
+     * @type {!ol.format.GeoJSON}
+     * @private
+     */
+    this.format_ = new ol.format.GeoJSON();
+
+    this.listenerKeys.push(
+      ol.events.listen(
+        this.feature_,
+        ol.Object.getChangeEventType(this.feature.getGeometryName()),
+        this.handleFeatureGeometryChange_,
+        this
+      )
+    );
+
+    this.setGeometryFromExpression_();
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.updatingExpression_ = false;
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.updatingGeometry_ = false;
+
+    /**
+     * @type {?ol.EventsKey}
+     * @private
+     */
+    this.geometryChangeListenerKey_ = null;
+
+  }
+
+  // === Static property getters/setters ===
+
+  /**
+   * @return {!ol.Feature} Feature.
+   * @export
+   */
+  get feature() {
+    return this.feature_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setExpression(expression) {
+    this.updatingExpression_ = true;
+    super.setExpression(expression);
+
+    if (!this.updatingGeometry_) {
+      this.setGeometryFromExpression_();
+    }
+
+    this.registerGeometryChange_();
+
+    this.updatingExpression_ = false;
+  }
+
+  // === Calculated property getters/setters ===
+
+  /**
+   * @return {?ol.geom.Geometry} Geometry
+   * @export
+   */
+  get geometry() {
+    return this.feature_.getGeometry() || null;
+  }
+
+  /**
+   * @param {?ol.geom.Geometry} geometry Geometry
+   * @export
+   */
+  set geometry(geometry) {
+    this.feature_.setGeometry(geometry);
+  }
+
+  // === Other methods ===
+
+  /**
+   * Called when the geometry property in the feature changes. Update the
+   * expression accordingly.
+   * @private
+   */
+  handleFeatureGeometryChange_() {
+    if (this.updatingExpression_) {
+      return;
+    }
+
+    this.updatingGeometry_ = true;
+
+    const geometry = this.feature_.getGeometry();
+    if (geometry) {
+      this.expression = this.format_.writeGeometry(geometry);
+    } else {
+      this.expression = null;
+    }
+
+    this.registerGeometryChange_();
+
+    this.updatingGeometry_ = false;
+  }
+
+  /**
+   * Called when the geometry of the features changes. Update the expression
+   * accordingly.
+   * @param {ol.Object.Event} evt Event
+   * @private
+   */
+  handleGeometryChange_(evt) {
+    const geometry = goog.asserts.assertInstanceof(
+      evt.target, ol.geom.Geometry
+    );
+    this.updatingGeometry_ = true;
+    this.expression = this.format_.writeGeometry(geometry);
+    this.updatingGeometry_ = false;
+  }
+
+  /**
+   * Set geometry property using the expression property.
+   * @private
+   */
+  setGeometryFromExpression_() {
+    let geometry = null;
+    if (this.expression) {
+      // An expression can only have a string value with a geometry rule.
+      const expression = goog.asserts.assertString(this.expression);
+      geometry = this.format_.readGeometry(expression);
+    }
+    this.geometry = geometry;
+  }
+
+  /**
+   * Unlisten the feature geometry change event, then listen to it if the
+   * feature has a geometry.
+   * @private
+   */
+  registerGeometryChange_() {
+
+    // (1) Unlisten
+    if (this.geometryChangeListenerKey_ !== null) {
+      ol.Observable.unByKey(this.geometryChangeListenerKey_);
+      this.geometryChangeListenerKey_ = null;
+    }
+
+    // (2) Listen, if geom
+    const geometry = this.feature_.getGeometry();
+    if (geometry) {
+      this.geometryChangeListenerKey_ = ol.events.listen(
+        geometry,
+        ol.events.EventType.CHANGE,
+        this.handleGeometryChange_,
+        this
+      );
+    }
+  }
+
+};

--- a/src/rule/select.js
+++ b/src/rule/select.js
@@ -10,7 +10,7 @@ ngeo.rule.Select = class extends ngeo.rule.Rule {
    * of choices.
    *
    * @struct
-   * @param {ngeox.rule.SelectOptions} options Options.
+   * @param {!ngeox.rule.SelectOptions} options Options.
    */
   constructor(options) {
 

--- a/src/rule/text.js
+++ b/src/rule/text.js
@@ -10,7 +10,7 @@ ngeo.rule.Text = class extends ngeo.rule.Rule {
    * default.
    *
    * @struct
-   * @param {ngeox.rule.TextOptions} options Options.
+   * @param {!ngeox.rule.TextOptions} options Options.
    */
   constructor(options) {
 

--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -943,6 +943,41 @@ ngeo.FeatureHelper.prototype.getRadiusLine = function(feature, azimut) {
 };
 
 
+/**
+ * Return the properties of a feature, with the exception of the geometry.
+ * @param {ol.Feature} feature Feature.
+ * @return {Object.<string, *>} Object.
+ * @export
+ */
+ngeo.FeatureHelper.prototype.getNonSpatialProperties = function(feature) {
+  const geometryName = feature.getGeometryName();
+  const nonSpatialProperties = {};
+  const properties = feature.getProperties();
+  for (const key in properties) {
+    if (key !== geometryName) {
+      nonSpatialProperties[key] = properties[key];
+    }
+  }
+  return nonSpatialProperties;
+};
+
+
+/**
+ * Clear all properties of a feature, with the exception of the geometry.
+ * @param {ol.Feature} feature Feature.
+ * @export
+ */
+ngeo.FeatureHelper.prototype.clearNonSpatialProperties = function(feature) {
+  const geometryName = feature.getGeometryName();
+  const properties = feature.getProperties();
+  for (const key in properties) {
+    if (key !== geometryName) {
+      feature.set(key, undefined);
+    }
+  }
+};
+
+
 ngeo.module.service('ngeoFeatureHelper', ngeo.FeatureHelper);
 
 


### PR DESCRIPTION
This PR adds the support of spatial rules to the `ngeo-rule` directive.

It also changes the way a rule is activated. Now, an `active` property exists within the `ngeo.rule.Rule` class to manage the activation. This allows the parent directive, `ngeo-filter`, to deactivate a rule before removing it.

Upon activating a geometry rule, an operator is immediately selected and the draw tools are shown.  The user can change the operator using the list and the draw tools are updated accordingly.

When a draw tool is clicked, the operator list is deactivated.  The user can then draw on the map. When the drawing is completed, the tool is deactivated and the geometry can be immediately modified.

Even when deactivated, the feature stays on the map.

## Note about the compiler and the 'expression' property

Also, the `ngeo.rule.Geometry` object has been created.  Because of a current limitation with the compiler, ES6 getter/setter functions can't be extended by child classes.  In the `ngeo.rule.Geometry`, the expression is still used as the common way to have a value for the rule.  It's a GeoJSON string of the geometry.  The rule also has a `feature` property to hold the actual geometry.  The conversion to the expression is done within the rule object itself.  In order to be able to perfectly synchronize both properties, the `expression` setter had to be extended, but the compiler threw an error.  For that reason, the getter/setter for the `expression` were renamed `getExpression` and `setExpression`.  This could be re-changed in the future when the issue with the compiler's gone.

## Todo

 * [x] Wait for #2394 to be merged
 * [ ] Validate the workflow, which is slighly different than the specs
 * [ ] Review

## Live demo

 * https://adube.github.io/ngeo/filter-spatial/examples/contribs/gmf/filterselector.html

Please, disregard the fact that there are missing fonts on that example.