### PR TITLE
Remove unneeded font-size on query window

### DIFF
--- a/contribs/gmf/less/displayquerywindow.less
+++ b/contribs/gmf/less/displayquerywindow.less
@@ -102,10 +102,6 @@
     line-height: @displayquerywindow-detailed-details-line-height;
     overflow-x: hidden;
     overflow-y: auto;
-    table {
-      font-size: @font-size-base;
-      width: 100%;
-    }
     .gmf-displayquerywindow-details-key {
       padding-right: @app-margin;
     }


### PR DESCRIPTION
it prevents the font-size to be changed with:
```css
.gmf-displayquerywindow-container {
  font-size: 12px;
}
```