### PR TITLE
searchtext icon overlaps placeholder on ipad

### DIFF
--- a/contribs/gmf/less/mobile-nav.less
+++ b/contribs/gmf/less/mobile-nav.less
@@ -232,7 +232,7 @@ nav.gmf-mobile-nav-right {
 
 // For small devices (in portrait mode) we want the navigation menus to take
 // 90% of the viewport width
-@media (max-width: @screen-xs) {
+@media (max-width: @screen-xs-max) {
   main {
     .gmf-mobile-nav-left-is-visible & {
       transform: translateX(90vw);

--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -113,7 +113,7 @@ button[ngeo-mobile-geolocation] {
   z-index: 2;
 }
 
-// Overrides for tablet devices
+// Overrides for tablet devices and up
 @media (min-width: @screen-sm-min) {
   .gmf-mobile-measure {
     right: 2 * @app-margin + @map-tools-size;

--- a/contribs/gmf/less/search.less
+++ b/contribs/gmf/less/search.less
@@ -55,7 +55,6 @@ gmf-search {
   }
   .form-control {
     box-shadow: none;
-    border: none;
     height: 100%;
     padding: @half-app-margin @map-tools-size;
     border: 1px solid @border-color;

--- a/contribs/gmf/less/search.less
+++ b/contribs/gmf/less/search.less
@@ -110,8 +110,8 @@ gmf-search {
   }
 }
 
-// Overrides for small browser widths
-@media (max-width: @screen-sm-min) {
+// Overrides for small browser widths only
+@media (max-width: @screen-xs-max) {
   gmf-search {
     .gmf-search {
       width: 100%;
@@ -124,7 +124,7 @@ gmf-search {
 
 @search-width: 6 * @map-tools-size;
 
-// Overrides for tablet devices
+// Overrides for tablet devices and up
 @media (min-width: @screen-sm-min) {
   gmf-search {
     .gmf-search {

--- a/contribs/gmf/less/searchmobile.less
+++ b/contribs/gmf/less/searchmobile.less
@@ -14,7 +14,6 @@
     right: 0;
     margin: 0 @app-margin + @map-tools-size;
     .gmf-search {
-      border-width: 1px 0;
       width: 100%;
     }
     .tt-menu {

--- a/contribs/gmf/less/searchmobile.less
+++ b/contribs/gmf/less/searchmobile.less
@@ -1,14 +1,14 @@
 @import "search.less";
 
-// Overrides for tablet devices
+// Overrides for tablet devices and up
 @media (min-width: @screen-sm-min) {
   gmf-search {
     left: 2 * @app-margin + @map-tools-size;
   }
 }
 
-// Overrides for phone devices
-@media (max-width: @screen-sm-min) {
+// Overrides for phone devices only
+@media (max-width: @screen-xs-max) {
   gmf-search {
     left: 0;
     right: 0;


### PR DESCRIPTION
fixes #2884