### PR TITLE
Multi-line layer name in layer-tree, allow icons to diplay regardless of label length

### DIFF
--- a/contribs/gmf/less/desktoplayertree.less
+++ b/contribs/gmf/less/desktoplayertree.less
@@ -94,10 +94,6 @@ gmf-layertree {
     display: none;
   }
 
-  .gmf-layertree-name {
-    white-space: nowrap;
-  }
-
   // leave space for the drag handle
   .gmf-layertree-depth-1 a.gmf-layertree-expand-node.fa {
     margin-left: @half-app-margin;


### PR DESCRIPTION
Fixes #2978 

This was already in use with the mobile interface, as this interface had no style for this element. 

In most case no changes are visible as the layer names are usually shorter than the panel width. 

In the longest label length, the text will now wrap to the next line and the icon will still be at the right end of the label. This will allow this icon to be displayed regardless of the label.