### PR TITLE
Add support for crossOrigin option

### DIFF
--- a/src/source/swisstopo.js
+++ b/src/source/swisstopo.js
@@ -113,7 +113,8 @@ exports = function(options) {
     style: 'default',
     matrixSet: projectionCode,
     format,
-    tileGrid: tilegrid
+    tileGrid: tilegrid,
+    crossOrigin: options.crossOrigin
   });
 };
 ol.inherits(exports, ol.source.WMTS);


### PR DESCRIPTION
Cross origin is required for [forEachLayerAtPixel](https://openlayers.org/en/latest/apidoc/ol.Map.html#forEachLayerAtPixel) method, for example. Without that option user gets an error:

```
intermediatecanvas.js:140 Uncaught DOMException: Failed to execute 'getImageData' on 'CanvasRenderingContext2D': The canvas has been tainted by cross-origin data.
    at ol.renderer.canvas.TileLayer.ol.renderer.canvas.IntermediateCanvas.forEachLayerAtCoordinate (http://localhost:8180/build/ol/renderer/canvas/intermediatecanvas.js:140:44)
    at ol.renderer.canvas.Map.forEachLayerAtPixel (http://localhost:8180/build/ol/renderer/canvas/map.js:207:30)
    at ol.Map.forEachLayerAtPixel (http://localhost:8180/build/ol/map.js:627:25)
    at ol.Map.hoverUnlistenKey_.map.on (http://localhost:8180/common/map/click.js:159:11)
    at ol.Map.boundListener (http://localhost:8180/build/ol/events.js:17:21)
    at ol.Map.ol.events.EventTarget.dispatchEvent (http://localhost:8180/build/ol/events/eventtarget.js:88:24)
    at ol.Map.handleMapBrowserEvent (http://localhost:8180/build/ol/map.js:944:12)
    at ol.MapBrowserEventHandler.boundListener (http://localhost:8180/build/ol/events.js:17:21)
    at ol.MapBrowserEventHandler.ol.events.EventTarget.dispatchEvent (http://localhost:8180/build/ol/events/eventtarget.js:88:24)
    at ol.MapBrowserEventHandler.relayEvent_ (http://localhost:8180/build/ol/mapbrowsereventhandler.js:280:8)
```

That exception is occurred because of [CORS](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image).
Link to OpenLayers doc: <https://openlayers.org/en/latest/apidoc/ol.source.WMTS.html>
