### PR TITLE
resizeMap when switching from opened panels to street-view panel and vice-versa

### DIFF
--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -264,7 +264,7 @@ gmf-backgroundlayerselector {
   .gmf-app-tools-content {
     width: @right-panel-width;
     margin-right: -@right-panel-width;
-    transition: margin-right 0.2s ease;
+    transition: margin-right 0.2s ease, width 0.001s ease;
     float: right;
     height: 100%;
     overflow: auto;


### PR DESCRIPTION
Fixes #2786 

This fix add a CSS transition on width changes used by street-view panel. The transition is then listened by the resizeMap directive that will run the resize actions at the 'transitionend' event: https://github.com/camptocamp/ngeo/blob/f6c897e3ada535f9f483ba18f290b056d9387703/src/directives/resizemap.js#L62-L65

The current duration used is 0.01s because we don't want a animation to start and be visible, we just want to run the transition to make the resizeMap directive do his job on width changes.