### PR TITLE
Adding missing datasource attribute to mapfish-print externs

### DIFF
--- a/externs/mapfish-print-v3.js
+++ b/externs/mapfish-print-v3.js
@@ -45,7 +45,7 @@ MapFishPrintAttributes.prototype.map;
 
 
 /**
- * @type {Array}
+ * @type {Array.<Object>}
  */
 MapFishPrintAttributes.prototype.datasource;
 

--- a/externs/mapfish-print-v3.js
+++ b/externs/mapfish-print-v3.js
@@ -44,6 +44,11 @@ let MapFishPrintAttributes = function() {};
 MapFishPrintAttributes.prototype.map;
 
 
+/**
+ * @type {Array}
+ */
+MapFishPrintAttributes.prototype.datasource;
+
 
 /**
  * @constructor


### PR DESCRIPTION
see:
https://mapfish.github.io/mapfish-print-doc/attributes.html#!datasource