### PR TITLE
Makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -747,15 +747,6 @@ contribs/gmf/fonts/fontawesome-webfont.%: node_modules/font-awesome/fonts/fontaw
 	mkdir -p $(dir $@)
 	cp $< $@
 
-.build/closure-compiler/compiler.jar: .build/closure-compiler/compiler-latest.zip
-	unzip $< -d .build/closure-compiler
-	touch $@
-
-.build/closure-compiler/compiler-latest.zip:
-	mkdir -p $(dir $@)
-	wget -O $@ http://closure-compiler.googlecode.com/files/compiler-latest.zip
-	touch $@
-
 .PRECIOUS: .build/examples/%.json
 .build/examples/%.json: buildtools/mako_build.json .build/python-venv/bin/mako-render
 	mkdir -p $(dir $@)

--- a/Makefile
+++ b/Makefile
@@ -830,11 +830,6 @@ $(EXTERNS_JQUERY): github_versions
 	.build/python-venv/bin/pip install `grep ^beautifulsoup4== $< --colour=never`
 	touch $@
 
-.build/closure-library: github_versions
-	mkdir -p $(dir $@)
-	git clone http://github.com/google/closure-library/ $@
-	cd $@; git checkout `grep ^closure-library= $< | cut -d = -f 2`
-
 .build/ol-deps.js: .build/python-venv .build/node_modules.timestamp
 	.build/python-venv/bin/python buildtools/closure/depswriter.py \
 		--root_with_prefix="node_modules/openlayers/src ../../../openlayers/src" \

--- a/Makefile
+++ b/Makefile
@@ -245,9 +245,9 @@ serve: .build/node_modules.timestamp $(JQUERY_UI) $(FONTAWESOME_WEBFONT) $(ANGUL
 
 .PHONY: examples-hosted
 examples-hosted: \
-		$(patsubst examples/%.html,.build/examples-hosted/%.html,$(EXAMPLES_HTML_FILES)) \
-		$(patsubst contribs/gmf/examples/%.html,.build/examples-hosted/contribs/gmf/%.html,$(GMF_EXAMPLES_HTML_FILES)) \
-		$(addprefix .build/examples-hosted/contribs/gmf/apps/,$(addsuffix /index.html,$(GMF_APPS)))
+		examples-hosted-ngeo \
+		examples-hosted-gmf \
+		examples-hosted-apps
 
 .PHONY: examples-hosted-ngeo
 examples-hosted-ngeo: \

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,0 @@
-# Infrastructure
-
-- use ng-annotate and get rid of annotations in the code
-- use a template cache
-- handle CSS (and CSS from OpenLayers)

--- a/github_versions
+++ b/github_versions
@@ -1,3 +1,2 @@
 angular.js=704123a
 closure-compiler=v20170409
-closure-library=v20170409


### PR DESCRIPTION
Only the first 4 commits of #3137, hopefully all trivial things that don't cause any build issues.


- Remove unused compiler-latest rules from Makefile
- Remove unused closure-library rule/version from Makefile/github_versions
- Remove outdated TODO file
- Reduce duplication in Makefile