### PR TITLE
Fix Manage FILTER param in WMS request issue

### DIFF
--- a/contribs/gmf/src/services/datasourcesmanager.js
+++ b/contribs/gmf/src/services/datasourcesmanager.js
@@ -246,7 +246,7 @@ gmf.DataSourcesManager = class {
             const cache = this.treeCtrlCache_;
             for (const id in this.treeCtrlCache_) {
               const item = cache[id];
-              if (!ol.array.includes(newTreeCtrls, item.treeCtrl)) {
+              if (!newTreeCtrls.includes(item.treeCtrl)) {
                 this.removeTreeCtrlCacheItem_(item);
               }
             }
@@ -591,9 +591,9 @@ gmf.DataSourcesManager = class {
     if (Array.isArray(siblingDataSourceIds)) {
       const ngeoDataSources = this.ngeoDataSources_.getArray();
       for (const ngeoDataSource of ngeoDataSources) {
-        if (ol.array.includes(siblingDataSourceIds, ngeoDataSource.id) &&
+        if (ngeoDataSource.filterRules !== null &&
             ngeoDataSource.id !== dataSource.id &&
-            ngeoDataSource.filterRules !== null &&
+            siblingDataSourceIds.includes(ngeoDataSource.id) &&
             ngeoDataSource.visible
         ) {
           goog.asserts.assertInstanceof(ngeoDataSource, gmf.DataSource);

--- a/contribs/gmf/src/services/datasourcesmanager.js
+++ b/contribs/gmf/src/services/datasourcesmanager.js
@@ -11,7 +11,6 @@ goog.require('ngeo.DataSources');
 goog.require('ngeo.LayerHelper');
 goog.require('ngeo.RuleHelper');
 goog.require('ngeo.WMSTime');
-goog.require('ol.array');
 goog.require('ol.obj');
 goog.require('ol.layer.Image');
 goog.require('ol.source.ImageWMS');

--- a/src/services/datasources.js
+++ b/src/services/datasources.js
@@ -8,6 +8,6 @@ ngeo.module.value('ngeoDataSources', new ol.Collection());
 
 
 /**
- * @typedef {ol.Collection.<ngeo.DataSource>}
+ * @typedef {!ol.Collection.<!ngeo.DataSource>}
  */
 ngeo.DataSources;


### PR DESCRIPTION
Patch for 2.2.  Replaces #2882.

In GMF, OpenLayers layer objects can be created with the combinaison of multiple data sources.

In GMF, only one data source may be filtered at a time.

The issue was: when playing with the visibility of the data sources, i.e. using the layer tree when toggling on/off the layer source params LAYERS, if the change occured on an other data source that's within the layer, then the synchronization between the WMS parameter FILTER and LAYERS becomes broken.

This patch fixes this.