### PR TITLE
Fix compiler warning

### DIFF
--- a/src/directives/profile.js
+++ b/src/directives/profile.js
@@ -111,7 +111,7 @@ ngeo.profileDirective = function(ngeoDebounce) {
           }
         });
 
-      ol.events.listen(window, 'resize', ngeoDebounce(refreshData, 50, true), this);
+      ol.events.listen(window, 'resize', ngeoDebounce(refreshData, 50, true));
 
       function refreshData() {
         if (profile !== undefined) {


### PR DESCRIPTION
Gets rid of this warning:

```
node buildtools/build.js .build/app-desktop.json .build/desktop.js
info ol Parsing dependencies
info ol Compiling 555 sources
ERR! compile /home/mkuenzli/dev/ngeo/src/directives/profile.js:39: WARNING - dangerous use of this in static method ngeo.profileDirective
ERR! compile ngeo.profileDirective = function(ngeoDebounce) {
ERR! compile                                                ^
ERR! compile 
ERR! compile 
ERR! compile 0 error(s), 1 warning(s), 96.9% typed
ERR! compile 
```
