### PR TITLE
Preserve map_zoom setting when using search parameter

### DIFF
--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -464,7 +464,11 @@ gmf.SearchController.prototype.$onInit = function() {
       if (this.ngeoLocation_.getParam('search-select-index')) {
         resultIndex = parseInt(this.ngeoLocation_.getParam('search-select-index'), 10);
       }
-      this.fulltextsearch_(searchQuery, resultIndex);
+      let mapZoom = null;
+      if (this.ngeoLocation_.getParam('map_zoom')) {
+        mapZoom = parseInt(this.ngeoLocation_.getParam('map_zoom'), 10);
+      }
+      this.fulltextsearch_(searchQuery, resultIndex, mapZoom);
     }
   }
 };
@@ -947,9 +951,10 @@ gmf.SearchController.datasetsempty_ = function(event, query, empty) {
  * Performs a full-text search and centers the map on the first search result.
  * @param {string} query Search query.
  * @param {number} resultIndex Return nth result instead.
+ * @param {?number} opt_zoom Optional zoom level.
  * @private
  */
-gmf.SearchController.prototype.fulltextsearch_ = function(query, resultIndex) {
+gmf.SearchController.prototype.fulltextsearch_ = function(query, resultIndex, opt_zoom) {
   if (resultIndex < 1) { // can't be lower than one
     resultIndex = 1;
   }
@@ -959,7 +964,11 @@ gmf.SearchController.prototype.fulltextsearch_ = function(query, resultIndex) {
         const format = new ol.format.GeoJSON();
         const feature = format.readFeature(data.features[resultIndex - 1]);
         this.featureOverlay_.addFeature(feature);
-        this.map_.getView().fit(feature.getGeometry().getExtent());
+        const fitOptions = /** @type {olx.view.FitOptions} */ ({});
+        if (opt_zoom) {
+          fitOptions.maxZoom = opt_zoom;
+        }
+        this.map_.getView().fit(feature.getGeometry().getExtent(), fitOptions);
         this.inputValue = /** @type {string} */ (feature.get('label'));
       }
     });


### PR DESCRIPTION
Fitting the map used to ignore the map_zoom parameter. This is annoying when dealing with small features as results. Those will set the map to an unreasonable high zoom level.

This change uses map_zoom as maximum zoom level when fitting the map to the search result.

To test the feature:
`make build-gmf-apps examples-hosted-apps serve`

Then visit:
http://localhost:3000/.build/examples-hosted/contribs/gmf/apps/desktop_alt/?search=bettingen (defaults to map_zoom == 5 because of the feature size)

http://localhost:3000/.build/examples-hosted/contribs/gmf/apps/desktop_alt/?search=bettingen&map_zoom=3

The example data doesn't have very small features to search for, but this should show the functionality.
