### PR TITLE
Remove legacy ImportLayer from desktop_alt

### DIFF
--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -23,11 +23,6 @@
       </div>
     </header>
     <main>
-      <div
-         ngeo-import-dnd
-         ngeo-import-dnd-options="::mainCtrl.importOptions">
-      </div>
-
       <div class="gmf-app-data-panel">
         <div class="gmf-app-header">
           <div class="dropdown">
@@ -37,32 +32,6 @@
               <span translate>Themes</span>
               <span class="caret"></span>
             </a>
-            <div class="import">
-              <div>Local</div>
-              <div class="import-local"
-                ngeo-import-local
-                ngeo-import-local-options="::mainCtrl.importOptions">
-              </div>
-              <div>Online</div>
-              <div
-                ngeo-import-online
-                ngeo-import-online-options="::mainCtrl.importOptions">
-              </div>
-
-              <!-- Display WMS GetCapabilities results -->
-              <div ng-if="wmsGetCap"
-                   ngeo-wms-get-cap="wmsGetCap"
-                   ngeo-wms-get-cap-map="::map"
-                   ngeo-wms-get-cap-options="::mainCtrl.importOptions">
-              </div>
-
-              <!-- Display WMTS GetCapabilities results -->
-              <div ng-if="wmtsGetCap"
-                   ngeo-wmts-get-cap="wmtsGetCap"
-                   ngeo-wmts-get-cap-map="::map"
-                   ngeo-wmts-get-cap-options="::mainCtrl.importOptions">
-              </div>
-            </div>
             <gmf-themeselector class="dropdown-menu"
               gmf-themeselector-currenttheme="mainCtrl.theme"
               gmf-themeselector-filter="::mainCtrl.filter">

--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -22,8 +22,6 @@ goog.require('ngeo.proj.EPSG2056');
 /** @suppress {extraRequire} */
 goog.require('ngeo.proj.EPSG21781');
 
-goog.require('app.GmfImportHelper');
-
 
 gmf.module.value('ngeoQueryOptions', {
   'limit': 20,
@@ -131,11 +129,6 @@ app.AlternativeDesktopController = function($scope, $injector, ngeoFile, gettext
   gettextCatalog.getString('Add a theme');
   gettextCatalog.getString('Add a sub theme');
   gettextCatalog.getString('Add a layer');
-
-  /**
-   * @export
-   */
-  this.importOptions = new app.GmfImportHelper(this.map, $scope, gettext, ngeoFile, $q).createOptions();
 };
 ol.inherits(app.AlternativeDesktopController, gmf.AbstractDesktopController);
 


### PR DESCRIPTION
This PR removes the legacy 'Import Layer' tool from the `desktop_alt` app.

Note that its components are not removed by this PR, as the new ImportDataSource tool replacing it doesn't currently support the "typeahead" feature, and code might still be borrowed from the legacy version.

Once the "typeahead" features is supported in the new tool, then we'll be able to do the last "cleanup" of the files that were used by the legacy tool.