### PR TITLE
Fix definitions leaking outside of the provide

### DIFF
--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -174,7 +174,7 @@ gmf.module.directive('gmfSearch', gmf.searchDirective);
  * @param {angular.$injector} $injector Main injector.
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @param {ngeo.AutoProjection} ngeoAutoProjection The ngeo coordinates service.
- * @param {ngeo.search.CreateGeoJSONBloodhound} ngeoSearchCreateGeoJSONBloodhound The ngeo
+ * @param {ngeo.search.createGeoJSONBloodhound.Function} ngeoSearchCreateGeoJSONBloodhound The ngeo
  *     create GeoJSON Bloodhound service.
  * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *     overlay manager service.
@@ -233,7 +233,7 @@ gmf.SearchController = function($scope, $compile, $timeout, $injector, gettextCa
   this.fullTextSearch_ = gmfFulltextSearchService;
 
   /**
-   * @type {ngeo.search.CreateGeoJSONBloodhound}
+   * @type {ngeo.search.createGeoJSONBloodhound.Function}
    * @private
    */
   this.ngeoSearchCreateGeoJSONBloodhound_ = ngeoSearchCreateGeoJSONBloodhound;

--- a/examples/search.js
+++ b/examples/search.js
@@ -58,7 +58,7 @@ app.module.directive('appSearch', app.searchDirective);
  * @constructor
  * @param {angular.Scope} $rootScope Angular root scope.
  * @param {angular.$compile} $compile Angular compile service.
- * @param {ngeo.search.CreateGeoJSONBloodhound} ngeoSearchCreateGeoJSONBloodhound The ngeo
+ * @param {ngeo.search.createGeoJSONBloodhound.Function} ngeoSearchCreateGeoJSONBloodhound The ngeo
  *     create GeoJSON Bloodhound service.
  * @ngInject
  */
@@ -149,7 +149,7 @@ app.SearchController.prototype.createVectorLayer_ = function() {
 
 
 /**
- * @param {ngeo.search.CreateGeoJSONBloodhound} ngeoSearchCreateGeoJSONBloodhound The ngeo
+ * @param {ngeo.search.createGeoJSONBloodhound.Function} ngeoSearchCreateGeoJSONBloodhound The ngeo
  *     create GeoJSON Bloodhound service.
  * @return {Bloodhound} The bloodhound engine.
  * @private

--- a/src/modules/search/creategeojsonbloodhound.js
+++ b/src/modules/search/creategeojsonbloodhound.js
@@ -6,45 +6,6 @@ goog.provide('ngeo.search.createGeoJSONBloodhound');
 goog.require('ol.format.GeoJSON');
 goog.require('ol.obj');
 
-/**
- * Provides a function that creates a Bloodhound engine
- * expecting GeoJSON responses from the search web service, which creates
- * `ol.Feature` objects as suggestions.
- *
- * Example:
- *
- *     let bloodhound = createGeoJSONBloodhound(
- *       'http://example.com/fulltextsearch?query=%QUERY',
- *       aFilterFunction,
- *       ol.proj.get('EPSG:3857'));
- *     bloodhound.initialize();
- *
- *     let bloodhound = createGeoJSONBloodhound(
- *       '',
- *       undefined,
- *       ol.proj.get('EPSG:3857'),
- *       ol.proj.get('EPSG:21781'),
- *       {
- *         remote: {
- *           url: mySearchEngineUrl,
- *           replace: function(url, query) {
- *             return url +
- *                 '?qtext=' + encodeURIComponent(query) +
- *                 '&lang=' + gettextCatalog.currentLanguage;
- *           }
- *         }
- *       }
- *     );
- *     bloodhound.initialize();
- *
- * @typedef {function(string, (function(GeoJSONFeature): boolean)=,
- * ol.proj.Projection=, ol.proj.Projection=, BloodhoundOptions=,
- * BloodhoundRemoteOptions=):Bloodhound}
- * @ngdoc service
- * @ngname search.createGeoJSONBloodhound
- */
-ngeo.search.CreateGeoJSONBloodhound;
-
 
 /**
  * @param {string} url an URL to a search service.
@@ -116,3 +77,43 @@ ngeo.search.createGeoJSONBloodhound.module = angular.module('ngeoSearchCreategeo
 ngeo.search.createGeoJSONBloodhound.module.value(
   'ngeoSearchCreateGeoJSONBloodhound',
   ngeo.search.createGeoJSONBloodhound);
+
+
+/**
+ * Provides a function that creates a Bloodhound engine
+ * expecting GeoJSON responses from the search web service, which creates
+ * `ol.Feature` objects as suggestions.
+ *
+ * Example:
+ *
+ *     let bloodhound = createGeoJSONBloodhound(
+ *       'http://example.com/fulltextsearch?query=%QUERY',
+ *       aFilterFunction,
+ *       ol.proj.get('EPSG:3857'));
+ *     bloodhound.initialize();
+ *
+ *     let bloodhound = createGeoJSONBloodhound(
+ *       '',
+ *       undefined,
+ *       ol.proj.get('EPSG:3857'),
+ *       ol.proj.get('EPSG:21781'),
+ *       {
+ *         remote: {
+ *           url: mySearchEngineUrl,
+ *           replace: function(url, query) {
+ *             return url +
+ *                 '?qtext=' + encodeURIComponent(query) +
+ *                 '&lang=' + gettextCatalog.currentLanguage;
+ *           }
+ *         }
+ *       }
+ *     );
+ *     bloodhound.initialize();
+ *
+ * @typedef {function(string, (function(GeoJSONFeature): boolean)=,
+ * ol.proj.Projection=, ol.proj.Projection=, BloodhoundOptions=,
+ * BloodhoundRemoteOptions=):Bloodhound}
+ * @ngdoc service
+ * @ngname search.createGeoJSONBloodhound
+ */
+ngeo.search.createGeoJSONBloodhound.Function;

--- a/src/modules/search/createlocationsearchbloodhound.js
+++ b/src/modules/search/createlocationsearchbloodhound.js
@@ -10,27 +10,6 @@ goog.require('ngeo.proj.EPSG21781');
 goog.require('ol.geom.Point');
 goog.require('ol.Feature');
 
-/**
- * Provides a function that creates a Bloodhound engine
- * for the GeoAdmin Location Search API, which creates `ol.Feature` objects
- * as suggestions.
- *
- * See: http://api3.geo.admin.ch/services/sdiservices.html#search
- *
- * Example:
- *
- *     let bloodhound = ngeoCreateLocationSearchBloodhound({
- *       targetProjection: ol.proj.get('EPSG:3857'),
- *       limit: 10
- *     });
- *     bloodhound.initialize();
- *
- * @typedef {function(ngeox.search.LocationSearchOptions=):Bloodhound}
- * @ngdoc service
- * @ngname search.createLocationSearchBloodhound
- */
-ngeo.search.CreateLocationSearchBloodhound;
-
 
 /**
  * @param {ngeox.search.LocationSearchOptions=} opt_options Options.
@@ -152,3 +131,25 @@ ngeo.search.createLocationSearchBloodhound.module = angular.module('ngeoCreateLo
 ngeo.search.createLocationSearchBloodhound.module.value(
   'ngeoCreateLocationSearchBloodhound',
   ngeo.search.createLocationSearchBloodhound);
+
+
+/**
+ * Provides a function that creates a Bloodhound engine
+ * for the GeoAdmin Location Search API, which creates `ol.Feature` objects
+ * as suggestions.
+ *
+ * See: http://api3.geo.admin.ch/services/sdiservices.html#search
+ *
+ * Example:
+ *
+ *     let bloodhound = ngeoCreateLocationSearchBloodhound({
+ *       targetProjection: ol.proj.get('EPSG:3857'),
+ *       limit: 10
+ *     });
+ *     bloodhound.initialize();
+ *
+ * @typedef {function(ngeox.search.LocationSearchOptions=):Bloodhound}
+ * @ngdoc service
+ * @ngname search.createLocationSearchBloodhound
+ */
+ngeo.search.createLocationSearchBloodhound.Function;


### PR DESCRIPTION
All definitions should be local to the provided symbol.
As such, a symbol ngeo.search.toto cannot define Toto in ngeo.search.