### PR TITLE
Support more attribute types in editing

### DIFF
--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -27,6 +27,13 @@ ngeox.AttributeBase.prototype.geomType;
 
 
 /**
+ * Set only if the attribute is a number type. Determines the type of number.
+ * @type {string|undefined}
+ */
+ngeox.AttributeBase.prototype.numType;
+
+
+/**
  * The attribute type, which determines how to render it.
  * @type {string|undefined}
  */
@@ -47,6 +54,13 @@ ngeox.Attribute = function() {};
  * @type {Array.<string>|undefined}
  */
 ngeox.Attribute.prototype.choices;
+
+
+/**
+ * Specifies the maximum number of character for the attribute value.
+ * @type {number|undefined}
+ */
+ngeox.Attribute.prototype.maxLength;
 
 
 /**

--- a/src/directives/partials/attributes.html
+++ b/src/directives/partials/attributes.html
@@ -3,8 +3,27 @@
       class="form-group"
       ng-repeat="attribute in ::attrCtrl.attributes">
     <div ng-if="attribute.type !== 'geometry'">
-      <label class="control-label">{{ ::attribute.name | translate }} <span class="text-muted">{{::attribute.required ? "*" : ""}}</span></label>
-      <div ng-switch="attribute.type">
+      <label
+          ng-if="::attribute.type !== 'boolean'"
+          class="control-label">{{ ::attribute.name | translate }} <span class="text-muted">{{::attribute.required ? "*" : ""}}</span>
+      </label>
+      <div ng-switch="::attribute.type">
+
+        <div
+            ng-switch-when="boolean"
+            class="checkbox">
+          <label>
+            <input
+                name="{{::attribute.name}}"
+                ng-required="attribute.required"
+                ng-model="attrCtrl.properties[attribute.name]"
+                ng-change="attrCtrl.handleInputChange(attribute.name);"
+                type="checkbox">
+            </input>
+            <span> {{ ::attribute.name | translate }} <span class="text-muted">{{::attribute.required ? "*" : ""}}</span></span>
+          </label>
+        </div>
+
         <select
             name="{{::attribute.name}}"
             ng-required="attribute.required"
@@ -42,12 +61,37 @@
             type="text">
         </input>
 
+        <div
+            ng-switch-when="number"
+            ng-switch="::attribute.numType">
+          <input
+              name="{{::attribute.name}}"
+              ng-required="attribute.required"
+              ng-switch-when="integer"
+              ng-model="attrCtrl.properties[attribute.name]"
+              ng-change="attrCtrl.handleInputChange(attribute.name);"
+              class="form-control"
+              step="1"
+              type="number">
+          </input>
+          <input
+              name="{{::attribute.name}}"
+              ng-required="attribute.required"
+              ng-switch-default
+              ng-model="attrCtrl.properties[attribute.name]"
+              ng-change="attrCtrl.handleInputChange(attribute.name);"
+              class="form-control"
+              type="number">
+          </input>
+        </div>
+
         <input
             name="{{::attribute.name}}"
             ng-required="attribute.required"
             ng-switch-default
             ng-model="attrCtrl.properties[attribute.name]"
             ng-change="attrCtrl.handleInputChange(attribute.name);"
+            ng-maxlength="attribute.maxLength"
             class="form-control"
             type="text">
         </input>

--- a/src/ngeo.js
+++ b/src/ngeo.js
@@ -59,6 +59,10 @@ ngeo.AttributeType = {
   /**
    * @type {string}
    */
+  BOOLEAN: 'boolean',
+  /**
+   * @type {string}
+   */
   DATE: 'date',
   /**
    * @type {string}
@@ -219,4 +223,22 @@ ngeo.GeometryType = {
    * @export
    */
   TEXT: 'Text'
+};
+
+
+/**
+ * @enum {string}
+ * @export
+ */
+ngeo.NumberType = {
+  /**
+   * @type {string}
+   * @export
+   */
+  FLOAT: 'float',
+  /**
+   * @type {string}
+   * @export
+   */
+  INTEGER: 'integer'
 };


### PR DESCRIPTION
Fixes #2527 

This PR introduces:

 * a new type of `ngeox.Attribute`: `boolean`
 * a new property for the `ngeox.Attribute`: `numType`, which distincts how to render a number attribute.  The two current values are: `integer` and `float`.
 * a new property for the `ngeox.Attribute`: `maxLength`

These changes are used in the `ngeo.Attributes` component, i.e. in the html template.  Only the text attribute support the "maxLength".  The boolean is rendered as a checkbox.  The "numType" is used to distinguish integers from floats accordingly, and are also both renderered as number input field.

**Note** This PR only changes the attributes that are used in the editing tools.  The ones used in the filter tools remain unchanged as they use WFS DescribeFeatureType requests to get the attributes.

## Todo

 * [ ] Review