### PR TITLE
Hide iframe content while dragging

### DIFF
--- a/contribs/gmf/less/base.less
+++ b/contribs/gmf/less/base.less
@@ -74,6 +74,10 @@ i, cite, em, var, address, dfn {
 
   &.ui-draggable-dragging {
     cursor: move;
+
+    iframe {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
Similar to #3128: when using the jQuery UI draggable widget, when the cursor of the mouse hovers an iframe, the dragging stops because we're no longer in the same frame.

While dragging, hide any iframe to prevent this issue.