### PR TITLE
Export modeFlush for layertree title

### DIFF
--- a/contribs/gmf/src/services/thememanager.js
+++ b/contribs/gmf/src/services/thememanager.js
@@ -64,6 +64,7 @@ gmf.ThemeManager = function($rootScope, gmfThemes, gmfTreeManagerModeFlush,
 
   /**
    * @type {boolean}
+   * @export
    */
   this.modeFlush = gmfTreeManagerModeFlush;
 


### PR DESCRIPTION
Commit 1: needed by the layertree title (otherwise, it doesn't exist in the HTML so the value is always false)

Questions:
 - It is useful in the mobile app ? https://github.com/camptocamp/ngeo/blob/2.2/contribs/gmf/apps/mobile/index.html#L177

- This line was switched, is there a reason for that ? (that make one change more in the ngeo.diff during an upgrade: https://github.com/camptocamp/ngeo/blob/2.2/contribs/gmf/apps/desktop/index.html#L303 (was at line 299)