### PR TITLE
Display edit feature postgres error

### DIFF
--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -413,10 +413,22 @@ gmf.EditfeatureController = function($element, $q, $scope, $timeout,
   this.geomType;
 
   /**
-   * @type{boolean}
+   * @type {boolean}
    * @export
    */
   this.showServerError = false;
+
+  /**
+   * @type {?string}
+   * @export
+   */
+  this.serverErrorMessage = null;
+
+  /**
+   * @type {?string}
+   * @export
+   */
+  this.serverErrorType = null;
 };
 
 
@@ -583,9 +595,11 @@ gmf.EditfeatureController.prototype.save = function() {
       this.pending = false;
       this.handleEditFeature_(response);
     },
-    () => {
+    (response) => {
       this.showServerError = true;
       this.pending = false;
+      this.serverErrorType =  `error type : ${response.data['error_type']}`;
+      this.serverErrorMessage = `error message : ${response.data['message']}`;
     }
   );
 };
@@ -674,9 +688,11 @@ gmf.EditfeatureController.prototype.delete = function() {
         // (2) Reset selected feature
         this.cancel();
       },
-      () => {
+      (response) => {
         this.showServerError = true;
         this.pending = false;
+        this.serverErrorType =  `error type : ${response.data['error_type']}`;
+        this.serverErrorMessage = `error message : ${response.data['message']}`;
       }
     );
 

--- a/contribs/gmf/src/directives/partials/editfeature.html
+++ b/contribs/gmf/src/directives/partials/editfeature.html
@@ -128,6 +128,7 @@
   </div>
   <ngeo-modal ng-model="efCtrl.showServerError" ngeo-modal-destroy-content-on-hide="true">
     <div class="modal-header">{{'Server error.' | translate}}</div>
-    <div class="modal-body">{{'Unexpected server error.' | translate}}</div>
+    <div class="modal-body">{{$parent.efCtrl.serverErrorType}}<br>
+    {{$parent.efCtrl.serverErrorMessage || ('Unexpected server error.' | translate)}}</div>
   </ngeo-modal>
 </div>


### PR DESCRIPTION
Will log the error message from  PostgreSQL when editing or updating a feature in GMF.
![capture du 2017-11-07 13-30-28](https://user-images.githubusercontent.com/10759614/32493899-d86484f4-c3bf-11e7-9760-f5fb62878c90.png)


See https://github.com/camptocamp/c2cgeoportal/issues/3233
