### PR TITLE
Allow use of gmfx.OpenIframePopup and gmfx.OpenTextPopup methods

### DIFF
--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -487,7 +487,9 @@ gmf.AbstractController = function(config, $scope, $injector) {
    * @param {string=} opt_height CSS height.
    * @export
    */
-  gmfx.openIframePopup = function(url, title, opt_width, opt_height) {
+  gmfx.openIframePopup = gmfx.OpenIframePopup = function(
+    url, title, opt_width, opt_height
+  ) {
     const popup = ngeoCreatePopup();
     popup.setUrl(`${url}`);
     gmfx.openPopup_(popup, title, opt_width, opt_height);
@@ -501,7 +503,9 @@ gmf.AbstractController = function(config, $scope, $injector) {
    * @param {string=} opt_height CSS height.
    * @export
    */
-  gmfx.openTextPopup = function(content, title, opt_width, opt_height) {
+  gmfx.openTextPopup = gmfx.OpenTextPopup = function(
+    content, title, opt_width, opt_height
+  ) {
     const popup = ngeoCreatePopup();
     popup.setContent(`${content}`, true);
     gmfx.openPopup_(popup, title, opt_width, opt_height);


### PR DESCRIPTION
A regression has been introduced in https://github.com/camptocamp/ngeo/commit/325be82aae174bd906f397f971f409e5091bb183

In the mobile version, the method that is written that is written in the HTML starts with a capital letter, i.e.: `gmfx.OpenIframeWindow`.  The fix above renamed that method to `gmfx.openIframeWindow`, which causes the link in mobile to no longer work.

The desktop version is different.  The method written in the HTML is: `cgxp.tools.openInfoWindow`, for your information.

Now, I don't know why this change was made, nor what is the exact name that should be used.

This PR allows the use of both names, the old and new ones.