### PR TITLE
Remove padding from collapsed items

### DIFF
--- a/contribs/gmf/less/desktoplayertree.less
+++ b/contribs/gmf/less/desktoplayertree.less
@@ -7,7 +7,6 @@ gmf-layertree {
   height: 100%;
   width: 100%;
   ul {
-    padding-top: @micro-app-margin;
     margin-bottom: 0;
     height: 100%;
   }
@@ -33,11 +32,11 @@ gmf-layertree {
     box-shadow: 0 0 4px 1px @input-border-focus;
 
     > ul {
-      //adding space after the last li elem of the first level nodes
-      padding-bottom: @half-app-margin;
-
       // no padding for the first list in first level nodes
       padding-left: 0;
+      > li:last-child {
+        padding-bottom: @half-app-margin;
+      }
     }
 
     &:hover {


### PR DESCRIPTION
To avoid the flickering effect when collapsing layer tree items.