### PR TITLE
Remove goog.events from eventhelper

### DIFF
--- a/src/directives/attributes.js
+++ b/src/directives/attributes.js
@@ -139,8 +139,7 @@ ngeo.AttributesController.prototype.$onInit = function() {
       ol.ObjectEventType.PROPERTYCHANGE,
       this.handleFeaturePropertyChange_,
       this
-    ),
-    true
+    )
   );
 
   const lang = this.gettextCatalog_.getCurrentLanguage();

--- a/src/directives/createfeature.js
+++ b/src/directives/createfeature.js
@@ -230,8 +230,7 @@ ngeo.CreatefeatureController.prototype.$onInit = function() {
         ol.interaction.DrawEventType.DRAWEND,
         this.handleDrawEnd_,
         this
-      ),
-      true
+      )
     );
   } else if (interaction instanceof ngeo.interaction.MeasureLength ||
      interaction instanceof ngeo.interaction.MeasureArea) {
@@ -242,8 +241,7 @@ ngeo.CreatefeatureController.prototype.$onInit = function() {
         ngeo.MeasureEventType.MEASUREEND,
         this.handleDrawEnd_,
         this
-      ),
-      true
+      )
     );
   }
 };

--- a/src/services/eventhelper.js
+++ b/src/services/eventhelper.js
@@ -1,14 +1,10 @@
 goog.provide('ngeo.EventHelper');
 
 goog.require('ngeo');
-goog.require('goog.events');
 
 
 /**
- * Provides methods to manage the listening/unlistening of all sorts of
- * events:
- * - events from OpenLayers
- * - events from Closure Library
+ * Provides methods to manage the listening/unlistening of OpenLayers events
  *
  * @constructor
  * @struct
@@ -19,7 +15,7 @@ goog.require('goog.events');
 ngeo.EventHelper = function() {
 
   /**
-   * @type {Object.<number|string, ngeo.EventHelper.ListenerKeys>}
+   * @type {Object.<number|string, Array.<ol.EventsKey>>}
    * @private
    */
   this.listenerKeys_ = {};
@@ -28,25 +24,17 @@ ngeo.EventHelper = function() {
 
 
 /**
- * Utility method to add a listener key bound to a unique id. The key can
- * come from an `ol.events` (default) or `goog.events`.
+ * Utility method to add a listener key bound to a unique id. The key has
+ * to come from `ol.events`.
  * @param {number|string} uid Unique id.
- * @param {ol.EventsKey|goog.events.Key} key Key.
- * @param {boolean=} opt_isol Whether it's an OpenLayers event or not. Defaults
- *     to true.
+ * @param {ol.EventsKey} key Key.
  * @export
  */
-ngeo.EventHelper.prototype.addListenerKey = function(uid, key, opt_isol) {
+ngeo.EventHelper.prototype.addListenerKey = function(uid, key) {
   if (!this.listenerKeys_[uid]) {
     this.initListenerKey_(uid);
   }
-
-  const isol = opt_isol !== undefined ? opt_isol : true;
-  if (isol) {
-    this.listenerKeys_[uid].ol.push(/** @type {ol.EventsKey} */ (key));
-  } else {
-    this.listenerKeys_[uid].goog.push(/** @type {goog.events.Key} */ (key));
-  }
+  this.listenerKeys_[uid].push(/** @type {ol.EventsKey} */ (key));
 };
 
 
@@ -71,34 +59,15 @@ ngeo.EventHelper.prototype.clearListenerKey = function(uid) {
  */
 ngeo.EventHelper.prototype.initListenerKey_ = function(uid) {
   if (!this.listenerKeys_[uid]) {
-    this.listenerKeys_[uid] = {
-      goog: [],
-      ol: []
-    };
+    this.listenerKeys_[uid] = [];
   } else {
-    if (this.listenerKeys_[uid].goog.length) {
-      this.listenerKeys_[uid].goog.forEach((key) => {
-        goog.events.unlistenByKey(key);
-      }, this);
-      this.listenerKeys_[uid].goog.length = 0;
-    }
-    if (this.listenerKeys_[uid].ol.length) {
-      this.listenerKeys_[uid].ol.forEach((key) => {
+    if (this.listenerKeys_[uid].length) {
+      this.listenerKeys_[uid].forEach((key) => {
         ol.events.unlistenByKey(key);
       }, this);
-      this.listenerKeys_[uid].ol.length = 0;
+      this.listenerKeys_[uid].length = 0;
     }
   }
 };
-
-
-/**
- * @typedef {{
- *     goog: (Array.<goog.events.Key>),
- *     ol: (Array.<ol.EventsKey>)
- * }}
- */
-ngeo.EventHelper.ListenerKeys;
-
 
 ngeo.module.service('ngeoEventHelper', ngeo.EventHelper);


### PR DESCRIPTION
Since the goog.event-part wasn't even used throughout the project, it seems to be safe to remove.