### PR TITLE
ObjectEditing - Ensure 2D geometry

### DIFF
--- a/src/coordinate.js
+++ b/src/coordinate.js
@@ -1,0 +1,15 @@
+goog.provide('ngeo.coordinate');
+
+
+ngeo.coordinate.toXY = function(coordinates, nesting) {
+  if (nesting === 0) {
+    if (coordinates.length > 2) {
+      coordinates = [coordinates[0], coordinates[1]];
+    }
+  } else {
+    for (let i = 0, ii = coordinates.length; i < ii; i++) {
+      coordinates[i] = ngeo.coordinate.toXY(coordinates[i], nesting - 1);
+    }
+  }
+  return coordinates;
+};

--- a/src/coordinate.js
+++ b/src/coordinate.js
@@ -1,6 +1,14 @@
 goog.provide('ngeo.coordinate');
 
 
+/**
+ * Convert a given coordinate or list of coordinates of any 'nesting' level
+ * to XY, i.e. remove any extra dimensions to the coordinates and keep only 2.
+ *
+ * @param {Array.<ol.Coordinate>|ol.Coordinate} coordinates Coordinates
+ * @param {number} nesting Nesting level.
+ * @return {Array.<ol.Coordinate>|ol.Coordinate} Converted coordinates.
+ */
 ngeo.coordinate.toXY = function(coordinates, nesting) {
   if (nesting === 0) {
     if (coordinates.length > 2) {

--- a/src/geom.js
+++ b/src/geom.js
@@ -8,7 +8,6 @@ goog.require('ngeo.coordinate');
  * extra dimension other than X and Y to the coordinates of a geometry.
  *
  * @param {ol.geom.Geometry} geom Geometry
- * @param {number} nesting Nesting level.
  */
 ngeo.geom.toXY = function(geom) {
   if (geom instanceof ol.geom.Point) {

--- a/src/geom.js
+++ b/src/geom.js
@@ -3,6 +3,13 @@ goog.provide('ngeo.geom');
 goog.require('ngeo.coordinate');
 
 
+/**
+ * Convert all coordinates within a geometry object to XY, i.e. remove any
+ * extra dimension other than X and Y to the coordinates of a geometry.
+ *
+ * @param {ol.geom.Geometry} geom Geometry
+ * @param {number} nesting Nesting level.
+ */
 ngeo.geom.toXY = function(geom) {
   if (geom instanceof ol.geom.Point) {
     geom.setCoordinates(

--- a/src/geom.js
+++ b/src/geom.js
@@ -1,0 +1,30 @@
+goog.provide('ngeo.geom');
+
+goog.require('ngeo.coordinate');
+
+
+ngeo.geom.toXY = function(geom) {
+  if (geom instanceof ol.geom.Point) {
+    geom.setCoordinates(
+      ngeo.coordinate.toXY(geom.getCoordinates(), 0)
+    );
+  } else if (geom instanceof ol.geom.MultiPoint ||
+             geom instanceof ol.geom.LineString
+  ) {
+    geom.setCoordinates(
+      ngeo.coordinate.toXY(geom.getCoordinates(), 1)
+    );
+  } else if (geom instanceof ol.geom.MultiLineString ||
+             geom instanceof ol.geom.Polygon
+  ) {
+    geom.setCoordinates(
+      ngeo.coordinate.toXY(geom.getCoordinates(), 2)
+    );
+  } else if (geom instanceof ol.geom.MultiPolygon) {
+    geom.setCoordinates(
+      ngeo.coordinate.toXY(geom.getCoordinates(), 3)
+    );
+  } else {
+    throw 'ngeo.geom.toXY - unsupported geometry type';
+  }
+};


### PR DESCRIPTION
In the ObjectEditing tool, when using the 'copy' tool, WMS GetFeatureInfo requests are made to fetch the geometry of the features to copy.  The geometry read may contains "XYZ" coordinates.  When those are used to INSERT features using GMF, it fails.  GMF doesn't seem to like having "XYZ" coordinates.

This only occurs on INSERT for features that are copied, because otherwise there would only be "XY" coordinates.

This patch makes sure to convert any "XYZ" coordinates to "XY" just before we save.