### PR TITLE
Dispatch a theme change on user change

### DIFF
--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -622,7 +622,7 @@ gmf.AbstractController.prototype.updateCurrentTheme_ = function(fallbackThemeNam
         this.gmfThemeManager.addTheme(theme, true);
       }
     } else {
-      this.gmfThemeManager.setThemeName(fallbackThemeName, true);
+      this.gmfThemeManager.setThemeName(fallbackThemeName);
     }
   });
 };


### PR DESCRIPTION
fixes #3113 

Without it, no theme change event is dispatched and the background layers are not re-computed correctly.