### PR TITLE
Disable autorotate on mobile app.

### DIFF
--- a/contribs/gmf/apps/mobile/js/controller.js
+++ b/contribs/gmf/apps/mobile/js/controller.js
@@ -28,7 +28,7 @@ goog.require('ngeo.proj.EPSG21781');
  */
 app.MobileController = function($scope, $injector) {
   gmf.AbstractMobileController.call(this, {
-    autorotate: true,
+    autorotate: false,
     srid: 21781,
     mapViewConfig: {
       center: [632464, 185457],


### PR DESCRIPTION
Disable 'autorotate' on mobile app.  Keep it enabled on mobile_alt app.

Wait for #2995 to be merged first.