### PR TITLE
Fix display query window minimum size

### DIFF
--- a/contribs/gmf/less/base.less
+++ b/contribs/gmf/less/base.less
@@ -66,3 +66,13 @@ i, cite, em, var, address, dfn {
   font-size: inherit;
   line-height: 1;
 }
+
+.ui-draggable {
+  cursor: grab;
+  cursor: -webkit-grab;
+  cursor:-moz-grab;
+
+  &.ui-draggable-dragging {
+    cursor: move;
+  }
+}

--- a/contribs/gmf/src/directives/displayquerywindow.js
+++ b/contribs/gmf/src/directives/displayquerywindow.js
@@ -267,7 +267,10 @@ gmf.DisplayquerywindowController.prototype.$onInit = function() {
 
   if (this.desktop) {
     this.element_.find('.gmf-displayquerywindow').draggable();
-    this.element_.find('.gmf-displayquerywindow-container').resizable();
+    this.element_.find('.gmf-displayquerywindow-container').resizable({
+      'minHeight': 240,
+      'minWidth': 240
+    });
   }
 };
 


### PR DESCRIPTION
Fix the min size the display query window.  Also, make sure to show the proper pointer cursor when hovered to tell that it can be dragged and show an other cursor while being dragged.