### PR TITLE
Switch to protocol-agnostic GitHub shortcut url [2.2]

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "async": "2.5.0",
     "bootstrap": "3.3.7",
     "clean-css-cli": "4.1.6",
-    "closure-util": "git://github.com/camptocamp/closure-util#487fac6",
+    "closure-util": "camptocamp/closure-util#487fac6",
     "console-control-strings": "1.1.0",
     "corejs-typeahead": "1.1.1",
     "coveralls": "2.13.1",


### PR DESCRIPTION
Using the git-protocol explicitly there has caused issues on multiple instances. This configuration change allows an automatic fall-back to https.

Same issue as #2875 