### PR TITLE
Make lint target reliable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ gh-pages:
 		$(GMF_SRC_JS_FILES) \
 		$(GMF_EXAMPLES_JS_FILES) \
 		$(GMF_APPS_JS_FILES)
-	./node_modules/.bin/eslint $(filter-out .build/node_modules.timestamp .eslintrc.yaml .eslintrc-es6.yaml, $?)
+	./node_modules/.bin/eslint $(filter-out .build/node_modules.timestamp .eslintrc.yaml .eslintrc-es6.yaml, $^)
 	touch $@
 
 dist/ngeo.js: .build/ngeo.json \


### PR DESCRIPTION
Previously only the files newer than the timestamp were passed to the linter.
Changing the linter config or version did not trigger a lint of all the files.

With this commit, all files are linted on changes.