### PR TITLE
Make sure string filtering is case insensitive for WFS requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ help:
 	@echo "- cleanall                Remove all the build artefacts"
 	@echo "- cleanallcache           Remove all the build artefacts and the extra caches (npm and pip)"
 	@echo
-	@echo "Segondary targets:"
+	@echo "Secondary targets:"
 	@echo
 	@echo "- apidoc                  Build the API documentation using JSDoc"
 	@echo "- examples-hosted         Build the hosted examples"

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -86,7 +86,7 @@ ngeox.Attribute.prototype.type;
 
 
 /**
- * The options to use when creating a filter uwing the `ngeo.RuleHelper`
+ * The options to use when creating a filter using the `ngeo.RuleHelper`
  * service.
  *
  * @typedef {{

--- a/src/services/rulehelper.js
+++ b/src/services/rulehelper.js
@@ -625,7 +625,11 @@ ngeo.RuleHelper = class {
       const stringExpression = String(expression);
       filter = ol.format.filter.like(
         propertyName,
-        stringExpression
+        stringExpression,
+        '*', /* wildCard */
+        '.', /* singleChar */
+        '!', /* escapeChar */
+        false /* matchCase */
       );
     } else if (operator === rot.NOT_EQUAL_TO) {
       filter = ol.format.filter.notEqualTo(


### PR DESCRIPTION
Related to https://github.com/camptocamp/ngeo/issues/2855

It seems there are no unit tests for the ``RuleHelper`` service and I see no other test that could be related.

Documentation of the ``ol.format.filter.like`` function, whose arguments are edited in this PR to explicitly add ``matchCase=false`` (default value is undefined => this attribute didn't appear previously in the WFS request):
http://openlayers.org/en/latest/apidoc/ol.format.filter.html#.like

Posted WFS ``GetFeature`` request formerly contained:
```
<PropertyIsLike wildCard="*" singleChar="." escapeChar="!"><PropertyName>name</PropertyName><Literal>linde</Literal></PropertyIsLike>
```
Now is:
```
<PropertyIsLike wildCard="*" singleChar="." escapeChar="!" matchCase="false"><PropertyName>name</PropertyName><Literal>linde</Literal></PropertyIsLike>
```
=> returns results whose name are eg. "Linde", "Lindenpark", ....