### PR TITLE
Remove trailing slash from authenticationBaseUrl

### DIFF
--- a/contribs/gmf/src/services/authenticationservice.js
+++ b/contribs/gmf/src/services/authenticationservice.js
@@ -121,10 +121,11 @@ gmf.Authentication = function($http, authenticationBaseUrl, gmfUser) {
   this.$http_ = $http;
 
   /**
+   * The authentication url without trailing slash
    * @type {string}
    * @private
    */
-  this.baseUrl_ = authenticationBaseUrl;
+  this.baseUrl_ = authenticationBaseUrl.replace(/\/$/, '');
 
   /**
    * @type {gmfx.User}


### PR DESCRIPTION
fixes https://github.com/camptocamp/c2cgeoportal/issues/2991