### PR TITLE
Make translation targets configurable

### DIFF
--- a/.tx/config.mako
+++ b/.tx/config.mako
@@ -5,12 +5,14 @@ host = https://www.transifex.com
 source_file = .build/locale/ngeo.pot
 source_lang = en
 type = PO
-trans.de = .build/locale/de/LC_MESSAGES/ngeo.po
-trans.fr = .build/locale/fr/LC_MESSAGES/ngeo.po
+% for lang in languages.split():
+trans.${lang} = .build/locale/${lang}/LC_MESSAGES/ngeo.po
+% endfor
 
 [ngeo.gmf-${tx_version.strip()}]
 source_file = .build/locale/gmf.pot
 source_lang = en
 type = PO
-trans.de = .build/locale/de/LC_MESSAGES/gmf.po
-trans.fr = .build/locale/fr/LC_MESSAGES/gmf.po
+% for lang in languages.split():
+trans.${lang} = .build/locale/${lang}/LC_MESSAGES/gmf.po
+% endfor

--- a/Makefile
+++ b/Makefile
@@ -927,7 +927,7 @@ $(HOME)/.transifexrc:
 
 .tx/config: .tx/config.mako .build/python-venv/bin/mako-render
 	PYTHONIOENCODING=UTF-8 .build/python-venv/bin/mako-render \
-		--var "tx_version=$(TX_VERSION)" $< > $@
+		--var "tx_version=$(TX_VERSION)" --var "languages=$(L10N_LANGUAGES)" $< > $@
 
 .build/locale/ngeo.pot: lingua.cfg .build/node_modules.timestamp \
 		$(NGEO_DIRECTIVES_PARTIALS_FILES) $(NGEO_MODULES_PARTIALS_FILES) $(NGEO_JS_FILES)


### PR DESCRIPTION
GeoMapfish uses .tx/config.mako as is for the project it generates and those
projects must support more than de and fr.
Now, the languages are passed as a variable to the MAKO file.