### PR TITLE
WIP - Fix empty disclaimer

### DIFF
--- a/contribs/gmf/src/directives/disclaimer.js
+++ b/contribs/gmf/src/directives/disclaimer.js
@@ -8,71 +8,6 @@ goog.require('ngeo.LayerHelper');
 
 
 /**
- * Provide a "disclaimer" component for GeoMapFish that is bound to the
- * layers added and removed from a map.
- *
- * Example:
- *
- *      <gmf-disclaimer
- *        gmf-disclaimer-map="::ctrl.map">
- *      </gmf-disclaimer>
- *
- * You can also display the disclaimer messages in popups or use them in another
- * context. The example below show you how to display the disclaimer messages
- * in a ngeo-modal window (external case).
- *
- * Example:
- *
- *      <gmf-disclaimer
- *        gmf-disclaimer-map="::ctrl.map"
- *        gmf-disclaimer-external="::true"
- *        gmf-disclaimer-external-msg="disclaimerMsg"
- *        gmf-disclaimer-external-visibility="disclaimerVisibility">
- *      </gmf-disclaimer>
- *      <ngeo-modal ng-model="disclaimerVisibility"
- *                  ngeo-modal-destroy-content-on-hide="true">
- *       <div class="modal-header">
- *         <button type="button" class="close" data-dismiss="modal"
- *                 aria-hidden="true">&times;</button>
- *       </div>
- *       <div class="modal-body">
- *         <div ng-bind-html="disclaimerMsg"></div>
- *       </div>
- *     </ngeo-modal>
- *
- * @htmlAttribute {boolean} gmf-disclaimer-popup Whether to show the disclaimer
- *     messages in popups or not. Defaults to `false`.
- * @htmlAttribute {boolean?} gmf-disclaimer-external Whether to use disclaimer
- *     messages elsewhere or not. Default to `false`. If true, you should use
- *     the gmf-disclaimer-external-msg and the
- *     gmf-disclaimer-external-visibility too.
- * @htmlAttribute {boolean?} gmf-disclaimer-external-visibility variable that
- *     will be set to true if the disclaimers contain a new message. To uses it,
- *     you must set the gmf-disclaimer-external to true.
- * @htmlAttribute {string?} gmf-disclaimer-external-msg variable that will
- *     contains the disclaimer messages. To uses it, you must set the
- *     gmf-disclaimer-external to true.
- * @htmlAttribute {ol.Map=} gmf-disclaimer-map The map.
- *
- * @ngdoc component
- * @ngname gmfDisclaimer
- */
-gmf.disclaimerComponent = {
-  controller: gmf.DisclaimerController,
-  bindings: {
-    'popup': '<?gmfDisclaimerPopup',
-    'map': '=gmfDisclaimerMap',
-    'external': '<?gmfDisclaimerExternal',
-    'visibility': '=?gmfDisclaimerExternalVisibility',
-    'msg': '=?gmfDisclaimerExternalMsg'
-  }
-};
-
-
-gmf.module.component('gmfDisclaimer', gmf.disclaimerComponent);
-
-
-/**
  * @constructor
  * @private
  * @param {!angular.JQLite} $element Element.
@@ -335,3 +270,68 @@ gmf.DisclaimerController.prototype.closeDisclaimerMessage_ = function(msg) {
     });
   }
 };
+
+
+/**
+ * Provide a "disclaimer" component for GeoMapFish that is bound to the
+ * layers added and removed from a map.
+ *
+ * Example:
+ *
+ *      <gmf-disclaimer
+ *        gmf-disclaimer-map="::ctrl.map">
+ *      </gmf-disclaimer>
+ *
+ * You can also display the disclaimer messages in popups or use them in another
+ * context. The example below show you how to display the disclaimer messages
+ * in a ngeo-modal window (external case).
+ *
+ * Example:
+ *
+ *      <gmf-disclaimer
+ *        gmf-disclaimer-map="::ctrl.map"
+ *        gmf-disclaimer-external="::true"
+ *        gmf-disclaimer-external-msg="disclaimerMsg"
+ *        gmf-disclaimer-external-visibility="disclaimerVisibility">
+ *      </gmf-disclaimer>
+ *      <ngeo-modal ng-model="disclaimerVisibility"
+ *                  ngeo-modal-destroy-content-on-hide="true">
+ *       <div class="modal-header">
+ *         <button type="button" class="close" data-dismiss="modal"
+ *                 aria-hidden="true">&times;</button>
+ *       </div>
+ *       <div class="modal-body">
+ *         <div ng-bind-html="disclaimerMsg"></div>
+ *       </div>
+ *     </ngeo-modal>
+ *
+ * @htmlAttribute {boolean} gmf-disclaimer-popup Whether to show the disclaimer
+ *     messages in popups or not. Defaults to `false`.
+ * @htmlAttribute {boolean?} gmf-disclaimer-external Whether to use disclaimer
+ *     messages elsewhere or not. Default to `false`. If true, you should use
+ *     the gmf-disclaimer-external-msg and the
+ *     gmf-disclaimer-external-visibility too.
+ * @htmlAttribute {boolean?} gmf-disclaimer-external-visibility variable that
+ *     will be set to true if the disclaimers contain a new message. To uses it,
+ *     you must set the gmf-disclaimer-external to true.
+ * @htmlAttribute {string?} gmf-disclaimer-external-msg variable that will
+ *     contains the disclaimer messages. To uses it, you must set the
+ *     gmf-disclaimer-external to true.
+ * @htmlAttribute {ol.Map=} gmf-disclaimer-map The map.
+ *
+ * @ngdoc component
+ * @ngname gmfDisclaimer
+ */
+gmf.disclaimerComponent = {
+  controller: gmf.DisclaimerController,
+  bindings: {
+    'popup': '<?gmfDisclaimerPopup',
+    'map': '=gmfDisclaimerMap',
+    'external': '<?gmfDisclaimerExternal',
+    'visibility': '=?gmfDisclaimerExternalVisibility',
+    'msg': '=?gmfDisclaimerExternalMsg'
+  }
+};
+
+
+gmf.module.component('gmfDisclaimer', gmf.disclaimerComponent);


### PR DESCRIPTION
An issue has been raised about the disclaimer messages in the `desktop_alt` application.  It's now showing an empty message.  It seems to be a combinaison of multiple things.  Here goes.

## First issue

First, when the update to Angular 1.6 was made, changes were made in several directives to change them as components without them being tested.  The `gmf-disclaimer` was one of them.  Look at the first commit of this PR. The component was created before its controller.  From this point moment on, the component stop from working under the 'development' environment.  When compiled, it worked because I suppose the compiler was smart enough to understand to define the controller before and then use it, I don't know...

Introduced in https://github.com/camptocamp/ngeo/pull/2142

Fixed in the "first step" commit.

## Second issue

This PR doesn't have any fix for this yet, as I don't understand how it works...

The second issue was caused when moving the modal from a directive to a component, see:

https://github.com/camptocamp/ngeo/pull/3154

Prior this, the modal was shown fine.

When not using the `external` option of the disclaimer, it's working fine (we have disclaimer messages correctly shown at the bottom left of the map).  When using it (that's what the desktop_alt app does), it's showing the empty messages.

From what I understand, we define a `ngeo-modal` that uses a custom defined model that's shared between the modal and disclaimer... and the visibility as well.  I don't understand how that's supposed to work now with components (nor how that was working before), as I'm not used to this kind of practice.