### PR TITLE
Remove duplicate param handling

### DIFF
--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -22,8 +22,6 @@ goog.require('gmf.mapDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.searchDirective');
 /** @suppress {extraRequire} */
-goog.require('gmf.FulltextSearchService');
-/** @suppress {extraRequire} */
 goog.require('gmf.themeselectorDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.BackgroundLayerMgr');
@@ -562,17 +560,6 @@ gmf.AbstractController = function(config, $scope, $injector) {
   cgxp.tools.openInfoWindow = function(url, title, opt_width, opt_height) {
     gmfx.openIframePopup(url, title, opt_width, opt_height);
   };
-
-  /**
-   * @private
-   */
-  this.fullTextSearch_ = $injector.get('gmfFulltextSearchService');
-
-  const searchQuery = this.ngeoLocation.getParam('search');
-  if (searchQuery) {
-    const overlay = ngeoFeatureOverlayMgr.getFeatureOverlay();
-    this.search_(searchQuery, overlay);
-  }
 };
 
 
@@ -654,24 +641,6 @@ gmf.AbstractController.prototype.getLocationIcon = function() {
   const arrowWrapper = document.createElement('span');
   arrowWrapper.appendChild(arrow);
   return arrowWrapper;
-};
-
-/**
- * Performs a full-text search and centers the map on the first search result.
- * @param {string} query Search query.
- * @param {ngeo.FeatureOverlay} overlay Feature overlay to add the feature if found.
- * @private
- */
-gmf.AbstractController.prototype.search_ = function(query, overlay) {
-  this.fullTextSearch_.search(query, {'limit': 1})
-    .then((data) => {
-      if (data && data.features[0]) {
-        const format = new ol.format.GeoJSON();
-        const feature = format.readFeature(data.features[0]);
-        overlay.addFeature(feature);
-        this.map.getView().fit(feature.getGeometry().getExtent());
-      }
-    });
 };
 
 gmf.module.controller('AbstractController', gmf.AbstractController);


### PR DESCRIPTION
It looks like I made a mistake while rebasing this [pull request](https://github.com/camptocamp/ngeo/pull/2719).

There shouldn't be any changes to contribs/gmf/src/controllers/abstract.js

Can someone else verify if the search-param works as intended now?