### PR TITLE
Switch to protocol-agnostic GitHub shortcut url

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "less-plugin-autoprefix": "1.5.1",
     "less-plugin-clean-css": "1.5.1",
     "nomnom": "1.8.1",
-    "openlayers": "git://github.com/camptocamp/ol3#ngeo_2.1",
+    "openlayers": "camptocamp/ol3#ngeo_2.1",
     "phantomjs-prebuilt": "2.1.13",
     "proj4": "2.3.15",
     "svg2ttf": "4.0.2",


### PR DESCRIPTION
Using the git-protocol explicitly there has caused issues on multiple instances. This configuration change allows an automatic fall-back to https.