### PR TITLE
Type for directives and components

### DIFF
--- a/jsdoc/template/tmpl/params.tmpl
+++ b/jsdoc/template/tmpl/params.tmpl
@@ -84,9 +84,10 @@
             <?js } ?>
 
             <td class="type">
-
             <?js if (param.typeDefinitionUrl) {?>
                 <?js= param.typeDefinitionUrl ?>
+            <?js } else if (param.type) { ?>
+                <?js= param.type.names.join('|') ?>
             <?js } ?>
             </td>
 

--- a/jsdoc/template/tmpl/params.tmpl
+++ b/jsdoc/template/tmpl/params.tmpl
@@ -87,7 +87,7 @@
             <?js if (param.typeDefinitionUrl) {?>
                 <?js= param.typeDefinitionUrl ?>
             <?js } else if (param.type) { ?>
-                <?js= param.type.names.join('|') ?>
+                <?js= self.partial('type.tmpl', param.type.names) ?>
             <?js } ?>
             </td>
 


### PR DESCRIPTION
Fix: #2848

The documentation is already better with that (type is now defined in directive and components).
But I still don't have links on documentation on the types.

To do that, I need to copy all the related content of "helper.registerLink" (like https://github.com/camptocamp/ngeo/blob/master/jsdoc/template/publish.js#L450-L461) in the "plugin" file.
It isn't a better way to do that ? Can't I have a "common" file ? Do you have any clue @sbrunner @gberaudo  ?