### PR TITLE
Change eslint object-shorthand check

### DIFF
--- a/.eslintrc-es6.yaml
+++ b/.eslintrc-es6.yaml
@@ -87,12 +87,9 @@
     # require let or const instead of var
     'no-var': 'error',
 
-    # require method and property shorthand syntax for object literals
+    # require method and property shorthand syntax for object literals to be consistent
     # http://eslint.org/docs/rules/object-shorthand
-    'object-shorthand': ['error', 'always', {
-      ignoreConstructors: false,
-      avoidQuotes: true,
-    }],
+    'object-shorthand': ['error', 'consistent'],
 
     # suggest using arrow functions as callbacks
     'prefer-arrow-callback': ['error', {

--- a/contribs/gmf/examples/displayquerygrid.js
+++ b/contribs/gmf/examples/displayquerygrid.js
@@ -107,9 +107,13 @@ gmfapp.MainController = function(gmfThemes, gmfDataSourcesManager,
    * @export
    */
   this.featureStyle = new ol.style.Style({
-    fill,
-    image: new ol.style.Circle({fill, radius: 5, stroke}),
-    stroke
+    fill: fill,
+    image: new ol.style.Circle({
+      fill: fill,
+      radius: 5,
+      stroke: stroke
+    }),
+    stroke: stroke
   });
 
   /**

--- a/contribs/gmf/examples/displayquerywindow.js
+++ b/contribs/gmf/examples/displayquerywindow.js
@@ -103,9 +103,13 @@ gmfapp.MainController = function(gmfThemes, gmfDataSourcesManager,
    * @export
    */
   this.featureStyle = new ol.style.Style({
-    fill,
-    image: new ol.style.Circle({fill, radius: 5, stroke}),
-    stroke
+    fill: fill,
+    image: new ol.style.Circle({
+      fill: fill,
+      radius: 5,
+      stroke: stroke
+    }),
+    stroke: stroke
   });
 
   /**

--- a/contribs/gmf/examples/drawfeature.js
+++ b/contribs/gmf/examples/drawfeature.js
@@ -65,7 +65,7 @@ gmfapp.MainController = function($scope, ngeoFeatureHelper, ngeoFeatures,
         source: new ol.source.OSM()
       })
     ],
-    view
+    view: view
   });
 
   /**

--- a/contribs/gmf/examples/editfeatureselector.js
+++ b/contribs/gmf/examples/editfeatureselector.js
@@ -95,9 +95,7 @@ gmfapp.MainController = function($scope, gmfThemes, gmfTreeManager, gmfUser,
       wrapX: false,
       features: new ol.Collection()
     }),
-    style(feature, resolution) {
-      return ngeoFeatureHelper.createEditingStyles(feature);
-    }
+    style: (feature, resolution) => ngeoFeatureHelper.createEditingStyles(feature)
   });
 
   /**

--- a/contribs/gmf/examples/featurestyle.js
+++ b/contribs/gmf/examples/featurestyle.js
@@ -158,11 +158,11 @@ gmfapp.MainController = function($scope, ngeoFeatureHelper) {
       new ol.layer.Vector({
         source: new ol.source.Vector({
           wrapX: false,
-          features
+          features: features
         })
       })
     ],
-    view
+    view: view
   });
 
   /**

--- a/contribs/gmf/examples/mobilemeasure.js
+++ b/contribs/gmf/examples/mobilemeasure.js
@@ -50,8 +50,8 @@ gmfapp.MainController = function(gmfPermalink) {
     view: new ol.View({
       projection: 'EPSG:21781',
       resolutions: [200, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5],
-      center,
-      zoom
+      center: center,
+      zoom: zoom
     })
   });
 

--- a/contribs/gmf/examples/profile.js
+++ b/contribs/gmf/examples/profile.js
@@ -106,7 +106,7 @@ gmfapp.MainController = function($scope, ngeoFeatureOverlayMgr) {
   this.drawLine = new ol.interaction.Draw(
     /** @type {olx.interaction.DrawOptions} */ ({
       type: 'LineString',
-      features
+      features: features
     }));
 
   this.drawLine.setActive(false);

--- a/contribs/gmf/examples/search.js
+++ b/contribs/gmf/examples/search.js
@@ -64,9 +64,13 @@ gmfapp.MainController = function(gmfThemes, ngeoFeatureOverlayMgr, ngeoNotificat
    */
   this.searchStyles = {
     'osm': new ol.style.Style({
-      fill,
-      image: new ol.style.Circle({fill, radius: 5, stroke}),
-      stroke
+      fill: fill,
+      image: new ol.style.Circle({
+        fill: fill,
+        radius: 5,
+        stroke: stroke
+      }),
+      stroke: stroke
     })
   };
 

--- a/contribs/gmf/examples/wfspermalink.js
+++ b/contribs/gmf/examples/wfspermalink.js
@@ -63,9 +63,13 @@ gmfapp.MainController = function() {
    * @export
    */
   this.featureStyle = new ol.style.Style({
-    fill,
-    image: new ol.style.Circle({fill, radius: 5, stroke}),
-    stroke
+    fill: fill,
+    image: new ol.style.Circle({
+      fill: fill,
+      radius: 5,
+      stroke: stroke
+    }),
+    stroke: stroke
   });
 };
 

--- a/contribs/gmf/src/controllers/abstractdesktop.js
+++ b/contribs/gmf/src/controllers/abstractdesktop.js
@@ -221,9 +221,7 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
       wrapX: false,
       features: new ol.Collection()
     }),
-    style(feature, resolution) {
-      return ngeoFeatureHelper.createEditingStyles(feature);
-    }
+    style: (feature, resolution) => ngeoFeatureHelper.createEditingStyles(feature)
     // style: ngeoFeatureHelper.createEditingStyles.bind(ngeoFeatureHelper)
   });
   this.editFeatureVectorLayer.setMap(this.map);

--- a/contribs/gmf/src/controllers/abstractmobile.js
+++ b/contribs/gmf/src/controllers/abstractmobile.js
@@ -101,8 +101,8 @@ gmf.AbstractMobileController = function(config, $scope, $injector) {
    * @export
    */
   this.mobileGeolocationOptions = {
-    positionFeatureStyle,
-    accuracyFeatureStyle,
+    positionFeatureStyle: positionFeatureStyle,
+    accuracyFeatureStyle: accuracyFeatureStyle,
     zoom: config.geolocationZoom,
     autorotate: config.autorotate
   };

--- a/contribs/gmf/src/datasource/datasourcesmanager.js
+++ b/contribs/gmf/src/datasource/datasourcesmanager.js
@@ -364,8 +364,8 @@ gmf.datasource.DataSourcesManager = class {
       if (layers) {
         ogcLayers = layers.split(',').map((layer) => {
           return {
-            maxResolution,
-            minResolution,
+            maxResolution: maxResolution,
+            minResolution: minResolution,
             name: layer,
             queryable: true
           };

--- a/contribs/gmf/src/datasource/externaldatasourcesmanager.js
+++ b/contribs/gmf/src/datasource/externaldatasourcesmanager.js
@@ -349,16 +349,16 @@ gmf.datasource.ExternalDataSourcesManager = class {
       // TODO - MaxScaleDenominator
       // TODO - MinScaleDenominator
       dataSource = new ngeo.datasource.OGC({
-        id,
+        id: id,
         name: layer['Title'],
-        ogcImageType,
+        ogcImageType: ogcImageType,
         ogcLayers: [{
           name: layer['Name'],
-          queryable
+          queryable: queryable
         }],
         ogcType: ngeo.datasource.OGC.Type.WMS,
         visible: true,
-        wmsInfoFormat,
+        wmsInfoFormat: wmsInfoFormat,
         wmsUrl: url
       });
 
@@ -381,7 +381,7 @@ gmf.datasource.ExternalDataSourcesManager = class {
         dataSources: [dataSource],
         injector: this.injector_,
         title: service['Title'],
-        url
+        url: url
       });
       this.addLayer_(wmsGroup.layer);
       this.addWMSGroup_(wmsGroup);
@@ -417,12 +417,12 @@ gmf.datasource.ExternalDataSourcesManager = class {
       // TODO - MaxScaleDenominator
       // TODO - MinScaleDenominator
       dataSource = new ngeo.datasource.OGC({
-        id,
-        name,
+        id: id,
+        name: name,
         ogcType: ngeo.datasource.OGC.Type.WMTS,
         visible: true,
-        wmtsLayer,
-        wmtsUrl
+        wmtsLayer: wmtsLayer,
+        wmtsUrl: wmtsUrl
       });
 
       // Keep a reference to the external data source in the cache
@@ -453,7 +453,7 @@ gmf.datasource.ExternalDataSourcesManager = class {
 
     // (6) Create and set WMTS cache item
     this.wmtsCache_[id] = {
-      layerObj,
+      layerObj: layerObj,
       // This watcher synchronizes the data source visible property to
       // the OL layer object visible property
       unregister: this.rootScope_.$watch(
@@ -527,7 +527,7 @@ gmf.datasource.ExternalDataSourcesManager = class {
 
           const dataSource = new ngeo.datasource.File({
             features: new ol.Collection(features),
-            id,
+            id: id,
             name: file.name,
             visible: true
           });

--- a/contribs/gmf/src/directives/contextualdata.js
+++ b/contribs/gmf/src/directives/contextualdata.js
@@ -58,7 +58,7 @@ gmf.contextualdataDirective = function() {
      * @param {angular.Attributes} attrs Attributes.
      * @param {gmf.ContextualdataController} controller Controller.
      */
-    link(scope, element, attrs, controller) {
+    link: (scope, element, attrs, controller) => {
       controller.init();
     }
   };

--- a/contribs/gmf/src/directives/disclaimer.js
+++ b/contribs/gmf/src/directives/disclaimer.js
@@ -309,7 +309,7 @@ gmf.DisclaimerController.prototype.showDisclaimerMessage_ = function(msg) {
   } else {
     this.disclaimer_.alert({
       popup: this.popup,
-      msg,
+      msg: msg,
       target: this.element_,
       type: ngeo.MessageType.WARNING
     });
@@ -329,7 +329,7 @@ gmf.DisclaimerController.prototype.closeDisclaimerMessage_ = function(msg) {
   } else {
     this.disclaimer_.close({
       popup: this.popup,
-      msg,
+      msg: msg,
       target: this.element_,
       type: ngeo.MessageType.WARNING
     });

--- a/contribs/gmf/src/directives/displayquerygrid.js
+++ b/contribs/gmf/src/directives/displayquerygrid.js
@@ -285,9 +285,13 @@ gmf.DisplayquerygridController.prototype.$onInit = function() {
     const fill = new ol.style.Fill({color: [255, 0, 0, 0.6]});
     const stroke = new ol.style.Stroke({color: [255, 0, 0, 1], width: 2});
     highlightFeatureStyle = new ol.style.Style({
-      fill,
-      image: new ol.style.Circle({fill, radius: 5, stroke}),
-      stroke,
+      fill: fill,
+      image: new ol.style.Circle({
+        fill: fill,
+        radius: 5,
+        stroke: stroke
+      }),
+      stroke: stroke,
       zIndex: 10
     });
   }
@@ -593,7 +597,7 @@ gmf.DisplayquerygridController.prototype.makeGrid_ = function(data, source) {
   }
   this.gridSources[sourceLabel] = {
     configuration: gridConfig,
-    source
+    source: source
   };
   return true;
 };

--- a/contribs/gmf/src/directives/displayquerywindow.js
+++ b/contribs/gmf/src/directives/displayquerywindow.js
@@ -251,9 +251,13 @@ gmf.DisplayquerywindowController.prototype.$onInit = function() {
     const fill = new ol.style.Fill({color: [255, 0, 0, 0.6]});
     const stroke = new ol.style.Stroke({color: [255, 0, 0, 1], width: 2});
     highlightFeatureStyle = new ol.style.Style({
-      fill,
-      image: new ol.style.Circle({fill, radius: 5, stroke}),
-      stroke
+      fill: fill,
+      image: new ol.style.Circle({
+        fill: fill,
+        radius: 5,
+        stroke: stroke
+      }),
+      stroke: stroke
     });
   }
   this.highlightFeatureOverlay_.setStyle(highlightFeatureStyle);

--- a/contribs/gmf/src/directives/drawprofileline.js
+++ b/contribs/gmf/src/directives/drawprofileline.js
@@ -51,7 +51,7 @@ gmf.drawprofilelineDirective = function() {
      * @param {angular.Attributes} attrs Attributes.
      * @param {gmf.ContextualdataController} controller Controller.
      */
-    link(scope, element, attrs, controller) {
+    link: (scope, element, attrs, controller) => {
       controller.init();
     }
   };

--- a/contribs/gmf/src/directives/elevation.js
+++ b/contribs/gmf/src/directives/elevation.js
@@ -50,7 +50,7 @@ gmf.elevationDirective = function() {
       'layer': '<gmfElevationLayer',
       'map': '=gmfElevationMap'
     },
-    link(scope, element, attr) {
+    link: (scope, element, attr) => {
       const ctrl = scope['ctrl'];
 
       // Watch active or not.

--- a/contribs/gmf/src/directives/mobilemeasurelength.js
+++ b/contribs/gmf/src/directives/mobilemeasurelength.js
@@ -68,7 +68,7 @@ gmf.mobileMeasureLengthDirective =
          * @param {angular.Attributes} attrs Attributes.
          * @param {gmf.MobileMeasureLengthController} controller Controller.
          */
-        link(scope, element, attrs, controller) {
+        link: (scope, element, attrs, controller) => {
           controller.init();
         }
       };

--- a/contribs/gmf/src/directives/mobilemeasurepoint.js
+++ b/contribs/gmf/src/directives/mobilemeasurepoint.js
@@ -83,7 +83,7 @@ gmf.mobileMeasurePointDirective =
          * @param {!angular.Attributes} attrs Attributes.
          * @param {!gmf.MobileMeasurePointController} controller Controller.
          */
-        link(scope, element, attrs, controller) {
+        link: (scope, element, attrs, controller) => {
           controller.init();
         }
       };

--- a/contribs/gmf/src/directives/mobilenav.js
+++ b/contribs/gmf/src/directives/mobilenav.js
@@ -55,7 +55,7 @@ gmf.mobileNavDirective = function() {
      * @param {angular.Attributes} attrs Atttributes.
      * @param {gmf.MobileNavController} navCtrl Controller.
      */
-    link(scope, element, attrs, navCtrl) {
+    link: (scope, element, attrs, navCtrl) => {
       navCtrl.init(element);
     }
   };
@@ -291,7 +291,7 @@ gmf.mobileNavBackDirective = function() {
      * @param {angular.Attributes} attrs Atttributes.
      * @param {gmf.MobileNavController} navCtrl Controller.
      */
-    link(scope, element, attrs, navCtrl) {
+    link: (scope, element, attrs, navCtrl) => {
       scope.$watch(attrs['gmfMobileNavBack'], (newVal, oldVal) => {
         if (newVal === true) {
           navCtrl.backIfActive(element[0]);
@@ -333,7 +333,7 @@ gmf.mobileNavBackOnClickDirective = function() {
      * @param {angular.Attributes} attrs Atttributes.
      * @param {gmf.MobileNavController} navCtrl Controller.
      */
-    link(scope, element, attrs, navCtrl) {
+    link: (scope, element, attrs, navCtrl) => {
       element.on('click', () => {
         navCtrl.backIfActive(element[0]);
       });

--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -791,7 +791,10 @@ gmf.ObjecteditingController.prototype.initializeStyles_ = function(
 
   const image = new ol.style.Circle({
     radius: 8,
-    stroke: new ol.style.Stroke({color, width: 1}),
+    stroke: new ol.style.Stroke({
+      color: color,
+      width: 1
+    }),
     fill: new ol.style.Fill({color: rgbaColor})
   });
 
@@ -805,7 +808,7 @@ gmf.ObjecteditingController.prototype.initializeStyles_ = function(
   styles[ol.geom.GeometryType.LINE_STRING] = [
     new ol.style.Style({
       stroke: new ol.style.Stroke({
-        color,
+        color: color,
         width: 3
       })
     })
@@ -818,7 +821,7 @@ gmf.ObjecteditingController.prototype.initializeStyles_ = function(
   styles[ol.geom.GeometryType.MULTI_LINE_STRING] = [
     new ol.style.Style({
       stroke: new ol.style.Stroke({
-        color,
+        color: color,
         width: 3
       })
     })
@@ -832,7 +835,7 @@ gmf.ObjecteditingController.prototype.initializeStyles_ = function(
   styles[ol.geom.GeometryType.POLYGON] = [
     new ol.style.Style({
       stroke: new ol.style.Stroke({
-        color,
+        color: color,
         width: 2
       }),
       fill: new ol.style.Fill({
@@ -848,7 +851,7 @@ gmf.ObjecteditingController.prototype.initializeStyles_ = function(
   styles[ol.geom.GeometryType.MULTI_POLYGON] = [
     new ol.style.Style({
       stroke: new ol.style.Stroke({
-        color,
+        color: color,
         width: 2
       }),
       fill: new ol.style.Fill({

--- a/contribs/gmf/src/directives/print.js
+++ b/contribs/gmf/src/directives/print.js
@@ -134,7 +134,7 @@ gmf.printDirective = function(gmfPrintTemplateUrl) {
       'hiddenAttributeNames': '=?gmfPrintHiddenattributes',
       'attributesOut': '=?gmfPrintAttributesOut'
     },
-    link(scope, element, attr) {
+    link: (scope, element, attr) => {
       const ctrl = scope['ctrl'];
 
       scope.$watch(() => ctrl.active, function(active) {

--- a/contribs/gmf/src/directives/profile.js
+++ b/contribs/gmf/src/directives/profile.js
@@ -627,7 +627,7 @@ gmf.ProfileController.prototype.getJsonProfile_ = function() {
   /** @type {Function} */ (this.$http_)({
     url: this.gmfProfileJsonUrl_,
     method: 'POST',
-    params,
+    params: params,
     paramSerializer: '$httpParamSerializerJQLike',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded'

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -144,7 +144,7 @@ gmf.searchDirective = function(gmfSearchTemplateUrl) {
      * @param {angular.JQLite} element Element.
      * @param {angular.Attributes} attrs Atttributes.
      */
-    link(scope, element, attrs) {
+    link: (scope, element, attrs) => {
       if (!scope['clearbutton']) {
         const ctrl = scope['ctrl'];
         // Empty the search field on focus and blur.
@@ -405,11 +405,11 @@ gmf.SearchController = function($scope, $compile, $timeout, $injector, gettextCa
     name: 'coordinates',
     display: 'label',
     templates: {
-      header() {
+      header: () => {
         const header = gettextCatalog.getString('Recenter to');
         return `<div class="gmf-search-header" translate>${header}</div>`;
       },
-      suggestion(suggestion) {
+      suggestion: (suggestion) => {
         const coordinates = suggestion['label'];
 
         let html = `<p class="gmf-search-label">${coordinates}</p>`;
@@ -521,12 +521,12 @@ gmf.SearchController.prototype.createDataset_ = function(config, opt_filter) {
   const typeaheadDataset = /** @type {TypeaheadDataset} */ ({
     limit: Infinity,
     source: bloodhoundEngine.ttAdapter(),
-    display(suggestion) {
+    display: (suggestion) => {
       const feature = /** @type {ol.Feature} */ (suggestion);
       return feature.get(config.labelKey);
     },
     templates: /* TypeaheadTemplates */ ({
-      header() {
+      header: () => {
         if (config.datasetTitle === undefined) {
           return '';
         } else {
@@ -534,7 +534,7 @@ gmf.SearchController.prototype.createDataset_ = function(config, opt_filter) {
           return `<div class="gmf-search-header">${header}</div>`;
         }
       },
-      suggestion(suggestion) {
+      suggestion: (suggestion) => {
         const feature = /** @type {ol.Feature} */ (suggestion);
 
         const scope = directiveScope.$new(true);
@@ -637,7 +637,7 @@ gmf.SearchController.prototype.getBloodhoudRemoteOptions_ = function() {
   const gettextCatalog = this.gettextCatalog_;
   return {
     rateLimitWait: 50,
-    prepare(query, settings) {
+    prepare: (query, settings) => {
       const url = settings.url;
       const lang = gettextCatalog.currentLanguage;
       const interfaceName = 'mobile'; // FIXME dynamic interfaces
@@ -676,7 +676,7 @@ gmf.SearchController.prototype.createSearchCoordinates_ = function(view) {
     }
     suggestions.push({
       label: coordinates.join(' '),
-      position,
+      position: position,
       'tt_source': 'coordinates'
     });
     callback(suggestions);
@@ -709,13 +709,13 @@ gmf.SearchController.prototype.initStyles_ = function() {
     width: 2
   });
   this.styles_['default'] = new ol.style.Style({
-    fill,
-    stroke,
+    fill: fill,
     image: new ol.style.Circle({
+      fill: fill,
       radius: 5,
-      fill,
-      stroke
-    })
+      stroke: stroke
+    }),
+    stroke: stroke
   });
   const customStyles = this.scope_['featuresStyles'] || {};
   ol.obj.assign(this.styles_, customStyles);
@@ -889,8 +889,9 @@ gmf.SearchController.prototype.selectFromGMF_ = function(event, feature, dataset
     const fitArray = featureGeometry.getType() === 'GeometryCollection' ?
       featureGeometry.getExtent() : featureGeometry;
     view.fit(fitArray, {
-      size,
-      maxZoom: this.maxZoom});
+      size: size,
+      maxZoom: this.maxZoom
+    });
   }
   this.leaveSearch_();
 };

--- a/contribs/gmf/src/services/objecteditingmanager.js
+++ b/contribs/gmf/src/services/objecteditingmanager.js
@@ -77,7 +77,7 @@ gmf.ObjectEditingManager.prototype.getFeature = function() {
         [layer],
         [{
           operator: 'eq',
-          property,
+          property: property,
           value: id
         }]
       ).then(this.handleGetFeatures_.bind(this, property, id));

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -1157,8 +1157,8 @@ gmf.Permalink.prototype.getWfsPermalinkData_ = function() {
 
   return {
     wfsType: wfsLayer,
-    showFeatures,
-    filterGroups
+    showFeatures: showFeatures,
+    filterGroups: filterGroups
   };
 };
 
@@ -1193,7 +1193,7 @@ gmf.Permalink.prototype.createFilterGroup_ = function(prefix, paramKeys) {
 
     const filter = {
       property: paramKey.replace(prefix, ''),
-      condition
+      condition: condition
     };
     filters.push(filter);
   });

--- a/contribs/gmf/src/services/share.js
+++ b/contribs/gmf/src/services/share.js
@@ -67,7 +67,7 @@ gmf.ShareService.prototype.getShortUrl = function(url) {
 gmf.ShareService.prototype.sendShortUrl = function(shortUrl, email, opt_message) {
   const params = /** @type {gmfx.ShortenerAPIRequestParams} */ ({
     url: shortUrl,
-    email
+    email: email
   });
 
   if (opt_message) {

--- a/contribs/gmf/src/services/snapping.js
+++ b/contribs/gmf/src/services/snapping.js
@@ -258,10 +258,10 @@ gmf.Snapping.prototype.registerTreeCtrl_ = function(treeCtrl) {
         interaction: null,
         maxFeatures: 50,
         requestDeferred: null,
-        snappingConfig,
-        treeCtrl,
-        wfsConfig,
-        stateWatcherUnregister
+        snappingConfig: snappingConfig,
+        treeCtrl: treeCtrl,
+        wfsConfig: wfsConfig,
+        stateWatcherUnregister: stateWatcherUnregister
       };
 
       // This extra call is to initialize the treeCtrl with its current state
@@ -500,7 +500,7 @@ gmf.Snapping.prototype.loadItemFeatures_ = function(item) {
     srsName: projCode,
     featureNS: item.featureNS,
     featurePrefix: item.featurePrefix,
-    featureTypes,
+    featureTypes: featureTypes,
     outputFormat: 'GML3',
     bbox: extent,
     geometryName: item.geometryName,

--- a/contribs/gmf/test/spec/controllers/gmfprintcontroller.spec.js
+++ b/contribs/gmf/test/spec/controllers/gmfprintcontroller.spec.js
@@ -11,12 +11,10 @@ describe('GmfPrintController', () => {
     $controller = _$controller_;
     $rootScope = _$rootScope_;
     $scope = $rootScope.$new();
-    gmfPrintCtrl = $controller('GmfPrintController',
-      {
-        $scope,
-        gmfPrintUrl: ''
-      }
-    );
+    gmfPrintCtrl = $controller('GmfPrintController', {
+      $scope: $scope,
+      gmfPrintUrl: ''
+    });
     gmfPrintCtrl.map = new ol.Map({
       view: new ol.View({
         center: [0, 0],

--- a/contribs/gmf/test/spec/directives/contextualdata.spec.js
+++ b/contribs/gmf/test/spec/directives/contextualdata.spec.js
@@ -86,7 +86,7 @@ describe('gmf.contextualdataDirective', () => {
       const event = {
         clientX: 100,
         clientY: 200,
-        preventDefault() {}
+        preventDefault: () => {}
       };
       contextualdataController.handleMapContextMenu_(event);
       // make sure the template for contextualdatacontent directive is loaded

--- a/contribs/gmf/test/spec/directives/displayquerygrid.spec.js
+++ b/contribs/gmf/test/spec/directives/displayquerygrid.spec.js
@@ -51,8 +51,10 @@ describe('gmf.displayquerygridComponent', () => {
           });
         }
       };
-      queryGridController = $controller(
-        'GmfDisplayquerygridController', {$scope, $element: $('<div></div>')}, data);
+      queryGridController = $controller('GmfDisplayquerygridController', {
+        $scope: $scope,
+        $element: $('<div></div>')
+      }, data);
       $rootScope.$digest();
     });
   });

--- a/contribs/gmf/test/spec/directives/profile.spec.js
+++ b/contribs/gmf/test/spec/directives/profile.spec.js
@@ -34,7 +34,7 @@ describe('gmf.GmfProfileController', () => {
       };
       profileController = $controller(
         'GmfProfileController', {
-          $scope,
+          $scope: $scope,
           ngeoCsvDownload: csvDownloadServiceMock,
           $element: $('<div></div>')}, data);
       $rootScope.$digest();

--- a/examples/animation.js
+++ b/examples/animation.js
@@ -29,7 +29,7 @@ app.mapDirective = function() {
       'map': '=appMap',
       'class': '=appMapClass'
     },
-    controller() {},
+    controller: () => {},
     controllerAs: 'ctrl',
     bindToController: true,
     template: '<div ngeo-map="ctrl.map"></div>'

--- a/examples/desktopgeolocation.js
+++ b/examples/desktopgeolocation.js
@@ -46,8 +46,8 @@ app.MainController = function($scope, ngeoFeatureOverlayMgr) {
    * @export
    */
   this.desktopGeolocationOptions = {
-    positionFeatureStyle,
-    accuracyFeatureStyle,
+    positionFeatureStyle: positionFeatureStyle,
+    accuracyFeatureStyle: accuracyFeatureStyle,
     zoom: 17
   };
 

--- a/examples/interactionbtngroup.js
+++ b/examples/interactionbtngroup.js
@@ -85,7 +85,7 @@ app.MainController = function(ngeoDecorateInteraction, ngeoFeatureOverlayMgr) {
   this.drawPolygon = new ol.interaction.Draw(
     /** @type {olx.interaction.DrawOptions} */ ({
       type: 'Polygon',
-      features
+      features: features
     }));
 
   const drawPolygon = this.drawPolygon;
@@ -101,7 +101,7 @@ app.MainController = function(ngeoDecorateInteraction, ngeoFeatureOverlayMgr) {
   this.drawPoint = new ol.interaction.Draw(
     /** @type {olx.interaction.DrawOptions} */ ({
       type: 'Point',
-      features
+      features: features
     }));
 
   const drawPoint = this.drawPoint;
@@ -116,7 +116,7 @@ app.MainController = function(ngeoDecorateInteraction, ngeoFeatureOverlayMgr) {
   this.drawLine = new ol.interaction.Draw(
     /** @type {olx.interaction.DrawOptions} */ ({
       type: 'LineString',
-      features
+      features: features
     }));
 
   const drawLine = this.drawLine;

--- a/examples/locationsearch.js
+++ b/examples/locationsearch.js
@@ -74,16 +74,14 @@ app.SearchController = function(ngeoCreateLocationSearchBloodhound) {
    */
   this.datasets = [{
     source: bloodhoundEngine.ttAdapter(),
-    limit,
-    display(suggestion) {
+    limit: limit,
+    display: (suggestion) => {
       const feature = /** @type {ol.Feature} */ (suggestion);
       return feature.get('label_no_html');
     },
     templates: {
-      header() {
-        return '<div class="ngeo-header">Locations</div>';
-      },
-      suggestion(suggestion) {
+      header: () => '<div class="ngeo-header">Locations</div>',
+      suggestion: (suggestion) => {
         const feature = /** @type {ol.Feature} */ (suggestion);
         return `<p>${feature.get('label')}</p>`;
       }
@@ -113,9 +111,9 @@ app.SearchController.prototype.createAndInitBloodhound_ = function(ngeoCreateLoc
   goog.asserts.assert(epsg3857 !== null);
   const bloodhound = ngeoCreateLocationSearchBloodhound({
     targetProjection: epsg3857,
-    limit,
+    limit: limit,
     origins: 'gazetteer',
-    prepare(query, settings) {
+    prepare: (query, settings) => {
       // in a real application the interface language could be used here
       const lang = 'fr';
       settings.url += `&lang=${lang}`;

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -49,7 +49,7 @@ app.measuretoolsDirective = function() {
      * @param {angular.Attributes} attrs Attributes.
      * @param {app.MeasuretoolsController} controller Controller.
      */
-    link(scope, element, attrs, controller) {
+    link: (scope, element, attrs, controller) => {
       controller.init();
     }
   };

--- a/examples/mobilegeolocation.js
+++ b/examples/mobilegeolocation.js
@@ -46,8 +46,8 @@ app.MainController = function($scope, ngeoFeatureOverlayMgr) {
    * @export
    */
   this.mobileGeolocationOptions = {
-    positionFeatureStyle,
-    accuracyFeatureStyle,
+    positionFeatureStyle: positionFeatureStyle,
+    accuracyFeatureStyle: accuracyFeatureStyle,
     zoom: 17,
     autorotate: true
   };

--- a/examples/modifyrectangle.js
+++ b/examples/modifyrectangle.js
@@ -123,7 +123,7 @@ app.MainController = function() {
   this.interaction = new ngeo.interaction.ModifyRectangle(
     /** @type {olx.interaction.ModifyOptions} */({
       features: this.features,
-      style
+      style: style
     }));
 
   const interaction = this.interaction;

--- a/examples/popupservice.js
+++ b/examples/popupservice.js
@@ -104,7 +104,7 @@ app.MainController.prototype.openPopupWithContent = function() {
     'This popup was opened using the <code>open</code> method.');
   popup.open({
     autoDestroy: true,
-    content,
+    content: content,
     height: '200px',
     title: 'Opened with "open"',
     width: '300px'

--- a/examples/profile.js
+++ b/examples/profile.js
@@ -181,7 +181,7 @@ app.MainController = function($http, $scope) {
       * @param {number=} opt_z Z value.
       * @return {number} Z value.
       */
-    z(item, opt_z) {
+    z: (item, opt_z) => {
       if (opt_z !== undefined) {
         item['z'] = opt_z;
       }

--- a/examples/rotate.js
+++ b/examples/rotate.js
@@ -120,7 +120,7 @@ app.MainController = function() {
     /** @type {olx.interaction.ModifyOptions} */({
       features: this.features,
       layers: [vectorLayer],
-      style
+      style: style
     }));
 
   const interaction = this.interaction;

--- a/examples/search.js
+++ b/examples/search.js
@@ -41,7 +41,7 @@ app.searchDirective = function() {
      * @param {angular.JQLite} element Element.
      * @param {angular.Attributes} attrs Atttributes.
      */
-    link(scope, element, attrs) {
+    link: (scope, element, attrs) => {
       // Empty the search field on focus and blur.
       element.find('input').on('focus blur', function() {
         $(this).val('');
@@ -96,15 +96,13 @@ app.SearchController = function($rootScope, $compile, ngeoSearchCreateGeoJSONBlo
    */
   this.datasets = [{
     source: bloodhoundEngine.ttAdapter(),
-    display(suggestion) {
+    display: (suggestion) => {
       const feature = /** @type {ol.Feature} */ (suggestion);
       return feature.get('label');
     },
     templates: {
-      header() {
-        return '<div class="ngeo-header">Addresses</div>';
-      },
-      suggestion(suggestion) {
+      header: () => '<div class="ngeo-header">Addresses</div>',
+      suggestion: (suggestion) => {
         const feature = /** @type {ol.Feature} */ (suggestion);
 
         // A scope for the ng-click on the suggestion's « i » button.
@@ -179,7 +177,10 @@ app.SearchController.select_ = function(event, suggestion, dataset) {
   const source = this.vectorLayer_.getSource();
   source.clear(true);
   source.addFeature(feature);
-  this.map.getView().fit(featureGeometry, {size, maxZoom: 16});
+  this.map.getView().fit(featureGeometry, {
+    size: size,
+    maxZoom: 16
+  });
 };
 
 

--- a/examples/toolActivate.js
+++ b/examples/toolActivate.js
@@ -107,7 +107,7 @@ app.MainController = function(ngeoFeatureOverlayMgr, ngeoToolActivateMgr,
   this.drawPoint = new ol.interaction.Draw(
     /** @type {olx.interaction.DrawOptions} */ ({
       type: 'Point',
-      features
+      features: features
     }));
   this.drawPoint.setActive(false);
   ngeoDecorateInteraction(this.drawPoint);
@@ -124,7 +124,7 @@ app.MainController = function(ngeoFeatureOverlayMgr, ngeoToolActivateMgr,
   this.drawLine = new ol.interaction.Draw(
     /** @type {olx.interaction.DrawOptions} */ ({
       type: 'LineString',
-      features
+      features: features
     }));
   this.drawLine.setActive(false);
   ngeoDecorateInteraction(this.drawLine);
@@ -141,7 +141,7 @@ app.MainController = function(ngeoFeatureOverlayMgr, ngeoToolActivateMgr,
   this.drawPolygon = new ol.interaction.Draw(
     /** @type {olx.interaction.DrawOptions} */ ({
       type: 'Polygon',
-      features
+      features: features
     }));
   this.drawPolygon.setActive(false);
   ngeoDecorateInteraction(this.drawPolygon);

--- a/src/directives/bboxquery.js
+++ b/src/directives/bboxquery.js
@@ -38,7 +38,7 @@ ngeo.bboxQueryDirective = function(ngeoMapQuerent) {
   return {
     restrict: 'A',
     scope: false,
-    link(scope, elem, attrs) {
+    link: (scope, elem, attrs) => {
       /**
        * @type {ol.Map}
        */
@@ -57,8 +57,8 @@ ngeo.bboxQueryDirective = function(ngeoMapQuerent) {
         const extent = interaction.getGeometry().getExtent();
         ngeoMapQuerent.issue({
           limit: scope.$eval(attrs['ngeoBboxQueryLimit']),
-          extent,
-          map
+          extent: extent,
+          map: map
         });
       };
       interaction.on('boxend', handleBoxEnd);

--- a/src/directives/btngroup.js
+++ b/src/directives/btngroup.js
@@ -47,7 +47,7 @@ ngeo.btngroupDirective = function($parse) {
      * @param {!angular.Attributes=} attrs Atttributes.
      * @param {!ngeo.BtnGroupController=} controller Controller.
      */
-    link(scope, element, attrs, controller) {
+    link: (scope, element, attrs, controller) => {
       const setActive = $parse(attrs['ngeoBtnGroupActive']).assign;
 
       if (setActive) {
@@ -144,7 +144,7 @@ ngeo.btnDirective = function($parse) {
      * @param {!angular.Attributes=} attrs Atttributes.
      * @param {!Array.<!Object>=} ctrls Controller.
      */
-    link(scope, element, attrs, ctrls) {
+    link: (scope, element, attrs, ctrls) => {
       const buttonsCtrl = ctrls[0];
       const ngModelCtrl = ctrls[1];
       let indexInGroup = -1;

--- a/src/directives/control.js
+++ b/src/directives/control.js
@@ -34,7 +34,7 @@ ngeo.controlDirective = function() {
      * @param {angular.JQLite} element Element.
      * @param {angular.Attributes} attrs Atttributes.
      */
-    link(scope, element, attrs) {
+    link: (scope, element, attrs) => {
 
       const control = /** @type {ol.control.Control} */
               (scope.$eval(attrs['ngeoControl']));

--- a/src/directives/datepicker.js
+++ b/src/directives/datepicker.js
@@ -39,14 +39,14 @@ ngeo.DatePicker = function(ngeoDatePickerTemplateUrl,  $timeout) {
     controller: 'ngeoDatePickerController as datepickerCtrl',
     restrict: 'AE',
     templateUrl: ngeoDatePickerTemplateUrl,
-    link(scope, element, attrs, ctrl) {
+    link: (scope, element, attrs, ctrl) => {
       ctrl.init();
 
       const lang =  ctrl.gettextCatalog_.getCurrentLanguage();
       $['datepicker']['setDefaults']($['datepicker']['regional'][lang]);
 
       ctrl.sdateOptions = angular.extend({}, ctrl.sdateOptions, {
-        'onClose': function(selectedDate) {
+        'onClose': (selectedDate) => {
           if (selectedDate) {
             $(element[0]).find('input[name="edate"]').datepicker('option', 'minDate', selectedDate);
           }
@@ -54,7 +54,7 @@ ngeo.DatePicker = function(ngeoDatePickerTemplateUrl,  $timeout) {
       });
 
       ctrl.edateOptions = angular.extend({}, ctrl.edateOptions, {
-        'onClose': function(selectedDate) {
+        'onClose': (selectedDate) => {
           if (selectedDate) {
             $(element[0]).find('input[name="sdate"]').datepicker('option', 'maxDate', selectedDate);
           }

--- a/src/directives/drawpoint.js
+++ b/src/directives/drawpoint.js
@@ -23,7 +23,7 @@ ngeo.drawpointDirective = function() {
      * @param {angular.Attributes} attrs Attributes.
      * @param {ngeo.DrawfeatureController} drawFeatureCtrl Controller.
      */
-    link($scope, element, attrs, drawFeatureCtrl) {
+    link: ($scope, element, attrs, drawFeatureCtrl) => {
 
       const drawPoint = new ol.interaction.Draw({
         type: ol.geom.GeometryType.POINT

--- a/src/directives/drawrectangle.js
+++ b/src/directives/drawrectangle.js
@@ -24,11 +24,11 @@ ngeo.drawrectangleDirective = function() {
      * @param {angular.Attributes} attrs Attributes.
      * @param {ngeo.DrawfeatureController} drawFeatureCtrl Controller.
      */
-    link($scope, element, attrs, drawFeatureCtrl) {
+    link: ($scope, element, attrs, drawFeatureCtrl) => {
 
       const drawRectangle = new ol.interaction.Draw({
         type: ol.geom.GeometryType.LINE_STRING,
-        geometryFunction(coordinates, geometry) {
+        geometryFunction: (coordinates, geometry) => {
           if (!geometry) {
             geometry = new ol.geom.Polygon(null);
           }

--- a/src/directives/drawtext.js
+++ b/src/directives/drawtext.js
@@ -23,7 +23,7 @@ ngeo.drawtextDirective = function() {
      * @param {angular.Attributes} attrs Attributes.
      * @param {ngeo.DrawfeatureController} drawFeatureCtrl Controller.
      */
-    link($scope, element, attrs, drawFeatureCtrl) {
+    link: ($scope, element, attrs, drawFeatureCtrl) => {
 
       const drawText = new ol.interaction.Draw({
         type: ol.geom.GeometryType.POINT

--- a/src/directives/filereader.js
+++ b/src/directives/filereader.js
@@ -37,7 +37,7 @@ ngeo.filereaderDirective = function($window) {
      * @param {angular.JQLite} element Element.
      * @param {angular.Attributes} attrs Atttributes.
      */
-    link(scope, element, attrs) {
+    link: (scope, element, attrs) => {
       const supported = 'FileReader' in $window;
       scope['supported'] = supported;
       if (!supported) {

--- a/src/directives/filter.js
+++ b/src/directives/filter.js
@@ -236,17 +236,17 @@ ngeo.FilterController = class {
     const map = this.map;
     const projCode = map.getView().getProjection().getCode();
     const filter = this.ngeoRuleHelper_.createFilter({
-      dataSource,
-      filterRules,
+      dataSource: dataSource,
+      filterRules: filterRules,
       srsName: projCode
     });
     goog.asserts.assert(filter);
 
     this.ngeoMapQuerent_.issue({
       dataSources: [dataSource],
-      filter,
-      limit,
-      map
+      filter: filter,
+      limit: limit,
+      map: map
     });
   }
 

--- a/src/directives/map.js
+++ b/src/directives/map.js
@@ -46,7 +46,7 @@ ngeo.mapDirective = function($window, ngeoSyncDataSourcesMap) {
      * @param {angular.JQLite} element Element.
      * @param {angular.Attributes} attrs Atttributes.
      */
-    link(scope, element, attrs) {
+    link: (scope, element, attrs) => {
       // Get the 'ol.Map' object from attributes and manage it accordingly
       const attr = 'ngeoMap';
       const prop = attrs[attr];

--- a/src/directives/mapquery.js
+++ b/src/directives/mapquery.js
@@ -38,7 +38,7 @@ ngeo.mapQueryDirective = function(ngeoMapQuerent, $injector) {
   return {
     restrict: 'A',
     scope: false,
-    link(scope, elem, attrs) {
+    link: (scope, elem, attrs) => {
       const map = scope.$eval(attrs['ngeoMapQueryMap']);
       let clickEventKey_ = null;
       let pointerMoveEventKey_ = null;

--- a/src/directives/measurearea.js
+++ b/src/directives/measurearea.js
@@ -28,7 +28,7 @@ ngeo.measureareaDirective = function($compile, gettextCatalog, $filter, $injecto
      * @param {angular.Attributes} attrs Attributes.
      * @param {ngeo.DrawfeatureController} drawFeatureCtrl Controller.
      */
-    link($scope, element, attrs, drawFeatureCtrl) {
+    link: ($scope, element, attrs, drawFeatureCtrl) => {
 
       const helpMsg = gettextCatalog.getString('Click to start drawing polygon');
       const contMsg = gettextCatalog.getString('Click to continue drawing<br/>' +

--- a/src/directives/measureazimut.js
+++ b/src/directives/measureazimut.js
@@ -30,7 +30,7 @@ ngeo.measureazimutDirective = function($compile, gettextCatalog, $filter, $injec
      * @param {angular.Attributes} attrs Attributes.
      * @param {ngeo.DrawfeatureController} drawFeatureCtrl Controller.
      */
-    link($scope, element, attrs, drawFeatureCtrl) {
+    link: ($scope, element, attrs, drawFeatureCtrl) => {
 
       const helpMsg = gettextCatalog.getString('Click to start drawing circle');
       const contMsg = gettextCatalog.getString('Click to finish');

--- a/src/directives/measurelength.js
+++ b/src/directives/measurelength.js
@@ -28,7 +28,7 @@ ngeo.measurelengthDirective = function($compile, gettextCatalog, $filter, $injec
      * @param {angular.Attributes} attrs Attributes.
      * @param {ngeo.DrawfeatureController} drawFeatureCtrl Controller.
      */
-    link($scope, element, attrs, drawFeatureCtrl) {
+    link: ($scope, element, attrs, drawFeatureCtrl) => {
 
       const helpMsg = gettextCatalog.getString('Click to start drawing line');
       const contMsg = gettextCatalog.getString('Click to continue drawing<br/>' +

--- a/src/directives/modal.js
+++ b/src/directives/modal.js
@@ -60,7 +60,7 @@ ngeo.modalDirective = function($parse) {
      * @param {!function(!angular.Scope=, !function(Element)=)=} transcludeFn is a transclude linking
      *      function pre-bound to the correct transclusion scope.
      */
-    link(scope, element, attrs, ngModelController, transcludeFn) {
+    link: (scope, element, attrs, ngModelController, transcludeFn) => {
       const modal = element.children();
       const destroyContent = attrs['ngeoModalDestroyContentOnHide'] === 'true';
       const resizable = attrs['ngeoModalResizable'] === 'true';

--- a/src/directives/popover.js
+++ b/src/directives/popover.js
@@ -27,7 +27,7 @@ ngeo.popoverDirective = function() {
     restrict: 'A',
     scope: true,
     controller: 'NgeoPopoverController as popoverCtrl',
-    link(scope, elem, attrs, ngeoPopoverCtrl) {
+    link: (scope, elem, attrs, ngeoPopoverCtrl) => {
       ngeoPopoverCtrl.anchorElm.on('hidden.bs.popover', () => {
         /**
          * @type {{inState : Object}}
@@ -73,7 +73,7 @@ ngeo.popoverAnchorDirective = function() {
   return {
     restrict: 'A',
     require: '^^ngeoPopover',
-    link(scope, elem, attrs, ngeoPopoverCtrl) {
+    link: (scope, elem, attrs, ngeoPopoverCtrl) => {
       ngeoPopoverCtrl.anchorElm = elem;
     }
   };
@@ -89,7 +89,7 @@ ngeo.popoverContentDirective = function() {
   return {
     restrict: 'A',
     require: '^^ngeoPopover',
-    link(scope, elem, attrs, ngeoPopoverCtrl) {
+    link: (scope, elem, attrs, ngeoPopoverCtrl) => {
       ngeoPopoverCtrl.bodyElm = elem;
       elem.hide();
     }

--- a/src/directives/popup.js
+++ b/src/directives/popup.js
@@ -47,7 +47,7 @@ ngeo.popupDirective = function(ngeoPopupTemplateUrl) {
      * @param {angular.JQLite} element Element.
      * @param {angular.Attributes} attrs Atttributes.
      */
-    link(scope, element, attrs) {
+    link: (scope, element, attrs) => {
       element.addClass('popover');
 
       /**

--- a/src/directives/profile.js
+++ b/src/directives/profile.js
@@ -44,7 +44,7 @@ ngeo.profileDirective = function(ngeoDebounce) {
      * @param {angular.JQLite} element Element.
      * @param {angular.Attributes} attrs Atttributes.
      */
-    link(scope, element, attrs) {
+    link: (scope, element, attrs) => {
 
       const optionsAttr = attrs['ngeoProfileOptions'];
       goog.asserts.assert(optionsAttr !== undefined);

--- a/src/directives/recenter.js
+++ b/src/directives/recenter.js
@@ -33,7 +33,7 @@ goog.require('ngeo');
 ngeo.recenterDirective = function() {
   return {
     restrict: 'A',
-    link($scope, $element, $attrs) {
+    link: ($scope, $element, $attrs) => {
       const mapExpr = $attrs['ngeoRecenterMap'];
       const map = /** @type {ol.Map} */ ($scope.$eval(mapExpr));
 

--- a/src/directives/resizemap.js
+++ b/src/directives/resizemap.js
@@ -36,7 +36,7 @@ ngeo.resizemapDirective = function($window) {
      * @param {angular.JQLite} element Element.
      * @param {angular.Attributes} attrs Atttributes.
      */
-    link(scope, element, attrs) {
+    link: (scope, element, attrs) => {
       const attr = 'ngeoResizemap';
       const prop = attrs[attr];
       const map = scope.$eval(prop);

--- a/src/directives/sortable.js
+++ b/src/directives/sortable.js
@@ -65,7 +65,7 @@ ngeo.sortableDirective = function($timeout) {
      * @param {angular.JQLite} element Element.
      * @param {angular.Attributes} attrs Atttributes.
      */
-    link(scope, element, attrs) {
+    link: (scope, element, attrs) => {
 
       const sortable = /** @type {Array} */
               (scope.$eval(attrs['ngeoSortable'])) || [];

--- a/src/modules/search/createlocationsearchbloodhound.js
+++ b/src/modules/search/createlocationsearchbloodhound.js
@@ -59,7 +59,7 @@ ngeo.search.createLocationSearchBloodhound = function(opt_options) {
   const bloodhoundOptions = /** @type {BloodhoundOptions} */ ({
     remote: {
       url: 'https://api3.geo.admin.ch/rest/services/api/SearchServer?type=locations&searchText=%QUERY',
-      prepare(query, settings) {
+      prepare: (query, settings) => {
         settings.url = settings.url.replace('%QUERY', query);
         if (options.limit !== undefined) {
           settings.url += `&limit=${options.limit}`;
@@ -71,7 +71,7 @@ ngeo.search.createLocationSearchBloodhound = function(opt_options) {
         return (options.prepare !== undefined) ?
           options.prepare(query, settings) : settings;
       },
-      transform(/** @type {geoAdminx.SearchLocationResponse} */ parsedResponse) {
+      transform: (/** @type {geoAdminx.SearchLocationResponse} */ parsedResponse) => {
         const features = parsedResponse.results.map((/** @type {geoAdminx.SearchLocationResult} */ result) => {
           const attrs = result.attrs;
 

--- a/src/modules/search/searchdirective.js
+++ b/src/modules/search/searchdirective.js
@@ -35,7 +35,7 @@ ngeo.search.searchDirective = function() {
      * @param {angular.JQLite} element Element.
      * @param {angular.Attributes} attrs Atttributes.
      */
-    link(scope, element, attrs) {
+    link: (scope, element, attrs) => {
 
       const typeaheadOptionsExpr = attrs['ngeoSearch'];
       const typeaheadOptions = /** @type {TypeaheadOptions} */

--- a/src/ol-ext/interaction/measure.js
+++ b/src/ol-ext/interaction/measure.js
@@ -219,7 +219,7 @@ ngeo.interaction.Measure = function(opt_options) {
    */
   this.vectorLayer_ = new ol.layer.Vector({
     source: new ol.source.Vector(),
-    style
+    style: style
   });
 
   /**

--- a/src/ol-ext/interaction/measurearea.js
+++ b/src/ol-ext/interaction/measurearea.js
@@ -59,8 +59,8 @@ ngeo.interaction.MeasureArea.prototype.createDrawInteraction = function(style,
   return new ol.interaction.Draw(
     /** @type {olx.interaction.DrawOptions} */ ({
       type: 'Polygon',
-      source,
-      style
+      source: source,
+      style: style
     }));
 
 };

--- a/src/ol-ext/interaction/measurelength.js
+++ b/src/ol-ext/interaction/measurelength.js
@@ -59,8 +59,8 @@ ngeo.interaction.MeasureLength.prototype.createDrawInteraction = function(style,
   return new ol.interaction.Draw(
     /** @type {olx.interaction.DrawOptions} */ ({
       type: 'LineString',
-      source,
-      style
+      source: source,
+      style: style
     }));
 
 };

--- a/src/ol-ext/interaction/modifycircle.js
+++ b/src/ol-ext/interaction/modifycircle.js
@@ -244,11 +244,11 @@ ngeo.interaction.ModifyCircle.prototype.writeCircleGeometry_ = function(feature,
     for (i = 0, ii = coordinates.length - 1; i < ii; ++i) {
       segment = coordinates.slice(i, i + 2);
       segmentData = /** @type {ol.ModifySegmentDataType} */ ({
-        feature,
-        geometry,
+        feature: feature,
+        geometry: geometry,
         depth: [j],
         index: i,
-        segment
+        segment: segment
       });
       this.rBush_.insert(ol.extent.boundingExtent(segment), segmentData);
     }

--- a/src/ol-ext/interaction/modifyrectangle.js
+++ b/src/ol-ext/interaction/modifyrectangle.js
@@ -55,7 +55,7 @@ ngeo.interaction.ModifyRectangle = function(options) {
       wrapX: !!options.wrapX
     }),
     visible: this.getActive(),
-    style,
+    style: style,
     updateWhileAnimating: true,
     updateWhileInteracting: true
   });

--- a/src/ol-ext/interaction/rotate.js
+++ b/src/ol-ext/interaction/rotate.js
@@ -142,7 +142,7 @@ ngeo.interaction.Rotate = function(options) {
       useSpatialIndex: false,
       wrapX: !!options.wrapX
     }),
-    style,
+    style: style,
     updateWhileAnimating: true,
     updateWhileInteracting: true
   });

--- a/src/services/decoratelayerloading.js
+++ b/src/services/decoratelayerloading.js
@@ -87,9 +87,7 @@ ngeo.decorateLayerLoading = function(layer, $scope) {
 
   Object.defineProperty(layer, 'loading', {
     configurable: true,
-    get() {
-      return /** @type {number} */ (layer.get('load_count')) > 0;
-    }
+    get: () => /** @type {number} */ (layer.get('load_count')) > 0
   });
 
   /**

--- a/src/services/disclaimer.js
+++ b/src/services/disclaimer.js
@@ -113,7 +113,7 @@ ngeo.Disclaimer.prototype.showMessage = function(message) {
     const content = this.sce_.trustAsHtml(message.msg);
     popup.open({
       autoDestroy: true,
-      content,
+      content: content,
       title: '&nbsp;'
     });
 

--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -208,7 +208,7 @@ ngeo.FeatureHelper.prototype.getLineStringStyle_ = function(feature) {
 
   const options = {
     stroke: new ol.style.Stroke({
-      color,
+      color: color,
       width: strokeWidth
     })
   };
@@ -317,7 +317,7 @@ ngeo.FeatureHelper.prototype.getPolygonStyle_ = function(feature) {
       color: fillColor
     }),
     stroke: new ol.style.Stroke({
-      color,
+      color: color,
       width: strokeWidth
     })
   })];
@@ -335,7 +335,7 @@ ngeo.FeatureHelper.prototype.getPolygonStyle_ = function(feature) {
           color: fillColor
         }),
         stroke: new ol.style.Stroke({
-          color,
+          color: color,
           width: strokeWidth
         }),
         text: this.createTextStyle_({
@@ -431,7 +431,7 @@ ngeo.FeatureHelper.prototype.createEditingStyles = function(feature) {
         new ol.style.Style({
           stroke: new ol.style.Stroke({
             color: blue,
-            width
+            width: width
           })
         })
       );

--- a/src/services/layerHelper.js
+++ b/src/services/layerHelper.js
@@ -86,7 +86,7 @@ ngeo.LayerHelper.prototype.createBasicWMSLayer = function(sourceURL,
   }
   const source = new ol.source.ImageWMS({
     url: sourceURL,
-    params,
+    params: params,
     serverType: olServerType,
     crossOrigin: opt_crossOrigin
   });
@@ -217,7 +217,7 @@ ngeo.LayerHelper.prototype.createWMTSLayerFromCapabilititesObj = function(
   return new ol.layer.Tile({
     'capabilitiesStyles': layerCap['Style'],
     preload: Infinity,
-    source
+    source: source
   });
 };
 

--- a/src/services/mapquerent.js
+++ b/src/services/mapquerent.js
@@ -124,8 +124,8 @@ ngeo.MapQuerent = class {
     //     request.
     const limit = options.limit !== undefined ? options.limit : this.limit_;
     ol.obj.assign(options, {
-      queryableDataSources,
-      limit,
+      queryableDataSources: queryableDataSources,
+      limit: limit,
       tolerancePx: this.tolerancePx_,
       wfsCount: this.queryCountFirst_
     });
@@ -188,13 +188,13 @@ ngeo.MapQuerent = class {
         const featuresByType = typeSeparatedFeatures[type];
         this.result_.sources.push({
           features: featuresByType,
-          id,
-          label,
-          limit,
+          id: id,
+          label: label,
+          limit: limit,
           pending: false,
           queried: true,
-          tooManyResults,
-          totalFeatureCount
+          tooManyResults: tooManyResults,
+          totalFeatureCount: totalFeatureCount
         });
         total += features.length;
       }

--- a/src/services/message.js
+++ b/src/services/message.js
@@ -129,7 +129,7 @@ ngeo.Message.prototype.getMessageObjects = function(object, opt_type) {
     object.forEach((msg) => {
       if (typeof object === 'string') {
         msgObject = {
-          msg,
+          msg: msg,
           type: opt_type !== undefined ? opt_type : defaultType
         };
       } else {

--- a/src/services/print.js
+++ b/src/services/print.js
@@ -165,7 +165,7 @@ ngeo.Print.prototype.createSpec = function(
   map, scale, dpi, layout, format, customAttributes) {
 
   const specMap = /** @type {MapFishPrintMap} */ ({
-    dpi,
+    dpi: dpi,
     rotation: /** number */ (customAttributes['rotation'])
   });
 
@@ -302,10 +302,10 @@ ngeo.Print.prototype.encodeWmsLayer_ = function(arr, opacity, url, params) {
     baseURL: ngeo.Print.getAbsoluteUrl_(url_url.origin + url_url.pathname),
     imageFormat: 'FORMAT' in params ? params['FORMAT'] : 'image/png',
     layers: params['LAYERS'].split(','),
-    customParams,
+    customParams: customParams,
     serverType: params['SERVERTYPE'],
     type: 'wms',
-    opacity,
+    opacity: opacity,
     version: params['VERSION']
   });
   arr.push(object);
@@ -382,7 +382,7 @@ ngeo.Print.prototype.encodeTileWmtsLayer_ = function(arr, layer) {
     dimensionParams: dimensions,
     imageFormat: source.getFormat(),
     layer: source.getLayer(),
-    matrices,
+    matrices: matrices,
     matrixSet: source.getMatrixSet(),
     opacity: layer.getOpacity(),
     requestEncoding: source.getRequestEncoding(),

--- a/src/services/querent.js
+++ b/src/services/querent.js
@@ -554,7 +554,7 @@ ngeo.Querent = class {
         let filter;
         if (options.filter) {
           filter = this.ngeoRuleHelper_.createFilter({
-            dataSource,
+            dataSource: dataSource,
             filter: options.filter,
             incTime: true
           });
@@ -568,9 +568,9 @@ ngeo.Querent = class {
           );
 
           filter = this.ngeoRuleHelper_.createFilter({
-            dataSource,
+            dataSource: dataSource,
             incTime: true,
-            srsName
+            srsName: srsName
           });
         }
 
@@ -620,7 +620,7 @@ ngeo.Querent = class {
           url,
           featureCountRequest,
           {
-            params,
+            params: params,
             timeout: canceler.promise
           }
         ).then(((response) => {
@@ -658,7 +658,7 @@ ngeo.Querent = class {
             url,
             featureRequest,
             {
-              params,
+              params: params,
               timeout: canceler.promise
             }
           ).then((response) => {
@@ -744,7 +744,7 @@ ngeo.Querent = class {
           goog.asserts.assert(dataSources.length === 1);
           filtrableLayerName = dataSource.getFiltrableOGCLayerName();
           filterString = this.ngeoRuleHelper_.createFilterString({
-            dataSource,
+            dataSource: dataSource,
             srsName: projCode
           });
         }

--- a/src/services/query.js
+++ b/src/services/query.js
@@ -543,7 +543,7 @@ ngeo.Query.prototype.doGetFeatureInfoRequests_ = function(
     const wmsGetFeatureInfoUrl = items[0].source.wmsSource.getGetFeatureInfoUrl(
       coordinate, resolution, projCode);
 
-    this.$http_.get(wmsGetFeatureInfoUrl, {params, timeout: this.registerCanceler_().promise})
+    this.$http_.get(wmsGetFeatureInfoUrl, {params: params, timeout: this.registerCanceler_().promise})
       .then(function(items, response) {
         items.forEach(function(item) {
           item['resultSource'].pending = false;
@@ -636,7 +636,7 @@ ngeo.Query.prototype.doGetFeatureRequests_ = function(
         featurePrefix: this.featurePrefix_,
         featureTypes: layers,
         outputFormat: 'GML3',
-        bbox,
+        bbox: bbox,
         geometryName: this.geometryName_
       };
 
@@ -656,7 +656,7 @@ ngeo.Query.prototype.doGetFeatureRequests_ = function(
         const featureRequest = xmlSerializer.serializeToString(featureRequestXml);
 
         const canceler = this.registerCanceler_();
-        this.$http_.post(url, featureRequest, {params, timeout: canceler.promise})
+        this.$http_.post(url, featureRequest, {params: params, timeout: canceler.promise})
           .then((response) => {
             item['resultSource'].pending = false;
             const features = [];

--- a/src/services/rulehelper.js
+++ b/src/services/rulehelper.js
@@ -86,7 +86,7 @@ ngeo.RuleHelper = class {
       case ngeo.AttributeType.DATETIME:
         if (isCustom) {
           rule = new ngeo.rule.Date({
-            name,
+            name: name,
             operator: ngeo.rule.Rule.TemporalOperatorType.EQUALS,
             operators: [
               ngeo.rule.Rule.TemporalOperatorType.EQUALS,
@@ -98,7 +98,7 @@ ngeo.RuleHelper = class {
           });
         } else {
           rule = new ngeo.rule.Date({
-            name,
+            name: name,
             operator: ngeo.rule.Rule.TemporalOperatorType.DURING,
             propertyName: attribute.name,
             type: attribute.type
@@ -107,7 +107,7 @@ ngeo.RuleHelper = class {
         break;
       case ngeo.AttributeType.GEOMETRY:
         rule = new ngeo.rule.Geometry({
-          name,
+          name: name,
           operator: ngeo.rule.Rule.SpatialOperatorType.WITHIN,
           operators: [
             ngeo.rule.Rule.SpatialOperatorType.CONTAINS,
@@ -121,7 +121,7 @@ ngeo.RuleHelper = class {
       case ngeo.AttributeType.NUMBER:
         if (isCustom) {
           rule = new ngeo.rule.Rule({
-            name,
+            name: name,
             operator: ngeo.rule.Rule.OperatorType.EQUAL_TO,
             operators: [
               ngeo.rule.Rule.OperatorType.EQUAL_TO,
@@ -136,7 +136,7 @@ ngeo.RuleHelper = class {
           });
         } else {
           rule = new ngeo.rule.Rule({
-            name,
+            name: name,
             operator: ngeo.rule.Rule.OperatorType.BETWEEN,
             propertyName: attribute.name,
             type: ngeo.AttributeType.NUMBER
@@ -146,14 +146,14 @@ ngeo.RuleHelper = class {
       case ngeo.AttributeType.SELECT:
         rule = new ngeo.rule.Select({
           choices: goog.asserts.assert(attribute.choices),
-          name,
+          name: name,
           propertyName: attribute.name
         });
         break;
       default:
         if (isCustom) {
           rule = new ngeo.rule.Text({
-            name,
+            name: name,
             operator: ngeo.rule.Rule.OperatorType.LIKE,
             operators: [
               ngeo.rule.Rule.OperatorType.LIKE,
@@ -164,7 +164,7 @@ ngeo.RuleHelper = class {
           });
         } else {
           rule = new ngeo.rule.Text({
-            name,
+            name: name,
             operator: ngeo.rule.Rule.OperatorType.LIKE,
             propertyName: attribute.name
           });

--- a/src/services/toolActivateMgr.js
+++ b/src/services/toolActivateMgr.js
@@ -130,9 +130,9 @@ ngeo.ToolActivateMgr.prototype.registerTool = function(groupName, tool,
     });
 
   entries.push({
-    tool,
+    tool: tool,
     defaultTool: opt_defaultActivate || false,
-    unlisten
+    unlisten: unlisten
   });
 
   if (goog.asserts.ENABLE_ASSERTS) {

--- a/src/services/wfspermalink.js
+++ b/src/services/wfspermalink.js
@@ -200,7 +200,7 @@ ngeo.WfsPermalink.prototype.issueRequest_ = function(wfsType, filter, map, showF
       wfsType.featurePrefix : this.defaultFeaturePrefix_,
     featureTypes: [wfsType.featureType],
     outputFormat: 'GML3',
-    filter,
+    filter: filter,
     maxFeatures: this.maxFeatures_
   });
 

--- a/src/source/swisstopo.js
+++ b/src/source/swisstopo.js
@@ -99,12 +99,12 @@ exports = function(options) {
     dimensions: {
       'Time': options.timestamp
     },
-    projection,
+    projection: projection,
     requestEncoding: 'REST',
     layer: options.layer,
     style: 'default',
     matrixSet: projectionCode,
-    format,
+    format: format,
     tileGrid: tilegrid,
     crossOrigin: options.crossOrigin
   });

--- a/test/spec/directives/filereader.spec.js
+++ b/test/spec/directives/filereader.spec.js
@@ -17,7 +17,7 @@ describe('ngeo.filereaderDirective', () => {
         };
         this.onload(progressEvent);
       };
-      $provide.value('$window', {FileReader, angular: window.angular});
+      $provide.value('$window', {FileReader: FileReader, angular: window.angular});
     });
 
     inject(($rootScope, $compile) => {

--- a/test/spec/services/print.spec.js
+++ b/test/spec/services/print.spec.js
@@ -196,12 +196,12 @@ describe('ngeo.CreatePrint', () => {
             format: 'image/jpeg',
             layer: 'layer',
             matrixSet: 'matrixset',
-            projection,
+            projection: projection,
             requestEncoding: 'REST',
             style: 'style',
             tileGrid: new ol.tilegrid.WMTS({
               matrixIds: ['00', '01', '02'],
-              extent,
+              extent: extent,
               origin: ol.extent.getTopLeft(extent),
               resolutions: [2000, 1000, 500],
               tileSize: 512

--- a/test/spec/services/query.spec.js
+++ b/test/spec/services/query.spec.js
@@ -66,8 +66,8 @@ describe('ngeo.Query', () => {
       source: wmsSource
     });
     const source = {
-      id,
-      layer,
+      id: id,
+      layer: layer,
       layers: ['bar']
     };
     ngeoQuery.addSource(source);
@@ -168,7 +168,7 @@ describe('ngeo.Query', () => {
           busStopLayer
         ],
         view: new ol.View({
-          projection,
+          projection: projection,
           resolutions: [200, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5],
           center: [537635, 152640],
           zoom: 0

--- a/test/spec/services/wfspermalink.spec.js
+++ b/test/spec/services/wfspermalink.spec.js
@@ -48,7 +48,7 @@ describe('ngeo.WfsPermalink', () => {
       map = new ol.Map({
         layers: [],
         view: new ol.View({
-          projection,
+          projection: projection,
           resolutions: [200, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5],
           center: [537635, 152640],
           zoom: 0


### PR DESCRIPTION
Don't force the shorthand syntax but ensures that either all shorthand or all longform will be used in an object literal.