### PR TITLE
Support of WFS attributes aliases

### DIFF
--- a/contribs/gmf/src/datasource/datasourcesmanager.js
+++ b/contribs/gmf/src/datasource/datasourcesmanager.js
@@ -4,6 +4,7 @@ goog.require('gmf');
 goog.require('gmf.datasource.OGC');
 goog.require('gmf.SyncLayertreeMap');
 goog.require('gmf.TreeManager');
+goog.require('gmf.WFSAliases');
 goog.require('ngeo.map.BackgroundLayerMgr');
 /** @suppress {extraRequire} */
 goog.require('ngeo.datasource.DataSources');
@@ -39,13 +40,14 @@ gmf.datasource.DataSourcesManager = class {
    * @param {!ngeo.map.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
    * @param {!ngeo.RuleHelper} ngeoRuleHelper Ngeo rule helper service.
    * @param {!ngeo.WMSTime} ngeoWMSTime wms time service.
+   * @param {!gmf.WFSAliases} gmfWFSAliases Gmf WFS aliases service.
    * @ngInject
    * @ngdoc service
    * @ngname gmfDataSourcesManager
    */
   constructor($q, $rootScope, $timeout, gmfThemes, gmfTreeManager,
     ngeoBackgroundLayerMgr, ngeoDataSources, ngeoLayerHelper, ngeoRuleHelper,
-    ngeoWMSTime
+    ngeoWMSTime, gmfWFSAliases
   ) {
 
     // === Injected properties ===
@@ -112,6 +114,12 @@ gmf.datasource.DataSourcesManager = class {
      * @private
      */
     this.ngeoWMSTime_ = ngeoWMSTime;
+
+    /**
+     * @type {!gmf.WFSAliases}
+     * @private
+     */
+    this.gmfWFSAliases_ = gmfWFSAliases;
 
 
     // === Inner properties ===
@@ -551,6 +559,8 @@ gmf.datasource.DataSourcesManager = class {
     };
 
     this.ngeoDataSources_.push(dataSource);
+
+    this.gmfWFSAliases_.describe(dataSource);
   }
 
   /**

--- a/contribs/gmf/src/services/wfsaliases.js
+++ b/contribs/gmf/src/services/wfsaliases.js
@@ -1,0 +1,47 @@
+goog.provide('gmf.WFSAliases');
+
+goog.require('gmf');
+goog.require('ngeo.datasource.DataSourcesHelper');
+
+
+gmf.WFSAliases = class {
+
+  /**
+   * Service that provides methods to get additional information and actions
+   * when perfoming WFS requests.
+   *
+   * @struct
+   * @param {ngeo.datasource.DataSourcesHelper} ngeoDataSourcesHelper Ngeo data
+   *     source helper service.
+   * @ngdoc service
+   * @ngname gmfWFSAliases
+   * @ngInject
+   */
+  constructor(ngeoDataSourcesHelper) {
+
+    // === Injected properties ===
+
+    /**
+     * @type {ngeo.datasource.DataSourcesHelper}
+     * @private
+     */
+    this.ngeoDataSourcesHelper_ = ngeoDataSourcesHelper;
+  }
+
+
+  /**
+   * @param {ngeo.datasource.OGC} dataSource Data source.
+   * @export
+   */
+  describe(dataSource) {
+    // Only QGIS Server supports WFS aliases
+    if (dataSource.ogcServerType === 'qgisserver' && !dataSource.attributes) {
+      // Trigger an additional WFS DescribeFeatureType request to get
+      // datasource attributes, including aliases.
+      this.ngeoDataSourcesHelper_.getDataSourceAttributes(dataSource);
+    }
+  }
+};
+
+
+gmf.module.service('gmfWFSAliases', gmf.WFSAliases);

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -71,6 +71,13 @@ ngeox.Attribute.prototype.name;
 
 
 /**
+ * The attribute alias.
+ * @type {string|null}
+ */
+ngeox.Attribute.prototype.alias;
+
+
+/**
  * Whether the attribute required to have a value set or not. Defaults to
  * `false`.
  * @type {boolean|undefined}

--- a/src/datasource/ogc.js
+++ b/src/datasource/ogc.js
@@ -15,11 +15,11 @@ goog.require('ol.format.WMSGetFeatureInfo');
 ngeo.datasource.OGC = class extends ngeo.datasource.DataSource {
 
   /**
-   * A data source contain information of a single source of data that can
+   * A data source contains information of a single source of data that can
    * show or fetch the data using an OGC server. Serveral OGC service types are
    * supported by this data source: WMS, WMTS and even WFS.
    *
-   * You can use the information stored within an OGC data source to do allo
+   * You can use the information stored within an OGC data source to do all
    * sorts of things:
    * - issue WMS/WFS queries
    * - apply filter rules on it
@@ -33,10 +33,10 @@ ngeo.datasource.OGC = class extends ngeo.datasource.DataSource {
 
     super(options);
 
-    // === DYNAMIC properties (i.e. that can change / be watched ===
+    // === DYNAMIC properties (i.e. that can change / be watched) ===
 
     /**
-     * The dimenions configuration for the data source.
+     * The dimensions configuration for the data source.
      * @type {?ngeox.Dimensions}
      * @private
      */

--- a/src/format/wfsattribute.js
+++ b/src/format/wfsattribute.js
@@ -30,10 +30,13 @@ ngeo.format.WFSAttribute = class {
   readFromComplexTypeElement_(object) {
 
     const name = goog.asserts.assertString(object['name']);
+    const alias = 'alias' in object ?
+      goog.asserts.assertString(object['alias']) : null;
     const required = object['minOccurs'] != '0';
 
     const attribute = {
       name,
+      alias,
       required
     };
 

--- a/src/format/xsdattribute.js
+++ b/src/format/xsdattribute.js
@@ -87,11 +87,13 @@ ngeo.format.XSDAttribute.prototype.readFromElementNode_ = function(node) {
   const name = node.getAttribute('name');
   goog.asserts.assertString(name, 'name should be defined in element node.');
 
+  const alias = node.getAttribute('alias');
   const nillable = node.getAttribute('nillable');
   const required = !(nillable === true || nillable === 'true');
 
   const attribute = {
     name,
+    alias,
     required
   };
 

--- a/src/services/mapquerent.js
+++ b/src/services/mapquerent.js
@@ -167,7 +167,6 @@ ngeo.MapQuerent = class {
       let label = dataSource.name;
       goog.asserts.assert(dataSource);
 
-
       const querentResultItem = response[id];
       const features = querentResultItem.features;
       const limit = querentResultItem.limit;
@@ -179,6 +178,21 @@ ngeo.MapQuerent = class {
         const type = goog.asserts.assertString(feature.get('ngeo_feature_type_'));
         if (!typeSeparatedFeatures[type]) {
           typeSeparatedFeatures[type] = [];
+        }
+        // Use properties aliases if any
+        if (dataSource.attributes && dataSource.attributes.length) {
+          const properties = feature.getProperties();
+          const filteredProperties = {};
+          dataSource.attributes.forEach((attribute) => {
+            if (attribute.alias) {
+              filteredProperties[attribute.alias] = properties[attribute.name];
+              feature.unset(attribute.name, /* silent */ true);
+            } else {
+              // No alias is available => use the attribute as is.
+              filteredProperties[attribute.name] = properties[attribute.name];
+            }
+          });
+          feature.setProperties(filteredProperties, /* silent */ true);
         }
         typeSeparatedFeatures[type].push(feature);
       });


### PR DESCRIPTION
Some WFS backends such as QGIS Server may provide ``alias`` attributes for results of WFS requests. They are made available through a WFS DescribeFeatureType request. For instance:
```
...
<element alias="Vitesse" type="integer" name="Speed"/>
...
```

This PR aims to display those aliases if any in the query results window. See  https://jira.camptocamp.com/browse/GEORD-21

Still to do:
* [x] get the aliases if any when showing the query results
* ~~support layers added using the WMS browser~~
* [ ] figure out if the code in the ``gmf.WFSAliases`` service really deserves a distinct service or if it can be moved for instance to ``gmf.datasource.DataSourcesManager``
* ~~make sure WMS GFI are supported~~
* [ ] tests?