### PR TITLE
Add Filter in desktop apps

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -55,6 +55,10 @@
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Draw & Measure'|translate}}">
               <span class="fa fa-paint-brush"></span>
             </button>
+            <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.filterSelectorActive"
+              data-toggle="tooltip" data-placement="left" data-original-title="{{'Filter'|translate}}">
+              <span class="fa fa-filter"></span>
+            </button>
             <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.editFeatureActive"
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Editing'|translate}}"
               ng-show="mainCtrl.hasEditableLayers" ng-cloak>
@@ -106,6 +110,19 @@
                   gmf-drawfeature-layer="::mainCtrl.drawFeatureLayer"
                   gmf-drawfeature-map="::mainCtrl.map">
               </gmf-drawfeature>
+            </div>
+          </div>
+          <div ng-show="mainCtrl.filterSelectorActive" class="row">
+            <div class="col-sm-12">
+              <div class="gmf-app-tools-content-heading">
+                {{'Filter'|translate}}
+                <a class="btn close" ng-click="mainCtrl.filterSelectorActive = false">&times;</a>
+              </div>
+              <gmf-filterselector
+                  active="mainCtrl.filterSelectorActive"
+                  map="mainCtrl.map"
+                  tool-group="mainCtrl.mapToolsGroup">
+              </gmf-filterselector>
             </div>
           </div>
           <div ng-show="mainCtrl.editFeatureActive" class="row">

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -78,6 +78,10 @@
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Draw & Measure'|translate}}">
               <span class="fa fa-paint-brush"></span>
             </button>
+            <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.filterSelectorActive"
+              data-toggle="tooltip" data-placement="left" data-original-title="{{'Filter'|translate}}">
+              <span class="fa fa-filter"></span>
+            </button>
             <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.editFeatureActive"
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Editing'|translate}}"
               ng-show="mainCtrl.hasEditableLayers" ng-cloak>
@@ -130,6 +134,19 @@
                   gmf-drawfeature-layer="::mainCtrl.drawFeatureLayer"
                   gmf-drawfeature-map="::mainCtrl.map">
               </gmf-drawfeature>
+            </div>
+          </div>
+          <div ng-show="mainCtrl.filterSelectorActive" class="row">
+            <div class="col-sm-12">
+              <div class="gmf-app-tools-content-heading">
+                {{'Filter'|translate}}
+                <a class="btn close" ng-click="mainCtrl.filterSelectorActive = false">&times;</a>
+              </div>
+              <gmf-filterselector
+                  active="mainCtrl.filterSelectorActive"
+                  map="mainCtrl.map"
+                  tool-group="mainCtrl.mapToolsGroup">
+              </gmf-filterselector>
             </div>
           </div>
           <div ng-show="mainCtrl.editFeatureActive" class="row">

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -548,3 +548,161 @@ gmf-objecteditingtools {
   margin: 0 0 1rem 0;
   padding: 0 0 1rem 0;
 }
+
+
+/**
+ * GMF FilterSelector component
+ */
+.gmf-filterselector-separator {
+  margin: 1.5rem 0 0.5rem 0;
+}
+
+.gmf-filterselector-savebtn {
+  display: block;
+  text-align: left;
+}
+
+.gmf-filterselector-savefilter-desc {
+  color: #999999;
+}
+
+.gmf-filterselector-savedfilters {
+  z-index: 1;
+
+  a.dropdown-toggle {
+    padding: 0.6rem 0;
+    position: absolute;
+    right: 0;
+  }
+
+  ul.dropdown-menu {
+    top: 3rem;
+
+    a {
+      overflow: hidden;
+      max-width: 25rem;
+      text-overflow: ellipsis;
+    }
+  }
+}
+
+.gmf-filterselector-managefilter-modal {
+  .modal-body {
+    padding: 0 1.5rem;
+
+    ul {
+      margin: 0;
+
+      li {
+        border-bottom: 1px solid #dddddd;
+        padding: 0.5rem;
+
+        &:last-child {
+          border-bottom: none;
+        }
+
+        a {
+          float: right;
+        }
+
+        span {
+          float: left;
+          max-width: 48rem;
+          text-overflow: ellipsis;
+          overflow: hidden;
+          white-space: nowrap;
+        }
+      }
+    }
+  }
+}
+
+
+/**
+ * Ngeo Filter component
+ */
+
+.ngeo-filter-condition-button,
+.ngeo-filter-condition-button:hover,
+.ngeo-filter-condition-button:focus {
+  text-decoration: none;
+}
+
+.ngeo-filter-condition-criteria-header {
+  color: #999999;
+  padding: 0.3rem 2rem;
+}
+
+.ngeo-filter-condition-criteria {
+  opacity: 0;
+}
+
+.ngeo-filter-condition-criteria-active {
+  opacity: 1;
+}
+
+.ngeo-filter-rule-custom-rm-btn {
+  float: right;
+  margin: 0.4rem 0;
+}
+
+
+/**
+ * Ngeo Rule component
+ */
+ngeo-rule {
+  display: block;
+  margin: 1rem 2.5rem 1rem 0;
+
+  .dropdown > a.btn {
+    display: block;
+    text-align: left;
+
+    span.caret {
+      float: right;
+      margin: 0.8rem 0 0 0;
+    }
+  }
+
+  .dropdown-menu {
+    padding: 1rem;
+  }
+
+  .ngeo-rule-operators-list {
+    margin: 0 0 1rem 0;
+  }
+
+  .ngeo-rule-btns {
+    float: right;
+  }
+
+  .ngeo-rule-type-select label {
+    width: 13.5rem;
+  }
+
+  .ngeo-rule-value {
+    color: #999999;
+    margin: 0.5rem;
+
+    a.btn {
+      color: #999999;
+      float: right;
+    }
+
+    a.btn:hover,
+    a.btn:focus {
+      color: #666666;
+    }
+
+    ngeo-date-picker {
+      display: block;
+      text-align: right;
+    }
+  }
+
+  .ngeo-rule-type-geometry-instructions {
+    font-size: 9pt;
+    font-style: italic;
+    margin: 0.5rem;
+  }
+}

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -339,6 +339,14 @@ gmf.AbstractController = function(config, $scope, $injector) {
 
   this.initLanguage();
 
+  const mapTools = 'mapTools';
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.mapToolsGroup = mapTools;
+
   /**
    * The ngeo feature overlay manager service
    * @type {ngeo.FeatureOverlayMgr}
@@ -353,22 +361,22 @@ gmf.AbstractController = function(config, $scope, $injector) {
   const ngeoToolActivateMgr = $injector.get('ngeoToolActivateMgr');
 
   const queryToolActivate = new ngeo.ToolActivate(this, 'queryActive');
-  ngeoToolActivateMgr.registerTool('mapTools', queryToolActivate, true);
+  ngeoToolActivateMgr.registerTool(mapTools, queryToolActivate, true);
 
   const measurePointActivate = new ngeo.ToolActivate(this, 'measurePointActive');
-  ngeoToolActivateMgr.registerTool('mapTools', measurePointActivate, false);
+  ngeoToolActivateMgr.registerTool(mapTools, measurePointActivate, false);
 
   const measureLengthActivate = new ngeo.ToolActivate(this, 'measureLengthActive');
-  ngeoToolActivateMgr.registerTool('mapTools', measureLengthActivate, false);
+  ngeoToolActivateMgr.registerTool(mapTools, measureLengthActivate, false);
 
   const drawFeatureActivate = new ngeo.ToolActivate(this, 'drawFeatureActive');
-  ngeoToolActivateMgr.registerTool('mapTools', drawFeatureActivate, false);
+  ngeoToolActivateMgr.registerTool(mapTools, drawFeatureActivate, false);
 
   const drawProfilePanelActivate = new ngeo.ToolActivate(this, 'drawProfilePanelActive');
-  ngeoToolActivateMgr.registerTool('mapTools', drawProfilePanelActivate, false);
+  ngeoToolActivateMgr.registerTool(mapTools, drawProfilePanelActivate, false);
 
   const printPanelActivate = new ngeo.ToolActivate(this, 'printPanelActive');
-  ngeoToolActivateMgr.registerTool('mapTools', printPanelActivate, false);
+  ngeoToolActivateMgr.registerTool(mapTools, printPanelActivate, false);
 
 
   $scope.$watch(() => this.gmfThemeManager.themeName, (name) => {

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -17,6 +17,8 @@ goog.require('gmf.editfeatureselectorDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.elevationDirective');
 /** @suppress {extraRequire} */
+goog.require('gmf.filterselectorComponent');
+/** @suppress {extraRequire} */
 goog.require('gmf.mousepositionComponent');
 /** @suppress {extraRequire} */
 goog.require('gmf.printDirective');
@@ -125,6 +127,12 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
    * @export
    */
   this.modalShareShown = false;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.filterSelectorActive = false;
 
   /**
    * @type {boolean}

--- a/contribs/gmf/src/directives/filterselector.js
+++ b/contribs/gmf/src/directives/filterselector.js
@@ -15,6 +15,9 @@ goog.require('ngeo.RuleHelper');
 goog.require('ol.CollectionEventType');
 
 
+/**
+ * @private
+ */
 gmf.FilterselectorController = class {
 
   /**
@@ -30,6 +33,7 @@ gmf.FilterselectorController = class {
    *     manager
    * @param {!ngeo.RuleHelper} ngeoRuleHelper Ngeo rule helper service.
    * @private
+   * @struct
    * @ngInject
    * @ngdoc controller
    * @ngname GmfFilterselectorController

--- a/contribs/gmf/src/directives/partials/filterselector.html
+++ b/contribs/gmf/src/directives/partials/filterselector.html
@@ -57,7 +57,7 @@
         data-toggle="dropdown"
         ng-click="fsCtrl.saveFilterShowModal()"
         ng-disabled="fsCtrl.aRuleIsActive">
-      <span class="glyphicon glyphicon-floppy-save"></span>
+      <span class="fa fa-save"></span>
       <span translate>Save</span>
     </a>
   </div>
@@ -98,33 +98,36 @@
   </ngeo-modal>
 
   <ngeo-modal ng-model="fsCtrl.saveFilterManageModalShown">
-    <div class="modal-header">
-      <button
-          type="button"
-          class="close"
-          data-dismiss="modal"
-          aria-label="{{'Close' | translate}}">
-        <span aria-hidden="true">&times;</span>
-      </button>
-      <h4 class="modal-title">{{'Manage filters' | translate}}</h4>
-    </div>
-    <div class="modal-body">
-      <ul>
-        <li ng-repeat="item in fsCtrl.gmfSavedFilters.currentDataSourceItems">
-          <span>{{::item.name}}</span>
-          <a
-              href
-              ng-click="fsCtrl.saveFilterRemoveItem(item)">
-              {{ 'Delete' | translate }}
-          </a>
-        </li>
-      </ul>
-    </div>
-    <div class="modal-footer">
-      <button
-          type="button"
-          class="btn btn-default"
-          data-dismiss="modal">{{'Close' | translate}}</button>
+    <div class="gmf-filterselector-managefilter-modal">
+      <div class="modal-header">
+        <button
+            type="button"
+            class="close"
+            data-dismiss="modal"
+            aria-label="{{'Close' | translate}}">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title">{{'Manage filters' | translate}}</h4>
+      </div>
+      <div class="modal-body">
+        <ul>
+          <li ng-repeat="item in fsCtrl.gmfSavedFilters.currentDataSourceItems">
+            <span>{{::item.name}}</span>
+            <a
+                href
+                ng-click="fsCtrl.saveFilterRemoveItem(item)">
+                {{ 'Delete' | translate }}
+            </a>
+            <div class="gmf-eol"></div>
+          </li>
+        </ul>
+      </div>
+      <div class="modal-footer">
+        <button
+            type="button"
+            class="btn btn-default"
+            data-dismiss="modal">{{'Close' | translate}}</button>
+      </div>
     </div>
   </ngeo-modal>
 

--- a/src/directives/filter.js
+++ b/src/directives/filter.js
@@ -7,6 +7,9 @@ goog.require('ngeo.RuleHelper');
 goog.require('ngeo.rule.Geometry');
 
 
+/**
+ * @private
+ */
 ngeo.FilterController = class {
 
   /**
@@ -15,6 +18,7 @@ ngeo.FilterController = class {
    * @param {!angular.$timeout} $timeout Angular timeout service.
    * @param {!ngeo.RuleHelper} ngeoRuleHelper Ngeo rule helper service.
    * @private
+   * @struct
    * @ngInject
    * @ngdoc controller
    * @ngname NgeoFilterController

--- a/src/directives/partials/filter.html
+++ b/src/directives/partials/filter.html
@@ -4,7 +4,7 @@
       type="button"
       data-toggle="dropdown"
       ng-disabled="filterCtrl.aRuleIsActive">
-    <span class="glyphicon glyphicon-cog"></span>
+    <span class="fa fa-cog"></span>
     <span class="caret"></span>
   </a>
   <ul class="dropdown-menu">
@@ -17,7 +17,7 @@
           ng-click="filterCtrl.setCondition(condition)">
           <span
               ng-class="{'ngeo-filter-condition-criteria-active': condition.value == filterCtrl.datasource.filterCondition}"
-              class="glyphicon glyphicon-ok ngeo-filter-condition-criteria">
+              class="fa fa-check ngeo-filter-condition-criteria">
           </span>
           <span>{{::condition.text | translate}}</span>
       </a>
@@ -42,7 +42,7 @@
       ng-click="filterCtrl.removeCustomRule(rule)"
       ng-disabled="filterCtrl.aRuleIsActive"
       href>
-    <span class="glyphicon glyphicon-remove"></span>
+    <span class="fa fa-remove"></span>
   </a>
   <ngeo-rule
       feature-overlay="::filterCtrl.featureOverlay"
@@ -87,6 +87,6 @@
     data-toggle="dropdown"
     ng-click="filterCtrl.apply()"
     ng-disabled="filterCtrl.aRuleIsActive">
-  <span class="glyphicon glyphicon-ok"></span>
+  <span class="fa fa-check"></span>
   <span translate>Apply</span>
 </a>

--- a/src/directives/partials/rule.html
+++ b/src/directives/partials/rule.html
@@ -79,7 +79,7 @@
                 href
                 ngeo-btn
                 ngeo-drawpoint
-                class="btn btn-xs btn-default ngeo-drawfeature-point"
+                class="btn btn-sm btn-default ngeo-drawfeature-point"
                 ng-show="['intersects', 'within'].indexOf(ruleCtrl.clone.operator) !== -1"
                 ng-class="{active: dfCtrl.drawPoint.active}"
                 ng-model="dfCtrl.drawPoint.active">
@@ -91,7 +91,7 @@
                 href
                 ngeo-btn
                 ngeo-measurelength
-                class="btn btn-xs btn-default ngeo-drawfeature-linestring"
+                class="btn btn-sm btn-default ngeo-drawfeature-linestring"
                 ng-show="['intersects', 'within'].indexOf(ruleCtrl.clone.operator) !== -1"
                 ng-class="{active: dfCtrl.measureLength.active}"
                 ng-model="dfCtrl.measureLength.active">
@@ -103,7 +103,7 @@
                 href
                 ngeo-btn
                 ngeo-measurearea
-                class="btn btn-xs btn-default ngeo-drawfeature-polygon"
+                class="btn btn-sm btn-default ngeo-drawfeature-polygon"
                 ng-class="{active: dfCtrl.measureArea.active}"
                 ng-model="dfCtrl.measureArea.active">
                 <span class="gmf-icon gmf-icon-polygon"></span>
@@ -114,7 +114,7 @@
                 href
                 ngeo-btn
                 ngeo-measureazimut
-                class="btn btn-xs btn-default ngeo-drawfeature-circle"
+                class="btn btn-sm btn-default ngeo-drawfeature-circle"
                 ng-class="{active: dfCtrl.measureAzimut.active}"
                 ng-model="dfCtrl.measureAzimut.active">
                 <span class="gmf-icon gmf-icon-circle"></span>
@@ -125,7 +125,7 @@
                 href
                 ngeo-btn
                 ngeo-drawrectangle
-                class="btn btn-xs btn-default ngeo-drawfeature-rectangle"
+                class="btn btn-sm btn-default ngeo-drawfeature-rectangle"
                 ng-class="{active: dfCtrl.drawRectangle.active}"
                 ng-model="dfCtrl.drawRectangle.active">
                 <span class="gmf-icon gmf-icon-rectangle"></span>
@@ -222,7 +222,7 @@
       ng-click="ruleCtrl.reset()"
       ng-disabled="ruleCtrl.rule.active"
       href>
-    <span class="glyphicon glyphicon-remove"></span>
+    <span class="fa fa-remove"></span>
   </a>
 
   <div ng-switch="::ruleCtrl.rule.type">

--- a/src/directives/rule.js
+++ b/src/directives/rule.js
@@ -15,6 +15,9 @@ goog.require('ngeo.rule.Select');
 goog.require('ol.Collection');
 
 
+/**
+ * @private
+ */
 ngeo.RuleController = class {
 
   /**
@@ -28,6 +31,7 @@ ngeo.RuleController = class {
    * @param {!ngeo.ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate
    *     manager service.
    * @private
+   * @struct
    * @ngInject
    * @ngdoc controller
    * @ngname NgeoRuleController


### PR DESCRIPTION
Add the filter tool in the `desktop` and `desktop_all` applications.

Fixes are made to adjust the CSS styling accordingly as well.

## Todo

 * [ ] review

## Live example

 * https://adube.github.io/ngeo/filter-add-in-apps/examples/contribs/gmf/apps/desktop_alt/

How to test the live example:

 1. Use the "Clear all" button to remove all layers
 1. Add the "Filters" theme
 1. Open the filter tool on the right
 1. Select a layer

From there on, you can test the UI accordingly.  The only thing that currently does nothing is the "apply" button.