### PR TITLE
[WIP] Add WMS/KML component

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -80,6 +80,10 @@
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Street View'|translate}}">
               <span class="fa fa-street-view"></span>
             </button>
+            <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.wmsKmlActive"
+              data-toggle="tooltip" data-placement="left" data-original-title="{{'WMS/KML'|translate}}">
+              <span class="fa fa-upload"></span>
+            </button>
           </div>
           <br/>
           <br/>
@@ -194,6 +198,21 @@
                   feature-style="mainCtrl.googleStreetViewStyle"
                   map="mainCtrl.map">
               </ngeo-googlestreetview>
+            </div>
+          </div>
+          <div ng-show="mainCtrl.wmsKmlActive" class="row">
+            <div class="col-sm-12">
+              <div class="gmf-app-tools-content-heading">
+                {{'WMS/KML'|translate}}
+                <a class="btn close" ng-click="mainCtrl.wmsKmlActive = false">&times;</a>
+              </div>
+              <gmf-wmskml
+                gmf-wmskml-active="mainCtrl.wmsKmlActive"
+                gmf-wmskml-map="::mainCtrl.map"
+                gmf-wmskml-import-options="::mainCtrl.importOptions"
+                gmf-wmskml-wms-get-cap="wmsGetCap"
+                gmf-wmskml-wmts-get-cap="wmtsGetCap">
+              </gmf-wmskml>
             </div>
           </div>
         </div>

--- a/contribs/gmf/apps/desktop/js/controller.js
+++ b/contribs/gmf/apps/desktop/js/controller.js
@@ -20,16 +20,21 @@ goog.require('ngeo.proj.EPSG2056');
 /** @suppress {extraRequire} */
 goog.require('ngeo.proj.EPSG21781');
 
+goog.require('app.GmfImportHelper');
+
 
 /**
  * @param {angular.Scope} $scope Scope.
  * @param {angular.$injector} $injector Main injector.
+ * @param {ngeo.File} ngeoFile The file service.
+ * @param {gettext} gettext The gettext service
+ * @param {angular.$q} $q Angular $q.
  * @constructor
  * @extends {gmf.AbstractDesktopController}
  * @ngInject
  * @export
  */
-app.DesktopController = function($scope, $injector) {
+app.DesktopController = function($scope, $injector, ngeoFile, gettext, $q) {
   gmf.AbstractDesktopController.call(this, {
     srid: 21781,
     mapViewConfig: {
@@ -96,6 +101,11 @@ app.DesktopController = function($scope, $injector) {
   gettextCatalog.getString('Add a theme');
   gettextCatalog.getString('Add a sub theme');
   gettextCatalog.getString('Add a layer');
+
+  /**
+   * @export
+   */
+  this.importOptions = new app.GmfImportHelper(this.map, $scope, gettext, ngeoFile, $q).createOptions();
 };
 ol.inherits(app.DesktopController, gmf.AbstractDesktopController);
 

--- a/contribs/gmf/apps/desktop/js/controller.js
+++ b/contribs/gmf/apps/desktop/js/controller.js
@@ -26,15 +26,13 @@ goog.require('app.GmfImportHelper');
 /**
  * @param {angular.Scope} $scope Scope.
  * @param {angular.$injector} $injector Main injector.
- * @param {ngeo.File} ngeoFile The file service.
- * @param {gettext} gettext The gettext service
  * @param {angular.$q} $q Angular $q.
  * @constructor
  * @extends {gmf.AbstractDesktopController}
  * @ngInject
  * @export
  */
-app.DesktopController = function($scope, $injector, ngeoFile, gettext, $q) {
+app.DesktopController = function($scope, $injector, $q) {
   gmf.AbstractDesktopController.call(this, {
     srid: 21781,
     mapViewConfig: {
@@ -105,7 +103,7 @@ app.DesktopController = function($scope, $injector, ngeoFile, gettext, $q) {
   /**
    * @export
    */
-  this.importOptions = new app.GmfImportHelper(this.map, $scope, gettext, ngeoFile, $q).createOptions();
+  this.importOptions = new app.GmfImportHelper($q).createOptions();
 };
 ol.inherits(app.DesktopController, gmf.AbstractDesktopController);
 

--- a/contribs/gmf/apps/desktop/js/importhelper.js
+++ b/contribs/gmf/apps/desktop/js/importhelper.js
@@ -1,7 +1,5 @@
 goog.provide('app.GmfImportHelper');
 
-goog.require('ol.format.GPX');
-goog.require('ol.format.KML');
 goog.require('ol.source.ImageWMS');
 goog.require('ol.layer.Image');
 goog.require('ol.source.Vector');
@@ -10,21 +8,10 @@ goog.require('ol.layer.Vector');
 
 /**
  * @constructor
- * @param {ol.Map} map The map.
- * @param {angular.Scope} $scope The scope.
- * @param {gettext} gettext .
- * @param {ngeo.File} ngeoFile Ngeo file.
  * @param {angular.$q} $q Q.
  */
-app.GmfImportHelper = function(map, $scope, gettext, ngeoFile, $q) {
-  this.map_ = map;
-  this.$scope_ = $scope;
-  $scope['map'] = map;
-  this.ngeoFile_ = ngeoFile;
+app.GmfImportHelper = function($q) {
   this.$q_ = $q;
-  this.gpxFormat_ = new ol.format.GPX();
-  this.kmlFormat_ = new ol.format.KML();
-  this.gettext_ = gettext;
 
   this.urls = [
     {'name': 'geoadmin', 'url': 'https://wms.geo.admin.ch/'},
@@ -122,84 +109,6 @@ app.GmfImportHelper.prototype.getOlLayerFromGetCapLayer = function(getCapLayer) 
 
 
 /**
- * @param {ol.Map} map The map
- * @param {Array<ol.Feature>} features The features
- */
-app.GmfImportHelper.prototype.addFeatures = function(map, features) {
-  const source = new ol.source.Vector({
-    features
-  });
-  const layer = new ol.layer.Vector({
-    source
-  });
-  map.addLayer(layer);
-  const size = map.getSize();
-  if (size) {
-    map.getView().fit(source.getExtent(), {size, padding: [30, 30, 30, 30]});
-  }
-};
-
-
-/** Manage data depending on the content
- * @param {string} data Content of the file.
- * @param {File} file Informations of the file (if available).
- * @return {angular.$q.Promise} The promise
- */
-app.GmfImportHelper.prototype.handleFileContent = function(data, file) {
-  const map = this.map_;
-  const defer = this.$q_.defer();
-  const $scope = this.$scope_;
-  const ngeoFile = this.ngeoFile_;
-  let features;
-
-  $scope['gpxContent'] = null;
-  $scope['kmlContent'] = null;
-  $scope['wmsGetCap'] = null;
-  $scope['wmtsGetCap'] = null;
-
-  if (ngeoFile.isWmsGetCap(data)) {
-    $scope['wmsGetCap'] = data;
-    defer.resolve({
-      'message': this.gettext_('Download succeeded')
-    });
-  } else if (ngeoFile.isWmtsGetCap(data)) {
-    $scope['wmtsGetCap'] = data;
-    defer.resolve({
-      'message': this.gettext_('Download succeeded')
-    });
-  } else if (ngeoFile.isKml(data)) {
-    features = this.kmlFormat_.readFeatures(data, {
-      featureProjection: map.getView().getProjection()
-    });
-
-    this.addFeatures(map, features);
-    defer.resolve({
-      'message': this.gettext_('Parsing succeeded')
-    });
-  } else if (ngeoFile.isGpx(data)) {
-    features = this.gpxFormat_.readFeatures(data, {
-      featureProjection: map.getView().getProjection()
-    });
-
-    this.addFeatures(map, features);
-    defer.resolve({
-      'message': this.gettext_('Parsing succeeded')
-    });
-
-  } else {
-    console.error('Unparseable content: ', data);
-    defer.reject({
-      'message': this.gettext_('Parsing failed'),
-      'reason': this.gettext_('unsupported format')
-    });
-  }
-  // WMTS
-
-  return defer.promise;
-};
-
-
-/**
  * @return {Object} the options
  */
 app.GmfImportHelper.prototype.createOptions = function() {
@@ -221,7 +130,6 @@ app.GmfImportHelper.prototype.createOptions = function() {
         url += '?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0';
       }
       return this.$q_.when(url);
-    },
-    'handleFileContent': this.handleFileContent.bind(this)
+    }
   };
 };

--- a/contribs/gmf/apps/desktop/js/importhelper.js
+++ b/contribs/gmf/apps/desktop/js/importhelper.js
@@ -1,10 +1,5 @@
 goog.provide('app.GmfImportHelper');
 
-goog.require('ol.source.ImageWMS');
-goog.require('ol.layer.Image');
-goog.require('ol.source.Vector');
-goog.require('ol.layer.Vector');
-
 
 /**
  * @constructor
@@ -22,100 +17,12 @@ app.GmfImportHelper = function($q) {
 
 
 /**
- * @param {Object} params .
- * @param {Object} options .
- * @return {ol.layer.Image} .
- */
-app.GmfImportHelper.prototype.createWmsLayer = function(params, options) {
-  options = options || {};
-  options.id = `WMS||${options.label}||${options.url}||${params['LAYERS']}`;
-
-  // If the WMS has a version specified, we add it in
-  // the id. It's important that the layer keeps the same id as the
-  // one in the url otherwise it breaks the asynchronous reordering of
-  // layers.
-  if (params.VERSION) {
-    options.id += `||${params.VERSION}`;
-
-    if (options['useReprojection']) {
-      options.projection = 'EPSG:4326';
-      options.id += '||true';
-    }
-  } else {
-    params.VERSION = '1.3.0';
-  }
-
-  const source = new ol.source.ImageWMS({
-    params,
-    url: options.url,
-    ratio: options.ratio || 1,
-    projection: options.projection
-  });
-
-  const layer = new ol.layer.Image({
-    id: options.id,
-    url: options.url,
-    type: 'WMS',
-    opacity: options.opacity,
-    visible: options.visible,
-    attribution: options.attribution,
-    extent: options.extent,
-    source
-  });
-  //gaDefinePropertiesForLayer(layer);
-  // FIXME: do we need this? layer.label = options.label;
-  return layer;
-};
-
-
-/**
- * @param {Object} options .
- * @return {ol.layer.Tile} .
- */
-app.GmfImportHelper.prototype.createWmtsLayer = function(options) {
-  const source = new ol.source.WMTS(options['sourceConfig']);
-
-  const layer = new ol.layer.Tile({
-    id: options['id'],
-    extent: options.extent,
-    source
-  });
-
-  return layer;
-};
-
-
-/**
- * @param {Object} getCapLayer .
- * @return {ol.layer.Image|ol.layer.Tile} .
- */
-app.GmfImportHelper.prototype.getOlLayerFromGetCapLayer = function(getCapLayer) {
-  if (getCapLayer['capabilitiesUrl']) {
-    return this.createWmtsLayer(getCapLayer);
-  }
-
-  const wmsParams = {
-    'LAYERS': getCapLayer['Name'],
-    'VERSION': getCapLayer['wmsVersion']
-  };
-  const wmsOptions = {
-    url: getCapLayer['wmsUrl'],
-    label: getCapLayer['Title'],
-    //extent: gaMapUtils.intersectWithDefaultExtent(getCapLayer.extent),
-    'useReprojection': getCapLayer['useReprojection']
-  };
-  return this.createWmsLayer(wmsParams, wmsOptions);
-};
-
-
-/**
  * @return {Object} the options
  */
 app.GmfImportHelper.prototype.createOptions = function() {
   return {
     'urls': this.urls,
     //'isValidUrl': gaUrlUtils.isValid,
-    'getOlLayerFromGetCapLayer': this.getOlLayerFromGetCapLayer.bind(this),
     'addPreviewLayer': function(map, layer) {
       return; // FIXME
     },

--- a/contribs/gmf/apps/desktop/js/importhelper.js
+++ b/contribs/gmf/apps/desktop/js/importhelper.js
@@ -173,9 +173,8 @@ app.GmfImportHelper.prototype.handleFileContent = function(data, file) {
     });
 
     this.addFeatures(map, features);
-    defer.reject({
-      'message': this.gettext_('Parsing failed'),
-      'reason': this.gettext_('Not implemented yet')
+    defer.resolve({
+      'message': this.gettext_('Parsing succeeded')
     });
   } else if (ngeoFile.isGpx(data)) {
     features = this.gpxFormat_.readFeatures(data, {

--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -41,15 +41,13 @@ gmf.module.value('ngeoMeasureDecimals', 2);
 /**
  * @param {angular.Scope} $scope Scope.
  * @param {angular.$injector} $injector Main injector.
- * @param {ngeo.File} ngeoFile The file service.
- * @param {gettext} gettext The gettext service
  * @param {angular.$q} $q Angular $q.
  * @constructor
  * @extends {gmf.AbstractDesktopController}
  * @ngInject
  * @export
  */
-app.AlternativeDesktopController = function($scope, $injector, ngeoFile, gettext, $q) {
+app.AlternativeDesktopController = function($scope, $injector, $q) {
   gmf.AbstractDesktopController.call(this, {
     srid: 21781,
     mapViewConfig: {
@@ -128,7 +126,7 @@ app.AlternativeDesktopController = function($scope, $injector, ngeoFile, gettext
   /**
    * @export
    */
-  this.importOptions = new app.GmfImportHelper(this.map, $scope, gettext, ngeoFile, $q).createOptions();
+  this.importOptions = new app.GmfImportHelper($q).createOptions();
 };
 ol.inherits(app.AlternativeDesktopController, gmf.AbstractDesktopController);
 

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -18,6 +18,7 @@
 @import 'contextualdata.less';
 @import 'fullscreenpopup.less';
 @import 'print.less';
+@import 'import.less';
 
 @map-tools-size: 3rem;
 @button-size: 4rem;

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -33,6 +33,8 @@ goog.require('gmf.TimeSliderDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.shareDirective');
 /** @suppress {extraRequire} */
+goog.require('gmf.wmskmlDirective');
+/** @suppress {extraRequire} */
 goog.require('ngeo.btngroupDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.resizemapDirective');
@@ -160,6 +162,12 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
    * @export
    */
   this.googleStreetViewActive = false;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.wmsKmlActive = false;
 
   /**
    * @type {!ol.style.Style}

--- a/contribs/gmf/src/directives/partials/wmskml.html
+++ b/contribs/gmf/src/directives/partials/wmskml.html
@@ -1,0 +1,26 @@
+<div class="import">
+  <div>Local</div>
+  <div class="import-local"
+       ngeo-import-local
+       ngeo-import-local-options="::wkCtrl.importOptions">
+  </div>
+  <div>Online</div>
+  <div
+       ngeo-import-online
+       ngeo-import-online-options="::wkCtrl.importOptions">
+  </div>
+
+  <!-- Display WMS GetCapabilities results -->
+  <div ng-if="wkCtrl.wmsGetCap"
+       ngeo-wms-get-cap="wkCtrl.wmsGetCap"
+       ngeo-wms-get-cap-map="::wkCtrl.map"
+       ngeo-wms-get-cap-options="::wkCtrl.importOptions">
+  </div>
+
+  <!-- Display WMTS GetCapabilities results -->
+  <div ng-if="wkCtrl.wmtsGetCap"
+       ngeo-wmts-get-cap="wkCtrl.wmtsGetCap"
+       ngeo-wmts-get-cap-map="::wkCtrl.map"
+       ngeo-wmts-get-cap-options="::wkCtrl.importOptions">
+  </div>
+</div>

--- a/contribs/gmf/src/directives/wmskml.js
+++ b/contribs/gmf/src/directives/wmskml.js
@@ -2,6 +2,8 @@ goog.provide('gmf.wmskmlDirective');
 
 goog.require('gmf');
 
+goog.require('ol.format.GPX');
+goog.require('ol.format.KML');
 
 /**
  * Directive used to add layers by adding a WMS URL or uploading a KML file.
@@ -31,11 +33,105 @@ gmf.module.directive('gmfWmskml', gmf.wmskmlDirective);
 /**
  * @constructor
  * @private
+ * @param {gmf.TreeManager} gmfTreeManager gmf Tree Manager service.
+ * @param {gettext} gettext .
+ * @param {ngeo.File} ngeoFile Ngeo file.
+ * @param {angular.$q} $q Q.
  * @ngInject
  * @ngdoc controller
  * @ngname GmfDrawfeatureController
  */
-gmf.WmskmlController = function() {
+gmf.WmskmlController = function(gmfTreeManager, gettext, ngeoFile, $q) {
+  /**
+   * @type {gmf.TreeManager}
+   * @private
+   */
+  this.gmfTreeManager_ = gmfTreeManager;
+
+  this.gettext_ = gettext;
+  this.ngeoFile_ = ngeoFile;
+  this.$q_ = $q;
+
+  this.gpxFormat_ = new ol.format.GPX();
+  this.kmlFormat_ = new ol.format.KML();
+};
+
+
+gmf.WmskmlController.prototype.$onInit = function() {
+  this['importOptions']['handleFileContent'] = this.handleFileContent_.bind(this);
+};
+
+
+/**
+ * @param {ol.Map} map The map
+ * @param {Array<ol.Feature>} features The features
+ */
+gmf.WmskmlController.prototype.addFeatures_ = function(map, features) {
+  const source = new ol.source.Vector({
+    features
+  });
+  const layer = new ol.layer.Vector({
+    source
+  });
+  map.addLayer(layer);
+  const size = map.getSize();
+  if (size) {
+    map.getView().fit(source.getExtent(), {size, padding: [30, 30, 30, 30]});
+  }
+};
+
+
+/** Manage data depending on the content
+ * @param {string} data Content of the file.
+ * @return {angular.$q.Promise} The promise
+ */
+gmf.WmskmlController.prototype.handleFileContent_ = function(data) {
+  const map = this.map;
+  const defer = this.$q_.defer();
+  const ngeoFile = this.ngeoFile_;
+
+  this['wmsGetCap'] = null;
+  this['wmtsGetCap'] = null;
+
+  if (ngeoFile.isWmsGetCap(data)) {
+    this['wmsGetCap'] = data;
+    defer.resolve({
+      'message': this.gettext_('Download succeeded')
+    });
+  } else if (ngeoFile.isWmtsGetCap(data)) {
+    this['wmtsGetCap'] = data;
+    defer.resolve({
+      'message': this.gettext_('Download succeeded')
+    });
+  } else if (ngeoFile.isKml(data)) {
+    const features = this.kmlFormat_.readFeatures(data, {
+      featureProjection: map.getView().getProjection()
+    });
+
+    this.addFeatures_(map, features);
+    defer.resolve({
+      'message': this.gettext_('Parsing succeeded')
+    });
+  } else if (ngeoFile.isGpx(data)) {
+    const features = this.gpxFormat_.readFeatures(data, {
+      featureProjection: map.getView().getProjection()
+    });
+
+    this.addFeatures_(map, features);
+    defer.resolve({
+      'message': this.gettext_('Parsing succeeded')
+    });
+
+  } else {
+    console.error('Unparseable content: ', data);
+    defer.reject({
+      'message': this.gettext_('Parsing failed'),
+      'reason': this.gettext_('unsupported format')
+    });
+  }
+  // WMTS
+
+  return defer.promise;
 };
 
 

--- a/contribs/gmf/src/directives/wmskml.js
+++ b/contribs/gmf/src/directives/wmskml.js
@@ -1,0 +1,42 @@
+goog.provide('gmf.wmskmlDirective');
+
+goog.require('gmf');
+
+
+/**
+ * Directive used to add layers by adding a WMS URL or uploading a KML file.
+ *
+ * @ngInject
+ * @ngdoc directive
+ * @ngname gmfWmskml
+ */
+gmf.wmskmlDirective = function() {
+  return {
+    controller: 'GmfWmskmlController as wkCtrl',
+    scope: {
+      'active': '=gmfWmskmlActive',
+      'map': '<gmfWmskmlMap',
+      'importOptions': '=gmfWmskmlImportOptions',
+      'wmsGetCap': '=gmfWmskmlWmsGetCap',
+      'wmtsGetCap': '=gmfWmskmlWmtsGetCap'
+    },
+    bindToController: true,
+    templateUrl: `${gmf.baseTemplateUrl}/wmskml.html`
+  };
+};
+
+gmf.module.directive('gmfWmskml', gmf.wmskmlDirective);
+
+
+/**
+ * @constructor
+ * @private
+ * @ngInject
+ * @ngdoc controller
+ * @ngname GmfDrawfeatureController
+ */
+gmf.WmskmlController = function() {
+};
+
+
+gmf.module.controller('GmfWmskmlController', gmf.WmskmlController);

--- a/contribs/gmf/src/directives/wmskml.js
+++ b/contribs/gmf/src/directives/wmskml.js
@@ -191,11 +191,13 @@ gmf.WmskmlController.prototype.handleFileContent_ = function(data, metadata) {
 
   if (ngeoFile.isWmsGetCap(data)) {
     this['wmsGetCap'] = data;
+    this['sourceName'] = metadata['name'];
     defer.resolve({
       'message': this.gettext_('Download succeeded')
     });
   } else if (ngeoFile.isWmtsGetCap(data)) {
     this['wmtsGetCap'] = data;
+    this['sourceName'] = metadata['name'];
     defer.resolve({
       'message': this.gettext_('Download succeeded')
     });

--- a/contribs/gmf/src/services/datasourcesmanager.js
+++ b/contribs/gmf/src/services/datasourcesmanager.js
@@ -467,6 +467,10 @@ gmf.DataSourcesManager = class {
 
     const id = treeCtrl.node.id;
     const dataSource = this.dataSourcesCache_[id];
+    // FIXME: find another way to handle source that was not added through theme
+    if (!dataSource) {
+      return;
+    }
     goog.asserts.assert(dataSource, 'DataSource should be set');
     treeCtrl.setDataSource(dataSource);
 

--- a/contribs/gmf/src/services/treemanager.js
+++ b/contribs/gmf/src/services/treemanager.js
@@ -430,6 +430,16 @@ gmf.TreeManager.prototype.getTreeCtrlByNodeId = function(id) {
 
 
 /**
+ * Add an OGC server.
+ * @param {string} ogcServerName Name of the OGC server to add.
+ * @param {!gmfThemes.GmfOgcServer} ogcServer OGC server to add.
+ */
+gmf.TreeManager.prototype.addOgcServer = function(ogcServerName, ogcServer) {
+  this.ogcServers_[ogcServerName] = ogcServer;
+};
+
+
+/**
  * Get the OGC server.
  * @param {ngeo.LayertreeController} treeCtrl ngeo layertree controller, from
  *     the current node.

--- a/src/modules/import/importonline.js
+++ b/src/modules/import/importonline.js
@@ -89,7 +89,7 @@ exports = function($q, $timeout, ngeoFile, gettext, ngeoImportOnlineTemplateUrl)
         // When a WMS is selected in the list, start downloading the
         // GetCapabilities
         scope['fileUrl'] = nameUrl['url'];
-        scope['handleFileUrl']();
+        scope['handleFileUrl'](nameUrl['name']);
         scope.$digest();
       });
 
@@ -126,7 +126,7 @@ exports = function($q, $timeout, ngeoFile, gettext, ngeoImportOnlineTemplateUrl)
       };
 
       // Handle URL of WMS
-      scope['handleFileUrl'] = function() {
+      scope['handleFileUrl'] = function(sourceName) {
         const transformUrl = options.transformUrl || $q.when;
 
         transformUrl(scope['fileUrl']).then((url) => {
@@ -140,6 +140,7 @@ exports = function($q, $timeout, ngeoFile, gettext, ngeoImportOnlineTemplateUrl)
             scope['canceler'] = null;
 
             return scope['handleFileContent'](fileContent, {
+              name: sourceName,
               url: scope['fileUrl']
             });
 

--- a/src/modules/import/partials/import-local.html
+++ b/src/modules/import/partials/import-local.html
@@ -2,7 +2,7 @@
   <input type="file" name="file"/>
   <!-- Button use to open the file chooser of the input file -->
   <input class="form-control" type="text" readonly
-         value="{{(file.name) ? file.name + ', ' + file.size/1000 + ' ko' : ''}}"
+         value="{{(file.name) ? file.name + ', ' + file.size/1000 + ' ' + ('kB' | translate) : ''}}"
          placeholder="{{'No file' | translate}}"/>
   <span class="input-group-btn">
     <button type="button" class="btn btn-default ngeo-import-browse" translate>Browse</button>

--- a/src/modules/import/wmsgetcap.js
+++ b/src/modules/import/wmsgetcap.js
@@ -166,7 +166,7 @@ exports = function($window, gettext, gettextCatalog, ngeoWmsGetCapTemplateUrl) {
       scope['addLayerSelected'] = function() {
         const getCapLay = scope['options'].layerSelected;
         if (getCapLay && scope['options']['getOlLayerFromGetCapLayer']) {
-          let msg = gettextCatalog.getString('WMS layer added succesfully');
+          // let msg = gettextCatalog.getString('WMS layer added succesfully');
           try {
             const olLayer = scope['options']['getOlLayerFromGetCapLayer'](getCapLay);
             if (olLayer) {
@@ -175,9 +175,10 @@ exports = function($window, gettext, gettextCatalog, ngeoWmsGetCapTemplateUrl) {
 
           } catch (e) {
             $window.console.error(`Add layer failed:${e}`);
-            msg = `${gettextCatalog.getString('WMS layer could not be added')} ${e.message}`;
+            // msg = `${gettextCatalog.getString('WMS layer could not be added')} ${e.message}`;
           }
-          $window.alert(msg);
+          // FIXME make this configurable?
+          // $window.alert(msg);
         }
       };
 

--- a/src/modules/import/wmtsgetcap.js
+++ b/src/modules/import/wmtsgetcap.js
@@ -114,7 +114,7 @@ exports = function(gettext, gettextCatalog, ngeoWmtsGetCapTemplateUrl) {
       scope['addLayerSelected'] = function() {
         const getCapLay = scope['options'].layerSelected;
         if (getCapLay && scope['options']['getOlLayerFromGetCapLayer']) {
-          let msg = gettextCatalog.getString('WMTS layer added succesfully');
+          // let msg = gettextCatalog.getString('WMTS layer added succesfully');
           try {
             const olLayer = scope['options']['getOlLayerFromGetCapLayer'](getCapLay);
             if (olLayer) {
@@ -123,9 +123,10 @@ exports = function(gettext, gettextCatalog, ngeoWmtsGetCapTemplateUrl) {
 
           } catch (e) {
             console.error(`Add layer failed:${e}`);
-            msg = `${gettextCatalog.getString('WMTS layer could not be added')} ${e.message}`;
+            // msg = `${gettextCatalog.getString('WMTS layer could not be added')} ${e.message}`;
           }
-          alert(msg);
+          // FIXME make this configurable?
+          // alert(msg);
         }
       };
 


### PR DESCRIPTION
See https://jira.camptocamp.com/browse/GSGMF-1

This PR is mostly a request for comments about how to integrate this new feature with the design of gmf.

The WMS/KML is (kind of) working, see proof of concept [here](https://camptocamp.github.io/ngeo/add-wmskml-component-GSGMF-2/examples/contribs/gmf/apps/desktop/). WMS and WMTS layers can be loaded and added to the layer tree. .gpx/.kml files can be loaded, but they are not yet added to the layer tree.

As far as I can tell, the gmf layer tree was not designed to allow adding layers that are not defined in a gmf theme. In particular, the following problems arise (see also FIXME comments for hacks in this POC):
- Every layer needs a unique integer id. I guess this usually comes from a database in the back end that generates the theme. I don't see a nice way of generating unique ids in the front end, the POC uses negative values as a hack.
- The `DataSourcesManager` has a cache that is populated when the theme changes, with data sources from the theme. There is a failing assert when it encounters a data source that was added later; for the POC, I just removed it.
- wmsgetcap.js / wmtsgetcap.js are not very generic, they always add new layers to the map. In our case the layers should be managed by the layer tree, so for the POC, the function that would usually return the layer just returns `null` instead. There is also an alert message that I commented out. I'm not sure what the process for refactoring these is, as it seems they are used by mf3-geoadmin.
- There is currently no mechanism to persist extra layers in the permalink. This is anyway not possible for layers that are local files, unless the local file is turned into an upload function, such that the file can be persisted in the backend.