### PR TITLE
Set correct print labelAlign

### DIFF
--- a/src/services/print.js
+++ b/src/services/print.js
@@ -747,11 +747,25 @@ ngeo.Print.prototype.encodeTextStyle_ = function(symbolizers, textStyle) {
   const label = textStyle.getText();
   if (label !== undefined) {
     symbolizer.label = label;
+    let xAlign = 'c';
+    let yAlign = 'm';
 
-    const labelAlign = textStyle.getTextAlign();
-    if (labelAlign !== undefined) {
-      symbolizer.labelAlign = labelAlign;
+    const olTextAlign = textStyle.getTextAlign();
+    // 'left', 'right', 'center', 'end' or 'start'.
+    if (olTextAlign === 'left' || olTextAlign === 'start') {
+      xAlign = 'l';
+    } else if (olTextAlign === 'right' || olTextAlign === 'end') {
+      xAlign = 'r';
     }
+
+    const olTextBaseline = textStyle.getTextBaseline();
+    // 'bottom', 'top', 'middle', 'alphabetic', 'hanging' or 'ideographic'
+    if (olTextBaseline === 'bottom') {
+      yAlign = 'l';
+    } else if (olTextBaseline === 'top') {
+      yAlign = 't';
+    }
+    symbolizer.labelAlign = `${xAlign}${yAlign}`;
 
     const labelRotation = textStyle.getRotation();
     if (labelRotation !== undefined) {

--- a/test/spec/services/print.spec.js
+++ b/test/spec/services/print.spec.js
@@ -361,7 +361,7 @@ describe('ngeo.CreatePrint', () => {
           })
         });
 
-        // Here to check that no offset are present if textAlign is not there.
+        // Here to check that textAlign default value is set.
         style4 = new ol.style.Style({
           text: new ol.style.Text({
             font: 'normal 16px "sans serif"',
@@ -454,7 +454,7 @@ describe('ngeo.CreatePrint', () => {
             fontSize: '16px',
             fontFamily: '"sans serif"',
             label: 'Ngeo',
-            labelAlign: 'left',
+            labelAlign: 'lm',
             labelXOffset: 42,
             labelYOffset: 42
           }]
@@ -466,7 +466,10 @@ describe('ngeo.CreatePrint', () => {
             fontWeight: 'normal',
             fontSize: '16px',
             fontFamily: '"sans serif"',
-            label: 'Ngeo'
+            label: 'Ngeo',
+            labelAlign: 'cm',
+            labelXOffset: 42,
+            labelYOffset: 42
           }]
         };
 


### PR DESCRIPTION
Default values in OpenLayers are 'center' and 'middle'.

This is a backport of #2964 for the 2.2 branch