### PR TITLE
gmf-displaywindow Component

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -211,6 +211,15 @@
           gmf-search-placeholder="{{'Search…'|translate}}"
           gmf-search-clearbutton="true">
         </gmf-search>
+        <gmf-displaywindow
+          content="mainCtrl.displaywindowContent"
+          desktop="true"
+          height="mainCtrl.displaywindowHeight"
+          open="mainCtrl.displaywindowOpen"
+          title="mainCtrl.displaywindowTitle"
+          url="mainCtrl.displaywindowUrl"
+          width="mainCtrl.displaywindowWidth"
+        ></gmf-displaywindow>
         <div class="gmf-app-map-bottom-controls">
           <div class="gmf-backgroundlayerbutton btn-group dropup">
             <button

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -252,6 +252,15 @@
           gmf-search-placeholder="{{'Search…'|translate}}"
           gmf-search-clearbutton="true">
         </gmf-search>
+        <gmf-displaywindow
+          content="mainCtrl.displaywindowContent"
+          desktop="true"
+          height="mainCtrl.displaywindowHeight"
+          open="mainCtrl.displaywindowOpen"
+          title="mainCtrl.displaywindowTitle"
+          url="mainCtrl.displaywindowUrl"
+          width="mainCtrl.displaywindowWidth"
+        ></gmf-displaywindow>
         <div class="gmf-app-map-bottom-controls">
           <div class="gmf-backgroundlayerbutton btn-group dropup">
             <button

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -72,6 +72,15 @@
         ngeo-mobile-geolocation-options="::mainCtrl.mobileGeolocationOptions">
         <span class="fa fa-dot-circle-o"></span>
       </button>
+      <gmf-displaywindow
+        content="mainCtrl.displaywindowContent"
+        desktop="false"
+        height="mainCtrl.displaywindowHeight"
+        open="mainCtrl.displaywindowOpen"
+        title="mainCtrl.displaywindowTitle"
+        url="mainCtrl.displaywindowUrl"
+        width="mainCtrl.displaywindowWidth"
+      ></gmf-displaywindow>
       <div class="gmf-app-map-messages">
         <gmf-disclaimer gmf-disclaimer-map="::mainCtrl.map"></gmf-disclaimer>
         <div class="alert alert-info alert-dismissible fade in hidden-xs" role="alert">

--- a/contribs/gmf/apps/mobile_alt/index.html
+++ b/contribs/gmf/apps/mobile_alt/index.html
@@ -72,6 +72,15 @@
         ngeo-mobile-geolocation-options="::mainCtrl.mobileGeolocationOptions">
         <span class="fa fa-dot-circle-o"></span>
       </button>
+      <gmf-displaywindow
+        content="mainCtrl.displaywindowContent"
+        desktop="false"
+        height="mainCtrl.displaywindowHeight"
+        open="mainCtrl.displaywindowOpen"
+        title="mainCtrl.displaywindowTitle"
+        url="mainCtrl.displaywindowUrl"
+        width="mainCtrl.displaywindowWidth"
+      ></gmf-displaywindow>
       <div class="gmf-app-map-messages">
         <gmf-disclaimer gmf-disclaimer-map="::mainCtrl.map"></gmf-disclaimer>
         <div class="alert alert-info alert-dismissible fade in hidden-xs" role="alert">

--- a/contribs/gmf/less/desktop.less
+++ b/contribs/gmf/less/desktop.less
@@ -12,6 +12,7 @@
 @import 'datepicker.less';
 @import 'displayquerygrid.less';
 @import 'displayquerywindow.less';
+@import 'displaywindow.less';
 @import 'profile.less';
 @import 'timeslider.less';
 @import 'share.less';

--- a/contribs/gmf/less/displaywindow.less
+++ b/contribs/gmf/less/displaywindow.less
@@ -1,0 +1,33 @@
+@import "../../../node_modules/font-awesome/less/variables.less";
+
+gmf-displaywindow {
+  .gmf-displayquerywindow {
+    height: 24rem;
+    left: 1rem;
+    margin: 0;
+    max-height: initial;
+    max-width: initial;
+    position: absolute;
+    right: auto;
+    top: 8rem;
+    z-index: @above-menus-index;
+
+    .gmf-displayquerywindow-animation-container {
+      height: 100%;
+    }
+
+    .gmf-displayquerywindow-details {
+      display: block;
+      height: 100%;
+
+      iframe {
+        height: ~"calc(100% - 1rem)";
+        width: 100%;
+      }
+    }
+
+    .gmf-displayquerywindow-container {
+      height: 100%;
+    }
+  }
+}

--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -11,6 +11,8 @@
 @import 'mobile-nav.less';
 @import 'icons.less';
 @import 'displayquerywindow.less';
+@import 'displaywindow.less';
+@import 'mobiledisplaywindow.less';
 
 /**
  * Mobile specific css only !

--- a/contribs/gmf/less/mobiledisplaywindow.less
+++ b/contribs/gmf/less/mobiledisplaywindow.less
@@ -1,0 +1,17 @@
+@import "../../../node_modules/font-awesome/less/variables.less";
+
+main > gmf-displaywindow {
+  left: 0;
+  position: relative;
+  top: 0;
+
+  .gmf-displayquerywindow {
+    height: calc(~"100% -" 2 * @app-margin);
+    left: 0;
+    margin: @app-margin;
+    position: relative;
+    top: 0;
+    width: calc(~"100% -" 2 * @app-margin);
+    z-index: @above-search-index;
+  }
+}

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -8,6 +8,8 @@ goog.require('gmf.backgroundlayerselectorComponent');
 /** @suppress {extraRequire} */
 goog.require('gmf.datasource.DataSourcesManager');
 /** @suppress {extraRequire} */
+goog.require('gmf.displaywindowComponent');
+/** @suppress {extraRequire} */
 goog.require('gmf.TreeManager');
 /** @suppress {extraRequire} */
 goog.require('gmf.Themes');
@@ -464,12 +466,6 @@ gmf.AbstractController = function(config, $scope, $injector) {
 
   this.updateCurrentBackgroundLayer_(false);
 
-  /**
-   * Ngeo create popup factory
-   * @type {ngeo.CreatePopup}
-   */
-  const ngeoCreatePopup = $injector.get('ngeoCreatePopup');
-
   // Static "not used" functions should be in the window because otherwise
   // closure remove them. "export" tag doens't work on static function below,
   // we "export" them as externs in the gmfx options file.
@@ -487,42 +483,46 @@ gmf.AbstractController = function(config, $scope, $injector) {
    * @param {string=} opt_height CSS height.
    * @export
    */
-  gmfx.openIframePopup = function(url, title, opt_width, opt_height) {
-    const popup = ngeoCreatePopup();
-    popup.setUrl(`${url}`);
-    gmfx.openPopup_(popup, title, opt_width, opt_height);
+  gmfx.openIframePopup = (
+    url, title, opt_width, opt_height
+  ) => {
+    this.displaywindowUrl = url;
+    gmfx.openPopup_(title, opt_width, opt_height);
   };
 
   /**
    * Static function to create a popup with html content.
    * @param {string} content (text or html).
    * @param {string} title (text).
-   * @param {string=} opt_width CSS width.
-   * @param {string=} opt_height CSS height.
+   * @param {number=} opt_width CSS width in pixel.
+   * @param {number=} opt_height CSS height in pixel.
    * @export
    */
-  gmfx.openTextPopup = function(content, title, opt_width, opt_height) {
-    const popup = ngeoCreatePopup();
-    popup.setContent(`${content}`, true);
-    gmfx.openPopup_(popup, title, opt_width, opt_height);
+  gmfx.openTextPopup = (
+    content, title, opt_width, opt_height
+  ) => {
+    this.displaywindowContent = content;
+    gmfx.openPopup_(title, opt_width, opt_height);
   };
 
   /**
-   * @param {ngeo.Popup!} popup a ngeoPopup.
    * @param {string} title (text).
-   * @param {string=} opt_width CSS width.
-   * @param {string=} opt_height CSS height.
+   * @param {number=} opt_width CSS width in pixel.
+   * @param {number=} opt_height CSS height in pixel.
    */
-  gmfx.openPopup_ = function(popup, title, opt_width, opt_height) {
+  gmfx.openPopup_ = (title, opt_width, opt_height) => {
+
+    this.displaywindowTitle = title;
+    this.displaywindowOpen = true;
+
     if (opt_width) {
-      popup.setWidth(`${opt_width}`);
+      this.displaywindowWidth = `${opt_width}px`;
     }
     if (opt_height) {
-      popup.setHeight(`${opt_height}`);
+      this.displaywindowHeight = `${opt_height}px`;
     }
-    popup.setTitle(`${title}`);
-    popup.setAutoDestroy(true);
-    popup.setOpen(true);
+
+    this.$scope.$apply();
   };
 
   /**
@@ -554,13 +554,49 @@ gmf.AbstractController = function(config, $scope, $injector) {
    * Static function to create a popup with an iframe.
    * @param {string} url an url.
    * @param {string} title (text).
-   * @param {string=} opt_width CSS width.
-   * @param {string=} opt_height CSS height.
+   * @param {number=} opt_width CSS width in pixel.
+   * @param {number=} opt_height CSS height in pixel.
    * @export
    */
   cgxp.tools.openInfoWindow = function(url, title, opt_width, opt_height) {
     gmfx.openIframePopup(url, title, opt_width, opt_height);
   };
+
+  /**
+   * @type {?string}
+   * @export
+   */
+  this.displaywindowContent = null;
+
+  /**
+   * @type {?string}
+   * @export
+   */
+  this.displaywindowHeight = null;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.displaywindowOpen = false;
+
+  /**
+   * @type {?string}
+   * @export
+   */
+  this.displaywindowTitle = null;
+
+  /**
+   * @type {?string}
+   * @export
+   */
+  this.displaywindowUrl = null;
+
+  /**
+   * @type {?string}
+   * @export
+   */
+  this.displaywindowWidth = null;
 };
 
 

--- a/contribs/gmf/src/directives/displaywindow.js
+++ b/contribs/gmf/src/directives/displaywindow.js
@@ -1,0 +1,207 @@
+goog.provide('gmf.displaywindowComponent');
+
+goog.require('gmf');
+
+
+/**
+ * @private
+ */
+gmf.DisplaywindowController = class {
+
+  /**
+   * The `gmf-displaywindow` component is an alternative to the `ngeo.Popup`.
+   * What they have in common:
+   *
+   * - support title
+   * - support url to be shown in an iframe
+   * - support plain HTML content
+   * - support sizing, i.e. height and width.
+   * - support being opened/closed
+   *
+   * The differences with the `ngeo.Popup` are:
+   *
+   * - it supports being dragged
+   * - it supports being resized
+   * - its UI looks exactly like the `gmf-displayquerywindow`. It evens
+   *   borrows some CSS class names and its HTML structure.
+   *
+   * @param {!jQuery} $element Element.
+   * @param {!angular.$sce} $sce Angular sce service.
+   * @private
+   * @struct
+   * @ngInject
+   * @ngdoc controller
+   * @ngname GmfDisplaywindowController
+   */
+  constructor($element, $sce) {
+
+    // === Binding Properties ===
+
+    /**
+     * @type {boolean}
+     * @export
+     */
+    this.clearOnClose;
+
+    /**
+     * @type {?string}
+     * @export
+     */
+    this.content;
+
+    /**
+     * @type {boolean}
+     * @export
+     */
+    this.draggable;
+
+    /**
+     * @type {boolean}
+     * @export
+     */
+    this.desktop;
+
+    /**
+     * @type {?string}
+     * @export
+     */
+    this.height;
+
+    /**
+     * @type {boolean}
+     * @export
+     */
+    this.open;
+
+    /**
+     * @type {boolean}
+     * @export
+     */
+    this.resizable;
+
+    /**
+     * @type {?string}
+     * @export
+     */
+    this.title;
+
+    /**
+     * @type {?string}
+     * @export
+     */
+    this.url;
+
+    /**
+     * @type {?string}
+     * @export
+     */
+    this.width;
+
+
+    // === Injected Properties ===
+
+    /**
+     * @type {!jQuery}
+     * @private
+     */
+    this.element_ = $element;
+
+    /**
+     * @type {!angular.$sce}
+     * @private
+     */
+    this.sce_ = $sce;
+  }
+
+  /**
+   * Called on initialization of the component.
+   */
+  $onInit() {
+
+    // Initialize binding properties
+    this.clearOnClose = this.clearOnClose !== false;
+    this.content = this.content || null;
+    this.desktop = this.desktop !== false;
+    this.height = this.height || null;
+    this.open = this.open === true;
+    this.title = this.title || null;
+    this.url = this.url || null;
+    this.width = this.width || null;
+
+    this.draggable = this.draggable !== undefined ?
+      this.draggable : this.desktop;
+    this.resizable = this.resizable !== undefined ?
+      this.resizable : this.desktop;
+
+    // Draggable
+    if (this.draggable) {
+      this.element_.find('.gmf-displayquerywindow').draggable();
+    }
+
+    // Resizable
+    if (this.resizable) {
+      this.element_.find('.gmf-displayquerywindow-container').resizable({
+        'minHeight': 240,
+        'minWidth': 240
+      });
+    }
+  }
+
+  /**
+   * @export
+   */
+  close() {
+    this.open = false;
+    if (this.clearOnClose) {
+      this.clear_();
+    }
+  }
+
+  /**
+   * @return {!Object.<string, string>} CSS style when using width/height
+   * @export
+   */
+  get style() {
+    return {
+      'height': this.height || undefined,
+      'width': this.height || undefined
+    };
+  }
+
+  /**
+   * @return {string} Trusted url.
+   * @export
+   */
+  get urlTrusted() {
+    return this.sce_.trustAsResourceUrl(this.url);
+  }
+
+  /**
+   * @export
+   */
+  clear_() {
+    this.content = null;
+    this.height = null;
+    this.title = null;
+    this.url = null;
+    this.width = null;
+  }
+};
+
+
+gmf.module.component('gmfDisplaywindow', {
+  bindings: {
+    'clearOnClose': '<',
+    'content': '=',
+    'desktop': '<',
+    'draggable': '<',
+    'height': '=',
+    'open': '=',
+    'resizable': '<',
+    'title': '=',
+    'url': '=',
+    'width': '='
+  },
+  controller: gmf.DisplaywindowController,
+  templateUrl: () => `${gmf.baseTemplateUrl}/displaywindow.html`
+});

--- a/contribs/gmf/src/directives/partials/displaywindow.html
+++ b/contribs/gmf/src/directives/partials/displaywindow.html
@@ -1,0 +1,39 @@
+<div
+  class="gmf-displayquerywindow"
+  ng-show="$ctrl.open"
+  ng-style="$ctrl.style"
+>
+
+  <div class="gmf-displayquerywindow-container">
+
+    <button
+      type="button"
+      class="btn fa-close close"
+      ng-click="$ctrl.close()">
+    </button>
+
+    <div class="gmf-displayquerywindow-animation-container">
+      <div class="gmf-displayquerywindow-slide-animation ">
+        <div
+          class="gmf-displayquerywindow-header"
+          ng-if="$ctrl.title !== null">
+          <p class="gmf-displayquerywindow-title">{{ $ctrl.title }}</p>
+        </div>
+        <div
+          class="gmf-displayquerywindow-details"
+          ng-if="$ctrl.content !== null"
+          ng-bind-html="$ctrl.content"></div>
+        <div
+          class="gmf-displayquerywindow-details"
+          ng-if="$ctrl.url !== null">
+          <iframe
+            frameborder="0"
+            type="text/html"
+            ng-src="{{ $ctrl.urlTrusted }}"></iframe>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+</div>


### PR DESCRIPTION
This PR includes a new component that can be used as replacement of the `ngeo.Popup`, but with the possibility to make it resizable/draggable.

It is used in all 4 apps, instead of the `ngeo.Popup`:

 * desktop
 * desktop_alt
 * mobile
 * mobile_alt

## Todo

 * [x] Review
 * ~~The dragging of the window doesn't work in the `desktop_alt` version.  I have no clue why...  Following these recommendations, everything seems to be OK, with my doubts being that something must mess with the event jQuery is supposed to listen.  Resizable works fine.  See: https://stackoverflow.com/questions/7159118/jquery-ui-draggable-not-working~~ Unrelated to this PR. Issue created: #3056