### PR TITLE
Show imported layers first in layertree, remove 100% height on ul

### DIFF
--- a/contribs/gmf/less/desktoplayertree.less
+++ b/contribs/gmf/less/desktoplayertree.less
@@ -8,7 +8,6 @@ gmf-layertree {
   width: 100%;
   ul {
     margin-bottom: 0;
-    height: 100%;
   }
   > :first-child {
     margin-right: @half-app-margin;

--- a/contribs/gmf/src/directives/partials/layertree.html
+++ b/contribs/gmf/src/directives/partials/layertree.html
@@ -243,27 +243,6 @@
 </div>
 
 <ul
-  id="gmf-layertree-layer-group-{{::layertreeCtrl.uid}}"
-  ng-if="::layertreeCtrl.node.children"
-  ng-class="{collapse: !layertreeCtrl.isRoot, in : layertreeCtrl.node.metadata.isExpanded}"
-  ngeo-sortable="::layertreeCtrl.isRoot && layertreeCtrl.node.children"
-  ngeo-sortable-options="{handleClassName: 'ngeo-sortable-handle', draggerClassName: 'gmf-layertree-dragger', currDragItemClassName : 'gmf-layertree-curr-drag-item'}"
-  ngeo-sortable-callback="::gmfLayertreeCtrl.afterReorder"
-  ngeo-sortable-callback-ctx="::gmfLayertreeCtrl">
-
-  <li
-    class="gmf-layertree-node"
-    ng-repeat="node in layertreeCtrl.node.children"
-    ng-class="'gmf-layertree-depth-' + layertreeCtrl.depth"
-    ngeo-layertree="node"
-    ngeo-layertree-notroot
-    ngeo-layertree-map="layertreeCtrl.map"
-    ngeo-layertree-nodelayerexpr="layertreeCtrl.nodelayerExpr"
-    ngeo-layertree-listenersexpr="layertreeCtrl.listenersExpr">
-  </li>
-</ul>
-
-<ul
    class="gmf-layertree-root-external-datasources"
    ng-if="layertreeCtrl.isRoot && (gmfLayertreeCtrl.gmfExternalDataSourcesManager.wmsGroups.length || gmfLayertreeCtrl.gmfExternalDataSourcesManager.wmtsGroups.length || gmfLayertreeCtrl.gmfExternalDataSourcesManager.fileGroup.dataSources.length)">
   <gmf-datasourcegrouptree
@@ -284,4 +263,25 @@
     group="gmfLayertreeCtrl.gmfExternalDataSourcesManager.fileGroup"
   >
   </gmf-datasourcegrouptree>
+</ul>
+
+<ul
+  id="gmf-layertree-layer-group-{{::layertreeCtrl.uid}}"
+  ng-if="::layertreeCtrl.node.children"
+  ng-class="{collapse: !layertreeCtrl.isRoot, in : layertreeCtrl.node.metadata.isExpanded}"
+  ngeo-sortable="::layertreeCtrl.isRoot && layertreeCtrl.node.children"
+  ngeo-sortable-options="{handleClassName: 'ngeo-sortable-handle', draggerClassName: 'gmf-layertree-dragger', currDragItemClassName : 'gmf-layertree-curr-drag-item'}"
+  ngeo-sortable-callback="::gmfLayertreeCtrl.afterReorder"
+  ngeo-sortable-callback-ctx="::gmfLayertreeCtrl">
+
+  <li
+    class="gmf-layertree-node"
+    ng-repeat="node in layertreeCtrl.node.children"
+    ng-class="'gmf-layertree-depth-' + layertreeCtrl.depth"
+    ngeo-layertree="node"
+    ngeo-layertree-notroot
+    ngeo-layertree-map="layertreeCtrl.map"
+    ngeo-layertree-nodelayerexpr="layertreeCtrl.nodelayerExpr"
+    ngeo-layertree-listenersexpr="layertreeCtrl.listenersExpr">
+  </li>
 </ul>


### PR DESCRIPTION
This PR changes how the external layers are added in the layer tree:

 * they are shown first (were last)
 * they are shown "as-if" they were part of the other layers, i.e. the gap between the 2 has been removed *

* Important note: the `height: 100%;` was removed to allow this. It was introduced in #1375.  I played with drag-dropping items and it didn't seem to affect the UI.  Please, make sure this PR didn't break #1375.