### PR TITLE
Fix typeahead selection in ImportDataSource component

### DIFF
--- a/contribs/gmf/src/directives/importdatasource.js
+++ b/contribs/gmf/src/directives/importdatasource.js
@@ -226,6 +226,8 @@ gmf.ImportdatasourceController = class {
       this.timeout_(() => {
         goog.asserts.assert(this.serversEngine_);
         const $urlInput = this.element_.find('input[name=url]');
+        const $connectBtn = this.element_.find(
+          'button.gmf-importdatasource-connect-btn');
         $urlInput.typeahead({
           hint: true,
           highlight: true,
@@ -233,6 +235,12 @@ gmf.ImportdatasourceController = class {
         }, {
           name: 'url',
           source: this.serversEngine_.ttAdapter()
+        }).bind('typeahead:select', (ev, suggestion) => {
+          this.timeout_(() => {
+            this.url = suggestion;
+            this.scope_.$apply();
+            $connectBtn.focus();
+          });
         });
       });
     }

--- a/contribs/gmf/src/directives/importdatasource.js
+++ b/contribs/gmf/src/directives/importdatasource.js
@@ -17,7 +17,7 @@ goog.require('ngeo.datasource.OGC');
 gmf.ImportdatasourceController = class {
 
   /**
-   * @param {!angular.JQLite} $element Element.
+   * @param {!jQuery} $element Element.
    * @param {!angular.$filter} $filter Angular filter.
    * @param {!angular.$injector} $injector Main injector.
    * @param {!angular.Scope} $scope Angular scope.
@@ -47,7 +47,7 @@ gmf.ImportdatasourceController = class {
     // Injected properties
 
     /**
-     * @type {!angular.JQLite}
+     * @type {!jQuery}
      * @private
      */
     this.element_ = $element;
@@ -95,7 +95,7 @@ gmf.ImportdatasourceController = class {
     // Inner properties
 
     /**
-     * @type {!angular.JQLite}
+     * @type {!jQuery}
      * @private
      */
     this.fileInput_ = $element.find('input[type=file]');
@@ -226,8 +226,7 @@ gmf.ImportdatasourceController = class {
       this.timeout_(() => {
         goog.asserts.assert(this.serversEngine_);
         const $urlInput = this.element_.find('input[name=url]');
-        const $connectBtn = this.element_.find(
-          'button.gmf-importdatasource-connect-btn');
+        const $connectBtn = this.element_.find('button.gmf-importdatasource-connect-btn');
         $urlInput.typeahead({
           hint: true,
           highlight: true,

--- a/contribs/gmf/src/directives/partials/importdatasource.html
+++ b/contribs/gmf/src/directives/partials/importdatasource.html
@@ -67,7 +67,7 @@
     </div>
     <div class="form-group">
       <button
-        class="btn btn-sm btn-default form-control"
+        class="btn btn-sm btn-default form-control gmf-importdatasource-connect-btn"
         title="{{'Connect to online resource' | translate}}"
         type="submit"
         ng-click="idsc_form.$valid && $ctrl.connect()"


### PR DESCRIPTION
This PR fixes the following issue: in the DataSourceBrowser component, the "connect" button was sometimes disabled after the selection of an item.

This was due to the fact that the field itself is of `url` type and there's an angular rule applied on the connect button that automatically disables it if the form is invalid.  The selection using the drop-down list uses typeahead. Now, I don't know exactly why, but the selected value was not always properly copied in the model, i.e. it was pasted in the input field, but not the model.

This fix ensures that, after the selection of an item among the typeahead selections, the value is properly copied.  At the same time, I do a "focus" on the connect button.

This solution keeps the `url` type on the field, because I think it's very useful to ensure that any url either selected or manually typed are valid urls.