### PR TITLE
Stop referencing ngeo symbols in ngeox.js

### DIFF
--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -377,8 +377,59 @@ ngeox.DataSourceOptions.prototype.wmtsUrl;
 
 /**
  * @interface
+ * @struct
  */
-ngeox.DataSource;
+ngeox.DataSource = function() {};
+
+/**
+ * @type {boolean}
+ */
+ngeox.DataSource.prototype.combinableForWMS;
+
+/**
+ * @type {boolean}
+ */
+ngeox.DataSource.prototype.combinableForWFS;
+
+/**
+ * @type {boolean}
+ */
+ngeox.DataSource.prototype.queryable;
+
+/**
+ * @type {boolean}
+ */
+ngeox.DataSource.prototype.supportsWFS;
+
+/**
+ * @type {boolean}
+ */
+ngeox.DataSource.prototype.supportsWMS;
+
+/**
+ * @type {string|undefined}
+ */
+ngeox.DataSource.prototype.wmsUrl;
+
+/**
+ * @type {string|undefined}
+ */
+ngeox.DataSource.prototype.wfsUrl;
+
+/**
+ * @param {ngeox.DataSource} dataSource Data source.
+ * @return {boolean} Whether this data source can be combined to the given
+ *     other data source to fetch features in a single WFS request.
+ */
+ngeox.DataSource.prototype.combinableWithDataSourceForWFS = function(dataSource) {}
+
+
+/**
+ * @param {ngeox.DataSource} dataSource Data source.
+ * @return {boolean} Whether this data source can be combined to the given
+ *     other data source to fetch features in a single WMS request.
+ */
+ngeox.DataSource.prototype.combinableWithDataSourceForWMS = function(dataSource) {}
 
 
 /**
@@ -1938,8 +1989,9 @@ ngeox.rule.RuleOptions.prototype.upperBoundary;
 
 /**
  * @interface
+ * @struct
  */
-ngeox.rule.Rule;
+ngeox.rule.Rule = function() {};
 
 
 /**

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -169,7 +169,7 @@ ngeox.DataSourceOptions.prototype.filterCondition;
 /**
  * A list of filter rules to apply to this data source using the filter
  * condition.
- * @type {!Array.<!ngeo.rule.Rule>|undefined}
+ * @type {!Array.<!ngeox.rule.Rule>|undefined}
  */
 ngeox.DataSourceOptions.prototype.filterRules;
 
@@ -376,11 +376,17 @@ ngeox.DataSourceOptions.prototype.wmtsUrl;
 
 
 /**
+ * @interface
+ */
+ngeox.DataSource;
+
+
+/**
  * The options to use when sending GetFeature/GetFeatureInfo requests using
  * the querent or map query service.
  * @typedef {{
  *     coordinate: (ol.Coordinate|undefined),
- *     dataSources: (Array.<ngeo.DataSource>|undefined),
+ *     dataSources: (Array.<ngeox.DataSource>|undefined),
  *     extent: (ol.Extent|undefined),
  *     filter: (ol.format.filter.Filter|undefined),
  *     limit: (number|undefined),
@@ -405,7 +411,7 @@ ngeox.IssueGetFeaturesOptions.prototype.coordinate;
  * List of data sources to query. Only those that meet the requirements will
  * actually be queried. The querent service requires either the `dataSources`
  * or `queryableDataSources` property to be set.
- * @type {Array.<ngeo.DataSource>|undefined}
+ * @type {Array.<ngeox.DataSource>|undefined}
  */
 ngeox.IssueGetFeaturesOptions.prototype.dataSources;
 
@@ -476,8 +482,8 @@ ngeox.IssueGetFeaturesOptions.prototype.wfsCount;
  * `wfs` list.
  *
  * @typedef {{
- *     wfs: (!Array.<!ngeo.DataSource>),
- *     wms: (!Array.<!ngeo.DataSource>)
+ *     wfs: (!Array.<!ngeox.DataSource>),
+ *     wms: (!Array.<!ngeox.DataSource>)
  * }}
  */
 ngeox.QueryableDataSources;
@@ -485,14 +491,14 @@ ngeox.QueryableDataSources;
 
 /**
  * List of queryable data sources that support WFS.
- * @type {Array.<ngeo.DataSource>}
+ * @type {Array.<ngeox.DataSource>}
  */
 ngeox.QueryableDataSources.prototype.wfs;
 
 
 /**
  * List of queryable data sources that support WMS.
- * @type {Array.<ngeo.DataSource>}
+ * @type {Array.<ngeox.DataSource>}
  */
 ngeox.QueryableDataSources.prototype.wms;
 
@@ -1928,6 +1934,12 @@ ngeox.rule.RuleOptions.prototype.type;
  * @type {number|undefined}
  */
 ngeox.rule.RuleOptions.prototype.upperBoundary;
+
+
+/**
+ * @interface
+ */
+ngeox.rule.Rule;
 
 
 /**

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -628,6 +628,7 @@ ngeo.DataSource = class {
   /**
    * @return {string|undefined} WMS url
    * @export
+   * @override
    */
   get wmsUrl() {
     return this.wmsUrl_;
@@ -644,6 +645,7 @@ ngeo.DataSource = class {
   /**
    * @return {string|undefined} WMTS url
    * @export
+   * @override
    */
   get wmtsUrl() {
     return this.wmtsUrl_;
@@ -660,6 +662,7 @@ ngeo.DataSource = class {
    * @return {boolean} Whether the data source can be combined to an other
    *     data source to fetch features in a single WFS request.
    * @export
+   * @override
    */
   get combinableForWFS() {
     return this.filterRules_ === null;
@@ -674,6 +677,7 @@ ngeo.DataSource = class {
    * @return {boolean} Whether the data source can be combined to an other
    *     data source to fetch features in a single WMS request.
    * @export
+   * @override
    */
   get combinableForWMS() {
     return this.filterRules_ === null;
@@ -712,6 +716,7 @@ ngeo.DataSource = class {
    * @return {boolean} Whether the data source supports making WFS requests
    *     or not.
    * @export
+   * @override
    */
   get supportsWFS() {
     return this.wfsUrl !== undefined;
@@ -742,6 +747,7 @@ ngeo.DataSource = class {
    * @return {boolean} Whether the data source supports making WMS requests
    *     or not.
    * @export
+   * @override
    */
   get supportsWMS() {
     return this.wmsUrl !== undefined;
@@ -775,10 +781,11 @@ ngeo.DataSource = class {
   // === Other public methods ===
 
   /**
-   * @param {ngeo.DataSource} dataSource Data source.
+   * @param {ngeox.DataSource} dataSource Data source.
    * @return {boolean} Whether this data source can be combined to the given
    *     other data source to fetch features in a single WFS request.
    * @export
+   * @override
    */
   combinableWithDataSourceForWFS(dataSource) {
     return this.combinableForWFS && dataSource.combinableForWFS &&
@@ -788,10 +795,11 @@ ngeo.DataSource = class {
   }
 
   /**
-   * @param {ngeo.DataSource} dataSource Data source.
+   * @param {ngeox.DataSource} dataSource Data source.
    * @return {boolean} Whether this data source can be combined to the given
    *     other data source to fetch features in a single WMS request.
    * @export
+   * @override
    */
   combinableWithDataSourceForWMS(dataSource) {
     return this.combinableForWMS && dataSource.combinableForWMS &&

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -6,6 +6,9 @@ goog.require('ol.format.WFS');
 goog.require('ol.format.WMSGetFeatureInfo');
 
 
+/**
+ * @implements {ngeox.DataSource}
+ */
 ngeo.DataSource = class {
 
   /**

--- a/src/rule/rule.js
+++ b/src/rule/rule.js
@@ -3,6 +3,9 @@ goog.provide('ngeo.rule.Rule');
 goog.require('ngeo');
 
 
+/**
+ * @implements {ngeox.rule.Rule}
+ */
 ngeo.rule.Rule = class {
 
   /**

--- a/src/services/querent.js
+++ b/src/services/querent.js
@@ -572,7 +572,7 @@ ngeo.Querent = class {
   }
 
   /**
-   * @param {!Array.<ngeo.DataSource>} dataSources List of queryable data
+   * @param {!Array.<ngeox.DataSource>} dataSources List of queryable data
    *     sources that supports WFS.
    * @return {ngeo.Querent.CombinedDataSources} Combined lists of data sources.
    * @private
@@ -602,7 +602,7 @@ ngeo.Querent = class {
   }
 
   /**
-   * @param {!Array.<ngeo.DataSource>} dataSources List of queryable data
+   * @param {!Array.<ngeox.DataSource>} dataSources List of queryable data
    *     sources that supports WMS.
    * @return {ngeo.Querent.CombinedDataSources} Combined lists of data sources.
    * @private


### PR DESCRIPTION
Referencing ngeo symbols adds a hard dependency on the referenced symbol, forcing applications using the library to pass extra js code to their invocation of the closure compiler.