### PR TITLE
Mobile border-radius fix (add it to all buttons uniformally)

### DIFF
--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -24,6 +24,7 @@ main button {
   height: @map-tools-size;
   width: @map-tools-size;
   padding: 0;
+  border-radius: @border-radius-base;
 }
 
 gmf-map {


### PR DESCRIPTION
Initially firefox mobile is using default border-radius for button when no value is provided.
This add a border-radius: 0 to all button uniformally to display the same result on all mobile browsers in the mobile homepage.