### PR TITLE
Set default decimals and precision values for drawing

### DIFF
--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -75,6 +75,9 @@ gmf.module.value('ngeoQueryOptions', {
   'limit': 20
 });
 
+gmf.module.value('ngeoMeasurePrecision', 3);
+gmf.module.value('ngeoMeasureDecimals', 0);
+
 
 /**
  * Desktop application abstract controller.


### PR DESCRIPTION
Fix #2756 

The current display will be 0 decimals (set in abstract controller) as default value. Then it can be overridden in project html or js files. I added the precision value as well as it wasn't set previously. Preview:
![image](https://user-images.githubusercontent.com/25748389/28425980-1c7db434-6d72-11e7-95db-4cbca2d958eb.png)

