### PR TITLE
Print - Able to get the legend in metadata

### DIFF
--- a/contribs/gmf/src/directives/print.js
+++ b/contribs/gmf/src/directives/print.js
@@ -440,6 +440,16 @@ gmf.PrintController = function($rootScope, $scope, $timeout, $q, $injector,
   gmfThemes.getOgcServersObject().then((ogcServersObject) => {
     this.ogcServers_ = ogcServersObject;
   });
+
+  /**
+   * @type {Array.<gmfThemes.GmfTheme>}
+   * @private
+   */
+  this.currentThemes_;
+
+  gmfThemes.getThemesObject().then((currentThemes) => {
+    this.currentThemes_ = currentThemes;
+  });
 };
 
 
@@ -985,16 +995,18 @@ gmf.PrintController.prototype.getLegend_ = function(scale) {
   // For each visible layer in reverse order, get the legend url.
   layers.reverse().forEach((layer) => {
     classes = [];
-
     if (layer.getVisible() && layer.getSource()) {
       // For WMTS layers.
       if (layer instanceof ol.layer.Tile) {
-        layerName = layer.get('layerNodeName');
-        icons = this.ngeoLayerHelper_.getWMTSLegendURL(layer);
+        layerName = `${layer.get('layerNodeName')}`;
+        icons = this.getMetadataLegendImage_(layerName);
+        if (!icons) {
+          icons = this.ngeoLayerHelper_.getWMTSLegendURL(layer);
+        }
         // Don't add classes without legend url.
         if (icons) {
           classes.push({
-            'name': gettextCatalog.getString(`${layerName}`),
+            'name': gettextCatalog.getString(layerName),
             'icons': [icons]
           });
         }
@@ -1003,13 +1015,16 @@ gmf.PrintController.prototype.getLegend_ = function(scale) {
         // For each name in a WMS layer.
         layerNames = source.getParams()['LAYERS'].split(',');
         layerNames.forEach((name) => {
-          icons = this.ngeoLayerHelper_.getWMSLegendURL(source.getUrl(), name,
-            scale);
+          icons = this.getMetadataLegendImage_(name);
+          if (!icons) {
+            icons = this.ngeoLayerHelper_.getWMSLegendURL(source.getUrl(), name,
+              scale);
+          }
           // Don't add classes without legend url or from layers without any
           // active name.
           if (icons && name.length !== 0) {
             classes.push({
-              'name': gettextCatalog.getString(`${name}`),
+              'name': gettextCatalog.getString(name),
               'icons': [icons]
             });
           }
@@ -1025,6 +1040,27 @@ gmf.PrintController.prototype.getLegend_ = function(scale) {
   });
 
   return legend['classes'].length > 0 ?  legend : null;
+};
+
+
+/**
+ * Return the metadata legendImage of a layer from the found corresponding node
+ * or undefined.
+ * @param {string} layerName a layer name.
+ * @return {string|undefined} The legendImage or undefined.
+ * @private
+ */
+gmf.PrintController.prototype.getMetadataLegendImage_ = function(layerName) {
+  const groupNode = gmf.Themes.findGroupByLayerNodeName(this.currentThemes_, layerName);
+  let node;
+  if (groupNode && groupNode.children) {
+    node = gmf.Themes.findObjectByName(groupNode.children, layerName);
+  }
+  let legendImage;
+  if (node && node.metadata) {
+    legendImage = node.metadata.legendImage;
+  }
+  return legendImage;
 };
 
 

--- a/contribs/gmf/src/services/themesservice.js
+++ b/contribs/gmf/src/services/themesservice.js
@@ -175,9 +175,8 @@ gmf.Themes.findGroupByName = function(themes, name) {
  * @param {string} objectName The object name.
  * @return {T} The object or null.
  * @template T
- * @private
  */
-gmf.Themes.findObjectByName_ = function(objects, objectName) {
+gmf.Themes.findObjectByName = function(objects, objectName) {
   return ol.array.find(objects, object => object['name'] === objectName);
 };
 
@@ -189,7 +188,7 @@ gmf.Themes.findObjectByName_ = function(objects, objectName) {
  * @return {gmfThemes.GmfTheme} The theme object or null.
  */
 gmf.Themes.findThemeByName = function(themes, themeName) {
-  return gmf.Themes.findObjectByName_(themes, themeName);
+  return gmf.Themes.findObjectByName(themes, themeName);
 };
 
 


### PR DESCRIPTION
Fix #2980 

You can temporarily try here : https://testgmf.sig.cloud.camptocamp.net/bge/s/ocFN (with the theme "demo", group "OSM functions mixed" activate layers "osm open" and, or "Cant. routes for exceptional loads"). Then print with the legend. You should get the same legend image in the print than in the layertree (both layers have have static-image).

Problem: I got a red square instead of my image. But (now) the url looks good in the print report request.