### PR TITLE
Fix displayquerywindow content height

### DIFF
--- a/contribs/gmf/less/displayquerywindow.less
+++ b/contribs/gmf/less/displayquerywindow.less
@@ -32,6 +32,7 @@
   .gmf-displayquerywindow-container {
     background-color: @nav-bg;
     border: solid 1px @border-color;
+    height: 24rem;
     position: relative;
   }
   .gmf-displayquerywindow-animation-container {
@@ -60,7 +61,7 @@
     }
   }
   .gmf-displayquerywindow-animation-container-detailed {
-    height: @displayquerywindow-detailed-header-height + @displayquerywindow-detailed-details-height + @app-margin * 3;
+    height: ~"calc(100% - 3rem)";
     .gmf-displayquerywindow-details {
       display: block;
     }


### PR DESCRIPTION
This PR makes the height content of the DisplayQueryWindow relative to its parent, i.e. the height is calculated instead of being fixed.

This allow the size to be dynamic.  For example, when resizing the window, the content height follows.

Note: the width is already working properly.