### PR TITLE
Add resizable option to ngeo.Modal

### DIFF
--- a/src/directives/modal.js
+++ b/src/directives/modal.js
@@ -33,8 +33,10 @@ goog.require('ngeo');
  *
  * @param {angular.$parse} $parse Angular parse service.
  * @return {angular.Directive} The directive specs.
- * @htmlAttribute {boolean} ngeo-modal-destroy-content-on-hide Destroy the content
- * when the modal is hidden
+ * @htmlAttribute {boolean} ngeo-modal-destroy-content-on-hide Destroy the
+ *     content when the modal is hidden
+ * @htmlAttribute {boolean} ngeo-modal-resizable Whether the modal can be
+ *     resized or not. Defaults to `false`.
  * @ngInject
  * @ngdoc directive
  * @ngname ngeoModal
@@ -61,6 +63,7 @@ ngeo.modalDirective = function($parse) {
     link(scope, element, attrs, ngModelController, transcludeFn) {
       const modal = element.children();
       const destroyContent = attrs['ngeoModalDestroyContentOnHide'] === 'true';
+      const resizable = attrs['ngeoModalResizable'] === 'true';
       let childScope = scope.$new();
 
       // move the modal to document body to ensure that it is on top of
@@ -85,20 +88,28 @@ ngeo.modalDirective = function($parse) {
         modal.on('hide.bs.modal', onHide);
         modal.on('show.bs.modal', onShow);
       } else {
-        modal.find('.modal-content').resizable().append(transcludeFn());
+        if (resizable) {
+          modal.find('.modal-content').resizable().append(transcludeFn());
+        } else {
+          modal.find('.modal-content').append(transcludeFn());
+        }
       }
 
       function onShow(e) {
         childScope = scope.$new();
         transcludeFn(childScope, (clone) => {
-          modal.find('.modal-content').resizable().append(clone);
+          if (resizable) {
+            modal.find('.modal-content').resizable().append(clone);
+          } else {
+            modal.find('.modal-content').append(clone);
+          }
         });
       }
 
       function onHide(e) {
         childScope.$destroy();
         const content = modal.find('.modal-content');
-        if (content.hasClass('ui-resizable')) {
+        if (resizable && content.hasClass('ui-resizable')) {
           content.resizable('destroy');
         }
         content.empty();


### PR DESCRIPTION
This PR adds the `ngeo-modal-resizable` option to the modal directive. Default value is: `false`.

This changes the default behaviour of the modals, which could all be resized before.  However, it makes little sense to do so, as most of the times modals are used to show content from an "controlled" interface, i.e. content from other directives / components.  The content container of the modal (bootstrap) already manages to be bigger in height if it has lots of content, and show a scroll bar if necessary.

Making the modal resizable doesn't help anyway, as the whole container of the modal is resized, unnaffecting the header, footer and content. This results in having more "blank" space and nothing more.