### PR TITLE
Remove unused editableIds property

### DIFF
--- a/contribs/gmf/src/services/syncLayertreeMap.js
+++ b/contribs/gmf/src/services/syncLayertreeMap.js
@@ -316,12 +316,6 @@ gmf.SyncLayertreeMap.prototype.updateLayerReferences_ = function(leafNode, layer
   querySourceIds.push(id);
   layer.set('querySourceIds', querySourceIds);
 
-  if (leafNode.editable) {
-    const editableIds = layer.get('editableIds') || [];
-    editableIds.push(id);
-    layer.set('editableIds', editableIds);
-  }
-
   const disclaimer = leafNode.metadata.disclaimer;
   if (disclaimer) {
     const disclaimers = layer.get('disclaimers') || [];

--- a/contribs/gmf/src/services/themesservice.js
+++ b/contribs/gmf/src/services/themesservice.js
@@ -249,7 +249,6 @@ gmf.Themes.prototype.getBgLayers = function(appDimensions) {
     const ids = [];
     getIds(item, ids);
     layer.set('querySourceIds', ids);
-    layer.set('editableIds', []);
     return layer;
   };
 


### PR DESCRIPTION
The value is set but never read.

The editable nodes are now collected here:
https://github.com/camptocamp/ngeo/blob/master/contribs/gmf/src/directives/editfeatureselector.js#L138-L141