### PR TITLE
ObjectEditing - Geometry changes can contain null values

### DIFF
--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -288,7 +288,7 @@ gmf.ObjecteditingController = function($scope, $timeout, gettextCatalog,
   this.state_;
 
   /**
-   * @type {!Array.<!ol.geom.Geometry>}
+   * @type {!Array.<?ol.geom.Geometry>}
    * @private
    */
   this.geometryChanges_ = [];
@@ -714,7 +714,6 @@ gmf.ObjecteditingController.prototype.resetGeometryChanges_ = function() {
   if (this.geometryChanges_.length === 0) {
     const geometry = this.feature.getGeometry();
     const clone = gmf.ObjecteditingController.cloneGeometry_(geometry);
-    goog.asserts.assert(clone);
     this.geometryChanges_.push(clone);
   }
 };


### PR DESCRIPTION
This patch fixes the regression introduced in https://github.com/camptocamp/ngeo/pull/2387/commits/114e05d2dba44bbfe8d7c957085f76cdf0cac1a9

The array `this.geometryChanges_` can have null values.  A null value occurs when the feature has no geometry, i.e. when a feature has no geometry yet in the ObjectEditing project.