### PR TITLE
Fix filter panel separators color

### DIFF
--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -581,6 +581,7 @@ gmf-objecteditingtools {
  */
 .gmf-filterselector-separator {
   margin: 1.5rem 0 0.5rem 0;
+  border-color: @color;
 }
 
 .gmf-filterselector-savefilter-desc {
@@ -676,6 +677,10 @@ hr.ngeo-filter-separator-criteria {
   margin: 0.5rem 0;
 }
 
+hr.ngeo-filter-separator-criteria,
+hr.ngeo-filter-separator-rules {
+  border-color: @color;
+}
 
 /**
  * Ngeo Rule component


### PR DESCRIPTION
Fixes #3012 for pt.1 filter panel.

Just apply the same color for the separator in the panel, was already used with the heading separator.