### PR TITLE
ObjectEditing - Disable save button when feature has no geom

### DIFF
--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -224,6 +224,12 @@ gmf.ObjecteditingController = function($scope, $timeout, gettextCatalog,
   this.deleteFromActive = false;
 
   /**
+   * @type {boolean}
+   * @export
+   */
+  this.featureHasGeom;
+
+  /**
    * @type {!ngeo.LayerHelper}
    * @private
    */
@@ -436,6 +442,8 @@ gmf.ObjecteditingController.prototype.$onInit = function() {
   );
 
   this.features_.push(this.feature);
+
+  this.featureHasGeom = !ngeo.geom.isEmpty(geometry);
 
   // Toggle on
   this.initializeInteractions_();
@@ -1014,11 +1022,15 @@ gmf.ObjecteditingController.prototype.handleSketchFeaturesAdd_ = function(evt) {
  */
 gmf.ObjecteditingController.prototype.handleFeatureGeometryChange_ = function() {
 
+  const geom = this.feature.getGeometry();
+  this.timeout_(() => {
+    this.featureHasGeom = !ngeo.geom.isEmpty(geom);
+  });
+
   if (this.skipGeometryChange_) {
     return;
   }
 
-  const geom = this.feature.getGeometry();
   if (geom) {
     // Use a timeout here, because there can be a scope digest already in
     // progress. For example, with tools that requires the user to draw

--- a/contribs/gmf/src/directives/partials/objectediting.html
+++ b/contribs/gmf/src/directives/partials/objectediting.html
@@ -36,7 +36,7 @@
     value="{{'Save' | translate}}"
     class="btn btn-sm btn-default gmf-objectediting-btn-save"
     ng-click="form.$valid && oeCtrl.save()"
-    ng-disabled="!oeCtrl.dirty || oeCtrl.pending"
+    ng-disabled="!oeCtrl.dirty || oeCtrl.pending || !oeCtrl.featureHasGeom"
     title="{{'Save modifications | translate'}}"></input>
   <a
     class="btn btn-sm btn-link gmf-objectediting-btn-undo"

--- a/src/geom.js
+++ b/src/geom.js
@@ -1,6 +1,32 @@
 goog.provide('ngeo.geom');
 
 goog.require('ngeo.coordinate');
+goog.require('ol.geom.LineString');
+goog.require('ol.geom.MultiLineString');
+goog.require('ol.geom.MultiPoint');
+goog.require('ol.geom.MultiPolygon');
+goog.require('ol.geom.Point');
+goog.require('ol.geom.Polygon');
+goog.require('ol.geom.SimpleGeometry');
+
+
+/**
+ * Determines whether a given geometry is empty or not. A null or undefined
+ * value can be given for convenience, i.e. when using methods than can
+ * return a geometry or not, for example:
+ * `ngeo.geom.isEmpty(feature.getGeometry())`.
+ *
+ * @param {?ol.geom.Geometry|undefined} geom Geometry.
+ * @return {boolean} Whether the given geometry is empty or not. A null or
+ *     undefined geometry is considered empty.
+ */
+ngeo.geom.isEmpty = function(geom) {
+  let isEmpty = true;
+  if (geom && geom instanceof ol.geom.SimpleGeometry) {
+    isEmpty = geom.getFlatCoordinates().length === 0;
+  }
+  return isEmpty;
+};
 
 
 /**


### PR DESCRIPTION
This PR fixes an issue that occured in the ObjectEditing tools.  When a user manually deletes the geometry of an existing feature, whether by using the "minus" or "scisors" buttons, clicking on "save" caused the server to fail because it was attempting to save with an empty geometry.

To prevent this, we add an additionnal condition to the save button.  It gets disabled automatically if the feature has no geometry at any point.  The user can still use the delete button to remove the feature, which doesn't use the empty geometry if the user had deleted it manually, and the request to delete it works.

## Todo

 * [x] Review