### PR TITLE
#2679 - Fix date filters

### DIFF
--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -2120,6 +2120,14 @@ ngeox.rule.Rule = function() {};
  * @struct
  * @extends ngeox.rule.RuleOptions
  */
+ngeox.rule.DateOptions = function() {};
+
+
+/**
+ * @record
+ * @struct
+ * @extends ngeox.rule.RuleOptions
+ */
 ngeox.rule.GeometryOptions = function() {};
 
 

--- a/src/directives/rule.js
+++ b/src/directives/rule.js
@@ -129,6 +129,7 @@ ngeo.RuleController = class {
 
     const ot = ngeo.rule.Rule.OperatorType;
     const sot = ngeo.rule.Rule.SpatialOperatorType;
+    const tot = ngeo.rule.Rule.TemporalOperatorType;
 
     /**
      * @type {Object.<string, string>}
@@ -146,7 +147,11 @@ ngeo.RuleController = class {
       [ot.LIKE]: gettextCatalog.getString('Contains'),
       [sot.CONTAINS]: gettextCatalog.getString('Contains'),
       [sot.INTERSECTS]: gettextCatalog.getString('Intersects'),
-      [sot.WITHIN]: gettextCatalog.getString('Is inside of')
+      [sot.WITHIN]: gettextCatalog.getString('Is inside of'),
+      [tot.BEGINS]: gettextCatalog.getString('Begins at'),
+      [tot.DURING]: gettextCatalog.getString('During'),
+      [tot.ENDS]: gettextCatalog.getString('Ends at'),
+      [tot.EQUALS]: gettextCatalog.getString('Is equal to')
     };
 
     /**

--- a/src/rule/date.js
+++ b/src/rule/date.js
@@ -1,0 +1,20 @@
+goog.provide('ngeo.rule.Date');
+
+goog.require('ngeo.rule.Rule');
+
+
+ngeo.rule.Date = class extends ngeo.rule.Rule {
+
+  /**
+   * A date rule.
+   *
+   * @struct
+   * @param {!ngeox.rule.DateOptions} options Options.
+   */
+  constructor(options) {
+
+    options.type = options.type || ngeo.AttributeType.DATE;
+
+    super(options);
+  }
+};

--- a/src/rule/rule.js
+++ b/src/rule/rule.js
@@ -279,7 +279,8 @@ ngeo.rule.Rule = class {
     const upperBoundary = this.upperBoundary;
 
     if (operator) {
-      if (operator === ngeo.rule.Rule.OperatorType.BETWEEN) {
+      if (operator === ngeo.rule.Rule.OperatorType.BETWEEN ||
+          operator === ngeo.rule.Rule.TemporalOperatorType.DURING) {
         if (lowerBoundary !== null && upperBoundary !== null) {
           value = {
             operator,
@@ -354,4 +355,15 @@ ngeo.rule.Rule.SpatialOperatorType = {
   CONTAINS: 'contains',
   INTERSECTS: 'intersects',
   WITHIN: 'within'
+};
+
+
+/**
+ * @enum {string}
+ */
+ngeo.rule.Rule.TemporalOperatorType = {
+  BEGINS: '>=',
+  DURING: '..',
+  ENDS: '<=',
+  EQUALS: '='
 };


### PR DESCRIPTION
Fixes #2679 

When using WFS, date filters need to use the proper type of operator.  The standard ones wont work, i.e. those with `property equals to`, `between`, etc. do not work.  We need to use temporal ones instead.

MapServer currently supports `During` only, so that's the one we'll use.

The fix is applied to the filter tool, when we're dealing with a date attribute.  We removed the `>`, `<` and `not` operators as they are not required / make less sense than just using `=`, `>=`, `<=`.

Since During always have a beginning and an end, we need to calculate their value when dealing with an operator other than "between".  For min value, we use `1970-01-01`.  For the max value, we add **30 years**.

## Todo

 * [x] Fix issues reported by Travis
 * [x] Show a live demo
 * [ ] Review

## Live demo

https://adube.github.io/ngeo/2679-fix-date-filters/examples/contribs/gmf/filterselector.html?tree_enable_osm_open=true&tree_enable_ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung&tree_enable_OSM%2520map&tree_enable_osm_time_r_dp_2&tree_groups=filters

* Select `osm_open` as layer to filter
 * Add criteria / timestamp
 * Choose November 9th 2010 as value, keep 'equals to' as operator
 * Apply / Apply

You can try other possibilities.