### PR TITLE
GetData on filtered data source only (2.2)

### DIFF
--- a/src/directives/filter.js
+++ b/src/directives/filter.js
@@ -243,6 +243,7 @@ ngeo.FilterController = class {
     goog.asserts.assert(filter);
 
     this.ngeoMapQuerent_.issue({
+      dataSources: [dataSource],
       filter,
       limit,
       map


### PR DESCRIPTION
Fixes #2927.

In the ngeo filter component, when using `getData`, only get data from the data source that is currently being filtered, not all currently visible data sources.