### PR TITLE
Be able to get legend for multiple layers

### DIFF
--- a/contribs/gmf/less/layertree.less
+++ b/contribs/gmf/less/layertree.less
@@ -177,5 +177,11 @@
         text-decoration: underline;
       }
     }
+    p {
+      margin: 0 0 0 1rem;
+    }
+    img {
+      margin-bottom: 1rem;
+    }
   }
 }

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -105,7 +105,7 @@
 
     <span
       ngeo-popover
-      ng-if="::(layertreeCtrl.depth === 1 && !layertreeCtrl.node.mixed) || (layertreeCtrl.depth > 1 && layertreeCtrl.parent.node.mixed && !layertreeCtrl.node.children) || (gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend)" ngeo-popover-dismiss=".content">
+      ng-if="::(layertreeCtrl.depth === 1 && !layertreeCtrl.node.mixed) || (layertreeCtrl.depth > 1 && layertreeCtrl.parent.node.mixed && !layertreeCtrl.node.children) || (gmfLayertreeCtrl.getLegendsObject(layertreeCtrl) && layertreeCtrl.node.metadata.legend)" ngeo-popover-dismiss=".content">
 
       <span
         ngeo-popover-anchor
@@ -126,7 +126,7 @@
               step="0.01"
               ng-model="layertreeCtrl.layer.opacity" />
           </li>
-          <li ng-if="::gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend">
+          <li ng-if="::gmfLayertreeCtrl.getLegendsObject(layertreeCtrl) && layertreeCtrl.node.metadata.legend">
             <i class="fa fa-th-list fa-fw"></i>
             <a
               title="{{'Show/hide legend'|translate}}"
@@ -171,7 +171,7 @@
 
     <a
       class="fa fa-align-left gmf-layertree-legend-button"
-      ng-if="::gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend"
+      ng-if="::gmfLayertreeCtrl.getLegendsObject(layertreeCtrl) && layertreeCtrl.node.metadata.legend"
       title="{{'Show/hide legend'|translate}}"
       data-toggle="collapse"
       ng-click="::gmfLayertreeCtrl.toggleNodeLegend('#gmf-layertree-node-' + layertreeCtrl.uid + '-legend')"
@@ -181,7 +181,7 @@
 </div>
 
 <div
-  ng-if="::!layertreeCtrl.isRoot && gmfLayertreeCtrl.getLegendURL(layertreeCtrl) && layertreeCtrl.node.metadata.legend" id="gmf-layertree-node-{{::layertreeCtrl.uid}}-legend"
+  ng-if="::!layertreeCtrl.isRoot && gmfLayertreeCtrl.getLegendsObject(layertreeCtrl) && layertreeCtrl.node.metadata.legend" id="gmf-layertree-node-{{::layertreeCtrl.uid}}-legend"
   class="collapse gmf-layertree-legend"
   ng-class="::[layertreeCtrl.node.metadata.isLegendExpanded ? 'in' : '']">
 
@@ -192,8 +192,12 @@
     href="">
     {{'Hide legend'|translate}}
   </a>
-
-  <img ng-if="gmfLayertreeCtrl.isNodeLegendVisible('#gmf-layertree-node-' + layertreeCtrl.uid + '-legend')" ng-src="{{gmfLayertreeCtrl.getLegendURL(layertreeCtrl)}}"></img>
+  <div ng-if="gmfLayertreeCtrl.isNodeLegendVisible('#gmf-layertree-node-' + layertreeCtrl.uid + '-legend')">
+    <div ng-repeat="(title, url) in ::gmfLayertreeCtrl.getLegendsObject(layertreeCtrl)">
+      <p ng-if="::gmfLayertreeCtrl.getNumberOfLegendsObject(layertreeCtrl) > 1">{{title|translate}}</p>
+      <img ng-src="{{url}}"></img>
+    </div>
+  </div>
 </div>
 
 <ul


### PR DESCRIPTION
FIX: #2950
Demo: (try with theme: Demo, layergroup "OSM function", layer "two_layers"): https://testgmf.sig.cloud.camptocamp.net/bge/theme/Demo?lang=en&tree_group_layers_Transport=fuel&baselayer_ref=OSM%20map&theme=Demo&tree_groups=OSM%20functions%20mixed%2CLayers%2CGroup%2COSM%20functions%2CExternal%2CFilters%20mixed%2CFilters&tree_group_opacity_Group=0.65&tree_enable_osm_scale&tree_enable_osm_time_r_s&tree_enable_osm_time_v_s&tree_enable_osm_time_v_dp&tree_enable_osm_time_r_dp&tree_enable_osm_time_r_year_mounth&tree_enable_osm_time_d_year_mounth&tree_enable_osm_time_r_mounth_year&tree_enable_osm_time_v_mounth_year&tree_group_layers_Layers&tree_group_layers_OSM%20functions

With multiple layers on one ol layer:
QGISServer: GetLegendGraphic with `LAYER=layer1,layer2,...` (non-standard but works)
Other server: Use multiple request (one per layer) and use the layerName as title for each image requested.

(Was not so easy with ng-repeat and AngularJS restrictive scopes)