### PR TITLE
Fix permalink background

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -30,8 +30,8 @@
               data-toggle="dropdown">
               <span class="fa fa-grid"></span>
               <span translate>Theme:</span>
-              <b ng-if="!mainCtrl.gmfThemeManager.themeName" translate>Loading...</b>
-              <b ng-if="mainCtrl.gmfThemeManager.themeName">{{mainCtrl.gmfThemeManager.themeName|translate}}</b>
+              <b ng-if="!mainCtrl.gmfThemeManager.getThemeName()" translate>Loading...</b>
+              <b ng-if="mainCtrl.gmfThemeManager.getThemeName()">{{mainCtrl.gmfThemeManager.getThemeName()|translate}}</b>
               <span class="caret"></span>
             </a>
             <gmf-themeselector class="dropdown-menu"

--- a/contribs/gmf/apps/oeedit/index.html
+++ b/contribs/gmf/apps/oeedit/index.html
@@ -21,8 +21,8 @@
               data-toggle="dropdown">
               <span class="fa fa-grid"></span>
               <span translate>Theme:</span>
-              <b ng-if="!mainCtrl.gmfThemeManager.themeName" translate>Loading...</b>
-              <b ng-if="mainCtrl.gmfThemeManager.themeName">{{mainCtrl.gmfThemeManager.themeName|translate}}</b>
+              <b ng-if="!mainCtrl.gmfThemeManager.getThemeName()" translate>Loading...</b>
+              <b ng-if="mainCtrl.gmfThemeManager.getThemeName()">{{mainCtrl.gmfThemeManager.getThemeName()|translate}}</b>
               <span class="caret"></span>
             </a>
             <gmf-themeselector class="dropdown-menu"

--- a/contribs/gmf/apps/oeview/index.html
+++ b/contribs/gmf/apps/oeview/index.html
@@ -21,8 +21,8 @@
               data-toggle="dropdown">
               <span class="fa fa-grid"></span>
               <span translate>Theme:</span>
-              <b ng-if="!mainCtrl.gmfThemeManager.themeName" translate>Loading...</b>
-              <b ng-if="mainCtrl.gmfThemeManager.themeName">{{mainCtrl.gmfThemeManager.themeName|translate}}</b>
+              <b ng-if="!mainCtrl.gmfThemeManager.getThemeName()" translate>Loading...</b>
+              <b ng-if="mainCtrl.gmfThemeManager.getThemeName()">{{mainCtrl.gmfThemeManager.getThemeName()|translate}}</b>
               <span class="caret"></span>
             </a>
             <gmf-themeselector class="dropdown-menu"

--- a/contribs/gmf/examples/objecteditinghub.js
+++ b/contribs/gmf/examples/objecteditinghub.js
@@ -170,7 +170,6 @@ gmfapp.MainController = function($http, $q, $scope, gmfThemes, gmfXSDAttributes)
    */
   this.themeName = 'ObjectEditing';
 
-
   this.gmfThemes_.loadThemes();
 
   this.gmfThemes_.getOgcServersObject().then((ogcServers) => {

--- a/contribs/gmf/examples/themeselector.html
+++ b/contribs/gmf/examples/themeselector.html
@@ -42,7 +42,7 @@
   <body ng-controller="MainController as ctrl">
     <div class="container">
       <gmf-themeselector gmf-themeselector-filter="::ctrl.filter"></gmf-themeselector>
-      <div> The theme selected is {{ctrl.manager.themeName}}</div>
+      <div> The theme selected is {{ctrl.manager.getThemeName()}}</div>
 
     </div>
     <p id="desc">This example shows how to use the <code>gmf.themeselector</code> directive from a c2c geoportal theme service.</p>

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -385,9 +385,7 @@ gmf.AbstractController = function(config, $scope, $injector) {
   const printPanelActivate = new ngeo.ToolActivate(this, 'printPanelActive');
   ngeoToolActivateMgr.registerTool(mapTools, printPanelActivate, false);
 
-
-  // TODO aabbcctt
-  $scope.$watch(() => this.gmfThemeManager.getThemeName(), (name) => {
+  $scope.$root.$on(gmf.ThemeManagerEventType.THEME_NAME_SET, (event, name) => {
     const map = this.map;
     this.gmfThemes_.getThemeObject(name).then((theme) => {
       if (theme) {

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -386,7 +386,8 @@ gmf.AbstractController = function(config, $scope, $injector) {
   ngeoToolActivateMgr.registerTool(mapTools, printPanelActivate, false);
 
 
-  $scope.$watch(() => this.gmfThemeManager.themeName, (name) => {
+  // TODO aabbcctt
+  $scope.$watch(() => this.gmfThemeManager.getThemeName(), (name) => {
     const map = this.map;
     this.gmfThemes_.getThemeObject(name).then((theme) => {
       if (theme) {

--- a/contribs/gmf/src/directives/partials/themeselector.html
+++ b/contribs/gmf/src/directives/partials/themeselector.html
@@ -2,7 +2,7 @@
   <li
       ng-repeat="theme in tsCtrl.themes"
       ng-click="tsCtrl.setTheme(theme)"
-      ng-class="{'gmf-theme-selector-active': tsCtrl.gmfThemeManager.themeName == theme.name}">
+      ng-class="{'gmf-theme-selector-active': tsCtrl.gmfThemeManager.getThemeName() == theme.name}">
     <img class="gmf-thumb"
          ng-src="{{::theme.icon}}" />
     <span class="gmf-text">{{theme.name | translate}}</span>

--- a/contribs/gmf/src/directives/themeselector.js
+++ b/contribs/gmf/src/directives/themeselector.js
@@ -15,8 +15,8 @@ goog.require('gmf.ThemesEventType');
  *      <a href class="btn btn-default btn-block btn-primary" data-toggle="dropdown">
  *          <span class="fa fa-grid"></span>
  *          <span translate>Theme:</span>
- *          <b ng-if="!mainCtrl.gmfThemeManager.themeName" translate>Loading...</b>
- *          <b ng-if="mainCtrl.gmfThemeManager.themeName">{{mainCtrl.gmfThemeManager.themeName|translate}}</b>
+ *          <b ng-if="!mainCtrl.gmfThemeManager.getThemeName()" translate>Loading...</b>
+ *          <b ng-if="mainCtrl.gmfThemeManager.getThemeName()">{{mainCtrl.gmfThemeManager.getThemeName()|translate}}</b>
  *          <span class="caret"></span>
  *      </a>
  *      <gmf-themeselector

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -388,9 +388,8 @@ gmf.Permalink = function($timeout, $rootScope, $injector, ngeoDebounce,
     });
   }
 
-  //TODO aabbcctt
   if (this.gmfThemeManager_) {
-    $rootScope.$watch(() => this.gmfThemeManager_.getThemeName(), (name) => {
+    this.rootScope_.$on(gmf.ThemeManagerEventType.THEME_NAME_SET, (event, name) => {
       this.setThemeInUrl_();
     });
   }

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -5,6 +5,8 @@ goog.require('ngeo');
 goog.require('ngeo.AutoProjection');
 goog.require('gmf.Themes');
 goog.require('gmf.TreeManager');
+/** @suppress {extraRequire} */
+goog.require('gmf.ThemeManager');
 goog.require('ngeo.BackgroundEventType');
 goog.require('ngeo.BackgroundLayerMgr');
 goog.require('ngeo.Debounce');

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -388,8 +388,9 @@ gmf.Permalink = function($timeout, $rootScope, $injector, ngeoDebounce,
     });
   }
 
+  //TODO aabbcctt
   if (this.gmfThemeManager_) {
-    $rootScope.$watch(() => this.gmfThemeManager_.themeName, (name) => {
+    $rootScope.$watch(() => this.gmfThemeManager_.getThemeName(), (name) => {
       this.setThemeInUrl_();
     });
   }
@@ -785,7 +786,8 @@ gmf.Permalink.prototype.themeInUrl_ = function(pathElements) {
  * @private
  */
 gmf.Permalink.prototype.setThemeInUrl_ = function() {
-  if (this.gmfThemeManager_ && this.gmfThemeManager_.themeName) {
+  const themeName = this.gmfThemeManager_ ? this.gmfThemeManager_.getThemeName() : null;
+  if (themeName) {
     const pathElements = this.ngeoLocation_.getPath().split('/');
     goog.asserts.assert(pathElements.length > 1);
     if (pathElements[pathElements.length - 1] === '') {
@@ -793,9 +795,9 @@ gmf.Permalink.prototype.setThemeInUrl_ = function() {
       pathElements.splice(pathElements.length - 1);
     }
     if (this.themeInUrl_(pathElements)) {
-      pathElements[pathElements.length - 1] = this.gmfThemeManager_.themeName;
+      pathElements[pathElements.length - 1] = themeName;
     } else {
-      pathElements.push('theme', this.gmfThemeManager_.themeName);
+      pathElements.push('theme', themeName);
     }
     this.ngeoLocation_.setPath(pathElements.join('/'));
   }
@@ -829,7 +831,8 @@ gmf.Permalink.prototype.initLayers_ = function() {
       themeName = this.defaultTheme_;
     }
     if (this.gmfThemeManager_ && this.gmfThemeManager_.modeFlush) {
-      this.gmfThemeManager_.themeName = `${themeName}`;
+      // Set theme in stealth mode, we just want to set the theme name, not more.
+      this.gmfThemeManager_.setThemeName(`${themeName}`, true);
     }
 
     /**

--- a/contribs/gmf/src/services/thememanager.js
+++ b/contribs/gmf/src/services/thememanager.js
@@ -125,7 +125,7 @@ gmf.ThemeManager.prototype.getThemeName = function() {
 gmf.ThemeManager.prototype.setThemeName = function(name, opt_stealth) {
   this.themeName_ = name;
   if (!opt_stealth) {
-    this.$rootScope_.$emit(gmf.ThemeManagerEventType.THEME_NAME_SET, null);
+    this.$rootScope_.$emit(gmf.ThemeManagerEventType.THEME_NAME_SET, name);
   }
 };
 

--- a/contribs/gmf/src/services/thememanager.js
+++ b/contribs/gmf/src/services/thememanager.js
@@ -13,6 +13,18 @@ gmf.module.value('gmfTreeManagerModeFlush', true);
 
 
 /**
+ * @enum {string}
+ * @export
+ */
+gmf.ThemeManagerEventType = {
+  /**
+   * Triggered when the theme name change.
+   */
+  THEME_NAME_SET: 'gmf-thememanager-theme_name_set'
+};
+
+
+/**
  * Manage a tree with children. This service can be used in mode 'flush'
  * (default) or not (mode 'add'). In mode 'flush', each theme, group or group
  * by layer that you add will replace the previous children's array. In mode
@@ -25,6 +37,7 @@ gmf.module.value('gmfTreeManagerModeFlush', true);
  * This service's theme is a GmfTheme with only children and a name.
  * Thought to be the tree source of the gmf layertree directive.
  * @constructor
+ * @param {angular.Scope} $rootScope Angular rootScope.
  * @param {gmf.Themes} gmfThemes gmf Themes service.
  * @param {boolean} gmfTreeManagerModeFlush Flush mode active?
  * @param {gmf.TreeManager} gmfTreeManager the tree manager.
@@ -34,7 +47,14 @@ gmf.module.value('gmfTreeManagerModeFlush', true);
  * @ngdoc service
  * @ngname gmfTreeManager
  */
-gmf.ThemeManager = function(gmfThemes, gmfTreeManagerModeFlush, gmfTreeManager, ngeoStateManager) {
+gmf.ThemeManager = function($rootScope, gmfThemes, gmfTreeManagerModeFlush,
+    gmfTreeManager, ngeoStateManager) {
+
+  /**
+   * @type {angular.Scope}
+   * @private
+   */
+  this.$rootScope_ = $rootScope;
 
   /**
    * @type {gmf.Themes}
@@ -61,9 +81,9 @@ gmf.ThemeManager = function(gmfThemes, gmfTreeManagerModeFlush, gmfTreeManager, 
 
   /**
    * @type {string}
-   * @export
+   * @private
    */
-  this.themeName = '';
+  this.themeName_ = '';
 };
 
 
@@ -80,10 +100,32 @@ gmf.ThemeManager.prototype.addTheme = function(theme, opt_silent) {
     this.ngeoStateManager_.updateState({
       'theme': theme.name
     });
-    this.themeName = theme.name;
+    this.setThemeName(theme.name);
     this.gmfTreeManager_.setFirstLevelGroups(theme.children);
   } else {
     this.gmfTreeManager_.addFirstLevelGroups(theme.children, false, opt_silent);
+  }
+};
+
+
+/**
+ * @return {string} The theme name. Will be empty on 'not flush' mode.
+ * @export
+ */
+gmf.ThemeManager.prototype.getThemeName = function() {
+  return this.themeName_;
+};
+
+
+/**
+ * @param {string} name The new theme name.
+ * @param {boolean=} opt_stealth Don't emit an event is true
+ * @export
+ */
+gmf.ThemeManager.prototype.setThemeName = function(name, opt_stealth) {
+  this.themeName_ = name;
+  if (!opt_stealth) {
+    this.$rootScope_.$emit(gmf.ThemeManagerEventType.THEME_NAME_SET, null);
   }
 };
 

--- a/contribs/gmf/test/spec/services/thememanager.spec.js
+++ b/contribs/gmf/test/spec/services/thememanager.spec.js
@@ -22,7 +22,7 @@ describe('gmf.ThemeManager', () => {
   it('Add a theme', () => {
     const theme0 = themes.themes[0];
     gmfThemeManager_.addTheme(theme0);
-    expect(gmfThemeManager_.themeName).toEqual(theme0.name);
+    expect(gmfThemeManager_.getThemeName()).toEqual(theme0.name);
     //expect(gmfTreeManager_.root.children).toEqual(theme0.children);
   });
 });


### PR DESCRIPTION
FIX #2714 

DEMO: https://testgmf.sig.cloud.camptocamp.net/bge_permalink

Be able to:
 - Set a theme linked to a backgound layer (here theme cadastre is linked to background layer "Blank")
 - Set the background layer again (like OSM)
 - Refresh the page using the permalink and get the Theme with the second background (here theme "cadastre" with background layer "OSM")

Please, try to find a bug (I've changed some things in the theme manager).
Only the "mode flush" (theme manager) should be different that before.