### PR TITLE
FeatureHash - Use same accuracy as in cgxp

### DIFF
--- a/src/ol-ext/format/featurehash.js
+++ b/src/ol-ext/format/featurehash.js
@@ -194,7 +194,7 @@ ngeo.format.FeatureHash.CHAR64_ =
  * @const
  * @private
  */
-ngeo.format.FeatureHash.ACCURACY_ = 1;
+ngeo.format.FeatureHash.ACCURACY_ = 0.1;
 
 
 /**

--- a/test/spec/ol-ext/format/featurehash.spec.js
+++ b/test/spec/ol-ext/format/featurehash.spec.js
@@ -18,6 +18,7 @@ describe('ngeo.format.FeatureHash', function() {
   var fhFormat;
 
   beforeEach(function() {
+    ngeo.format.FeatureHash.ACCURACY_ = 1; // Easier to test
     fhFormat = new ngeo.format.FeatureHash();
   });
 


### PR DESCRIPTION
FIX #2573 

Use accuracy of 0.1m instead of 1m. Like in cgxp: https://github.com/camptocamp/cgxp/blob/95ee7b5dbe9a49119d141e302047850787e623ae/core/src/script/CGXP/widgets/RedLiningPanel.js#L75