### PR TITLE
gmf-displaywindow - drag/resize on same div

### DIFF
--- a/contribs/gmf/src/directives/displayquerywindow.js
+++ b/contribs/gmf/src/directives/displayquerywindow.js
@@ -278,7 +278,7 @@ gmf.DisplayquerywindowController.prototype.$onInit = function() {
   this.highlightFeatureOverlay_.setStyle(highlightFeatureStyle);
 
   if (this.desktop) {
-    this.element_.find('.gmf-displayquerywindow').draggable({
+    this.element_.find('.gmf-displayquerywindow-container').draggable({
       'cancel': 'input,textarea,button,select,option,tr',
       'containment': this.draggableContainment
     });

--- a/contribs/gmf/src/directives/displaywindow.js
+++ b/contribs/gmf/src/directives/displaywindow.js
@@ -149,7 +149,7 @@ gmf.DisplaywindowController = class {
 
     // Resizable
     if (this.resizable) {
-      this.element_.find('.gmf-displayquerywindow-container').resizable({
+      this.element_.find('.gmf-displayquerywindow').resizable({
         'minHeight': 240,
         'minWidth': 240
       });

--- a/contribs/gmf/src/directives/displaywindow.js
+++ b/contribs/gmf/src/directives/displaywindow.js
@@ -142,14 +142,14 @@ gmf.DisplaywindowController = class {
 
     // Draggable
     if (this.draggable) {
-      this.element_.find('.gmf-displayquerywindow').draggable({
+      this.element_.find('.gmf-displayquerywindow-container').draggable({
         'containment': this.draggableContainment
       });
     }
 
     // Resizable
     if (this.resizable) {
-      this.element_.find('.gmf-displayquerywindow').resizable({
+      this.element_.find('.gmf-displayquerywindow-container').resizable({
         'minHeight': 240,
         'minWidth': 240
       });


### PR DESCRIPTION
When the `gmf-displaywindow` was made smaller using the jQueryUI resizable widget, the parent div was keeping the original size.  That parent div had the jQueryUI draggable widget on it, which allows the window to be dragged even when seemed to be dragging outside the window.

To fix this, both widgets now interact with the same div: the first div within the widget (at the root).