### PR TITLE
Fix layertree dimensions precedence

### DIFF
--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -315,9 +315,11 @@ gmf.LayertreeController.prototype.updateLayerDimensions_ = function(layer, node)
   if (this.dimensions && node.dimensions) {
     const dimensions = {};
     for (const key in node.dimensions) {
-      const value = this.dimensions[key];
-      if (value !== undefined) {
-        dimensions[key] = value;
+      if (node.dimensions[key] === null) {
+        const value = this.dimensions[key];
+        if (value !== undefined) {
+          dimensions[key] = value;
+        }
       }
     }
     if (!ol.obj.isEmpty(dimensions)) {


### PR DESCRIPTION
Apply global dimensions only if layer config value is null.
To be consitent with ngeo.datasource.

Replace #2819