### PR TITLE
Only update the scale value at the end of the zoom animation

### DIFF
--- a/src/directives/scaleselector.js
+++ b/src/directives/scaleselector.js
@@ -225,9 +225,11 @@ ngeo.ScaleselectorController.prototype.handleResolutionChange_ = function(e) {
   //
   // For that reason we use $applyAsync instead of $apply here.
 
-  this.$scope_.$applyAsync(() => {
-    this.currentScale = currentScale;
-  });
+  if (currentScale !== undefined) {
+    this.$scope_.$applyAsync(() => {
+      this.currentScale = currentScale;
+    });
+  }
 };
 
 


### PR DESCRIPTION
Otherwise `$applyAsync` is called on every frame change (~60 / second)