### PR TITLE
Add draggable containment opt 2 gmf display-[query-]window

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -239,6 +239,7 @@
             </gmf-disclaimer>
           </div>
           <gmf-displayquerywindow
+            gmf-displayquerywindow-draggable-containment="::mainCtrl.displaywindowDraggableContainment"
             gmf-displayquerywindow-featuresstyle="::mainCtrl.queryFeatureStyle"
             gmf-displayquerywindow-desktop="true">
           </gmf-displayquerywindow>

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -224,6 +224,7 @@
         <gmf-displaywindow
           content="mainCtrl.displaywindowContent"
           desktop="true"
+          draggable-containment="mainCtrl.displaywindowDraggableContainment"
           height="mainCtrl.displaywindowHeight"
           open="mainCtrl.displaywindowOpen"
           title="mainCtrl.displaywindowTitle"

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -573,6 +573,12 @@ gmf.AbstractController = function(config, $scope, $injector) {
   this.displaywindowContent = null;
 
   /**
+   * @type {string}
+   * @export
+   */
+  this.displaywindowDraggableContainment = '.gmf-map';
+
+  /**
    * @type {?string}
    * @export
    */

--- a/contribs/gmf/src/directives/displayquerywindow.js
+++ b/contribs/gmf/src/directives/displayquerywindow.js
@@ -73,6 +73,7 @@ function gmfDisplayquerywindowTemplateUrl($element, $attrs, gmfDisplayquerywindo
 gmf.displayquerywindowComponent = {
   controller: 'GmfDisplayquerywindowController as ctrl',
   bindings: {
+    'draggableContainment': '<?gmfDisplayquerywindowDraggableContainment',
     'featuresStyleFn': '&gmfDisplayquerywindowFeaturesstyle',
     'selectedFeatureStyleFn': '&gmfDisplayquerywindowSelectedfeaturestyle',
     'defaultCollapsedFn': '&?gmfDisplayquerywindowDefaultcollapsed',
@@ -100,6 +101,12 @@ gmf.module.component('gmfDisplayquerywindow', gmf.displayquerywindowComponent);
  */
 gmf.DisplayquerywindowController = function($element, $scope, ngeoQueryResult,
   ngeoFeatureOverlayMgr) {
+
+  /**
+   * @type {Element|string}
+   * @export
+   */
+  this.draggableContainment;
 
   /**
    * @type {boolean}
@@ -227,6 +234,7 @@ gmf.DisplayquerywindowController = function($element, $scope, ngeoQueryResult,
  * Initialise the controller.
  */
 gmf.DisplayquerywindowController.prototype.$onInit = function() {
+  this.draggableContainment = this.draggableContainment || 'document';
   this.desktop = this.desktop;
   this.collapsed = this['defaultCollapsedFn'] ?
     this['defaultCollapsedFn']() === true : !this.desktop;
@@ -264,7 +272,8 @@ gmf.DisplayquerywindowController.prototype.$onInit = function() {
 
   if (this.desktop) {
     this.element_.find('.gmf-displayquerywindow').draggable({
-      'cancel': 'input,textarea,button,select,option,tr'
+      'cancel': 'input,textarea,button,select,option,tr',
+      'containment': this.draggableContainment
     });
     this.element_.find('.gmf-displayquerywindow-container').resizable({
       'minHeight': 240,

--- a/contribs/gmf/src/directives/displaywindow.js
+++ b/contribs/gmf/src/directives/displaywindow.js
@@ -56,6 +56,12 @@ gmf.DisplaywindowController = class {
     this.draggable;
 
     /**
+     * @type {Element|string}
+     * @export
+     */
+    this.draggableContainment;
+
+    /**
      * @type {boolean}
      * @export
      */
@@ -122,6 +128,7 @@ gmf.DisplaywindowController = class {
     this.clearOnClose = this.clearOnClose !== false;
     this.content = this.content || null;
     this.desktop = this.desktop !== false;
+    this.draggableContainment = this.draggableContainment || 'document';
     this.height = this.height || null;
     this.open = this.open === true;
     this.title = this.title || null;
@@ -135,7 +142,9 @@ gmf.DisplaywindowController = class {
 
     // Draggable
     if (this.draggable) {
-      this.element_.find('.gmf-displayquerywindow').draggable();
+      this.element_.find('.gmf-displayquerywindow').draggable({
+        'containment': this.draggableContainment
+      });
     }
 
     // Resizable
@@ -197,6 +206,7 @@ gmf.module.component('gmfDisplaywindow', {
     'content': '=',
     'desktop': '<',
     'draggable': '<',
+    'draggableContainment': '<',
     'height': '=',
     'open': '=',
     'resizable': '<',


### PR DESCRIPTION
This PR adds:

 * the `draggable-containment` option to the `gmf-displaywindow` component
 * the `gmf-displayquerywindow-draggable-containment` option to the `gmf-displayquerywindow` directive

I chose `draggable` as first word for the option, because it's the name of the jQuery UI widget.
I chose `containment` as last word for the option, because it's the name of the option of the jQuery UI draggable widget.

## Known issue

There is an issue with the desktop version.  We're able to drag slighly more to the left, i.e. outside of the containment.  I don't know why that happens.  On the desktop_alt site, it works properly.

Please, let me know if this is a blocker.