### PR TITLE
Enforce ngeo.rule.Rule and ngeo.DataSource are not used in ngeox.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,7 @@ dist: dist/ngeo.js dist/ngeo-debug.js dist/gmf.js
 
 .PHONY: check
 check: git-attributes eof-newline lint check-examples test dist build-gmf-apps
+	grep -nE "ngeo.rule.Rule|ngeo.DataSource" options/ngeox.js && (echo "Only use ngeox.rule.Rule and ngeox.DataSource in options/ngeox.js" && exit 1)
 
 .PHONY: build-gmf-apps
 build-gmf-apps: $(foreach APP,$(GMF_APPS),$(addprefix contribs/gmf/build/$(APP),.js .css)) \

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -90,10 +90,10 @@ ngeox.Attribute.prototype.type;
  * service.
  *
  * @typedef {{
- *     dataSource: (ngeo.DataSource),
+ *     dataSource: (ngeox.DataSource),
  *     incTime: (boolean|undefined),
  *     filter: (ol.format.filter.Filter|undefined),
- *     filterRules: (!Array.<ngeo.rule.Rule>|undefined),
+ *     filterRules: (!Array.<ngeox.rule.Rule>|undefined),
  *     srsName: (string|undefined)
  * }}
  */
@@ -103,7 +103,7 @@ ngeox.CreateFilterOptions;
 /**
  * The data source from which to get the filterRules that will be used to
  * create the OL filter object.
- * @type {ngeo.DataSource}
+ * @type {ngeox.DataSource}
  */
 ngeox.CreateFilterOptions.prototype.dataSource;
 
@@ -131,7 +131,7 @@ ngeox.CreateFilterOptions.prototype.filter;
  * An alternative list of filter rules to use instead of those that are defined
  * within the data source. Useful when one wants to get the data of a given
  * filter without applying it to the data source.
- * @type {Array.<!ngeo.rule.Rule>|undefined}
+ * @type {Array.<!ngeox.rule.Rule>|undefined}
  */
 ngeox.CreateFilterOptions.prototype.filterRules;
 
@@ -180,7 +180,7 @@ ngeox.DataSourceLayer.prototype.queryable;
 
 
 /**
- * The options to create a `ngeo.DataSource` with.
+ * The options to create a `ngeox.DataSource` with.
  * @record
  * @struct
  */
@@ -503,6 +503,16 @@ ngeox.DataSource.prototype.wmsUrl;
  * @type {string|undefined}
  */
 ngeox.DataSource.prototype.wfsUrl;
+
+/**
+ * @type {string}
+ */
+ngeox.DataSource.prototype.filterCondition;
+
+/**
+ * @type {?Array.<!ngeox.rule.Rule>}
+ */
+ngeox.DataSource.prototype.filterRules;
 
 /**
  * @param {ngeox.DataSource} dataSource Data source.

--- a/src/services/rulehelper.js
+++ b/src/services/rulehelper.js
@@ -379,7 +379,7 @@ ngeo.RuleHelper = class {
    */
   createFilter(options) {
 
-    const dataSource = options.dataSource;
+    const dataSource = /** @type {ngeo.DataSource} */ (options.dataSource);
     let mainFilter = null;
 
     if (options.filter) {


### PR DESCRIPTION
Depending on actual types in ngeox.js is bad since it forces users of
ngeo to depend on the js files providing these types, even if they are
not used in their project.

To avoid this, use ngeox.rule.Rule instead of ngeo.rule.Rule and
ngeox.DataSource instead of ngeo.DataSource.

See c6d6e8fd9cef1e308073fd3c65441163ddb6e0b4.