### PR TITLE
Handle dimensions in ngeoMapQuery and ngeoBboxQuery

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -237,10 +237,12 @@
           ngeo-map-query-map="::mainCtrl.map"
           ngeo-map-query-active="mainCtrl.queryActive"
           ngeo-map-query-autoclear="mainCtrl.queryAutoClear"
+          ngeo-map-query-dimensions="mainCtrl.dimensions"
           ngeo-bbox-query=""
           ngeo-bbox-query-map="::mainCtrl.map"
           ngeo-bbox-query-active="mainCtrl.queryActive"
-          ngeo-bbox-query-autoclear="mainCtrl.queryAutoClear">
+          ngeo-bbox-query-autoclear="mainCtrl.queryAutoClear"
+          ngeo-bbox-query-dimensions="mainCtrl.dimensions">
         </gmf-map>
 
         <!--infobar-->

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -24,7 +24,8 @@
       <gmf-map gmf-map-map="mainCtrl.map"
         ngeo-map-query=""
         ngeo-map-query-map="::mainCtrl.map"
-        ngeo-map-query-active="mainCtrl.queryActive"></gmf-map>
+        ngeo-map-query-active="mainCtrl.queryActive"
+        ngeo-map-query-dimensions="mainCtrl.dimensions"></gmf-map>
       <gmf-displayquerywindow
         gmf-displayquerywindow-featuresstyle="::mainCtrl.queryFeatureStyle"
         gmf-displayquerywindow-defaultcollapsed="false">

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -480,6 +480,11 @@ ngeox.DataSource.prototype.combinableForWMS;
 ngeox.DataSource.prototype.combinableForWFS;
 
 /**
+ * @type {?Object.<string, string>}
+ */
+ngeox.DataSource.prototype.dimensions;
+
+/**
  * @type {boolean}
  */
 ngeox.DataSource.prototype.queryable;
@@ -526,6 +531,7 @@ ngeox.DataSource.prototype.combinableWithDataSourceForWMS = function(dataSource)
  * @typedef {{
  *     coordinate: (ol.Coordinate|undefined),
  *     dataSources: (Array.<ngeox.DataSource>|undefined),
+ *     dimensions: (Object.<string, string>|undefined),
  *     extent: (ol.Extent|undefined),
  *     filter: (ol.format.filter.Filter|undefined),
  *     limit: (number|undefined),

--- a/src/directives/bboxquery.js
+++ b/src/directives/bboxquery.js
@@ -21,8 +21,9 @@ goog.require('ol.interaction.DragBox');
  *      <span
  *        ngeo-bbox-query=""
  *        ngeo-bbox-query-map="::ctrl.map"
- *        ngeo-bbox-query-active="ctrl.queryActive">
- *        ngeo-bbox-query-autoclear="ctrl.queryAutoClear">
+ *        ngeo-bbox-query-active="ctrl.queryActive"
+ *        ngeo-bbox-query-autoclear="ctrl.queryAutoClear"
+ *        ngeo-bbox-query-dimensions="ctrl.dimensions">
  *      </span>
  *
  * See the live example: [../examples/bboxquery.html](../examples/bboxquery.html)
@@ -42,6 +43,7 @@ ngeo.bboxQueryDirective = function(ngeoMapQuerent) {
        * @type {ol.Map}
        */
       const map = scope.$eval(attrs['ngeoBboxQueryMap']);
+      const dimensions = scope.$eval(attrs['ngeoBboxQueryDimensions']);
 
       const interaction = new ol.interaction.DragBox({
         condition: ol.events.condition.platformModifierKeyOnly
@@ -56,7 +58,8 @@ ngeo.bboxQueryDirective = function(ngeoMapQuerent) {
         const extent = interaction.getGeometry().getExtent();
         ngeoMapQuerent.issue({
           extent,
-          map
+          map,
+          dimensions
         });
       };
       interaction.on('boxend', handleBoxEnd);

--- a/src/directives/mapquery.js
+++ b/src/directives/mapquery.js
@@ -21,7 +21,8 @@ goog.require('ngeo.MapQuerent');
  *        ngeo-map-query=""
  *        ngeo-map-query-map="::ctrl.map"
  *        ngeo-map-query-active="ctrl.queryActive"
- *        ngeo-map-query-autoclear="ctrl.queryAutoClear">
+ *        ngeo-map-query-autoclear="ctrl.queryAutoClear"
+ *        ngeo-map-query-dimensions="ctrl.dimensions">
  *      </span>
  *
  * See our live example: [../examples/mapquery.html](../examples/mapquery.html)
@@ -39,6 +40,8 @@ ngeo.mapQueryDirective = function(ngeoMapQuerent, $injector) {
     scope: false,
     link(scope, elem, attrs) {
       const map = scope.$eval(attrs['ngeoMapQueryMap']);
+      const dimensions = scope.$eval(attrs['ngeoMapQueryDimensions']);
+
       let clickEventKey_ = null;
       let pointerMoveEventKey_ = null;
 
@@ -51,7 +54,8 @@ ngeo.mapQueryDirective = function(ngeoMapQuerent, $injector) {
         const coordinate = evt.coordinate;
         ngeoMapQuerent.issue({
           coordinate,
-          map
+          map,
+          dimensions
         });
       };
 


### PR DESCRIPTION
Add dimensions attributes to ngeo.mapQueryDirective and
ngeo.bboxQueryDirective and bind them with mainCtrl.dimensions.

Pass query directives dimensions to MapQuerent and Querent services throught
ngeox.IssueGetFeaturesOptions.

In Querent service:
- combine data sources regarding dimensions
- combine datasources default dimensions with ones from options
- pass dimensions in getFeature and getFeatureInfo requests as query parameters.