### PR TITLE
ServiceProvider is optional in WMTS GetCapabilities

### DIFF
--- a/src/modules/import/wmtsgetcap.js
+++ b/src/modules/import/wmtsgetcap.js
@@ -35,8 +35,10 @@ exports = function(gettext, gettextCatalog, ngeoWmtsGetCapTemplateUrl) {
           'requestEnconding': requestEncoding
         };
         layer['sourceConfig'] = ol.source.WMTS.optionsFromCapabilities(getCap, layerOptions);
-        layer['attribution'] = getCap['ServiceProvider']['ProviderName'];
-        layer['attributionUrl'] = getCap['ServiceProvider']['ProviderSite'];
+        if ('ServiceProvider' in getCap) {
+          layer['attribution'] =  getCap['ServiceProvider']['ProviderName'];
+          layer['attributionUrl'] = getCap['ServiceProvider']['ProviderSite'];
+        }
         layer['capabilitiesUrl'] = getCapUrl;
       }
 


### PR DESCRIPTION

See https://github.com/camptocamp/ngeo/issues/2673

