### PR TITLE
FIX: Don't overwrite gmf-search-maxzoom if set

### DIFF
--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -280,7 +280,7 @@ gmf.SearchController = function($scope, $compile, $timeout, gettextCatalog,
    * @type {number}
    * @export
    */
-  this.maxZoom = parseInt(this.scope_['maxZoom']) || 16;
+  this.maxZoom = parseInt(this.scope_['maxZoom'], 10) || 16;
 
   let coordProj = this.scope_['coordinatesProjections'];
   if (coordProj === undefined) {

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -280,7 +280,7 @@ gmf.SearchController = function($scope, $compile, $timeout, gettextCatalog,
    * @type {number}
    * @export
    */
-  this.maxZoom = 16;
+  this.maxZoom = parseInt(this.scope_['maxZoom']) || 16;
 
   let coordProj = this.scope_['coordinatesProjections'];
   if (coordProj === undefined) {


### PR DESCRIPTION
Was using the gmf-search-maxzoom config and noticed that the value still always is 16.