### PR TITLE
Support user functionalities to toggle the filter tool on upon init

### DIFF
--- a/contribs/gmf/externs/gmf-themes.js
+++ b/contribs/gmf/externs/gmf-themes.js
@@ -375,6 +375,28 @@ gmfThemes.GmfFunctionalities = function() {};
  */
 gmfThemes.GmfFunctionalities.prototype.default_basemap;
 
+
+/**
+ * When set, contains the name of the panel to open upon loading an application.
+ *
+ * Note: altough this is a list, only one can be defined.
+ *
+ * @type {Array.<!string>|undefined}
+ */
+gmfThemes.GmfFunctionalities.prototype.open_panel;
+
+
+/**
+ * Name of the layer (data source) that should be toggled in the filter tool
+ * upon loading an application.
+ *
+ * Note: altough this is a list, only one can be defined.
+ *
+ * @type {Array.<!string>|undefined}
+ */
+gmfThemes.GmfFunctionalities.prototype.preset_layer_filter;
+
+
 /**
  * @constructor
  * @struct

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -133,6 +133,18 @@ gmf.AbstractController = function(config, $scope, $injector) {
 
   const userChange = function(evt) {
     const roleId = (evt.user.username !== null) ? evt.user.role_id : undefined;
+
+    // Open filter panel if 'open_panel' is set in functionalities and
+    // has 'layer_filter' as first value
+    this.gmfThemes_.getThemesObject().then((themes) => {
+      const functionalities = this.gmfUser.functionalities;
+      if (functionalities &&
+          functionalities.open_panel &&
+          functionalities.open_panel[0] === 'layer_filter') {
+        this.filterSelectorActive = true;
+      }
+    });
+
     // Reload theme and background layer when login status changes.
     if (evt.type !== gmf.AuthenticationEventType.READY) {
       this.updateCurrentTheme_();
@@ -224,6 +236,12 @@ gmf.AbstractController = function(config, $scope, $injector) {
     }),
     stroke: queryStroke
   });
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.filterSelectorActive = false;
 
   /**
    * The active state of the ngeo query directive.

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -153,12 +153,6 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
    * @type {boolean}
    * @export
    */
-  this.filterSelectorActive = false;
-
-  /**
-   * @type {boolean}
-   * @export
-   */
   this.editFeatureActive = false;
 
   /**

--- a/contribs/gmf/src/directives/filterselector.js
+++ b/contribs/gmf/src/directives/filterselector.js
@@ -251,6 +251,14 @@ gmf.FilterselectorController = class {
       this.handleEnableDataSourceRegistrationChange_.bind(this)
     );
 
+    /**
+     * The name of the data source that should be automatically selected
+     * by this component.
+     * @type {string|undefined}
+     * @private
+     */
+    this.defaultFiltrableDataSourceName_;
+
     // Initialize the data sources registration
     this.toggleDataSourceRegistration_();
   }
@@ -265,6 +273,14 @@ gmf.FilterselectorController = class {
       this.filtrableLayerNodeNames_ = usrFunc['filterable_layers'];
     } else {
       this.filtrableLayerNodeNames_ = null;
+    }
+    if (usrFunc &&
+        usrFunc['preset_layer_filter'] &&
+        usrFunc['preset_layer_filter'][0]
+    ) {
+      this.defaultFiltrableDataSourceName_ = usrFunc['preset_layer_filter'][0];
+    } else {
+      this.defaultFiltrableDataSourceName_ = undefined;
     }
     this.toggleDataSourceRegistration_();
   }
@@ -381,6 +397,12 @@ gmf.FilterselectorController = class {
 
     if (dataSource.filtrable) {
       this.filtrableDataSources.push(dataSource);
+
+      if (this.defaultFiltrableDataSourceName_ !== undefined &&
+          dataSource.name === this.defaultFiltrableDataSourceName_
+      ) {
+        this.gmfDataSourceBeingFiltered.dataSource = dataSource;
+      }
     }
   }
 


### PR DESCRIPTION
This PR introduces the support of the two following GMF user "functionalities":

`"open_layer_filter_panel": ["true"]` - when defined, the filter panel is open upon loading a desktop application.

`"preset_layer_filter": ["inventaire_equipements"]` - when defined, the name of the layer (data source) automatically: 1) open the filter panel, 2) select the data source in the filter selector tool.