### PR TITLE
Prepend protocol to WMS url

### DIFF
--- a/src/services/print.js
+++ b/src/services/print.js
@@ -279,6 +279,9 @@ ngeo.Print.prototype.encodeImageWmsLayer_ = function(arr, layer) {
  * @private
  */
 ngeo.Print.prototype.encodeWmsLayer_ = function(arr, opacity, url, params) {
+  if (url.startsWith('//')) {
+    url = window.location.protocol  + url;
+  }
   const url_url = new URL(url);
   const customParams = {'TRANSPARENT': true};
   if (url_url.searchParams) {


### PR DESCRIPTION
The URL constructor does not support protocol-relative URLs.