### PR TITLE
UI adjustments to gmf oeedit app based on user feedback

### DIFF
--- a/contribs/gmf/apps/oeedit/index.html
+++ b/contribs/gmf/apps/oeedit/index.html
@@ -67,7 +67,7 @@
             <div class="col-sm-12">
               <div class="gmf-app-tools-content-heading">
                 {{'Object Editing' | translate}}
-                <a class="btn close" ng-click="mainCtrl.oeEditActive = false">&times;</a>
+                <a class="btn close" ng-click="mainCtrl.oeEditActive = false; mainCtrl.queryActive = true">&times;</a>
               </div>
               <gmf-objectediting
                 ng-if="mainCtrl.oeFeature && mainCtrl.oeLayerNodeId"

--- a/contribs/gmf/apps/oeedit/index.html
+++ b/contribs/gmf/apps/oeedit/index.html
@@ -53,7 +53,7 @@
             </button>
           </div>
         </div>
-        <div class="gmf-app-tools-content container-fluid gmf-app-active">
+        <div class="gmf-app-tools-content container-fluid" ng-class="{'gmf-app-active': mainCtrl.oeEditActive }">
           <div ng-show="mainCtrl.queryActive" class="row">
             <div class="col-sm-12">
               <div class="gmf-app-tools-content-heading">

--- a/contribs/gmf/apps/oeedit/less/main.less
+++ b/contribs/gmf/apps/oeedit/less/main.less
@@ -4,3 +4,11 @@
   width: 36rem;
   max-width: 36rem;
 }
+
+.gmf-displayquerywindow .gmf-displayquerywindow-details {
+  overflow-x: auto;
+}
+
+::-webkit-scrollbar {
+  height: @half-app-margin;
+}

--- a/contribs/gmf/apps/oeedit/less/main.less
+++ b/contribs/gmf/apps/oeedit/less/main.less
@@ -1,1 +1,6 @@
 @import '../../../less/desktop.less';
+
+.gmf-displayquerywindow {
+  width: 36rem;
+  max-width: 36rem;
+}


### PR DESCRIPTION
- Removed panel when in query mode, because there is no content to display in there and it uses up valuable space.
- Closing edit mode panel switches state to the only other option, query mode.
- Query details window didn't handle long content well. Now it allows horizontal scrolling and is 50% wider, since there is more space available because the query mode doesn't have a panel any more.