### PR TITLE
StreetView - make 100% height in gmf desktop apps

### DIFF
--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -264,6 +264,13 @@ gmf-backgroundlayerselector {
     height: 100%;
     overflow: auto;
 
+    & > div {
+      height: 100%;
+      & > div {
+        height: 100%;
+      }
+    }
+
     &.gmf-app-active {
       margin-right: 0;
     }
@@ -741,6 +748,6 @@ ngeo-rule {
  */
 ngeo-googlestreetview {
   display: block;
-  height: 80rem;
+  height: ~"calc(100% - 6rem)";
   width: 40rem;
 }


### PR DESCRIPTION
Fixes #2570.

Variable height for StreetView in desktop and desktop_alt applications.