### PR TITLE
Show draw&measure separator only when a geometry is drawn on the map

### DIFF
--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -374,10 +374,9 @@ gmf-backgroundlayerselector {
   clear: both;
 }
 
-.gmf-drawfeature-featurelistctn {
-  border-top: 1px solid #333;
-  margin-top: @app-margin;
-  padding: 10px 0 0 0;
+hr.gmf-drawfeature-separator {
+  border-color: @color;
+  margin: 10px 0;
 }
 
 .gmf-drawfeature-featurelist {

--- a/contribs/gmf/src/directives/partials/drawfeature.html
+++ b/contribs/gmf/src/directives/partials/drawfeature.html
@@ -71,10 +71,9 @@
   </a>
 </ngeo-drawfeature>
 
-<div
-    ng-switch="efCtrl.selectedFeature"
-    class="gmf-drawfeature-featurelistctn">
+<div ng-switch="efCtrl.selectedFeature">
 
+  <hr class="gmf-drawfeature-separator" ng-show="efCtrl.getFeaturesArray().length > 0">
   <div ng-switch-when="null">
     <div ng-show="efCtrl.getFeaturesArray().length > 0">
       <div class="ngeo-drawfeature-actionbuttons">


### PR DESCRIPTION
Fixes #3012 pt. 2 for draw and measure panel

I added a hr element that is shown if there is something drawn (aka there is actual information for the drawn feature shown in the partial list). This fix uniformize with the separator display in filter panel.