### PR TITLE
Query set type feature

### DIFF
--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -114,7 +114,7 @@ app.AlternativeDesktopController = function($scope, $injector, ngeoFile, gettext
    * @export
    */
   this.gridMergeTabs = {
-    'OSM time merged': ['110', '126', '147']
+    'OSM time merged': ['osm_time', 'osm_time2']
   };
 
   // Allow angular-gettext-tools to collect the strings to translate

--- a/contribs/gmf/examples/displayquerygrid.html
+++ b/contribs/gmf/examples/displayquerygrid.html
@@ -250,6 +250,7 @@
     <script src="../../../node_modules/floatthead/dist/jquery.floatThead.min.js"></script>
     <script src="../../../node_modules/proj4/dist/proj4.js"></script>
     <script src="../../../node_modules/moment/min/moment.min.js"></script>
+    <script src="../../../node_modules/file-saver/FileSaver.min.js"></script>
     <script src="/@?main=displayquerygrid.js"></script>
     <script src="default.js"></script>
     <script src="../../../utils/watchwatchers.js"></script>

--- a/contribs/gmf/examples/displayquerywindow.html
+++ b/contribs/gmf/examples/displayquerywindow.html
@@ -278,8 +278,12 @@
   <body ng-controller="MainController as ctrl">
 
     <gmf-map gmf-map-map="ctrl.map"
-        ngeo-map-query="" ngeo-map-query-map="::ctrl.map"
-        ngeo-map-query-active="ctrl.queryActive">
+        ngeo-map-query=""
+        ngeo-map-query-map="::ctrl.map"
+        ngeo-map-query-active="ctrl.queryActive"
+        ngeo-bbox-query=""
+        ngeo-bbox-query-map="::ctrl.map"
+        ngeo-bbox-query-active="ctrl.queryActive">
     </gmf-map>
 
     <div id="tree-container">

--- a/contribs/gmf/examples/displayquerywindow.js
+++ b/contribs/gmf/examples/displayquerywindow.js
@@ -11,6 +11,8 @@ goog.require('gmf.mapDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.proj.EPSG21781');
 /** @suppress {extraRequire} */
+goog.require('ngeo.bboxQueryDirective');
+/** @suppress {extraRequire} */
 goog.require('ngeo.btnDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.mapQueryDirective');

--- a/contribs/gmf/examples/partials/queryresult.html
+++ b/contribs/gmf/examples/partials/queryresult.html
@@ -28,7 +28,7 @@
       <h3>{{ ::feature.get('display_name') }}</h3>
       <div ng-repeat="(key, value) in ::feature.getProperties()"
            ng-init="value = value !== undefined ? value : ''">
-        <span ng-if="::(key !== 'THE_GEOM' && key !== 'POINT')">
+        <span ng-if="::(key !== feature.getGeometryName() && key !== 'ngeo_feature_type_')">
           <span ng-bind="::key"></span>:
           <span ng-bind="::value"></span>
         </span>

--- a/contribs/gmf/options/gmfx.js
+++ b/contribs/gmf/options/gmfx.js
@@ -104,8 +104,8 @@ gmfx.GridSource.prototype.source;
  * Configuration option for {@link gmf.displayquerygridComponent} to merge
  * grid tabs.
  *
- * E.g. `'my_merged_source': ['123', '234']}` merges the sources with id `123`
- * and `234` into a new source `my_merged_source`.
+ * E.g. `'two_wheels_park': ['velo_park', 'moto_park']}` merges the sources
+ * with label `velo_park` and `moto_park` into a new source `two_wheels_park`.
  *
  * @typedef {Object<string, Array.<string>>}
  */

--- a/contribs/gmf/src/directives/displayquerygrid.js
+++ b/contribs/gmf/src/directives/displayquerygrid.js
@@ -307,7 +307,7 @@ gmf.DisplayquerygridController.prototype.$onInit = function() {
  * @return {Array.<gmfx.GridSource>} Grid sources.
  */
 gmf.DisplayquerygridController.prototype.getGridSources = function() {
-  return this.loadedGridSources.map(sourceId => this.gridSources[sourceId]);
+  return this.loadedGridSources.map(sourceLabel => this.gridSources[sourceLabel]);
 };
 
 
@@ -381,7 +381,7 @@ gmf.DisplayquerygridController.prototype.hasOneWithTooManyResults_ = function() 
  * @return {boolean} Is selected?
  */
 gmf.DisplayquerygridController.prototype.isSelected = function(gridSource) {
-  return this.selectedTab === gridSource.source.id;
+  return this.selectedTab === gridSource.source.label;
 };
 
 
@@ -428,8 +428,8 @@ gmf.DisplayquerygridController.prototype.getMergedSource_ = function(source, mer
   let mergeSourceId = null;
 
   for (const currentMergeSourceId in this.mergeTabs_) {
-    const sourceIds = this.mergeTabs_[currentMergeSourceId];
-    const containsSource = sourceIds.some(sourceId => sourceId == source.id);
+    const sourceLabels = this.mergeTabs_[currentMergeSourceId];
+    const containsSource = sourceLabels.some(sourceLabel => sourceLabel == source.label);
     if (containsSource) {
       mergeSourceId = currentMergeSourceId;
       break;
@@ -510,7 +510,7 @@ gmf.DisplayquerygridController.prototype.collectData_ = function(source) {
   if (allProperties.length > 0) {
     const gridCreated = this.makeGrid_(allProperties, source);
     if (gridCreated) {
-      this.featuresForSources_[`${source.id}`] = featuresForSource;
+      this.featuresForSources_[`${source.label}`] = featuresForSource;
     }
   }
 };
@@ -529,6 +529,7 @@ gmf.DisplayquerygridController.prototype.cleanProperties_ = function(
       delete properties[featureGeometryName];
     });
     delete properties['boundedBy'];
+    delete properties['ngeo_feature_type_'];
   });
 
   if (this.removeEmptyColumns_ === true) {
@@ -579,7 +580,7 @@ gmf.DisplayquerygridController.prototype.removeEmptyColumnsFn_ = function(
  * @private
  */
 gmf.DisplayquerygridController.prototype.makeGrid_ = function(data, source) {
-  const sourceId = `${source.id}`;
+  const sourceLabel = `${source.label}`;
   let gridConfig = null;
   if (data !== null) {
     gridConfig = this.getGridConfiguration_(data);
@@ -587,10 +588,10 @@ gmf.DisplayquerygridController.prototype.makeGrid_ = function(data, source) {
       return false;
     }
   }
-  if (this.loadedGridSources.indexOf(sourceId) == -1) {
-    this.loadedGridSources.push(sourceId);
+  if (this.loadedGridSources.indexOf(sourceLabel) == -1) {
+    this.loadedGridSources.push(sourceLabel);
   }
-  this.gridSources[sourceId] = {
+  this.gridSources[sourceLabel] = {
     configuration: gridConfig,
     source
   };
@@ -656,7 +657,7 @@ gmf.DisplayquerygridController.prototype.clear = function() {
  */
 gmf.DisplayquerygridController.prototype.selectTab = function(gridSource) {
   const source = gridSource.source;
-  this.selectedTab = source.id;
+  this.selectedTab = source.label;
 
   if (this.unregisterSelectWatcher_) {
     this.unregisterSelectWatcher_();
@@ -680,15 +681,15 @@ gmf.DisplayquerygridController.prototype.selectTab = function(gridSource) {
 
 /**
  * @private
- * @param {string|number} sourceId Id of the source that should be refreshed.
+ * @param {string|number} sourceLabel Id of the source that should be refreshed.
  */
-gmf.DisplayquerygridController.prototype.reflowGrid_ = function(sourceId) {
+gmf.DisplayquerygridController.prototype.reflowGrid_ = function(sourceLabel) {
   // this is a "work-around" to make sure that the grid is rendered correctly.
   // when a pane is activated by setting `this.selectedTab`, the class `active`
   // is not yet set on the pane. that's why the class is set manually, and
   // after the pane is shown (in the next digest loop), the grid table can
   // be refreshed.
-  const activePane = this.$element_.find(`div.tab-pane#${sourceId}`);
+  const activePane = this.$element_.find(`div.tab-pane#${sourceLabel}`);
   activePane.removeClass('active').addClass('active');
   this.$timeout_(() => {
     activePane.find('div.ngeo-grid-table-container table')['trigger']('reflow');
@@ -722,8 +723,8 @@ gmf.DisplayquerygridController.prototype.updateFeatures_ = function(gridSource) 
     return;
   }
 
-  const sourceId = `${gridSource.source.id}`;
-  const featuresForSource = this.featuresForSources_[sourceId];
+  const sourceLabel = `${gridSource.source.label}`;
+  const featuresForSource = this.featuresForSources_[sourceLabel];
   const selectedRows = gridSource.configuration.selectedRows;
 
   for (const rowId in featuresForSource) {

--- a/contribs/gmf/src/directives/displayquerywindow.js
+++ b/contribs/gmf/src/directives/displayquerywindow.js
@@ -87,7 +87,6 @@ gmf.module.component('gmfDisplayquerywindow', gmf.displayquerywindowComponent);
 /**
  * @param {!angular.Scope} $scope Angular scope.
  * @param {!ngeox.QueryResult} ngeoQueryResult ngeo query result.
- * @param {!ngeo.FeatureHelper} ngeoFeatureHelper the ngeo FeatureHelper service.
  * @param {!ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *     overlay manager service.
  * @constructor
@@ -97,7 +96,7 @@ gmf.module.component('gmfDisplayquerywindow', gmf.displayquerywindowComponent);
  * @ngname GmfDisplayquerywindowController
  */
 gmf.DisplayquerywindowController = function($scope, ngeoQueryResult,
-  ngeoFeatureHelper, ngeoFeatureOverlayMgr) {
+  ngeoFeatureOverlayMgr) {
 
   /**
    * @type {boolean}
@@ -135,12 +134,6 @@ gmf.DisplayquerywindowController = function($scope, ngeoQueryResult,
     total: 0,
     pending: false
   };
-
-  /**
-   * @type {ngeo.FeatureHelper}
-   * @export
-   */
-  this.ngeoFeatureHelper_ = ngeoFeatureHelper;
 
   /**
    * @type {?ngeox.QueryResultSource}
@@ -369,7 +362,7 @@ gmf.DisplayquerywindowController.prototype.updateQueryResult_ = function(queryRe
     const source = queryResult.sources[i];
     source.features = source.features.filter(function(feature) {
       goog.asserts.assert(feature);
-      return !ol.obj.isEmpty(this.ngeoFeatureHelper_.getFilteredFeatureValues(feature));
+      return !ol.obj.isEmpty(ngeo.FeatureHelper.getFilteredFeatureValues(feature));
     }, this);
     this.ngeoQueryResult.sources.push(source);
     this.ngeoQueryResult.total += source.features.length;
@@ -419,7 +412,7 @@ gmf.DisplayquerywindowController.prototype.getFeatureValues = function() {
   if (!this.feature) {
     return null;
   }
-  return this.ngeoFeatureHelper_.getFilteredFeatureValues(this.feature);
+  return ngeo.FeatureHelper.getFilteredFeatureValues(this.feature);
 };
 
 

--- a/contribs/gmf/src/directives/displayquerywindow.js
+++ b/contribs/gmf/src/directives/displayquerywindow.js
@@ -360,10 +360,10 @@ gmf.DisplayquerywindowController.prototype.updateQueryResult_ = function(queryRe
   this.ngeoQueryResult.sources.length = 0;
   for (let i = 0; i < queryResult.sources.length; i++) {
     const source = queryResult.sources[i];
-    source.features = source.features.filter(function(feature) {
+    source.features = source.features.filter((feature) => {
       goog.asserts.assert(feature);
       return !ol.obj.isEmpty(ngeo.FeatureHelper.getFilteredFeatureValues(feature));
-    }, this);
+    });
     this.ngeoQueryResult.sources.push(source);
     this.ngeoQueryResult.total += source.features.length;
   }

--- a/contribs/gmf/src/directives/partials/displayquerygrid.html
+++ b/contribs/gmf/src/directives/partials/displayquerygrid.html
@@ -10,15 +10,15 @@
     role="tablist">
 
     <li
-      ng-repeat="gridSource in ctrl.getGridSources() track by gridSource.source.id"
+      ng-repeat="gridSource in ctrl.getGridSources() track by gridSource.source.label"
       role="presentation"
       ng-class="{'active' : ctrl.isSelected(gridSource)}"
       ng-click="ctrl.selectTab(gridSource)">
 
       <a
-        href="#{{gridSource.source.id}}"
-        data-target="#{{gridSource.source.id}}"
-        aria-controls="{{gridSource.source.id}}"
+        href="#{{gridSource.source.label}}"
+        data-target="#{{gridSource.source.label}}"
+        aria-controls="{{gridSource.source.label}}"
         role="tab"
         data-toggle="tab">
 
@@ -34,11 +34,11 @@
 
   <div class="tab-content">
     <div
-      ng-repeat="gridSource in ctrl.getGridSources() track by gridSource.source.id"
+      ng-repeat="gridSource in ctrl.getGridSources() track by gridSource.source.label"
       role="tabpanel"
       class="tab-pane"
       ng-class="{'active' : ctrl.isSelected(gridSource)}"
-      id="{{gridSource.source.id}}">
+      id="{{gridSource.source.label}}">
 
       <ngeo-grid
         ngeo-grid-configuration="gridSource.configuration"

--- a/contribs/gmf/src/directives/print.js
+++ b/contribs/gmf/src/directives/print.js
@@ -163,7 +163,6 @@ gmf.module.directive('gmfPrint', gmf.printDirective);
  * @param {string} gmfPrintUrl A MapFishPrint url.
  * @param {gmf.Authentication} gmfAuthentication The authentication service.
  * @param {ngeox.QueryResult} ngeoQueryResult ngeo query result.
- * @param {ngeo.FeatureHelper} ngeoFeatureHelper the ngeo FeatureHelper service.
  * @param {angular.$filter} $filter Angular $filter service.
  * @param {gmf.PrintStateEnum} gmfPrintState GMF print state.
  * @param {gmf.Themes} gmfThemes The gmf Themes service.
@@ -176,7 +175,7 @@ gmf.module.directive('gmfPrint', gmf.printDirective);
 gmf.PrintController = function($rootScope, $scope, $timeout, $q, $injector,
   gettextCatalog, ngeoLayerHelper, ngeoFeatureOverlayMgr,  ngeoPrintUtils,
   ngeoCreatePrint, gmfPrintUrl, gmfAuthentication, ngeoQueryResult,
-  ngeoFeatureHelper, $filter, gmfPrintState, gmfThemes) {
+  $filter, gmfPrintState, gmfThemes) {
 
   /**
    * @type {gmf.PrintStateEnum}
@@ -189,12 +188,6 @@ gmf.PrintController = function($rootScope, $scope, $timeout, $q, $injector,
    * @private
    */
   this.translate_ = $filter('translate');
-
-  /**
-   * @type {ngeo.FeatureHelper}
-   * @private
-   */
-  this.ngeoFeatureHelper_ = ngeoFeatureHelper;
 
   /**
    * @type {boolean}
@@ -873,7 +866,7 @@ gmf.PrintController.prototype.getDataSource_ = function() {
     columns = [];
     source.features.forEach(function(feature, i) {
       goog.asserts.assert(feature);
-      const properties = this.ngeoFeatureHelper_.getFilteredFeatureValues(feature);
+      const properties = ngeo.FeatureHelper.getFilteredFeatureValues(feature);
       if (i === 0) {
         columns = Object.keys(properties).map(function tanslateColumns(prop) {
           return this.translate_(prop);

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -236,10 +236,11 @@ gmf.Permalink = function($timeout, $rootScope, $injector, ngeoDebounce,
     $injector.get('ngeoWfsPermalink') : null;
 
   /**
-   * @type {gmfx.User}
+   * @type {?gmfx.User}
    * @export
    */
-  this.gmfUser_ = $injector.get('gmfUser');
+  this.gmfUser_ = $injector.has('gmfUser') ?
+    $injector.get('gmfUser') : null;
 
   /**
    * @type {?ol.Map}
@@ -895,6 +896,9 @@ gmf.Permalink.prototype.defaultThemeName = function() {
  */
 gmf.Permalink.prototype.defaultThemeNameFromFunctionalities = function() {
   //check if we have a theme in the user functionalities
+  if (!this.gmfUser_) {
+    return null;
+  }
   const functionalities = this.gmfUser_.functionalities;
   if (functionalities && 'default_theme' in functionalities) {
     const defaultTheme = functionalities.default_theme;

--- a/contribs/gmf/test/spec/directives/displayquerygrid.spec.js
+++ b/contribs/gmf/test/spec/directives/displayquerygrid.spec.js
@@ -89,12 +89,12 @@ describe('gmf.displayquerygridComponent', () => {
       $rootScope.$digest();
       $timeout.flush();
       expect(queryGridController.active).toBe(true);
-      expect(queryGridController.selectedTab).toBe(123);
+      expect(queryGridController.selectedTab).toBe('Test');
 
-      const featuresForSource = queryGridController.featuresForSources_['123'];
+      const featuresForSource = queryGridController.featuresForSources_['Test'];
       expect(Object.keys(featuresForSource).length).toBe(2);
 
-      const gridSource = queryGridController.gridSources['123'];
+      const gridSource = queryGridController.gridSources['Test'];
       expect(gridSource).toBeDefined();
 
       const gridConfig = gridSource.configuration;
@@ -146,7 +146,7 @@ describe('gmf.displayquerygridComponent', () => {
       $timeout.flush();
       expect(queryGridController.active).toBe(true);
 
-      const gridSource = queryGridController.gridSources['123'];
+      const gridSource = queryGridController.gridSources['Test'];
       expect(gridSource).toBeDefined();
 
       const gridConfig = gridSource.configuration;
@@ -193,7 +193,7 @@ describe('gmf.displayquerygridComponent', () => {
       $timeout.flush();
       expect(queryGridController.active).toBe(false);
 
-      const gridSource = queryGridController.gridSources['123'];
+      const gridSource = queryGridController.gridSources['Test'];
       expect(gridSource).toBeUndefined();
     });
 
@@ -237,7 +237,7 @@ describe('gmf.displayquerygridComponent', () => {
       expect(queryGridController.active).toBe(true);
 
       // grid source 1
-      const gridSource1 = queryGridController.gridSources['123'];
+      const gridSource1 = queryGridController.gridSources['Test 1'];
       expect(gridSource1).toBeDefined();
 
       const gridConfig1 = gridSource1.configuration;
@@ -260,11 +260,11 @@ describe('gmf.displayquerygridComponent', () => {
       expect(gridConfig1.columnDefs).toEqual(expectedColumnDefs1);
 
       // grid source 2
-      const gridSource2 = queryGridController.gridSources['234'];
+      const gridSource2 = queryGridController.gridSources['Test 2'];
       expect(gridSource2).not.toBeDefined();
 
       // grid source 3
-      const gridSource3 = queryGridController.gridSources['345'];
+      const gridSource3 = queryGridController.gridSources['Test 3'];
       expect(gridSource3).toBeDefined();
 
       const gridConfig3 = gridSource3.configuration;
@@ -314,11 +314,11 @@ describe('gmf.displayquerygridComponent', () => {
       expect(queryGridController.active).toBe(true);
 
       // grid source 1
-      const gridSource1 = queryGridController.gridSources['123'];
+      const gridSource1 = queryGridController.gridSources['Test 1'];
       expect(gridSource1).toBeDefined();
 
       // grid source 2
-      const gridSource2 = queryGridController.gridSources['345'];
+      const gridSource2 = queryGridController.gridSources['Test 3'];
       expect(gridSource2).toBeDefined();
       expect(gridSource2.configuration).toBe(null);
     });
@@ -347,12 +347,12 @@ describe('gmf.displayquerygridComponent', () => {
       expect(queryGridController.active).toBe(true);
 
       // grid source 1
-      const gridSource1 = queryGridController.gridSources['123'];
+      const gridSource1 = queryGridController.gridSources['Test 1'];
       expect(gridSource1).toBeDefined();
       expect(gridSource1.configuration).toBe(null);
 
       // grid source 2
-      const gridSource2 = queryGridController.gridSources['345'];
+      const gridSource2 = queryGridController.gridSources['Test 3'];
       expect(gridSource2).toBeDefined();
       expect(gridSource2.configuration).toBe(null);
     });
@@ -399,7 +399,7 @@ describe('gmf.displayquerygridComponent', () => {
       }];
 
       queryGridController.mergeTabs_ = {
-        'merged_source': ['123', '234']
+        'merged_source': ['Test 1', 'Test 2']
       };
 
       $rootScope.$digest();
@@ -434,7 +434,7 @@ describe('gmf.displayquerygridComponent', () => {
       expect(gridConfig1.columnDefs).toEqual(expectedColumnDefs1);
 
       // grid source 3
-      const gridSource3 = queryGridController.gridSources['345'];
+      const gridSource3 = queryGridController.gridSources['Test 3'];
       expect(gridSource3).toBeDefined();
 
       const gridConfig3 = gridSource3.configuration;
@@ -492,7 +492,7 @@ describe('gmf.displayquerygridComponent', () => {
       }];
 
       queryGridController.mergeTabs_ = {
-        'merged_source': ['123', '234']
+        'merged_source': ['Test 1', 'Test 2']
       };
 
       $rootScope.$digest();
@@ -508,7 +508,7 @@ describe('gmf.displayquerygridComponent', () => {
       expect(gridSource1.source.features).toEqual([]);
 
       // grid source 3
-      const gridSource3 = queryGridController.gridSources['345'];
+      const gridSource3 = queryGridController.gridSources['Test 3'];
       expect(gridSource3).toBeDefined();
     });
 
@@ -548,38 +548,38 @@ describe('gmf.displayquerygridComponent', () => {
     it('allows to switch between tabs', () => {
       $timeout.flush();
       // check that the first source is selected by default
-      expect(queryGridController.selectedTab).toBe(123);
+      expect(queryGridController.selectedTab).toBe('Test 1');
       expect(queryGridController.features_.item(0).get('name')).toBe('A');
       expect(queryGridController.highlightFeatures_.getLength()).toBe(0);
 
       // select the 2nd source
-      queryGridController.selectTab(queryGridController.gridSources['345']);
-      expect(queryGridController.selectedTab).toBe(345);
+      queryGridController.selectTab(queryGridController.gridSources['Test 3']);
+      expect(queryGridController.selectedTab).toBe('Test 3');
       expect(queryGridController.features_.item(0).get('label')).toBe('C');
       expect(queryGridController.highlightFeatures_.getLength()).toBe(0);
     });
 
     it('remembers selected rows when switching tabs', () => {
-      const gridSource1 = queryGridController.gridSources['123'];
+      const gridSource1 = queryGridController.gridSources['Test 1'];
       const row1 = gridSource1.configuration.data[0];
       gridSource1.configuration.selectRow(row1);
       $rootScope.$digest();
       $timeout.flush();
 
       // check that the first source is selected by default
-      expect(queryGridController.selectedTab).toBe(123);
+      expect(queryGridController.selectedTab).toBe('Test 1');
       expect(queryGridController.features_.getLength()).toBe(0);
       expect(queryGridController.highlightFeatures_.item(0).get('name')).toBe('A');
 
       // select the 2nd source
-      queryGridController.selectTab(queryGridController.gridSources['345']);
-      expect(queryGridController.selectedTab).toBe(345);
+      queryGridController.selectTab(queryGridController.gridSources['Test 3']);
+      expect(queryGridController.selectedTab).toBe('Test 3');
       expect(queryGridController.features_.item(0).get('label')).toBe('C');
       expect(queryGridController.highlightFeatures_.getLength()).toBe(0);
 
       // and then select again source 1
-      queryGridController.selectTab(queryGridController.gridSources['123']);
-      expect(queryGridController.selectedTab).toBe(123);
+      queryGridController.selectTab(queryGridController.gridSources['Test 1']);
+      expect(queryGridController.selectedTab).toBe('Test 1');
       expect(queryGridController.features_.getLength()).toBe(0);
       expect(queryGridController.highlightFeatures_.item(0).get('name')).toBe('A');
     });

--- a/examples/partials/queryresult.html
+++ b/examples/partials/queryresult.html
@@ -5,8 +5,8 @@
   <li ng-repeat="source in qrCtrl.result.sources"
       role="presentation"
       ng-class="::{active: $index == 0}">
-    <a href="#{{ ::source.id }}"
-       aria-controls="{{ ::source.id }}"
+    <a href="#{{ ::source.label }}"
+       aria-controls="{{ ::source.label }}"
        role="tab"
        data-toggle="tab">
       <span>{{ ::source.label }}</span>
@@ -19,11 +19,11 @@
 </ul>
 
 <div class="tab-content">
-  <div ng-repeat="source in ::qrCtrl.result.sources"
+  <div ng-repeat="source in qrCtrl.result.sources"
        role="tabpanel"
        class="tab-pane"
        ng-class="::{active: $index == 0}"
-       id="{{ ::source.id }}">
+       id="{{ ::source.label }}">
     <div ng-switch="source.features.length">
       <div ng-switch-when="0">
         <span ng-switch="source.pending">
@@ -36,7 +36,7 @@
           <h3>{{ ::feature.get('display_name') }}</h3>
           <div ng-repeat="(key, value) in ::feature.getProperties()"
                ng-init="value = value !== undefined ? value : ''">
-            <span ng-if="::(key !== 'THE_GEOM')">
+            <span ng-if="::(key !== feature.getGeometryName() && key !== 'ngeo_feature_type_')">
               <span ng-bind="::key"></span>:
               <span ng-bind="::value"></span>
             </span>

--- a/examples/profile.js
+++ b/examples/profile.js
@@ -6,7 +6,6 @@ goog.require('ngeo.mapDirective');
 goog.require('ngeo.profileDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.proj.EPSG21781');
-goog.require('ol.Attribution');
 goog.require('ol.Feature');
 goog.require('ol.Map');
 goog.require('ol.View');
@@ -49,12 +48,9 @@ app.MainController = function($http, $scope) {
         source: new ol.source.ImageWMS({
           url: 'http://wms.geo.admin.ch/',
           crossOrigin: 'anonymous',
-          attributions: [new ol.Attribution({
-            html: '&copy; ' +
-                '<a href="http://www.geo.admin.ch/internet/geoportal/' +
-                'en/home.html">' +
-                'Pixelmap 1:500000 / geo.admin.ch</a>'
-          })],
+          attributions: '&copy; ' +
+            '<a href="http://www.geo.admin.ch/internet/geoportal/' +
+            'en/home.html">Pixelmap 1:500000 / geo.admin.ch</a>',
           params: {
             'LAYERS': 'ch.swisstopo.pixelkarte-farbe-pk1000.noscale',
             'FORMAT': 'image/jpeg'

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -987,7 +987,7 @@ ngeox.QueryResultSource.prototype.features;
 
 
 /**
- * Identifier.
+ * Identifier (can be not unique).
  * @type {number|string}
  */
 ngeox.QueryResultSource.prototype.id;

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "less-plugin-clean-css": "1.5.1",
     "moment": "2.18.1",
     "nomnom": "1.8.1",
-    "openlayers": "4.3.1",
+    "openlayers": "openlayers/openlayers#4a6317d",
     "phantomjs-prebuilt": "2.1.14",
     "proj4": "2.4.3",
     "svg2ttf": "4.1.0",

--- a/src/ol-ext/interaction/modify.js
+++ b/src/ol-ext/interaction/modify.js
@@ -116,7 +116,7 @@ ngeo.interaction.Modify.prototype.setActive = function(active) {
  * Remove the interaction from its current map and attach it to the new map.
  * Subclasses may set up event handlers to get notified about changes to
  * the map here.
- * @param {ol.Map} map Map.
+ * @param {ol.PluggableMap} map Map.
  * @override
  */
 ngeo.interaction.Modify.prototype.setMap = function(map) {

--- a/src/ol-ext/interaction/modifycircle.js
+++ b/src/ol-ext/interaction/modifycircle.js
@@ -418,7 +418,7 @@ ngeo.interaction.ModifyCircle.prototype.handlePointerMove_ = function(evt) {
 
 /**
  * @param {ol.Pixel} pixel Pixel
- * @param {ol.Map} map Map.
+ * @param {ol.PluggableMap} map Map.
  * @private
  */
 ngeo.interaction.ModifyCircle.prototype.handlePointerAtPixel_ = function(pixel, map) {

--- a/src/ol-ext/interaction/translate.js
+++ b/src/ol-ext/interaction/translate.js
@@ -114,7 +114,7 @@ ngeo.interaction.Translate.prototype.setActive = function(active) {
  * Remove the interaction from its current map and attach it to the new map.
  * Subclasses may set up event handlers to get notified about changes to
  * the map here.
- * @param {ol.Map} map Map.
+ * @param {ol.PluggableMap} map Map.
  * @override
  */
 ngeo.interaction.Translate.prototype.setMap = function(map) {

--- a/src/ol-ext/menu.js
+++ b/src/ol-ext/menu.js
@@ -138,7 +138,7 @@ ol.inherits(ngeo.Menu, ol.Overlay);
 
 
 /**
- * @param {ol.Map|undefined} map Map.
+ * @param {ol.PluggableMap|undefined} map Map.
  * @export
  * @override
  */

--- a/src/ol-ext/popover.js
+++ b/src/ol-ext/popover.js
@@ -58,7 +58,7 @@ ol.inherits(ngeo.Popover, ol.Overlay);
 
 
 /**
- * @param {ol.Map|undefined} map Map.
+ * @param {ol.PluggableMap|undefined} map Map.
  * @export
  * @override
  */

--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -603,14 +603,16 @@ ngeo.FeatureHelper.prototype.getHaloStyle_ = function(feature) {
 /**
  * Delete the unwanted ol3 properties from the current feature then return the
  * properties.
+ * Delete also the 'ngeo_feature_type_' from the ngeo query system.
  * @param {!ol.Feature} feature Feature.
  * @return {!Object.<string, *>} Filtered properties of the current feature.
  * @export
  */
-ngeo.FeatureHelper.prototype.getFilteredFeatureValues = function(feature) {
+ngeo.FeatureHelper.getFilteredFeatureValues = function(feature) {
   const properties = feature.getProperties();
   delete properties['boundedBy'];
   delete properties[feature.getGeometryName()];
+  delete properties['ngeo_feature_type_'];
   return properties;
 };
 

--- a/src/services/mapquerent.js
+++ b/src/services/mapquerent.js
@@ -164,7 +164,7 @@ ngeo.MapQuerent = class {
     for (const idStr in response) {
       const id = Number(idStr);
       const dataSource = this.ngeoDataSourcesHelper_.getDataSource(id);
-      const label = dataSource.name;
+      let label = dataSource.name;
       goog.asserts.assert(dataSource);
 
 
@@ -174,17 +174,30 @@ ngeo.MapQuerent = class {
       const tooManyResults = querentResultItem.tooManyFeatures === true;
       const totalFeatureCount = querentResultItem.totalFeatureCount;
 
-      this.result_.sources.push({
-        features,
-        id,
-        label,
-        limit,
-        pending: false,
-        queried: true,
-        tooManyResults,
-        totalFeatureCount
+      const typeSeparatedFeatures = {};
+      features.forEach((feature) => {
+        const type = goog.asserts.assertString(feature.get('ngeo_feature_type_'));
+        if (!typeSeparatedFeatures[type]) {
+          typeSeparatedFeatures[type] = [];
+        }
+        typeSeparatedFeatures[type].push(feature);
       });
-      total += features.length;
+
+      for (const type in typeSeparatedFeatures) {
+        label = type ? type : label;
+        const featuresByType = typeSeparatedFeatures[type];
+        this.result_.sources.push({
+          features: featuresByType,
+          id,
+          label,
+          limit,
+          pending: false,
+          queried: true,
+          tooManyResults,
+          totalFeatureCount
+        });
+        total += features.length;
+      }
     }
 
     // (2) Update total & pending

--- a/src/services/querent.js
+++ b/src/services/querent.js
@@ -306,17 +306,17 @@ ngeo.Querent = class {
     let types;
     if (wfs) {
       if (opt_types) {
-        dataSource.wfsFormat['featureType_'] = opt_types;
+        dataSource.wfsFormat.setFeatureType(opt_types);
       }
-      types = dataSource.wfsFormat['featureType_'];
+      types = dataSource.wfsFormat.getFeatureType();
     } else {
       if (opt_types) {
-        dataSource.wmsFormat['layers_'] = opt_types;
+        dataSource.wmsFormat.setLayers(opt_types);
       }
-      types = dataSource.wmsFormat['layers_'];
+      types = dataSource.wmsFormat.getLayers();
     }
     if (!types) {
-      return null;
+      return [];
     }
     return (Array.isArray(types)) ? types : [types];
   }

--- a/src/services/rulehelper.js
+++ b/src/services/rulehelper.js
@@ -10,7 +10,6 @@ goog.require('ngeo.rule.Select');
 goog.require('ngeo.rule.Text');
 goog.require('ol.format.WFS');
 goog.require('ol.format.filter');
-goog.require('ol.format.filter.Spatial');
 
 
 ngeo.RuleHelper = class {
@@ -570,8 +569,7 @@ ngeo.RuleHelper = class {
       goog.asserts.assertInstanceof(rule, ngeo.rule.Geometry);
       const geometry = goog.asserts.assert(rule.geometry);
       if (operator === rsot.CONTAINS) {
-        filter = new ol.format.filter.Spatial(
-          'Contains',
+        filter = ol.format.filter.contains(
           geometryName,
           geometry,
           opt_srsName

--- a/src/source/asitvd.js
+++ b/src/source/asitvd.js
@@ -2,17 +2,9 @@ goog.module('ngeo.source.AsitVD');
 goog.module.declareLegacyNamespace();
 
 goog.require('ol');
-goog.require('ol.Attribution');
 goog.require('ol.source.WMTS');
 goog.require('ol.tilegrid.WMTS');
 
-
-/**
- * @const {ol.Attribution}
- */
-const ATTRIBUTION = new ol.Attribution({
-  html: 'géodonnées &copy; Etat de Vaud & &copy; contributeurs OpenStreetMap'
-});
 
 /**
  * @const {!Array.<number>}
@@ -45,7 +37,7 @@ const asitVDTileGrid = new ol.tilegrid.WMTS({
 exports = function(options) {
 
   ol.source.WMTS.call(this, {
-    attributions: [ATTRIBUTION],
+    attributions: 'géodonnées &copy; Etat de Vaud & &copy; contributeurs OpenStreetMap',
     url: 'https://ows{1-4}.asitvd.ch/wmts/1.0.0/{Layer}/default/default/0/' +
         '21781/{TileMatrix}/{TileRow}/{TileCol}.png',
     projection: 'EPSG:21781',

--- a/src/source/swisstopo.js
+++ b/src/source/swisstopo.js
@@ -3,18 +3,10 @@ goog.module.declareLegacyNamespace();
 
 goog.require('goog.asserts');
 
-goog.require('ol.Attribution');
 goog.require('ol');
 goog.require('ol.source.WMTS');
 goog.require('ol.tilegrid.WMTS');
 
-
-/**
- * @const {ol.Attribution}
- */
-const ATTRIBUTION = new ol.Attribution({
-  html: '&copy; <a href="http://www.swisstopo.admin.ch">swisstopo</a>'
-});
 
 /**
  * Available resolutions as defined in
@@ -102,7 +94,7 @@ exports = function(options) {
   goog.asserts.assert(extension);
 
   ol.source.WMTS.call(this, {
-    attributions: [ATTRIBUTION],
+    attributions: '&copy; <a href="http://www.swisstopo.admin.ch">swisstopo</a>',
     url: swisstopoCreateUrl(projection, extension),
     dimensions: {
       'Time': options.timestamp


### PR DESCRIPTION
Fix: #2604 (query groups)
Fix: #2672 (ngeo query examples broken)
Fix: #2844 (fix examples broken by permalink)
Also for GEO-471
And update ol3 (to a tag)

Example: https://testgmf.sig.cloud.camptocamp.net/bge

also (for grid): https://camptocamp.github.io/ngeo/query_set_type_feature/examples/contribs/gmf/apps/desktop_alt/index.html?debug&lang=en&baselayer_ref=OSM%20map%20WMS&tree_groups=Layers%2CGroup&tree_group_layers_Transport=fuel&map_x=615823&map_y=177798&map_zoom=4&tree_group_opacity_Group=0.65&tree_group_layers_Group=osm&tree_group_layers_Layers

or other changes like debug examples: https://camptocamp.github.io/ngeo/query_set_type_feature/examples/bboxquery.html
...