### PR TITLE
Text constraint filter expression

### DIFF
--- a/src/services/rulehelper.js
+++ b/src/services/rulehelper.js
@@ -622,10 +622,13 @@ ngeo.RuleHelper = class {
         expression
       );
     } else if (operator === rot.LIKE) {
-      const stringExpression = String(expression);
+      const stringExpression = String(expression)
+        .replace(/!/g, '!!')
+        .replace(/\./g, '!.')
+        .replace(/\*/g, '!*');
       filter = ol.format.filter.like(
         propertyName,
-        stringExpression
+        `*${stringExpression}*`
       );
     } else if (operator === rot.NOT_EQUAL_TO) {
       filter = ol.format.filter.notEqualTo(


### PR DESCRIPTION
Fixes #3186

This PR allow the 'contains' filter to fetch result with pattern that are not only starting a attribute value, but also be in the middle of a word, or string, or at the end.

Example:
"med" will not give us only with result "medbase" but now the following results are valid as well:
"Bergrestaurant Jatzmeder", "Dr. med. dent. V. Nielsen", etc

Escaping works partially. Character '.' are working while the characters '!', '*' is not giving us the wanted result, but the issue is probably from MapServer does interpret it anyways as part of the expression.