### PR TITLE
Fix rotate button on mobile devices

### DIFF
--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -105,6 +105,15 @@ gmf-map {
   }
 }
 
+.ol-rotate,
+.ol-zoom {
+  button {
+    &:hover {
+      background-color: @map-tools-bg-color;
+    }
+  }
+}
+
 .ol-scale-line {
   bottom: @app-margin;
   left: @app-margin;


### PR DESCRIPTION
Make sure that the rotate button, on mobile devices, is white (not grey).