### PR TITLE
Fix #2712 - Support background layers in query (regression fix)

### DIFF
--- a/src/services/backgroundlayermgr.js
+++ b/src/services/backgroundlayermgr.js
@@ -27,12 +27,19 @@ ngeo.BackgroundEventType = {
  * @struct
  * @extends {ol.events.Event}
  * @param {ngeo.BackgroundEventType} type Type.
+ * @param {ol.layer.Base} current Current background layer.
  * @param {ol.layer.Base} previous Previous background layer.
  * @implements {ngeox.BackgroundEvent}
  */
-ngeo.BackgroundEvent = function(type, previous) {
+ngeo.BackgroundEvent = function(type, current, previous) {
 
   ol.events.Event.call(this, type);
+
+  /**
+   * The current (new) layer used as background.
+   * @type {ol.layer.Base}
+   */
+  this.current = current;
 
   /**
    * The layer used as background before a change.
@@ -139,7 +146,7 @@ ngeo.BackgroundLayerMgr.prototype.set = function(map, layer) {
   }
 
   this.dispatchEvent(new ngeo.BackgroundEvent(ngeo.BackgroundEventType.CHANGE,
-      previous));
+      layer, previous));
   return previous;
 };
 


### PR DESCRIPTION
Fixes #2712.

In 2.2, the `ngeo.Query` service was changed to the `ngeo.Querent`:

 * `ngeo.Query` - used to loop in the current map layers to find those that are queryable and issue requests from there
 * `ngeo.Querent` - uses the `ngeo.DataSource` as way to fetch the queryable information and issue requests.

To be queryable, a data source:

 * must be in the `ngeo.DataSources` collection
 * must be visible
 * must be queryable (property)

The data sources from the "overlay" layers are managed with the layer tree manager.  The background layer were **not** managed at all.

## Fix

To fix this, the ngeo background layer manager was added to the data sources manager service.  On change, we get the current background layer, get its `querySourceIds` property (which happens to be the list of ids of the data sources bound to this layer) and add them to the ngeo data sources collection.  The `visible` property is also managed.

## Todo

 * [x] Review
 * ~~Install a live demo~~