### PR TITLE
Add missing gmfLayersUrl in mobile_alt app

### DIFF
--- a/contribs/gmf/apps/mobile_alt/index.html
+++ b/contribs/gmf/apps/mobile_alt/index.html
@@ -204,6 +204,7 @@
         module.constant('authenticationBaseUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi');
         module.constant('fulltextsearchUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/fulltextsearch?limit=20&interface=mobile');
         module.constant('gmfTreeUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/themes?version=2&background=background&interface=mobile');
+        module.constant('gmfLayersUrl', 'https://geomapfish-demo.camptocamp.net/2.2/wsgi/layers/');
         module.constant('gmfRasterUrl', 'https://geomapfish-demo.camptocamp.net/2.1/wsgi/raster');
         module.constant('gmfShortenerCreateUrl', '');
         module.constant('gmfSearchGroups', []);


### PR DESCRIPTION
Add the missing dependency in `mobile_alt` application to make it work again.