### PR TITLE
Filter - Activate from layer tree

### DIFF
--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -3,6 +3,7 @@ goog.provide('gmf.layertreeComponent');
 
 goog.require('ngeo.SyncArrays');
 goog.require('gmf');
+goog.require('gmf.DataSourceBeingFiltered');
 goog.require('gmf.Permalink');
 goog.require('gmf.SyncLayertreeMap');
 goog.require('gmf.TreeManager');
@@ -110,6 +111,9 @@ gmf.module.component('gmfLayertree', gmf.layertreeComponent);
  * @param {!angular.Scope} $scope Angular scope.
  * @param {!ngeo.CreatePopup} ngeoCreatePopup Popup service.
  * @param {!ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
+ * @param {gmf.DataSourceBeingFiltered} gmfDataSourceBeingFiltered The
+ *     Gmf value service that determines the data source currently being
+ *     filtered.
  * @param {!gmf.Permalink} gmfPermalink The gmf permalink service.
  * @param {!gmf.TreeManager} gmfTreeManager gmf Tree Manager service.
  * @param {!gmf.SyncLayertreeMap} gmfSyncLayertreeMap gmfSyncLayertreeMap service.
@@ -124,8 +128,8 @@ gmf.module.component('gmfLayertree', gmf.layertreeComponent);
  * @ngname gmfLayertreeController
  */
 gmf.LayertreeController = function($http, $sce, $scope, ngeoCreatePopup,
-    ngeoLayerHelper, gmfPermalink, gmfTreeManager, gmfSyncLayertreeMap,
-    ngeoSyncArrays, gmfWMSTime, gmfThemes) {
+    ngeoLayerHelper, gmfDataSourceBeingFiltered, gmfPermalink, gmfTreeManager,
+    gmfSyncLayertreeMap, ngeoSyncArrays, gmfWMSTime, gmfThemes) {
 
   /**
    * @type {?ol.Map}
@@ -162,6 +166,12 @@ gmf.LayertreeController = function($http, $sce, $scope, ngeoCreatePopup,
    * @private
    */
   this.layerHelper_ = ngeoLayerHelper;
+
+  /**
+   * @type {gmf.DataSourceBeingFiltered}
+   * @export
+   */
+  this.gmfDataSourceBeingFiltered = gmfDataSourceBeingFiltered;
 
   /**
    * @type {!gmf.Permalink}
@@ -652,6 +662,15 @@ gmf.LayertreeController.prototype.toggleNodeLegend = function(legendNodeId) {
   $(legendNodeId).toggle({
     toggle: true
   });
+};
+
+
+/**
+ * @param {gmf.DataSource} ds Data source to filter.
+ * @export
+ */
+gmf.LayertreeController.prototype.toggleFiltrableDataSource = function(ds) {
+  this.gmfDataSourceBeingFiltered.dataSource = ds;
 };
 
 

--- a/contribs/gmf/src/directives/partials/filterselector.html
+++ b/contribs/gmf/src/directives/partials/filterselector.html
@@ -5,7 +5,7 @@
   <select
       class="form-control"
       ng-switch-default
-      ng-model="fsCtrl.selectedDataSource"
+      ng-model="fsCtrl.gmfDataSourceBeingFiltered.dataSource"
       ng-options="dataSource.name | translate for dataSource in fsCtrl.filtrableDataSources">
     <option value="" translate>-- Layer to filter --</option>
   </select>

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -136,6 +136,15 @@
               {{'Show/hide legend'|translate}}
             </a>
           </li>
+          <li ng-if="layertreeCtrl.getDataSource() && layertreeCtrl.getDataSource().filtrable">
+            <i class="fa fa-filter"></i>
+            <a
+              title="{{'Filter'|translate}}"
+              ng-click="gmfLayertreeCtrl.toggleFiltrableDataSource(layertreeCtrl.getDataSource())"
+              href="">
+              {{'Filter'|translate}}
+            </a>
+          </li>
         </ul>
       </div>
     </span>

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -137,7 +137,7 @@
             </a>
           </li>
           <li ng-if="layertreeCtrl.getDataSource() && layertreeCtrl.getDataSource().filtrable">
-            <i class="fa fa-filter"></i>
+            <i class="fa fa-filter fa-fw"></i>
             <a
               title="{{'Filter'|translate}}"
               ng-click="gmfLayertreeCtrl.toggleFiltrableDataSource(layertreeCtrl.getDataSource())"

--- a/contribs/gmf/src/services/datasourcebeingfiltered.js
+++ b/contribs/gmf/src/services/datasourcebeingfiltered.js
@@ -11,11 +11,13 @@ gmf.module.value('gmfDataSourceBeingFiltered', {
 /**
  * @record
  * @struct
+ * @export
  */
 gmf.DataSourceBeingFiltered = function() {};
 
 
 /**
  * @type {?gmf.DataSource}
+ * @export
  */
 gmf.DataSourceBeingFiltered.prototype.dataSource;

--- a/contribs/gmf/src/services/datasourcebeingfiltered.js
+++ b/contribs/gmf/src/services/datasourcebeingfiltered.js
@@ -1,0 +1,21 @@
+goog.provide('gmf.DataSourceBeingFiltered');
+
+goog.require('gmf');
+
+
+gmf.module.value('gmfDataSourceBeingFiltered', {
+  dataSource: null
+});
+
+
+/**
+ * @record
+ * @struct
+ */
+gmf.DataSourceBeingFiltered = function() {};
+
+
+/**
+ * @type {?gmf.DataSource}
+ */
+gmf.DataSourceBeingFiltered.prototype.dataSource;

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -161,6 +161,13 @@ ngeox.DataSourceOptions.prototype.filterRules;
 
 
 /**
+ * Whether the data source is filtrable or not.
+ * @type {boolean|undefined}
+ */
+ngeox.DataSourceOptions.prototype.filtrable;
+
+
+/**
  * The name of the geometry attribute.
  * @type {string|undefined}
  */

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -50,6 +50,16 @@ ngeo.DataSource = class {
     this.filterRules_ = options.filterRules || null;
 
     /**
+     * Whether the data source is filtrable or not. When `null`, that means
+     * that we do not know if the data source if filtrable or not, yet. In
+     * that case, the value of the property needs to be determined from an
+     * external way.
+     * @type {?boolean}
+     * @private
+     */
+    this.filtrable_ = options.filtrable || null;
+
+    /**
      * A data source is considered 'in range' when it is synchronized to
      * a map view and the resolution of that view is within the range of
      * the `maxResolution` and `minResolution`. These 2 properties are
@@ -433,6 +443,22 @@ ngeo.DataSource = class {
    */
   get dimensions() {
     return this.dimensions_;
+  }
+
+  /**
+   * @return {?boolean} Filtrable.
+   * @export
+   */
+  get filtrable() {
+    return this.filtrable_;
+  }
+
+  /**
+   * @param {?boolean} filtrable Filtrable.
+   * @export
+   */
+  set filtrable(filtrable) {
+    this.filtrable_ = filtrable;
   }
 
   /**


### PR DESCRIPTION
This PR introduces the possibility to activate the filter tool from the layer tree, from a particular layer.

It also introduces the `filtrable` property of the `ngeo.DataSource` object, which is calculated by the `gmf.FilterSelector` directive once, then re-used "as-is" thereafter when trying to determine if a data source if filtrable or not.

That same `filtrable` property is from now on watched by the layer tree as well to add the `Filter` link in the dropdown menu.

A `gmf.DataSourceBeingFiltered` angular value service has been created to hold the data source currently being filtrered.

## Todo

 * [x] Wait for #2429 to be merged
 * [x] Fix bug in minimized version (list is no longer working)...
 * [ ] Review

## Live example

 * https://adube.github.io/ngeo/filter-from-layertree/examples/contribs/gmf/apps/desktop_alt/