### PR TITLE
Enable fullscreen opening for iOS

### DIFF
--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <link rel="shortcut icon" href="image/favicon.ico"/>
     <link rel="stylesheet" href="../../build/mobile.css">
     <script>


### PR DESCRIPTION
Currently we have a meta balise supporting chrome for android: 
`<meta name="mobile-web-app-capable" content="yes">`

I added the iOS supported meta balise to allow this feature on iOS:
`<meta name="apple-mobile-web-app-capable" content="yes">`

This allow to save the page on desk screen and open it in full-screen mode without the browser UI (navbar, etc.)