### PR TITLE
ImportDataSource - Add twitter typeahead to list servers

### DIFF
--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -30,9 +30,17 @@ gmf.module.value('ngeoQueryOptions', {
 });
 
 gmf.module.value('gmfExternalOGCServers', [{
-  'name': 'Swiss Topo',
+  'name': 'Swiss Topo WMS',
   'type': 'WMS',
   'url': 'http://wms.geo.admin.ch/?lang=fr'
+}, {
+  'name': 'ASIT VD',
+  'type': 'WMTS',
+  'url': 'https://ows.asitvd.ch/wmts/1.0.0/WMTSCapabilities.xml'
+}, {
+  'name': 'Swiss Topo WMTS',
+  'type': 'WMTS',
+  'url': 'https://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml?lang=fr'
 }]);
 
 gmf.module.value('gmfPrintOptions', {

--- a/contribs/gmf/examples/importdatasource.html
+++ b/contribs/gmf/examples/importdatasource.html
@@ -26,6 +26,70 @@
       }
 
 
+      /* CSS stolen from https://github.com/bassjobsen/typeahead.js-bootstrap-css/ */
+      span.twitter-typeahead .tt-menu {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        z-index: 1000;
+        display: none;
+        float: left;
+        min-width: 160px;
+        padding: 5px 0;
+        margin: 2px 0 0;
+        list-style: none;
+        font-size: 14px;
+        text-align: left;
+        background-color: #ffffff;
+        border: 1px solid #cccccc;
+        border: 1px solid rgba(0, 0, 0, 0.15);
+        border-radius: 4px;
+        -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+        box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+        background-clip: padding-box;
+      }
+      span.twitter-typeahead .tt-suggestion {
+        display: block;
+        padding: 3px 20px;
+        margin-bottom: 0px;
+        clear: both;
+        font-weight: normal;
+        line-height: 1.42857143;
+        color: #333333;
+        white-space: nowrap;
+      }
+      span.twitter-typeahead .tt-suggestion.tt-cursor,
+      span.twitter-typeahead .tt-suggestion:hover,
+      span.twitter-typeahead .tt-suggestion:focus {
+        color: #ffffff;
+        text-decoration: none;
+        outline: 0;
+        background-color: #428bca;
+      }
+      span.twitter-typeahead .tt-suggestion button {
+        background: none;
+        border: 0;
+        float: right;
+      }
+      span.twitter-typeahead {
+        width: 100%;
+      }
+      .input-group span.twitter-typeahead {
+        display: block !important;
+      }
+      .input-group span.twitter-typeahead .tt-menu {
+        top: 32px !important;
+      }
+      .input-group.input-group-lg span.twitter-typeahead .tt-menu {
+        top: 44px !important;
+      }
+      .input-group.input-group-sm span.twitter-typeahead .tt-menu {
+        top: 28px !important;
+      }
+
+
+      /* CSS for this example */
+
       body {
         padding: 0;
       }
@@ -290,6 +354,7 @@
     <script src="../../../node_modules/angular-ui-date/dist/date.js"></script>
     <script src="../../../node_modules/angular-float-thead/angular-floatThead.js"></script>
     <script src="../../../node_modules/floatthead/dist/jquery.floatThead.min.js"></script>
+    <script src="../../../node_modules/corejs-typeahead/dist/typeahead.bundle.js"></script>
     <script src="../../../node_modules/angular-ui-slider/src/slider.js"></script>
     <script src="../../../node_modules/angular-dynamic-locale/dist/tmhDynamicLocale.js"></script>
     <script src="../../../node_modules/moment/min/moment.min.js"></script>

--- a/contribs/gmf/examples/importdatasource.js
+++ b/contribs/gmf/examples/importdatasource.js
@@ -41,9 +41,17 @@ gmfapp.module.value('gmfLayersUrl',
   'https://geomapfish-demo.camptocamp.net/2.2/wsgi/layers/');
 
 gmfapp.module.value('gmfExternalOGCServers', [{
-  'name': 'Swiss Topo',
+  'name': 'Swiss Topo WMS',
   'type': 'WMS',
   'url': 'http://wms.geo.admin.ch/?lang=fr'
+}, {
+  'name': 'ASIT VD',
+  'type': 'WMTS',
+  'url': 'https://ows.asitvd.ch/wmts/1.0.0/WMTSCapabilities.xml'
+}, {
+  'name': 'Swiss Topo WMTS',
+  'type': 'WMTS',
+  'url': 'https://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml?lang=fr'
 }]);
 
 

--- a/contribs/gmf/less/importdatasource.less
+++ b/contribs/gmf/less/importdatasource.less
@@ -1,8 +1,13 @@
 @import "../../../node_modules/font-awesome/less/variables.less";
+@import "typeahead.less";
 
 gmf-importdatasource {
   input[type=file] {
     display: none;
+  }
+
+  .gmf-importdatasource-url-form-group {
+    background-color: #fff;
   }
 }
 

--- a/contribs/gmf/less/search.less
+++ b/contribs/gmf/less/search.less
@@ -1,4 +1,5 @@
 @import "../../../node_modules/font-awesome/less/variables.less";
+@import "typeahead.less";
 
 @search-results-max-height: calc(~"100vh -" 6 * @app-margin);
 
@@ -49,10 +50,6 @@ gmf-search {
       background-color: @onhover-color;
     }
   }
-  .twitter-typeahead {
-    width: 100%;
-    height: 100%;
-  }
   .form-control {
     box-shadow: none;
     height: 100%;
@@ -68,18 +65,8 @@ gmf-search {
     z-index: @search-index;
   }
 
-  .tt-hint {
-    display: none;
-  }
-
   .tt-menu {
-    width: 100%;
     max-height: @search-results-max-height;
-    overflow-x: hidden;
-    overflow-y: auto;
-    background-color: @map-tools-bg-color;
-    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-    border: solid 1px @border-color;
     .gmf-search-no-results {
       padding: @app-margin;
       cursor: default;
@@ -89,13 +76,6 @@ gmf-search {
       display: none;
     }
     .gmf-search-datum {
-      border-bottom: solid 1px @border-color;
-      padding: @app-margin;
-      text-align: left;
-      &:hover, &.tt-cursor {
-        cursor: pointer;
-        background-color: @onhover-color;
-      }
       p {
         margin: 0;
       }

--- a/contribs/gmf/less/typeahead.less
+++ b/contribs/gmf/less/typeahead.less
@@ -1,0 +1,28 @@
+.twitter-typeahead {
+  width: 100%;
+  height: 100%;
+
+  .tt-hint {
+    display: none;
+  }
+
+  .tt-menu {
+    width: 100%;
+    overflow-x: hidden;
+    overflow-y: auto;
+    background-color: @map-tools-bg-color;
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+    border: solid 1px @border-color;
+
+    .tt-suggestion {
+      text-align: left;
+      padding: @app-margin;
+      border-bottom: solid 1px @border-color;
+
+      &:hover, &.tt-cursor {
+        cursor: pointer;
+        background-color: @onhover-color;
+      }
+    }
+  }
+}

--- a/contribs/gmf/src/datasource/externaldatasourcesmanager.js
+++ b/contribs/gmf/src/datasource/externaldatasourcesmanager.js
@@ -107,25 +107,6 @@ gmf.datasource.ExternalDataSourcesManager = class {
     this.map_ = null;
 
     /**
-     * @type {!Object.<string, !gmfx.ExternalOGCServer>}
-     * @private
-     */
-    this.wmsServers_ = {};
-
-    const servers = $injector.has('gmfExternalOGCServers') ?
-      /** @type {Array.<!gmfx.ExternalOGCServer>|undefined} */ (
-        $injector.get('gmfExternalOGCServers')
-      ) : undefined;
-
-    if (servers) {
-      for (const server of servers) {
-        if (server.type === 'WMS') {
-          this.wmsServers_[server.name] = server;
-        }
-      }
-    }
-
-    /**
      * Group that contains file data sources.
      * @type {!ngeo.datasource.FileGroup}
      * @private

--- a/contribs/gmf/src/directives/partials/importdatasource.html
+++ b/contribs/gmf/src/directives/partials/importdatasource.html
@@ -53,8 +53,9 @@
     name="idsc_form"
     novalidate
     ng-show="$ctrl.mode === 'Online'">
-    <div class="form-group">
+    <div class="form-group gmf-importdatasource-url-form-group">
       <input
+        autocomplete="off"
         class="form-control"
         name="url"
         placeholder="{{'Choose or enter online resource URL' | translate}}"

--- a/externs/typeahead.js
+++ b/externs/typeahead.js
@@ -7,7 +7,7 @@
 
 
 /**
- * @typedef {Object.<string,*>}
+ * @typedef {Object.<string,*>|string}
  */
 let BloodhoundDatum;
 
@@ -39,7 +39,7 @@ let BloodhoundPrefetchOptions;
  *   datumTokenizer: function(BloodhoundDatum):Array.<string>,
  *   queryTokenizer: function(string):Array.<string>,
  *   initialize: (string|undefined),
- *   identify: (function(BloodhoundDatum):string|undefined),
+ *   identify: ((function(BloodhoundDatum):string|undefined)|boolean),
  *   sufficient: (number|undefined),
  *   sorter: (function(BloodhoundDatum,BloodhoundDatum):number|undefined),
  *   local: (Array.<BloodhoundDatum>|function():Array.<BloodhoundDatum>|undefined),


### PR DESCRIPTION
This PR introduces Twitter's typeahead in the ImportDataSource component.

The url is displayed in the suggestions, and used in the search.  This could be enhanced in the future (i.e. we could use the name instead / too).

## Todo

 * [x] review
 * [x] ~~validate CSS style - I "borrowed" the code from https://github.com/bassjobsen/typeahead.js-bootstrap-css/, is that okay?~~ Fixed by fred, thanks.
 * [x] find a solution about the fact that Typeahead only matches from the beginning of the searched string...
 * [x] requires master to build properly, see: #3071 