### PR TITLE
Enable to configurate the default display of measurements

### DIFF
--- a/contribs/gmf/src/directives/displayquerygrid.js
+++ b/contribs/gmf/src/directives/displayquerygrid.js
@@ -240,6 +240,14 @@ gmf.DisplayquerygridController = function($injector, $scope, ngeoQueryResult,
   this.highlightFeatureOverlay_.setFeatures(this.highlightFeatures_);
 
   /**
+   * Filename
+   * @type {string}
+   * @private
+   */
+  this.filename_ = $injector.has('gmfCsvFilename') ?
+    $injector.get('gmfCsvFilename') : 'query-results.csv';
+
+  /**
    * @type {ol.Map}
    * @private
    */
@@ -853,7 +861,7 @@ gmf.DisplayquerygridController.prototype.downloadCsv = function() {
     const selectedRows = source.configuration.getSelectedRows();
 
     this.ngeoCsvDownload_.startDownload(
-      selectedRows, columnDefs, 'query-results.csv');
+      selectedRows, columnDefs, this.filename_);
   }
 };
 

--- a/contribs/gmf/src/directives/drawfeature.js
+++ b/contribs/gmf/src/directives/drawfeature.js
@@ -45,7 +45,8 @@ gmf.drawfeatureDirective = function() {
     controller: 'GmfDrawfeatureController as efCtrl',
     scope: {
       'active': '=gmfDrawfeatureActive',
-      'map': '<gmfDrawfeatureMap'
+      'map': '<gmfDrawfeatureMap',
+      'showMeasure': '=?gmfDrawfeatureShowmeasure'
     },
     bindToController: true,
     templateUrl: `${gmf.baseTemplateUrl}/drawfeature.html`

--- a/contribs/gmf/src/directives/partials/drawfeature.html
+++ b/contribs/gmf/src/directives/partials/drawfeature.html
@@ -2,7 +2,8 @@
     ngeo-btn-group
     class="btn-group"
     ngeo-drawfeature-active="efCtrl.drawActive"
-    ngeo-drawfeature-map="efCtrl.map">
+    ngeo-drawfeature-map="efCtrl.map"
+    ngeo-drawfeature-showmeasure="efCtrl.showMeasure">
   <a
     data-toggle="tooltip"
     title="{{'Draw a point on the map' | translate}}"

--- a/src/directives/drawfeature.js
+++ b/src/directives/drawfeature.js
@@ -85,6 +85,9 @@ goog.require('ol.Feature');
  *     collection in which to push the drawn features. If none is provided,
  *     then the `ngeoFeatures` collection is used.
  * @htmlAttribute {ol.Map} ngeo-drawfeature-map The map.
+ * @htmlAttribute {boolean} ngeo-drawfeature-showmeasure. Checks the
+ *      checkbox in order to display the feature measurements as a label.
+ *      Default to false.
  * @return {angular.Directive} The directive specs.
  * @ngInject
  * @ngdoc directive

--- a/src/directives/drawfeature.js
+++ b/src/directives/drawfeature.js
@@ -97,7 +97,8 @@ ngeo.drawfeatureDirective = function() {
     bindToController: {
       'active': '=ngeoDrawfeatureActive',
       'features': '=?ngeoDrawfeatureFeatures',
-      'map': '=ngeoDrawfeatureMap'
+      'map': '=ngeoDrawfeatureMap',
+      'showMeasure': '=?ngeoDrawfeatureShowmeasure'
     }
   };
 };
@@ -146,6 +147,12 @@ ngeo.DrawfeatureController = function($scope, $sce, gettextCatalog,
    * @export
    */
   this.map;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.showMeasure;
 
   /**
    * @type {angularGettext.Catalog}
@@ -321,7 +328,7 @@ ngeo.DrawfeatureController.prototype.handleDrawEnd = function(type, event) {
 
   feature.set(prop.ANGLE, 0);
   feature.set(prop.OPACITY, 0.2);
-  feature.set(prop.SHOW_MEASURE, false);
+  feature.set(prop.SHOW_MEASURE, this.showMeasure ? true : false);
   feature.set(prop.SIZE, 10);
   feature.set(prop.STROKE, 1);
 


### PR DESCRIPTION
Adds a showMeasure variable that can be configurated in the template to check by default the display measurement check box.

`                  gmf-drawfeature-showmeasure="true"
`