### PR TITLE
Add missing .csv extension for displayquerygrid csv export

### DIFF
--- a/contribs/gmf/src/directives/displayquerygrid.js
+++ b/contribs/gmf/src/directives/displayquerygrid.js
@@ -836,7 +836,7 @@ gmf.DisplayquerygridController.prototype.downloadCsv = function() {
     var selectedRows = source.configuration.getSelectedRows();
 
     this.ngeoCsvDownload_.startDownload(
-        selectedRows, columnDefs, 'query-results');
+        selectedRows, columnDefs, 'query-results.csv');
   }
 };
 


### PR DESCRIPTION
Fixes #2778

I added the extension to the startDownload function (on third parameter, for the filename) for displayquerygrid directive, as it is actually done with the same function used in the profile directive for csv export : https://github.com/camptocamp/ngeo/blob/868618f9ebdf2b1a0d68d07b23d6f3223be2ff1b/contribs/gmf/src/directives/profile.js#L704.