### PR TITLE
Allow injection of gmfObjectEditingManager to fail in Permalink

### DIFF
--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -239,12 +239,14 @@ gmf.Permalink = function($q, $timeout, $rootScope, $injector, ngeoDebounce, ngeo
    * @private
    */
   this.gmfObjectEditingManager_;
-  if ($injector.has('gmfObjectEditingManager')) {
-    try {
-      this.gmfObjectEditingManager_ = $injector.get('gmfObjectEditingManager');
-    } catch (e) {
-      this.gmfObjectEditingManager_ = null;
-    }
+  try {
+    // Attempt to inject gmfObjectEditingManager.
+    // This fails if the GMF application is not completely configured, like
+    // in the examples, where there is no gmfLayersUrl defined. Usually in
+    // those cases the gmfObjectEditingManager is not being used.
+    this.gmfObjectEditingManager_ = $injector.get('gmfObjectEditingManager');
+  } catch (e) {
+    this.gmfObjectEditingManager_ = null;
   }
 
   /**

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -238,8 +238,14 @@ gmf.Permalink = function($q, $timeout, $rootScope, $injector, ngeoDebounce, ngeo
    * @type {?gmf.ObjectEditingManager}
    * @private
    */
-  this.gmfObjectEditingManager_ = $injector.has('gmfObjectEditingManager') ?
-    $injector.get('gmfObjectEditingManager') : null;
+  this.gmfObjectEditingManager_;
+  if ($injector.has('gmfObjectEditingManager')) {
+    try {
+      this.gmfObjectEditingManager_ = $injector.get('gmfObjectEditingManager');
+    } catch (e) {
+      this.gmfObjectEditingManager_ = null;
+    }
+  }
 
   /**
    * @type {?gmf.ThemeManager}


### PR DESCRIPTION
Fixes #2844 

Not sure if try/catch is a good practice.