### PR TITLE
Do not freeze background dimensions on init

### DIFF
--- a/contribs/gmf/src/services/themesservice.js
+++ b/contribs/gmf/src/services/themesservice.js
@@ -259,13 +259,6 @@ gmf.Themes.prototype.getBgLayers = function(appDimensions) {
    * @return {angular.$q.Promise.<ol.layer.Base>|ol.layer.Base} the created layer.
    */
   const layerLayerCreationFn = function(ogcServers, gmfLayer) {
-    // Overwrite conflicting server dimensions with application ones
-    for (const dimkey in gmfLayer.dimensions) {
-      if (appDimensions[dimkey] !== undefined) {
-        gmfLayer.dimensions[dimkey] = appDimensions[dimkey];
-      }
-    }
-
     if (gmfLayer.type === 'WMTS') {
       const gmfLayerWMTS = /** @type gmfThemes.GmfLayerWMTS */ (gmfLayer);
       goog.asserts.assert(gmfLayerWMTS.url, 'Layer URL is required');


### PR DESCRIPTION
The previous code rewrote the theme dimension rules at init time.

This was wrong since dynamic dimensions should be updated during the life of the application.