### PR TITLE
Fix CreateFeature - revert to being a directive

### DIFF
--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -12,7 +12,7 @@ goog.require('ngeo.attributesComponent');
 /** @suppress {extraRequire} */
 goog.require('ngeo.btnDirective');
 /** @suppress {extraRequire} */
-goog.require('ngeo.createfeatureComponent');
+goog.require('ngeo.createfeatureDirective');
 goog.require('ngeo.DecorateInteraction');
 goog.require('ngeo.EventHelper');
 goog.require('ngeo.FeatureHelper');

--- a/contribs/gmf/src/directives/objecteditingtools.js
+++ b/contribs/gmf/src/directives/objecteditingtools.js
@@ -5,7 +5,7 @@ goog.require('gmf.objecteditinggetwmsfeatureDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.btnDirective');
 /** @suppress {extraRequire} */
-goog.require('ngeo.createfeatureComponent');
+goog.require('ngeo.createfeatureDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.createregularpolygonfromclickComponent');
 goog.require('ngeo.DecorateInteraction');

--- a/examples/createfeature.js
+++ b/examples/createfeature.js
@@ -7,7 +7,7 @@ goog.require('ngeo.btngroupDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.btnDirective');
 /** @suppress {extraRequire} */
-goog.require('ngeo.createfeatureComponent');
+goog.require('ngeo.createfeatureDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.mapDirective');
 goog.require('ol.Collection');

--- a/src/directives/createfeature.js
+++ b/src/directives/createfeature.js
@@ -1,4 +1,4 @@
-goog.provide('ngeo.createfeatureComponent');
+goog.provide('ngeo.createfeatureDirective');
 
 goog.require('ngeo');
 goog.require('ngeo.EventHelper');
@@ -15,7 +15,7 @@ goog.require('ol.style.Style');
 
 
 /**
- * A component used to draw vector features of a single geometry type using
+ * A directive used to draw vector features of a single geometry type using
  * either a 'draw' or 'measure' interaction. Once a feature is finished being
  * drawn, it is added to a collection of features.
  *
@@ -40,28 +40,32 @@ goog.require('ol.style.Style');
  *       ng-model="ctrl.createPointActive">
  *     </a>
  *
- * @htmlAttribute {boolean} ngeo-createfeature-active Whether the component is
+ * @htmlAttribute {boolean} ngeo-createfeature-active Whether the directive is
  *     active or not.
  * @htmlAttribute {ol.Collection} ngeo-createfeature-features The collection of
- *     features where to add those created by this component.
+ *     features where to add those created by this directive.
  * @htmlAttribute {string} ngeo-createfeature-geom-type Determines the type
- *     of geometry this component should draw.
+ *     of geometry this directive should draw.
  * @htmlAttribute {ol.Map} ngeo-createfeature-map The map.
  *
- * @ngdoc component
+ * @return {angular.Directive} The directive specs.
+ * @ngdoc directive
  * @ngname ngeoCreatefeature
  */
-ngeo.createfeatureComponent = {
-  controller: 'ngeoCreatefeatureController as cfCtrl',
-  bindings: {
-    'active': '=ngeoCreatefeatureActive',
-    'features': '=ngeoCreatefeatureFeatures',
-    'geomType': '=ngeoCreatefeatureGeomType',
-    'map': '=ngeoCreatefeatureMap'
-  }
+ngeo.createfeatureDirective = function() {
+  return {
+    controller: 'ngeoCreatefeatureController as cfCtrl',
+    bindToController: true,
+    scope: {
+      'active': '=ngeoCreatefeatureActive',
+      'features': '=ngeoCreatefeatureFeatures',
+      'geomType': '=ngeoCreatefeatureGeomType',
+      'map': '=ngeoCreatefeatureMap'
+    }
+  };
 };
 
-ngeo.module.component('ngeoCreatefeature', ngeo.createfeatureComponent);
+ngeo.module.directive('ngeoCreatefeature', ngeo.createfeatureDirective);
 
 
 /**
@@ -161,7 +165,7 @@ ngeo.CreatefeatureController = function(gettext, $compile, $filter, $scope,
 
 
 /**
- * Initialise the component.
+ * Initialize the directive.
  */
 ngeo.CreatefeatureController.prototype.$onInit = function() {
   this.active = this.active === true;


### PR DESCRIPTION
In the [Upgrades for Angular 1.6](784c025fe04c956c5d1df5c0571f5060013fd3bb) task, a bunch of changes were made, such as switching from directives to components.  For one of them, the `ngeo-createfeature`, the change was incompatible.  A component only support being declared as the element level, i.e. `<ngeo-createfeature>`, i.e. it doesn't support being declared using the attribute of an existing element`<div ngeo-createfeature>`.

The tool was made so that it supported being declared using attributes, making it not compatible with components.  The change that was made broke the tool.

This PR reverts that specific change for that tool only.