### PR TITLE
Fix displaywindow resizing with iframe

### DIFF
--- a/contribs/gmf/less/base.less
+++ b/contribs/gmf/less/base.less
@@ -76,3 +76,11 @@ i, cite, em, var, address, dfn {
     cursor: move;
   }
 }
+
+.ui-resizable {
+  &.ui-resizable-resizing {
+    iframe {
+      display: none;
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes an issue that occurs in the `gmf-displaywindow` component when its content is an iframe (url) and while resizing it.

When the mouse cursor moves over the iframe, then the jQuery UI draggable widget no longer works because the event isn't fired, i.e. we're no longer in the main frame.

To fix this, while resizing, we hide the iframe using CSS, which prevents the issue from occuring.