### PR TITLE
Use 'dimensions' properly in querent service

### DIFF
--- a/contribs/gmf/externs/gmf-themes.js
+++ b/contribs/gmf/externs/gmf-themes.js
@@ -121,7 +121,7 @@ gmfThemes.GmfGroup.prototype.children;
 /**
  * The dimensions managed by the OpenLayers layer, if the value is null we will take the dimension from the application.
  * This is present only on non mixed first level group.
- * @type {!Object.<string, string>}
+ * @type {!ngeox.Dimensions}
  */
 gmfThemes.GmfGroup.prototype.dimensions;
 
@@ -167,7 +167,7 @@ gmfThemes.GmfLayer = function() {};
 /**
  * The dimensions managed by the layer, if the value is null we will take the dimension from the application.
  * Present only on layer in a mixed group.
- * @type {!Object.<string, string>}
+ * @type {!ngeox.Dimensions}
  */
 gmfThemes.GmfLayer.prototype.dimensions;
 

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -166,12 +166,11 @@ gmf.AbstractController = function(config, $scope, $injector) {
   // watch any change on dimensions object to refresh the url
   permalink.setDimensions(this.dimensions);
 
-  // FIXME - manage dimensions ...
-  //const queryManager = $injector.get('gmfQueryManager');
-  //queryManager.setDimensions(this.dimensions);
-
   // Injecting the gmfDataSourcesManager service creates the data sources
-  $injector.get('gmfDataSourcesManager');
+  const gmfDataSourcesManager = $injector.get('gmfDataSourcesManager');
+
+  // Give the dimensions to the gmfDataSourcesManager
+  gmfDataSourcesManager.setDimensions(this.dimensions);
 
   if ($injector.has('gmfDefaultDimensions')) {
     // Set defaults

--- a/contribs/gmf/src/services/datasourcesmanager.js
+++ b/contribs/gmf/src/services/datasourcesmanager.js
@@ -126,6 +126,13 @@ gmf.DataSourcesManager = class {
     this.dataSourcesCache_ = {};
 
     /**
+     * A reference to the global dimensions object.
+     * @type {ngeox.Dimensions|undefined}
+     * @private
+     */
+    this.globalDimensions_;
+
+    /**
      * The cache of layertree leaf controller, i.e. those that are added to
      * the tree manager. When treeCtrl is added in this cache, it's given
      * a reference to its according data source.
@@ -152,6 +159,14 @@ gmf.DataSourcesManager = class {
     );
     ol.events.listen(this.gmfThemes_, gmf.ThemesEventType.CHANGE,
       this.handleThemesChange_, this);
+  }
+
+  /**
+   * @param {!ngeox.Dimensions} dimensions A reference to the global dimensions
+   *     object to keep a reference of in this service.
+   */
+  setDimensions(dimensions) {
+    this.globalDimensions_ = dimensions;
   }
 
   /**
@@ -384,8 +399,8 @@ gmf.DataSourcesManager = class {
       meta.snappingConfig.vertex : undefined;
 
     // (7) Dimensions
-    const dimensions = node.dimensions || firstLevelGroup.dimensions;
-    const activeDimensions = dimensions;
+    const globalDimensions = this.globalDimensions_;
+    const innerDimensions = node.dimensions || firstLevelGroup.dimensions;
 
     // (8) Time values (lower or lower/upper)
     let timeLowerValue;
@@ -409,12 +424,12 @@ gmf.DataSourcesManager = class {
 
     // Create the data source and add it to the cache
     cache[id] = new gmf.DataSource({
-      activeDimensions,
       copyable,
-      dimensions,
+      globalDimensions,
       gmfLayer,
       id,
       identifierAttribute,
+      innerDimensions,
       maxResolution,
       minResolution,
       name,

--- a/contribs/gmf/src/services/datasourcesmanager.js
+++ b/contribs/gmf/src/services/datasourcesmanager.js
@@ -126,11 +126,11 @@ gmf.DataSourcesManager = class {
     this.dataSourcesCache_ = {};
 
     /**
-     * A reference to the global dimensions object.
+     * A reference to the dimensions object.
      * @type {ngeox.Dimensions|undefined}
      * @private
      */
-    this.globalDimensions_;
+    this.dimensions_;
 
     /**
      * The cache of layertree leaf controller, i.e. those that are added to
@@ -162,11 +162,11 @@ gmf.DataSourcesManager = class {
   }
 
   /**
-   * @param {!ngeox.Dimensions} dimensions A reference to the global dimensions
+   * @param {!ngeox.Dimensions} dimensions A reference to the dimensions
    *     object to keep a reference of in this service.
    */
   setDimensions(dimensions) {
-    this.globalDimensions_ = dimensions;
+    this.dimensions_ = dimensions;
   }
 
   /**
@@ -399,8 +399,8 @@ gmf.DataSourcesManager = class {
       meta.snappingConfig.vertex : undefined;
 
     // (7) Dimensions
-    const globalDimensions = this.globalDimensions_;
-    const innerDimensions = node.dimensions || firstLevelGroup.dimensions;
+    const dimensions = this.dimensions_;
+    const dimensionsConfig = node.dimensions || firstLevelGroup.dimensions;
 
     // (8) Time values (lower or lower/upper)
     let timeLowerValue;
@@ -425,11 +425,11 @@ gmf.DataSourcesManager = class {
     // Create the data source and add it to the cache
     cache[id] = new gmf.DataSource({
       copyable,
-      globalDimensions,
+      dimensions,
+      dimensionsConfig,
       gmfLayer,
       id,
       identifierAttribute,
-      innerDimensions,
       maxResolution,
       minResolution,
       name,

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -545,7 +545,7 @@ ngeox.DataSource.prototype.combinableWithDataSourceForWMS = function(dataSource)
 
 
 /**
- * @param {ngeox.DataSource} dataSource Remote data source to compare with
+ * @param {!ngeox.DataSource} dataSource Remote data source to compare with
  *     this one.
  * @return {boolean}  Whether the two data sources have the same active
  *     dimensions. If both have no dimensions, they are considered to be

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -210,6 +210,22 @@ ngeox.DataSourceOptions.prototype.copyable;
 
 
 /**
+ * A reference to the dimensions.
+ * @type {ngeox.Dimensions|undefined}
+ */
+ngeox.DataSourceOptions.prototype.dimensions;
+
+
+/**
+ * The dimensions configuration, which determines those supported by this data
+ * source and whether they should use a static value or the one defined in the
+ * dimensions.
+ * @type {ngeox.Dimensions|undefined}
+ */
+ngeox.DataSourceOptions.prototype.dimensionsConfig;
+
+
+/**
  * The filter condition to apply to the filter rules (if any). Defaults to
  * `ngeo.FilterCondition.AND`.
  * @type {string|undefined}
@@ -240,13 +256,6 @@ ngeox.DataSourceOptions.prototype.geometryName;
 
 
 /**
- * A reference to the global dimensions.
- * @type {ngeox.Dimensions|undefined}
- */
-ngeox.DataSourceOptions.prototype.globalDimensions;
-
-
-/**
  * (Required) The data source id.
  * @type {number}
  */
@@ -274,13 +283,6 @@ ngeox.DataSourceOptions.prototype.identifierAttribute;
  * @type {boolean|undefined}
  */
 ngeox.DataSourceOptions.prototype.inRange;
-
-
-/**
- * A the dimensions supported by this data source.
- * @type {ngeox.Dimensions|undefined}
- */
-ngeox.DataSourceOptions.prototype.innerDimensions;
 
 
 /**

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -189,7 +189,7 @@ ngeox.DataSourceOptions = function() {};
 
 /**
  * The dimensions that are currently active on the data source.
- * @type {Object.<string, string>|undefined}
+ * @type {ngeox.Dimensions|undefined}
  */
 ngeox.DataSourceOptions.prototype.activeDimensions;
 
@@ -207,13 +207,6 @@ ngeox.DataSourceOptions.prototype.attributes;
  * @type {boolean|undefined}
  */
 ngeox.DataSourceOptions.prototype.copyable;
-
-
-/**
- * The dimensions this data source supports.
- * @type {Object.<string, string>|undefined}
- */
-ngeox.DataSourceOptions.prototype.dimensions;
 
 
 /**
@@ -247,6 +240,13 @@ ngeox.DataSourceOptions.prototype.geometryName;
 
 
 /**
+ * A reference to the global dimensions.
+ * @type {ngeox.Dimensions|undefined}
+ */
+ngeox.DataSourceOptions.prototype.globalDimensions;
+
+
+/**
  * (Required) The data source id.
  * @type {number}
  */
@@ -274,6 +274,13 @@ ngeox.DataSourceOptions.prototype.identifierAttribute;
  * @type {boolean|undefined}
  */
 ngeox.DataSourceOptions.prototype.inRange;
+
+
+/**
+ * A the dimensions supported by this data source.
+ * @type {ngeox.Dimensions|undefined}
+ */
+ngeox.DataSourceOptions.prototype.innerDimensions;
 
 
 /**
@@ -519,7 +526,7 @@ ngeox.DataSource.prototype.filterRules;
  * @return {boolean} Whether this data source can be combined to the given
  *     other data source to fetch features in a single WFS request.
  */
-ngeox.DataSource.prototype.combinableWithDataSourceForWFS = function(dataSource) {}
+ngeox.DataSource.prototype.combinableWithDataSourceForWFS = function(dataSource) {};
 
 
 /**
@@ -527,7 +534,31 @@ ngeox.DataSource.prototype.combinableWithDataSourceForWFS = function(dataSource)
  * @return {boolean} Whether this data source can be combined to the given
  *     other data source to fetch features in a single WMS request.
  */
-ngeox.DataSource.prototype.combinableWithDataSourceForWMS = function(dataSource) {}
+ngeox.DataSource.prototype.combinableWithDataSourceForWMS = function(dataSource) {};
+
+
+/**
+ * @param {ngeox.DataSource} dataSource Remote data source to compare with
+ *     this one.
+ * @return {boolean}  Whether the two data sources have the same active
+ *     dimensions. If both have no dimensions, they are considered to be
+ *     sharing the same dimensions.
+ */
+ngeox.DataSource.prototype.haveTheSameActiveDimensions = function(dataSource) {};
+
+
+/**
+ * Dimensions definition.
+ * @typedef {Object.<string, ?string>}
+ */
+ngeox.Dimensions;
+
+
+/**
+ * Active dimensions definition, where the value can't be null.
+ * @typedef {Object.<string, string>}
+ */
+ngeox.DimensionsActive;
 
 
 /**

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -477,6 +477,11 @@ ngeox.DataSourceOptions.prototype.wmtsUrl;
 ngeox.DataSource = function() {};
 
 /**
+ * @type {!ngeox.DimensionsActive}
+ */
+ngeox.DataSource.prototype.activeDimensions;
+
+/**
  * @type {boolean}
  */
 ngeox.DataSource.prototype.combinableForWMS;

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -34,6 +34,13 @@ ngeo.DataSource = class {
     // === DYNAMIC properties (i.e. that can change / be watched ===
 
     /**
+     * The dimenions configuration for the data source.
+     * @type {?ngeox.Dimensions}
+     * @private
+     */
+    this.dimensionsConfig_ = options.dimensionsConfig || null;
+
+    /**
      * The filter condition to apply to the filter rules (if any).
      * @type {string}
      * @private
@@ -73,13 +80,6 @@ ngeo.DataSource = class {
     this.inRange_ = options.inRange !== false;
 
     /**
-     * The inner dimenions of the data source.
-     * @type {?ngeox.Dimensions}
-     * @private
-     */
-    this.innerDimensions_ = options.innerDimensions || null;
-
-    /**
      * Whether the data source is visible or not, i.e. whether its is ON or OFF.
      * Defaults to `false`.
      * @type {boolean}
@@ -106,11 +106,11 @@ ngeo.DataSource = class {
     this.copyable_ = options.copyable === true;
 
     /**
-     * A reference to the global dimensions object.
+     * A reference to the dimensions object.
      * @type {?ngeox.Dimensions}
      * @private
      */
-    this.globalDimensions_ = options.globalDimensions || null;
+    this.dimensions_ = options.dimensions || null;
 
     /**
      * The name of the geometry attribute.
@@ -373,6 +373,22 @@ ngeo.DataSource = class {
   // ========================================
 
   /**
+   * @return {?ngeox.Dimensions} Dimensions configuration for this data source
+   * @export
+   */
+  get dimensionsConfig() {
+    return this.dimensionsConfig_;
+  }
+
+  /**
+   * @param {?ngeox.Dimensions} dimensionsConfig Dimensions configuration
+   * @export
+   */
+  set dimensionsConfig(dimensionsConfig) {
+    this.dimensionsConfig_ = dimensionsConfig;
+  }
+
+  /**
    * @return {string} Filter condition
    * @export
    */
@@ -418,22 +434,6 @@ ngeo.DataSource = class {
    */
   set inRange(inRange) {
     this.inRange_ = inRange;
-  }
-
-  /**
-   * @return {?ngeox.Dimensions} Inner dimensions
-   * @export
-   */
-  get innerDimensions() {
-    return this.innerDimensions_;
-  }
-
-  /**
-   * @param {?ngeox.Dimensions} innerDimensions Inner dimensions
-   * @export
-   */
-  set innerDimensions(innerDimensions) {
-    this.innerDimensions_ = innerDimensions;
   }
 
   /**
@@ -772,16 +772,16 @@ ngeo.DataSource = class {
    */
   get activeDimensions() {
     const active = {};
-    const global = this.globalDimensions_ || {};
-    const inner = this.innerDimensions || {};
+    const dimensions = this.dimensions_ || {};
+    const config = this.dimensionsConfig || {};
 
-    for (const key in inner) {
-      if (inner[key] === null) {
-        if (global[key] !== undefined && global[key] !== null) {
-          active[key] = global[key];
+    for (const key in config) {
+      if (config[key] === null) {
+        if (dimensions[key] !== undefined && dimensions[key] !== null) {
+          active[key] = dimensions[key];
         }
       } else {
-        active[key] = inner[key];
+        active[key] = config[key];
       }
     }
 
@@ -1055,6 +1055,8 @@ ngeo.DataSource = class {
    * @return {boolean} Whether the two data sources have the same active
    *     dimensions. If both have no dimensions, they are considered to be
    *     sharing the same dimensions.
+   * @export
+   * @override
    */
   haveTheSameActiveDimensions(dataSource) {
     let share = true;

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -74,7 +74,7 @@ ngeo.DataSource = class {
 
     /**
      * The inner dimenions of the data source.
-     * @type {?mgx.Dimensions}
+     * @type {?ngeox.Dimensions}
      * @private
      */
     this.innerDimensions_ = options.innerDimensions || null;
@@ -107,7 +107,7 @@ ngeo.DataSource = class {
 
     /**
      * A reference to the global dimensions object.
-     * @type {?mgx.Dimensions}
+     * @type {?ngeox.Dimensions}
      * @private
      */
     this.globalDimensions_ = options.globalDimensions || null;

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -1050,7 +1050,7 @@ ngeo.DataSource = class {
   }
 
   /**
-   * @param {!ngeo.DataSource} dataSource Remote data source to compare with
+   * @param {!ngeox.DataSource} dataSource Remote data source to compare with
    *     this one.
    * @return {boolean} Whether the two data sources have the same active
    *     dimensions. If both have no dimensions, they are considered to be


### PR DESCRIPTION
This is an alternative to #2718, i.e. a fix for the use of the `dimensions` property within the querent service.

### Technical details

The dimensions are globally defined in the GMF abstract controller.  From there, the `gmf.DataSourcesManager` is injected and given the global dimensions, allowing it to give them to the created data sources.

Within a data source, we have:

 * `globalDimensions`: property, is a reference to the global dimensions that come from 
 * `innerDimensions`: property, the static dimensions that are unique for the data source
 * `activeDimensions`: method, returns the "current" dimensions to use with the data source.  If a inner dimensions is defined with a `null` value, then the global dimensions is used.

Two data sources can be **combined** for a WMS or WFS query if they both have the exact same **active dimensions**.

Then, the ngeo querent service use these active dimensions for both WMS and WFS types of queries.  Note that we only pick the first data source active dimensions, since we always issue queries with combinable data sources and they all share the same active dimensions.