### PR TITLE
Fix gmf.EditFeature#getFeaturesInExtent, use ol.uri.appendParams

### DIFF
--- a/contribs/gmf/src/services/editfeature.js
+++ b/contribs/gmf/src/services/editfeature.js
@@ -47,7 +47,12 @@ gmf.EditFeature = function($http, gmfLayersUrl) {
  * @export
  */
 gmf.EditFeature.prototype.getFeaturesInExtent = function(layerIds, extent) {
-  const url = `${this.baseUrl_}/${layerIds.join(',')}/bbox/${extent.join(',')}`;
+  const url = ol.uri.appendParams(
+    `${this.baseUrl_}/${layerIds.join(',')}`,
+    {
+      'bbox': extent.join(',')
+    }
+  );
   return this.http_.get(url).then(this.handleGetFeatures_.bind(this));
 };
 


### PR DESCRIPTION
This fixes a regression introduced in the [Don't use goog.uri anymore](https://github.com/camptocamp/ngeo/commit/f41d24686ce7ea7a6d880544ed73a994a47a6c9c#diff-884a73f388e9658f99da80f09af55ff5L51) task.  The use of parameters was replaced by `/`, but that's invalid.