### PR TITLE
Fix activeDimensions precedence order

### DIFF
--- a/src/datasource.js
+++ b/src/datasource.js
@@ -776,10 +776,8 @@ ngeo.DataSource = class {
     const config = this.dimensionsConfig || {};
 
     for (const key in config) {
-      if (config[key] === null) {
-        if (dimensions[key] !== undefined && dimensions[key] !== null) {
-          active[key] = dimensions[key];
-        }
+      if (dimensions[key] !== undefined && dimensions[key] !== null) {
+        active[key] = dimensions[key];
       } else {
         active[key] = config[key];
       }


### PR DESCRIPTION
Regarding layertree, global dimensions take precedence over node ones.
https://github.com/camptocamp/ngeo/blob/5aede6eda19fe7bbcd07b76be77c93cb42e1caba/contribs/gmf/src/directives/layertree.js#L318:L321

With this, the selected features are the visible ones.