### PR TITLE
Correct return type of some get template URL functions

### DIFF
--- a/contribs/gmf/src/directives/authenticationdirective.js
+++ b/contribs/gmf/src/directives/authenticationdirective.js
@@ -11,7 +11,7 @@ gmf.module.value('gmfAuthenticationTemplateUrl',
     /**
      * @param {angular.JQLite} element Element.
      * @param {angular.Attributes} attrs Attributes.
-     * @return {boolean} Template URL.
+     * @return {string} Template URL.
      */
     (element, attrs) => {
       const templateUrl = attrs['gmfAuthenticationTemplateurl'];

--- a/src/directives/grid.js
+++ b/src/directives/grid.js
@@ -11,7 +11,7 @@ ngeo.module.value('ngeoGridTemplateUrl',
     /**
      * @param {!angular.JQLite} $element Element.
      * @param {!angular.Attributes} $attrs Attributes.
-     * @return {boolean} Template URL.
+     * @return {string} Template URL.
      */
     ($element, $attrs) => {
       const templateUrl = $attrs['ngeoGridTemplateurl'];

--- a/src/directives/layertree.js
+++ b/src/directives/layertree.js
@@ -9,7 +9,7 @@ ngeo.module.value('ngeoLayertreeTemplateUrl',
     /**
      * @param {angular.JQLite} element Element.
      * @param {angular.Attributes} attrs Attributes.
-     * @return {boolean} Template URL.
+     * @return {string} Template URL.
      */
     (element, attrs) => {
       const templateUrl = attrs['ngeoLayertreeTemplateurl'];

--- a/src/modules/import/importdnd.js
+++ b/src/modules/import/importdnd.js
@@ -114,7 +114,7 @@ exports.module.value('ngeoImportDndTemplateUrl',
     /**
      * @param {angular.JQLite} element Element.
      * @param {angular.Attributes} attrs Attributes.
-     * @return {boolean} Template URL.
+     * @return {string} Template URL.
      */
     (element, attrs) => {
       const templateUrl = attrs['ngeoImportDndTemplateUrl'];

--- a/src/modules/import/importlocal.js
+++ b/src/modules/import/importlocal.js
@@ -137,7 +137,7 @@ exports.module.value('ngeoImportLocalTemplateUrl',
     /**
      * @param {angular.JQLite} element Element.
      * @param {angular.Attributes} attrs Attributes.
-     * @return {boolean} Template URL.
+     * @return {string} Template URL.
      */
     (element, attrs) => {
       const templateUrl = attrs['ngeoImportLocalTemplateUrl'];

--- a/src/modules/import/importonline.js
+++ b/src/modules/import/importonline.js
@@ -170,7 +170,7 @@ exports.module.value('ngeoImportOnlineTemplateUrl',
     /**
      * @param {angular.JQLite} element Element.
      * @param {angular.Attributes} attrs Attributes.
-     * @return {boolean} Template URL.
+     * @return {string} Template URL.
      */
     (element, attrs) => {
       const templateUrl = attrs['ngeoImportOnlineTemplateUrl'];

--- a/src/modules/import/wmsgetcap.js
+++ b/src/modules/import/wmsgetcap.js
@@ -198,7 +198,7 @@ exports.module.value('ngeoWmsGetCapTemplateUrl',
     /**
      * @param {angular.JQLite} element Element.
      * @param {angular.Attributes} attrs Attributes.
-     * @return {boolean} Template URL.
+     * @return {string} Template URL.
      */
     (element, attrs) => {
       const templateUrl = attrs['ngeoWmsGetCapTemplateUrl'];

--- a/src/modules/import/wmsgetcapitem.js
+++ b/src/modules/import/wmsgetcapitem.js
@@ -154,7 +154,7 @@ exports.module.value('ngeoWmsGetCapItemTemplateUrl',
     /**
      * @param {angular.JQLite} element Element.
      * @param {angular.Attributes} attrs Attributes.
-     * @return {boolean} Template URL.
+     * @return {string} Template URL.
      */
     (element, attrs) => {
       const templateUrl = attrs['ngeoWmsGetCapItemTemplateUrl'];


### PR DESCRIPTION
They used boolean instead of string.

See [this comment](https://github.com/camptocamp/ngeo/pull/2543#discussion_r114507611) in #2543 for the original report.