### PR TITLE
Can use desktop displayQueryWindow

### DIFF
--- a/contribs/gmf/src/directives/displayquerywindow.js
+++ b/contribs/gmf/src/directives/displayquerywindow.js
@@ -74,8 +74,8 @@ gmf.displayquerywindowComponent = {
     'featuresStyleFn': '&gmfDisplayquerywindowFeaturesstyle',
     'selectedFeatureStyleFn': '&gmfDisplayquerywindowSelectedfeaturestyle',
     'defaultCollapsedFn': '&?gmfDisplayquerywindowDefaultcollapsed',
-    'desktopIn': '=gmfDisplayquerywindowDesktop',
-    'showUnqueriedLayersIn': '=gmfDisplayquerywindowShowunqueriedlayers'
+    'desktop': '=gmfDisplayquerywindowDesktop',
+    'showUnqueriedLayers': '=gmfDisplayquerywindowShowunqueriedlayers'
   },
   templateUrl: gmfDisplayquerywindowTemplateUrl
 };
@@ -103,7 +103,7 @@ gmf.DisplayquerywindowController = function($scope, ngeoQueryResult,
    * @type {boolean}
    * @export
    */
-  this.desktopIn = false;
+  this.desktop = false;
 
   /**
    * Is the window currently collapsed?
@@ -111,7 +111,7 @@ gmf.DisplayquerywindowController = function($scope, ngeoQueryResult,
    * @type {boolean}
    * @export
    */
-  this.collapsed = !this.desktopIn;
+  this.collapsed = !this.desktop;
 
   /**
    * @type {boolean}
@@ -225,11 +225,12 @@ gmf.DisplayquerywindowController = function($scope, ngeoQueryResult,
  * Initialise the controller.
  */
 gmf.DisplayquerywindowController.prototype.$onInit = function() {
+  this.desktop = this.desktop;
   this.collapsed = this['defaultCollapsedFn'] ?
-    this['defaultCollapsedFn']() === true : !this.desktopIn;
+    this['defaultCollapsedFn']() === true : !this.desktop;
 
-  this.showUnqueriedLayers_ = this['showUnqueriedLayersIn'] ?
-    this['showUnqueriedLayersIn'] === true : false;
+  this.showUnqueriedLayers_ = this['showUnqueriedLayers'] ?
+    this['showUnqueriedLayers'] === true : false;
 
   this.sourcesFilter = this.showUnqueriedLayers_ ? {} : {'queried': true};
 


### PR DESCRIPTION
And remove annoying acronym.

FIX #2567

We use `desktopIn` in js and `desktop` in partial => bug

I've remove the "In". (And what does it means ?  Integration ? Input ? Integer ? We have a compilation system to reduce our code, why using acronym ?)