### PR TITLE
Change seperator in csv download

### DIFF
--- a/src/services/csvdownload.js
+++ b/src/services/csvdownload.js
@@ -62,7 +62,7 @@ ngeo.CsvDownload = function($injector, gettextCatalog) {
    * @private
    */
   this.separator_ = $injector.has('ngeoCsvSeparator') ?
-    $injector.get('ngeoCsvSeparator') : ',';
+    $injector.get('ngeoCsvSeparator') : ';';
 
   /**
    * Download service.

--- a/test/spec/services/csvdownload.spec.js
+++ b/test/spec/services/csvdownload.spec.js
@@ -28,9 +28,9 @@ describe('ngeo.csvdownload', () => {
       const csv = ngeoCsvDownload.generateCsv(data, columnDefs);
 
       const expectedCsv =
-          '"col 1","col 2","col 3"\n' +
-          '"some text","123","true"\n' +
-          '"some ""more"" text",,\n';
+          '"col 1";"col 2";"col 3"\n' +
+          '"some text";"123";"true"\n' +
+          '"some ""more"" text";;\n';
 
       expect(csv).toBe(expectedCsv);
     });


### PR DESCRIPTION
In order for the csv file to be opened directly in both excel & open/libre office. 
Changing the separator from ',' to ';' makes sense, especially in Europe
 