### PR TITLE
[WIP] Filter out empty layers send to mapfish-print

### DIFF
--- a/src/services/print.js
+++ b/src/services/print.js
@@ -217,7 +217,12 @@ ngeo.Print.prototype.encodeMap_ = function(map, scale, object) {
   layers.forEach((layer) => {
     if (layer.getVisible()) {
       goog.asserts.assert(viewResolution !== undefined);
-      this.encodeLayer(object.layers, layer, viewResolution);
+
+      // Filter out some empty layers sent to mapfish-print with type ol.source.ImageWMS
+      const source_ = layer.getSource();
+      if ((source_ instanceof ol.source.ImageWMS && source_.getParams().LAYERS.length !== 0) || !(source_ instanceof ol.source.ImageWMS)) {
+        this.encodeLayer(object.layers, layer, viewResolution);
+      }
     }
   });
 };


### PR DESCRIPTION
Fixes #2895 

This fix filter out some empty layers that are send to Mapfish-print via the json report. In the report we could see the layers param being empty, so this is specifically the layers that I filter out:
```
{
                "baseURL": "https://geomapfish-demo.camptocamp.net/2.2/wsgi/mapserv_proxy",
                "imageFormat": "image/png",
                "layers": [""],
                "customParams": {
                    "TRANSPARENT": true,
                    "ogcserver": "Main PNG",
                    "cache_version": "320e30192ed348a4a30236f3bba7b925"
                },
                "serverType": "mapserver",
                "type": "wms",
                "opacity": 0.65
 }
```
Each layer with no 'layers' parameter filled were printed with a transparent layers, although not being visible in the gmf layer-tree.

@fredj If you can take a look at this, to find a better solution.