### PR TITLE
Filter - Support saved filters

### DIFF
--- a/contribs/gmf/examples/filterselector.html
+++ b/contribs/gmf/examples/filterselector.html
@@ -95,6 +95,16 @@
         margin: 1.5rem 0 0.5rem 0;
       }
 
+      .gmf-filterselector-savebtn {
+        display: block;
+        text-align: left;
+      }
+
+      .gmf-filterselector-savefilter-desc {
+        color: #999999;
+      }
+
+
       .ngeo-filter-condition-button,
       .ngeo-filter-condition-button:hover,
       .ngeo-filter-condition-button:focus {

--- a/contribs/gmf/src/directives/partials/filterselector.html
+++ b/contribs/gmf/src/directives/partials/filterselector.html
@@ -12,7 +12,37 @@
 
   <div ng-if="fsCtrl.customRules && fsCtrl.directedRules && fsCtrl.readyDataSource">
     <hr class="gmf-filterselector-separator" />
+
+    <div class="dropdown gmf-filterselector-savedfilters">
+      <a
+          class="btn btn-link dropdown-toggle ngeo-filter-condition-button"
+          type="button"
+          data-toggle="dropdown"
+          ng-disabled="fsCtrl.aRuleIsActive || fsCtrl.gmfSavedFilters.currentDataSourceItems.length === 0">
+        <span translate>Saved</span>
+        <span class="caret"></span>
+      </a>
+      <ul class="dropdown-menu">
+        <li ng-repeat="item in fsCtrl.gmfSavedFilters.currentDataSourceItems">
+          <a
+              href
+              ng-click="fsCtrl.saveFilterLoadItem(item)">
+            <span>{{::item.name}}</span>
+          </a>
+        </li>
+        <li role="separator" class="divider"></li>
+        <li>
+          <a
+              href
+              ng-click="fsCtrl.saveFilterManage()">
+            <span translate>Manage saved filters</span>
+          </a>
+        </li>
+      </ul>
+    </div>
+
     <ngeo-filter
+        a-rule-is-active="fsCtrl.aRuleIsActive"
         custom-rules="fsCtrl.customRules"
         datasource="fsCtrl.readyDataSource"
         directed-rules="fsCtrl.directedRules"
@@ -20,5 +50,82 @@
         map="fsCtrl.map"
         tool-group="fsCtrl.toolGroup">
     </ngeo-filter>
+
+    <a
+        class="btn btn-link gmf-filterselector-savebtn"
+        type="button"
+        data-toggle="dropdown"
+        ng-click="fsCtrl.saveFilterShowModal()"
+        ng-disabled="fsCtrl.aRuleIsActive">
+      <span class="glyphicon glyphicon-floppy-save"></span>
+      <span translate>Save</span>
+    </a>
   </div>
+
+  <ngeo-modal ng-model="fsCtrl.saveFilterSaveModalShown">
+    <div class="modal-header">
+      <button
+          type="button"
+          class="close"
+          data-dismiss="modal"
+          aria-label="{{'Close' | translate}}">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <h4 class="modal-title">{{'Save filter' | translate}}</h4>
+    </div>
+    <div class="modal-body">
+      <p class="gmf-filterselector-savefilter-desc" translate>
+        You can save the filter that you created to re-load it later.
+      </p>
+      <input
+          type="text"
+          class="form-control"
+          name="name"
+          ng-model="fsCtrl.saveFilterName"
+          placeholder="{{'Filter name' | translate}}" />
+    </div>
+    <div class="modal-footer">
+      <button
+          type="button"
+          class="btn btn-default"
+          data-dismiss="modal">{{'Cancel' | translate}}</button>
+      <button
+          type="button"
+          ng-click="fsCtrl.saveFilterSave()"
+          ng-disabled="fsCtrl.saveFilterName === ''"
+          class="btn btn-primary">{{'Save' | translate}}</button>
+    </div>
+  </ngeo-modal>
+
+  <ngeo-modal ng-model="fsCtrl.saveFilterManageModalShown">
+    <div class="modal-header">
+      <button
+          type="button"
+          class="close"
+          data-dismiss="modal"
+          aria-label="{{'Close' | translate}}">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <h4 class="modal-title">{{'Manage filters' | translate}}</h4>
+    </div>
+    <div class="modal-body">
+      <ul>
+        <li ng-repeat="item in fsCtrl.gmfSavedFilters.currentDataSourceItems">
+          <span>{{::item.name}}</span>
+          <a
+              href
+              ng-click="fsCtrl.saveFilterRemoveItem(item)">
+              {{ 'Delete' | translate }}
+          </a>
+        </li>
+      </ul>
+    </div>
+    <div class="modal-footer">
+      <button
+          type="button"
+          class="btn btn-default"
+          data-dismiss="modal">{{'Close' | translate}}</button>
+    </div>
+  </ngeo-modal>
+
 </div>

--- a/contribs/gmf/src/services/savedfilters.js
+++ b/contribs/gmf/src/services/savedfilters.js
@@ -1,0 +1,266 @@
+goog.provide('gmf.SavedFilters');
+
+goog.require('gmf');
+
+
+gmf.SavedFilters = class {
+
+  /**
+   * The GeoMapFish service responsible of storing filters that can be applied
+   * to data sources. A filter consists of:
+   *
+   * - a condition
+   * - a list of directed rules
+   * - a list of custom rules
+   * - a data source
+   * - a name
+   *
+   * The filters are saved in the browser local storage, if available.
+   * Otherwise, they are kept in this service for the duration of the visit.
+   *
+   * @param {!angular.Scope} $rootScope Angular rootScope.
+   * @struct
+   * @ngInject
+   * @ngdoc service
+   * @ngname gmfSavedFilters
+   */
+  constructor($rootScope) {
+
+    /**
+     * @type {!angular.Scope}
+     * @private
+     */
+    this.rootScope_ = $rootScope;
+
+    /**
+     * This service can have a data source id bound to it, which automatically
+     * populates an array of items that are only bound to this data source.
+     * @type {?number}
+     * @private
+     */
+    this.currentDataSourceId_ = null;
+
+    /**
+     * @type {!Array.<!gmf.SavedFilters.FilterItem>}
+     * @private
+     */
+    this.currentDataSourceItems_ = [];
+
+    /**
+     * The used by this service to save in the local storage.
+     * @type {string}
+     * @private
+     */
+    this.localStorageKey_ = 'gmf_savedfilters';
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.useLocalStorage_ = true;
+
+    try {
+      if ('localStorage' in window) {
+        window.localStorage['test'] = '';
+        delete window.localStorage['test'];
+      } else {
+        this.useLocalStorage_ = false;
+      }
+    } catch (err) {
+      console.error(err);
+      this.useLocalStorage_ = false;
+    }
+
+    /**
+     * @type {!Array.<!gmf.SavedFilters.FilterItem>}
+     * @private
+     */
+    this.items_ = [];
+
+    this.rootScope_.$watchCollection(
+      () => this.items,
+      () => {
+        this.rePopulateCurrentDataSourceItems_();
+      }
+    );
+
+    if (this.useLocalStorage_) {
+      this.loadItemsFromLocalStorage_();
+    }
+
+  }
+
+  /**
+   * @return {!Array.<!gmf.SavedFilters.FilterItem>} Items
+   * @export
+   */
+  get currentDataSourceItems() {
+    return this.currentDataSourceItems_;
+  }
+
+  /**
+   * @param {?number} id Current data source id.
+   * @export
+   */
+  set currentDataSourceId(id) {
+    this.currentDataSourceId_ = id;
+    this.rePopulateCurrentDataSourceItems_();
+  }
+
+  /**
+   * @return {!Array.<!gmf.SavedFilters.FilterItem>} Items
+   * @export
+   */
+  get items() {
+    return this.items_;
+  }
+
+  /**
+   * Read the filter items that are saved in the local storage and set them
+   * as this service's items.
+   * @private
+   */
+  loadItemsFromLocalStorage_() {
+    if (window.localStorage[this.localStorageKey_]) {
+      const items = JSON.parse(window.localStorage[this.localStorageKey_]);
+      goog.asserts.assertArray(items);
+      this.items_ = items;
+    }
+  }
+
+  /**
+   * Search for an item using a given name and data source id. Returns the
+   * index if it exists, otherwise -1 is returned.
+   * @param {string} name Name.
+   * @param {number} id Data source id.
+   * @return {number} The index of the item, if it exists.
+   * @export
+   */
+  indexOfItem(name, id) {
+
+    let item;
+    let idx = -1;
+    for (let i = 0, ii = this.items_.length; i < ii; i++) {
+      item = this.items[i];
+      if (item.dataSourceId === id && item.name === name) {
+        idx = i;
+        break;
+      }
+    }
+
+    return idx;
+  }
+
+  /**
+   * @param {!gmf.SavedFilters.FilterItem} item Item.
+   * @export
+   */
+  save(item) {
+
+    // (1) Add or replace item
+    const idx = this.indexOfItem(item.name, item.dataSourceId);
+    if (idx !== -1) {
+      this.items[idx] = item;
+    } else {
+      this.items.push(item);
+    }
+
+    // (2) Update local storage
+    if (this.useLocalStorage_) {
+      this.saveItemsInLocalStorage_();
+    }
+  }
+
+  /**
+   * @param {!gmf.SavedFilters.FilterItem} item Item.
+   * @export
+   */
+  remove(item) {
+
+    // (1) Remove the item
+    const found = ol.array.remove(this.items, item);
+
+    // (2) Update local storage
+    if (found && this.useLocalStorage_) {
+      this.saveItemsInLocalStorage_();
+    }
+  }
+
+  /**
+   * Save all items in the local storage.
+   * @private
+   */
+  saveItemsInLocalStorage_() {
+    window.localStorage[this.localStorageKey_] = JSON.stringify(this.items);
+  }
+
+  /**
+   * @private
+   */
+  rePopulateCurrentDataSourceItems_() {
+    // (1) Clear existing items
+    this.currentDataSourceItems_.length = 0;
+
+    // (2) Populate
+    if (this.currentDataSourceId_ !== null) {
+      for (const item of this.items) {
+        if (item.dataSourceId === this.currentDataSourceId_) {
+          this.currentDataSourceItems_.push(item);
+        }
+      }
+    }
+  }
+
+};
+
+
+gmf.module.service('gmfSavedFilters', gmf.SavedFilters);
+
+
+/**
+ * The definition of a saved filter item.
+ * @constructor
+ * @struct
+ * @export
+ */
+gmf.SavedFilters.FilterItem = function() {};
+
+
+/**
+ * The condition of the saved filter item.
+ * @type {string}
+ * @export
+ */
+gmf.SavedFilters.FilterItem.prototype.condition;
+
+
+/**
+ * The list of custom rules of the saved filter item.
+ * @type {!Array.<!ngeox.rule.AnyOptions>}
+ * @export
+ */
+gmf.SavedFilters.FilterItem.prototype.customRules;
+
+
+/**
+ * The data source id related to the filter.
+ * @type {number}
+ * @export
+ */
+gmf.SavedFilters.FilterItem.prototype.dataSourceId;
+
+
+/**
+ * The list of directed rules of the saved filter item.
+ * @type {!Array.<!ngeox.rule.AnyOptions>}
+ * @export
+ */
+gmf.SavedFilters.FilterItem.prototype.directedRules;
+
+
+/**
+ * A human-readable name given to the saved filter item.
+ * @type {string}
+ * @export
+ */
+gmf.SavedFilters.FilterItem.prototype.name;

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -1889,6 +1889,21 @@ ngeox.rule.RuleOptions.prototype.upperBoundary;
  * @struct
  * @extends ngeox.rule.RuleOptions
  */
+ngeox.rule.GeometryOptions = function() {};
+
+
+/**
+ * Properties for the feature.
+ * @type {Object.<string, *>|undefined}
+ */
+ngeox.rule.GeometryOptions.prototype.featureProperties;
+
+
+/**
+ * @record
+ * @struct
+ * @extends ngeox.rule.RuleOptions
+ */
 ngeox.rule.SelectOptions = function() {};
 
 
@@ -1905,6 +1920,13 @@ ngeox.rule.SelectOptions.prototype.choices;
  * @extends ngeox.rule.RuleOptions
  */
 ngeox.rule.TextOptions = function() {};
+
+
+/**
+ * @typedef {!ngeox.rule.RuleOptions|!ngeox.rule.GeometryOptions|!ngeox.rule.SelectOptions|!ngeox.rule.TextOptions}
+ */
+ngeox.rule.AnyOptions;
+
 
 
 /**

--- a/src/directives/partials/filter.html
+++ b/src/directives/partials/filter.html
@@ -2,7 +2,8 @@
   <a
       class="btn btn-link dropdown-toggle ngeo-filter-condition-button"
       type="button"
-      data-toggle="dropdown">
+      data-toggle="dropdown"
+      ng-disabled="filterCtrl.aRuleIsActive">
     <span class="glyphicon glyphicon-cog"></span>
     <span class="caret"></span>
   </a>
@@ -39,6 +40,7 @@
   <a
       class="btn btn-xs btn-link ngeo-filter-rule-custom-rm-btn"
       ng-click="filterCtrl.removeCustomRule(rule)"
+      ng-disabled="filterCtrl.aRuleIsActive"
       href>
     <span class="glyphicon glyphicon-remove"></span>
   </a>
@@ -55,7 +57,8 @@
   <a
       class="btn btn-link dropdown-toggle"
       type="button"
-      data-toggle="dropdown">
+      data-toggle="dropdown"
+      ng-disabled="filterCtrl.aRuleIsActive">
     <span translate>+ Add a new criteria</span>
     <span class="caret"></span>
   </a>
@@ -82,7 +85,8 @@
     class="btn btn-link"
     type="button"
     data-toggle="dropdown"
-    ng-click="filterCtrl.apply()">
+    ng-click="filterCtrl.apply()"
+    ng-disabled="filterCtrl.aRuleIsActive">
   <span class="glyphicon glyphicon-ok"></span>
   <span translate>Apply</span>
 </a>

--- a/src/directives/partials/rule.html
+++ b/src/directives/partials/rule.html
@@ -220,6 +220,7 @@
   <a
       class="btn btn-xs btn-link"
       ng-click="ruleCtrl.reset()"
+      ng-disabled="ruleCtrl.rule.active"
       href>
     <span class="glyphicon glyphicon-remove"></span>
   </a>

--- a/src/directives/rule.js
+++ b/src/directives/rule.js
@@ -497,13 +497,13 @@ ngeo.RuleController = class {
 
 
   /**
-   * Called when the active property changes. Only used when this component
-   * is bound to a geometry rule.
+   * Called when the active property of a rule changes. Only used when this
+   * component is bound to a geometry rule.
    *
    * Manage the activation/deactivation of the interactions.
    *
-   * @param {boolean} active Whether the component is active or not.
-   * @param {boolean} oldActive Whether the component was active or not.
+   * @param {boolean} active Whether the rule is active or not.
+   * @param {boolean} oldActive Whether the rule was active or not.
    * @private
    */
   handleActiveChange_(active, oldActive) {

--- a/src/rule/geometry.js
+++ b/src/rule/geometry.js
@@ -12,7 +12,7 @@ ngeo.rule.Geometry = class extends ngeo.rule.Rule {
    * to the geometry are applied to the `expression` property of the rule.
    *
    * @struct
-   * @param {!ngeox.rule.RuleOptions} options Options.
+   * @param {!ngeox.rule.GeometryOptions} options Options.
    */
   constructor(options) {
 
@@ -22,28 +22,19 @@ ngeo.rule.Geometry = class extends ngeo.rule.Rule {
 
     // === STATIC properties ===
 
+    const properties = options.featureProperties || {};
+
     /**
      * @type {!ol.Feature}
      * @private
      */
-    this.feature_ = new ol.Feature();
+    this.feature_ = new ol.Feature(properties);
 
     /**
      * @type {!ol.format.GeoJSON}
      * @private
      */
     this.format_ = new ol.format.GeoJSON();
-
-    this.listenerKeys.push(
-      ol.events.listen(
-        this.feature_,
-        ol.Object.getChangeEventType(this.feature.getGeometryName()),
-        this.handleFeatureGeometryChange_,
-        this
-      )
-    );
-
-    this.setGeometryFromExpression_();
 
     /**
      * @type {boolean}
@@ -62,6 +53,17 @@ ngeo.rule.Geometry = class extends ngeo.rule.Rule {
      * @private
      */
     this.geometryChangeListenerKey_ = null;
+
+    this.listenerKeys.push(
+      ol.events.listen(
+        this.feature_,
+        ol.Object.getChangeEventType(this.feature.getGeometryName()),
+        this.handleFeatureGeometryChange_,
+        this
+      )
+    );
+
+    this.setGeometryFromExpression_();
 
   }
 


### PR DESCRIPTION
This PR introduces the saving of filters in the local storage.

The `gmf.SavedFilters` is a new service responsible of:

 * storing a list of saved filter items locally
 * storing a list of saved filters for a particular 'active' data source, i.e. it's built using the above list items that have an id equal to the current active data source.
 * saving the items in the local storage

The service is injected in the `gmf-filterselector` component to be able to have the list of items bound to a single data source.  The component has 2 new items added: a drop-down list of the items and a save button.

When saving, we check if there's an item that has the same name for the given active data source first.  If that's the case, an confirmation to overwrite the previous one is prompted.  Otherwise, the save occurs.

## Also introduced in this PR

A new `aRuleIsActive` property has been added to the `gmf-filterselector` and `ngeo-filter` components.  That property is set on when there's one rule currently active.  When that's the case, a bunch of components are disabled, such as: remove buttons, save button, apply button, etc.

When a rule is active, its edition must be completed first before being able to do something else.  This prevents a lot of unwanted behaviour.

## Todo

 * [x] Wait for #2402 to be merged
 * [ ] Review

## Live demo

 * https://adube.github.io/ngeo/filter-saved/examples/contribs/gmf/filterselector.html