### PR TITLE
Fix ImportDataSource description position (CSS, flex)

### DIFF
--- a/contribs/gmf/less/importdatasource.less
+++ b/contribs/gmf/less/importdatasource.less
@@ -98,6 +98,7 @@ a.gmf-wmscapabilitylayertreenode-expand-node.fa {
 
 .gmf-wmscapabilitylayertreenode-header {
   display: flex;
+  flex-wrap: wrap;
 
   &:hover > span > .gmf-wmscapabilitylayertreenode-actions {
     opacity: 1;
@@ -117,6 +118,7 @@ a.gmf-wmscapabilitylayertreenode-expand-node.fa {
 .gmf-wmscapabilitylayertreenode-description {
   background-color: #fafafa;
   border: 0.1rem solid #ddd;
+  order: 1;
   padding: 1rem;
 
   a {


### PR DESCRIPTION
Fixes the position (CSS) of the description in the ImportDataSource tool.