### PR TITLE
Don't use local storage if theme has changed and no groups in permalink

### DIFF
--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -834,8 +834,8 @@ gmf.Permalink.prototype.initLayers_ = function() {
      */
     var firstLevelGroups = [];
     var theme;
-    // check if we have the groups in the permalink
-    var groupsNames = this.ngeoStateManager_.getInitialValue(gmf.PermalinkParam.TREE_GROUPS);
+    // Check if we have the groups in the permalink
+    var groupsNames = this.ngeoLocation_.getParam(gmf.PermalinkParam.TREE_GROUPS);
     if (!groupsNames) {
       theme = gmf.Themes.findThemeByName(themes, themeName);
       if (theme) {


### PR DESCRIPTION
Fix: #2386

In my change, I take the groups from the url, not from the local storage.
So if you use an url without groups, we don't load groups defined in the local storage.