### PR TITLE
Use magick convert if in Windows or Cygwin

### DIFF
--- a/npm.mk
+++ b/npm.mk
@@ -1,3 +1,11 @@
+OS := $(shell uname)
+ifneq (, $(findstring CYGWIN_NT, $(OS)))
+	CONVERT_CMD := magick convert
+else ifeq ($(OS),Windows_NT)
+	CONVERT_CMD := magick convert
+else
+	CONVERT_CMD := convert
+endif
 
 .PHONY: install
 install: $(addprefix contribs/gmf/fonts/gmf-icons.,ttf eot woff) \
@@ -13,4 +21,4 @@ contribs/gmf/fonts/gmf-icons.woff: contribs/gmf/fonts/gmf-icons.ttf
 	ttf2woff $< $@
 
 contribs/gmf/cursors/%.cur: contribs/gmf/cursors/%.png
-	convert $< $@
+	$(CONVERT_CMD) $< $@


### PR DESCRIPTION
In Windows, `convert` is a system command. Moreover, in Windows, all ImageMagick commands are prefixed by `magick` in order not to be interpreted as a system command.

The current PR relies on a suggestion made by @sbrunner.

Please merge (if I manage to make Travis happy for once...)