### PR TITLE
Allow text in gmf-displayquerywindow to be selectable

### DIFF
--- a/contribs/gmf/less/displayquerywindow.less
+++ b/contribs/gmf/less/displayquerywindow.less
@@ -172,6 +172,11 @@
       font-family: FontAwesome;
     }
   }
+  &.ui-draggable {
+    tr {
+      cursor: text;
+    }
+  }
 }
 
 .gmf-displayquerywindow-mobile {

--- a/contribs/gmf/src/directives/displayquerywindow.js
+++ b/contribs/gmf/src/directives/displayquerywindow.js
@@ -263,7 +263,9 @@ gmf.DisplayquerywindowController.prototype.$onInit = function() {
   this.highlightFeatureOverlay_.setStyle(highlightFeatureStyle);
 
   if (this.desktop) {
-    this.element_.find('.gmf-displayquerywindow').draggable();
+    this.element_.find('.gmf-displayquerywindow').draggable({
+      'cancel': 'input,textarea,button,select,option,tr'
+    });
     this.element_.find('.gmf-displayquerywindow-container').resizable({
       'minHeight': 240,
       'minWidth': 240


### PR DESCRIPTION
Allow text in the gmf-displayquerywindow directive to be selectable.

The jQuery UI draggable widget was preventing text to be selected using a drag of the mouse.  Instead, it dragged the window.  To fix this, we use the `cancel` option of the widget, see: http://api.jqueryui.com/draggable/#option-cancel.  This prevents the dragging to occur for any defined selector.

Since the gmf-displayquerywindow always shows its content in a table, the `tr` is the chosen selector to prevent the selection. The rest of the selector are the default values that I thought made sense to keep.

While mouse hovering a `tr`, the CSS cursor changes to `text`.