### PR TITLE
Make example match actual attribute name

### DIFF
--- a/contribs/gmf/src/directives/print.js
+++ b/contribs/gmf/src/directives/print.js
@@ -87,7 +87,7 @@ gmf.module.value('gmfPrintTemplateUrl',
  *        gmf-print-map="mainCtrl.map"
  *        gmf-print-active="printActive"
  *        gmf-print-rotatemask="true"
- *        gmf-print-hiddenfields="['name']"
+ *        gmf-print-hiddenattributes="['name']"
  *        gmf-print-attributes-out="attributes">
  *        <div ng-repeat="attribute in attributes">
  *          <div ng-if="attribute.name == 'name'">


### PR DESCRIPTION
The attribute did not match the name anymore:

`'hiddenAttributeNames': '=gmfPrintHiddenattributes',`

The [full example](https://github.com/camptocamp/ngeo/blob/master/contribs/gmf/examples/print.html#L199) is correct.