### PR TITLE
Search-parameter

### DIFF
--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -534,7 +534,8 @@ gmf.AbstractController = function(config, $scope, $injector) {
 
   const searchQuery = this.ngeoLocation.getParam('search');
   if (searchQuery) {
-    this.search_(searchQuery);
+    const overlay = ngeoFeatureOverlayMgr.getFeatureOverlay();
+    this.search_(searchQuery, overlay);
   }
 };
 
@@ -623,14 +624,16 @@ gmf.AbstractController.prototype.getLocationIcon = function() {
 /**
  * Performs a full-text search and centers the map on the first search result.
  * @param {string} query Search query.
+ * @param {ngeo.FeatureOverlay} overlay Feature overlay to add the feature if found.
  * @private
  */
-gmf.AbstractController.prototype.search_ = function(query) {
+gmf.AbstractController.prototype.search_ = function(query, overlay) {
   this.fullTextSearch_.search(query, {'limit': 1})
     .then((data) => {
       if (data && data.features[0]) {
         const format = new ol.format.GeoJSON();
         const feature = format.readFeature(data.features[0]);
+        overlay.addFeature(feature);
         this.map.getView().fit(feature.getGeometry().getExtent());
       }
     });

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -22,7 +22,7 @@ goog.require('gmf.mapDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.searchDirective');
 /** @suppress {extraRequire} */
-goog.require('gmf.fulltextSearchService');
+goog.require('gmf.FulltextSearchService');
 /** @suppress {extraRequire} */
 goog.require('gmf.themeselectorDirective');
 /** @suppress {extraRequire} */

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -460,11 +460,11 @@ gmf.SearchController.prototype.$onInit = function() {
   if (this.ngeoLocation_) {
     const searchQuery = this.ngeoLocation_.getParam('search');
     if (searchQuery) {
-      let resultOffset = 0;
-      if (this.ngeoLocation_.getParam('search-offset')) {
-        resultOffset = parseInt(this.ngeoLocation_.getParam('search-offset'), 10);
+      let resultIndex = 1;
+      if (this.ngeoLocation_.getParam('search-select-index')) {
+        resultIndex = parseInt(this.ngeoLocation_.getParam('search-select-index'), 10);
       }
-      this.fulltextsearch_(searchQuery, resultOffset);
+      this.fulltextsearch_(searchQuery, resultIndex);
     }
   }
 };
@@ -946,15 +946,18 @@ gmf.SearchController.datasetsempty_ = function(event, query, empty) {
 /**
  * Performs a full-text search and centers the map on the first search result.
  * @param {string} query Search query.
- * @param {number} resultOffset Return (n + 1)th result instead.
+ * @param {number} resultIndex Return nth result instead.
  * @private
  */
-gmf.SearchController.prototype.fulltextsearch_ = function(query, resultOffset) {
-  this.fullTextSearch_.search(query, {'limit': 1 + resultOffset})
+gmf.SearchController.prototype.fulltextsearch_ = function(query, resultIndex) {
+  if (resultIndex < 1) { // can't be lower than one
+    resultIndex = 1;
+  }
+  this.fullTextSearch_.search(query, {'limit': resultIndex})
     .then((data) => {
-      if (data && data.features[resultOffset]) {
+      if (data && data.features[resultIndex - 1]) {
         const format = new ol.format.GeoJSON();
-        const feature = format.readFeature(data.features[resultOffset]);
+        const feature = format.readFeature(data.features[resultIndex - 1]);
         this.featureOverlay_.addFeature(feature);
         this.map_.getView().fit(feature.getGeometry().getExtent());
         this.inputValue = /** @type {string} */ (feature.get('label'));

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -453,7 +453,11 @@ gmf.SearchController.prototype.$onInit = function() {
 
   const searchQuery = this.ngeoLocation_.getParam('search');
   if (searchQuery) {
-    this.fulltextsearch_(searchQuery);
+    let resultOffset = 0;
+    if (this.ngeoLocation_.getParam('search-offset')) {
+      resultOffset = parseInt(this.ngeoLocation_.getParam('search-offset'), 10);
+    }
+    this.fulltextsearch_(searchQuery, resultOffset);
   }
 };
 
@@ -934,14 +938,15 @@ gmf.SearchController.datasetsempty_ = function(event, query, empty) {
 /**
  * Performs a full-text search and centers the map on the first search result.
  * @param {string} query Search query.
+ * @param {number} resultOffset Return (n + 1)th result instead.
  * @private
  */
-gmf.SearchController.prototype.fulltextsearch_ = function(query) {
-  this.fullTextSearch_.search(query, {'limit': 1})
+gmf.SearchController.prototype.fulltextsearch_ = function(query, resultOffset) {
+  this.fullTextSearch_.search(query, {'limit': 1 + resultOffset})
     .then((data) => {
-      if (data && data.features[0]) {
+      if (data && data.features[resultOffset]) {
         const format = new ol.format.GeoJSON();
-        const feature = format.readFeature(data.features[0]);
+        const feature = format.readFeature(data.features[resultOffset]);
         this.featureOverlay_.addFeature(feature);
         this.map_.getView().fit(feature.getGeometry().getExtent());
         this.inputValue = /** @type {string} */ (feature.get('label'));

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -11,7 +11,7 @@ goog.require('ngeo.colorpickerDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.popoverDirective');
 /** @suppress {extraRequire} */
-goog.require('gmf.fulltextSearchService');
+goog.require('gmf.FulltextSearchService');
 goog.require('ol.Feature');
 goog.require('ol.Map');
 goog.require('ol.geom.Point');
@@ -180,13 +180,14 @@ gmf.module.directive('gmfSearch', gmf.searchDirective);
  *     overlay manager service.
  * @param {gmf.Themes} gmfThemes gmf Themes service.
  * @param {gmf.TreeManager} gmfTreeManager gmf Tree Manager service.
+ * @param {gmf.FulltextSearchService} gmfFulltextSearchService gmf Full text search service.
  * @ngInject
  * @ngdoc controller
  * @ngname GmfSearchController
  */
 gmf.SearchController = function($scope, $compile, $timeout, $injector, gettextCatalog,
   ngeoAutoProjection, ngeoSearchCreateGeoJSONBloodhound, ngeoFeatureOverlayMgr,
-  gmfThemes, gmfTreeManager) {
+  gmfThemes, gmfTreeManager, gmfFulltextSearchService) {
 
 
   /**
@@ -208,17 +209,6 @@ gmf.SearchController = function($scope, $compile, $timeout, $injector, gettextCa
   this.timeout_ = $timeout;
 
   /**
-   * @type {ngeo.Location}
-   * @private
-   */
-  this.ngeoLocation_ = $injector.get('ngeoLocation');
-
-  /**
-   * @private
-   */
-  this.fullTextSearch_ = $injector.get('gmfFulltextSearchService');
-
-  /**
    * @type {angularGettext.Catalog}
    * @private
    */
@@ -237,6 +227,12 @@ gmf.SearchController = function($scope, $compile, $timeout, $injector, gettextCa
   this.gmfTreeManager_ = gmfTreeManager;
 
   /**
+   * @type {gmf.FulltextSearchService}
+   * @private
+   */
+  this.fullTextSearch_ = gmfFulltextSearchService;
+
+  /**
    * @type {ngeo.search.CreateGeoJSONBloodhound}
    * @private
    */
@@ -247,6 +243,16 @@ gmf.SearchController = function($scope, $compile, $timeout, $injector, gettextCa
    * @private
    */
   this.ngeoFeatureOverlayMgr = ngeoFeatureOverlayMgr;
+
+  /**
+   * @type {ngeo.Location|undefined}
+   * @private
+   */
+  this.ngeoLocation_;
+
+  if ($injector.has('ngeoLocation')) {
+    this.ngeoLocation_ = $injector.get('ngeoLocation');
+  }
 
   /**
    * @type {ngeo.AutoProjection}
@@ -451,13 +457,15 @@ gmf.SearchController.prototype.$onInit = function() {
   this.inputValue = this.inputValue || '';
   this.placeholder = this.placeholder || '';
 
-  const searchQuery = this.ngeoLocation_.getParam('search');
-  if (searchQuery) {
-    let resultOffset = 0;
-    if (this.ngeoLocation_.getParam('search-offset')) {
-      resultOffset = parseInt(this.ngeoLocation_.getParam('search-offset'), 10);
+  if (this.ngeoLocation_) {
+    const searchQuery = this.ngeoLocation_.getParam('search');
+    if (searchQuery) {
+      let resultOffset = 0;
+      if (this.ngeoLocation_.getParam('search-offset')) {
+        resultOffset = parseInt(this.ngeoLocation_.getParam('search-offset'), 10);
+      }
+      this.fulltextsearch_(searchQuery, resultOffset);
     }
-    this.fulltextsearch_(searchQuery, resultOffset);
   }
 };
 

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -944,7 +944,7 @@ gmf.SearchController.prototype.fulltextsearch_ = function(query) {
         const feature = format.readFeature(data.features[0]);
         this.featureOverlay_.addFeature(feature);
         this.map_.getView().fit(feature.getGeometry().getExtent());
-        this.inputValue = feature.get('label');
+        this.inputValue = /** @type {string} */ (feature.get('label'));
       }
     });
 };

--- a/contribs/gmf/src/services/fulltextsearch.js
+++ b/contribs/gmf/src/services/fulltextsearch.js
@@ -39,7 +39,7 @@ gmf.fulltextSearchService = function($injector, $http) {
    * @type {Object.<string, string>}
    * @private
    */
-  this.params_ = ngeo.utils.decodeQueryString(queryString);
+  this.defaultParams_ = ngeo.utils.decodeQueryString(queryString);
 };
 
 /**
@@ -49,8 +49,7 @@ gmf.fulltextSearchService = function($injector, $http) {
  * @returns {Promise} Request promise with data array.
  */
 gmf.fulltextSearchService.prototype.search = function(query, params) {
-  let queryParams = Object.assign({}, this.params_); // clone it
-  queryParams = Object.assign(queryParams, params);
+  const queryParams = Object.assign({}, this.defaultParams_, params);
 
   queryParams['query'] = query;
 

--- a/contribs/gmf/src/services/fulltextsearch.js
+++ b/contribs/gmf/src/services/fulltextsearch.js
@@ -1,0 +1,66 @@
+goog.provide('gmf.fulltextSearchService');
+
+goog.require('gmf');
+goog.require('ngeo.utils');
+
+/**
+ * Provides the c2c-geoportal full-text search.
+ * @param {angular.$injector} $injector Main injector.
+ * @param {angular.$http} $http Angular http service.
+ * @constructor
+ * @struct
+ * @ngInject
+ * @export
+ * @ngname gmfFulltextSearchService
+ */
+gmf.fulltextSearchService = function($injector, $http) {
+
+  /**
+   * @type {angular.$http}
+   * @private
+   */
+  this.$http_ = $http;
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.url_ = /** @type {string} **/ ($injector.get('fulltextsearchUrl'));
+
+  const url = this.url_.split('?');
+  /**
+   * @type {string}
+   * @private
+   */
+  this.baseUrl_ = url[0];
+
+  const queryString = (url.length == 2) ? url[1] : '';
+  /**
+   * @type {Object.<string, string>}
+   * @private
+   */
+  this.params_ = ngeo.utils.decodeQueryString(queryString);
+};
+
+/**
+ * Perform a search query on the c2c-geoportal full-text search.
+ * @param {string} query Search query.
+ * @param {Object.<string, string>} params Additional parameters.
+ * @returns {Promise} Request promise with data array.
+ */
+gmf.fulltextSearchService.prototype.search = function(query, params) {
+  let queryParams = Object.assign({}, this.params_); // clone it
+  queryParams = Object.assign(queryParams, params);
+
+  queryParams['query'] = query;
+
+  const url = `${this.baseUrl_}?${ngeo.utils.encodeQueryString(queryParams)}`;
+
+  return new Promise((resolve, reject) => {
+    this.$http_.get(url)
+      .then(resp => resolve(resp['data']))
+      .catch(reject);
+  });
+};
+
+gmf.module.service('gmfFulltextSearchService', gmf.fulltextSearchService);

--- a/contribs/gmf/src/services/fulltextsearch.js
+++ b/contribs/gmf/src/services/fulltextsearch.js
@@ -34,7 +34,7 @@ gmf.fulltextSearchService = function($injector, $http) {
    */
   this.baseUrl_ = url[0];
 
-  const queryString = (url.length == 2) ? url[1] : '';
+  const queryString = (url.length == 2) ? `?${url[1]}` : '';
   /**
    * @type {Object.<string, string>}
    * @private

--- a/contribs/gmf/src/services/fulltextsearch.js
+++ b/contribs/gmf/src/services/fulltextsearch.js
@@ -1,4 +1,4 @@
-goog.provide('gmf.fulltextSearchService');
+goog.provide('gmf.FulltextSearchService');
 
 goog.require('gmf');
 goog.require('ngeo.utils');
@@ -13,7 +13,7 @@ goog.require('ngeo.utils');
  * @export
  * @ngname gmfFulltextSearchService
  */
-gmf.fulltextSearchService = function($injector, $http) {
+gmf.FulltextSearchService = function($injector, $http) {
 
   /**
    * @type {angular.$http}
@@ -48,7 +48,7 @@ gmf.fulltextSearchService = function($injector, $http) {
  * @param {Object.<string, string>} params Additional parameters.
  * @returns {Promise} Request promise with data array.
  */
-gmf.fulltextSearchService.prototype.search = function(query, params) {
+gmf.FulltextSearchService.prototype.search = function(query, params) {
   const queryParams = Object.assign({}, this.defaultParams_, params);
 
   queryParams['query'] = query;
@@ -62,4 +62,4 @@ gmf.fulltextSearchService.prototype.search = function(query, params) {
   });
 };
 
-gmf.module.service('gmfFulltextSearchService', gmf.fulltextSearchService);
+gmf.module.service('gmfFulltextSearchService', gmf.FulltextSearchService);


### PR DESCRIPTION
## New feature
Introduces two new parameters:

- **search**: (string) recenters map on first result of fulltext search
- **search-select-index**: (number) use nth result from search instead

If a feature is found, it gets added to the search input field. Clicking the X-button there deletes the feature from the feature-overlay.

## Example:
![demo-search-param](https://user-images.githubusercontent.com/621371/27860551-69965c54-617d-11e7-95df-66a125b06971.gif)

`[APP-URL]/desktop/?search=Lausanne`
In the gmf demo app, this would center the map on "District de Lausanne" (district layer)

`[APP-URL]/desktop/?search=Lausanne&search-select-index=4`
In the gmf demo app, this would center the map on "Lausanne" (osm layer), the fourth result in the response of the fulltextsearch call.

## Open questions / issues:

- [technical] Is the search directive the right place to put this?
- ~[usability] Different name/behaviour for _search-offset_?~ Changed to **search-select-index**
- [usability / technical] The result order does not always match the drop down menu of the search bar. This is due some re-arranging. Is this a problem?



