### PR TITLE
Move last ngeo map services

### DIFF
--- a/contribs/gmf/examples/displayquerygrid.js
+++ b/contribs/gmf/examples/displayquerygrid.js
@@ -27,9 +27,14 @@ goog.require('ol.style.Fill');
 goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 
+goog.require('ngeo.map.module');
+
 
 /** @type {!angular.Module} **/
-gmfapp.module = angular.module('gmfapp', ['gmf']);
+gmfapp.module = angular.module('gmfapp', [
+  gmf.module.name, // Change me when gmf.Theme and other dependencies are in a module
+  ngeo.map.module.name // for ngeo.map.FeatureOverlay, perhaps remove me
+]);
 
 
 gmfapp.module.constant('ngeoQueryOptions', {
@@ -84,7 +89,7 @@ gmfapp.module.controller('gmfappQueryresultController', gmfapp.QueryresultContro
  * @param {gmf.Themes} gmfThemes The gmf themes service.
  * @param {gmf.datasource.DataSourcesManager} gmfDataSourcesManager The gmf
  *     data sources manager service.
- * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
+ * @param {ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *   overlay manager service.
  * @ngInject
  */

--- a/contribs/gmf/examples/displayquerywindow.js
+++ b/contribs/gmf/examples/displayquerywindow.js
@@ -25,9 +25,14 @@ goog.require('ol.style.Fill');
 goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 
+goog.require('ngeo.map.module');
+
 
 /** @type {!angular.Module} **/
-gmfapp.module = angular.module('gmfapp', ['gmf']);
+gmfapp.module = angular.module('gmfapp', [
+  gmf.module.name, // Change me when gmf.Theme and other dependencies are in a module
+  ngeo.map.module.name // for ngeo.map.FeatureOverlay, perhaps remove me
+]);
 
 
 gmfapp.module.value('ngeoQueryOptions', {
@@ -81,7 +86,7 @@ gmfapp.module.controller('AppQueryresultController', gmfapp.QueryresultControlle
  * @param {gmf.Themes} gmfThemes The gmf themes service.
  * @param {gmf.datasource.DataSourcesManager} gmfDataSourcesManager The gmf
  *     data sources manager service.
- * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
+ * @param {ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *   overlay manager service.
  * @ngInject
  */

--- a/contribs/gmf/examples/drawfeature.js
+++ b/contribs/gmf/examples/drawfeature.js
@@ -13,9 +13,14 @@ goog.require('ol.View');
 goog.require('ol.layer.Tile');
 goog.require('ol.source.OSM');
 
+goog.require('ngeo.map.module');
+
 
 /** @type {!angular.Module} **/
-gmfapp.module = angular.module('gmfapp', ['gmf']);
+gmfapp.module = angular.module('gmfapp', [
+  gmf.module.name, // Change me when gmf.Theme and other dependencies are in a module
+  ngeo.map.module.name // for ngeo.map.FeatureOverlay, perhaps remove me
+]);
 
 
 gmfapp.module.value('ngeoExportFeatureFormats', [
@@ -30,7 +35,7 @@ gmfapp.module.value('ngeoExportFeatureFormats', [
  * @param {ol.Collection.<ol.Feature>} ngeoFeatures Collection of features.
  * @param {ngeo.ToolActivate.Mgr} ngeoToolActivateMgr Ngeo ToolActivate manager
  *     service.
- * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr Ngeo FeatureOverlay
+ * @param {ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr Ngeo FeatureOverlay
  *     manager
  * @constructor
  * @ngInject

--- a/contribs/gmf/examples/print.js
+++ b/contribs/gmf/examples/print.js
@@ -14,9 +14,14 @@ goog.require('ol.View');
 goog.require('ol.layer.Tile');
 goog.require('ol.source.OSM');
 
+goog.require('ngeo.map.module');
+
 
 /** @type {!angular.Module} **/
-gmfapp.module = angular.module('gmfapp', ['gmf']);
+gmfapp.module = angular.module('gmfapp', [
+  gmf.module.name, // Change me when gmf.Theme and other dependencies are in a module
+  ngeo.map.module.name //for ngeo.map.FeatureOverlay, perhaps remove me
+]);
 
 
 gmfapp.module.value(
@@ -42,7 +47,7 @@ gmfapp.module.value('gmfLayersUrl',
 /**
  * @constructor
  * @param {gmf.Themes} gmfThemes The gmf themes service.
- * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
+ * @param {ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *   overlay manager service.
  * @ngInject
  */

--- a/contribs/gmf/examples/profile.js
+++ b/contribs/gmf/examples/profile.js
@@ -1,6 +1,5 @@
 goog.provide('gmfapp.profile');
 
-goog.require('ngeo.FeatureOverlayMgr');
 /** @suppress {extraRequire} */
 goog.require('gmf.Permalink');
 /** @suppress {extraRequire} */
@@ -20,9 +19,14 @@ goog.require('ol.source.OSM');
 goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 
+goog.require('ngeo.map.module');
+
 
 /** @type {!angular.Module} **/
-gmfapp.module = angular.module('gmfapp', ['gmf']);
+gmfapp.module = angular.module('gmfapp', [
+  gmf.module.name, // Change me when gmf.Theme and other dependencies are in a module
+  ngeo.map.module.name // for ngeo.map.FeatureOverlay, perhaps remove me
+]);
 
 
 gmfapp.module.value(
@@ -31,7 +35,7 @@ gmfapp.module.value(
 
 /**
  * @param {angular.Scope} $scope Angular scope.
- * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr Feature overlay
+ * @param {ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr Feature overlay
  *     manager.
  * @constructor
  * @ngInject

--- a/contribs/gmf/examples/search.js
+++ b/contribs/gmf/examples/search.js
@@ -2,7 +2,6 @@ goog.provide('gmfapp.search');
 
 /** @suppress {extraRequire} */
 goog.require('gmf.mapDirective');
-goog.require('ngeo.FeatureOverlayMgr');
 goog.require('ngeo.Notification');
 /** @suppress {extraRequire} */
 goog.require('ngeo.proj.EPSG21781');
@@ -16,12 +15,14 @@ goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 
 goog.require('gmf.search.module');
+goog.require('ngeo.map.module');
 
 
 /** @type {!angular.Module} **/
 gmfapp.module = angular.module('gmfapp', [
   gmf.module.name, // Change me when gmf.Theme and other dependencies are in a module
-  gmf.search.module.name
+  gmf.search.module.name,
+  ngeo.map.module.name // for ngeo.map.FeatureOverlay, perhaps remove me
 ]);
 
 
@@ -36,7 +37,7 @@ gmfapp.module.value('gmfLayersUrl',
 
 /**
  * @param {gmf.Themes} gmfThemes Themes service.
- * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature overlay manager service.
+ * @param {ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature overlay manager service.
  * @param {ngeo.Notification} ngeoNotification Ngeo notification service.
  * @constructor
  * @ngInject

--- a/contribs/gmf/src/controllers/AbstractAppController.js
+++ b/contribs/gmf/src/controllers/AbstractAppController.js
@@ -27,7 +27,6 @@ goog.require('gmf.themeselectorComponent');
 goog.require('ngeo.filters');
 /** @suppress {extraRequire} */
 goog.require('ngeo.mapQueryDirective');
-goog.require('ngeo.FeatureOverlayMgr');
 goog.require('ngeo.GetBrowserLanguage');
 /** @suppress {extraRequire} */
 goog.require('ngeo.MapQuerent');
@@ -390,7 +389,7 @@ gmf.AbstractAppController = function(config, $scope, $injector) {
 
   /**
    * The ngeo feature overlay manager service
-   * @type {ngeo.FeatureOverlayMgr}
+   * @type {ngeo.map.FeatureOverlayMgr}
    */
   const ngeoFeatureOverlayMgr = $injector.get('ngeoFeatureOverlayMgr');
   ngeoFeatureOverlayMgr.init(this.map);

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -37,10 +37,6 @@ goog.require('ngeo.FeatureHelper');
 /** @suppress {extraRequire} */
 goog.require('ngeo.Features');
 /** @suppress {extraRequire} */
-goog.require('ngeo.FeatureOverlay');
-/** @suppress {extraRequire} */
-goog.require('ngeo.FeatureOverlayMgr');
-/** @suppress {extraRequire} */
 goog.require('ngeo.ToolActivate');
 goog.require('ol.Collection');
 goog.require('ol.Map');
@@ -193,7 +189,7 @@ gmf.AbstractDesktopController = function(config, $scope, $injector) {
   const ngeoFeatures = $injector.get('ngeoFeatures');
 
   /**
-   * @type {ngeo.FeatureOverlay}
+   * @type {ngeo.map.FeatureOverlay}
    * @export
    */
   this.drawFeatureLayer = $injector.get('ngeoFeatureOverlayMgr')

--- a/contribs/gmf/src/datasource/datasourcesmanager.js
+++ b/contribs/gmf/src/datasource/datasourcesmanager.js
@@ -7,7 +7,7 @@ goog.require('gmf.TreeManager');
 goog.require('ngeo.map.BackgroundLayerMgr');
 /** @suppress {extraRequire} */
 goog.require('ngeo.datasource.DataSources');
-goog.require('ngeo.LayerHelper');
+goog.require('ngeo.map.LayerHelper');
 goog.require('ngeo.RuleHelper');
 goog.require('ngeo.WMSTime');
 goog.require('ol.events');
@@ -36,7 +36,7 @@ gmf.datasource.DataSourcesManager = class {
    *     manager.
    * @param {ngeo.datasource.DataSources} ngeoDataSources Ngeo collection of
    *     data sources objects.
-   * @param {!ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
+   * @param {!ngeo.map.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
    * @param {!ngeo.RuleHelper} ngeoRuleHelper Ngeo rule helper service.
    * @param {!ngeo.WMSTime} ngeoWMSTime wms time service.
    * @ngInject
@@ -96,7 +96,7 @@ gmf.datasource.DataSourcesManager = class {
     this.ngeoDataSources_ = ngeoDataSources;
 
     /**
-     * @type {!ngeo.LayerHelper}
+     * @type {!ngeo.map.LayerHelper}
      * @private
      */
     this.ngeoLayerHelper_ = ngeoLayerHelper;

--- a/contribs/gmf/src/datasource/externaldatasourcesmanager.js
+++ b/contribs/gmf/src/datasource/externaldatasourcesmanager.js
@@ -30,7 +30,7 @@ gmf.datasource.ExternalDataSourcesManager = class {
    * @param {!ngeo.datasource.DataSources} ngeoDataSources Ngeo collection of
    *     data sources objects.
    * @param {!ngeo.utils.File} ngeoFile Ngeo file.
-   * @param {!ngeo.LayerHelper} ngeoLayerHelper Ngeo layer helper service
+   * @param {!ngeo.map.LayerHelper} ngeoLayerHelper Ngeo layer helper service
    * @struct
    * @ngInject
    * @ngdoc service
@@ -74,7 +74,7 @@ gmf.datasource.ExternalDataSourcesManager = class {
     this.ngeoFile_ = ngeoFile;
 
     /**
-     * @type {!ngeo.LayerHelper}
+     * @type {!ngeo.map.LayerHelper}
      * @private
      */
     this.ngeoLayerHelper_ = ngeoLayerHelper;

--- a/contribs/gmf/src/directives/backgroundlayerselector.js
+++ b/contribs/gmf/src/directives/backgroundlayerselector.js
@@ -8,7 +8,7 @@ goog.require('ol.events');
 goog.require('ngeo.map.BackgroundLayerMgr');
 
 
-// In futur module declaration, don't forget to require:
+// In the future module declaration, don't forget to require:
 // - ngeo.map.BackgroundLayerMgr.module.name
 
 

--- a/contribs/gmf/src/directives/disclaimer.js
+++ b/contribs/gmf/src/directives/disclaimer.js
@@ -4,7 +4,7 @@ goog.require('ol.events');
 goog.require('gmf');
 goog.require('ngeo.Disclaimer');
 goog.require('ngeo.EventHelper');
-goog.require('ngeo.LayerHelper');
+goog.require('ngeo.map.LayerHelper');
 
 
 /**
@@ -17,7 +17,7 @@ goog.require('ngeo.LayerHelper');
  * @param {!ngeo.Popup.Factory} ngeoCreatePopup Popup service.
  * @param {!ngeo.Disclaimer} ngeoDisclaimer Ngeo Disclaimer service.
  * @param {!ngeo.EventHelper} ngeoEventHelper Ngeo Event Helper.
- * @param {!ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
+ * @param {!ngeo.map.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
  * @struct
  * @ngInject
  * @ngdoc controller
@@ -101,7 +101,7 @@ gmf.DisclaimerController = function($element, $scope, $sce, $timeout,
   this.eventHelper_ = ngeoEventHelper;
 
   /**
-   * @type {!ngeo.LayerHelper}
+   * @type {!ngeo.map.LayerHelper}
    * @private
    */
   this.ngeoLayerHelper_ = ngeoLayerHelper;

--- a/contribs/gmf/src/directives/displayquerygrid.js
+++ b/contribs/gmf/src/directives/displayquerygrid.js
@@ -5,8 +5,6 @@ goog.require('ngeo.CsvDownload');
 goog.require('ngeo.GridConfig');
 /** @suppress {extraRequire} */
 goog.require('ngeo.gridComponent');
-goog.require('ngeo.FeatureOverlay');
-goog.require('ngeo.FeatureOverlayMgr');
 /** @suppress {extraRequire} - required for `ngeoQueryResult` */
 goog.require('ngeo.MapQuerent');
 goog.require('ol.Collection');
@@ -14,6 +12,12 @@ goog.require('ol.style.Circle');
 goog.require('ol.style.Fill');
 goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
+
+goog.require('ngeo.map.FeatureOverlayMgr');
+
+
+// In the future module declaration, don't forget to require:
+// - ngeo.map.FeatureOverlayMgr.module.name
 
 
 ngeo.module.value('gmfDisplayquerygridTemplateUrl',
@@ -45,7 +49,7 @@ function gmfDisplayquerygridTemplateUrl($element, $attrs, gmfDisplayquerygridTem
 /**
  * Provides a component to display results of the {@link ngeo.queryResult} in a
  * grid and shows related features on the map using
- * the {@link ngeo.FeatureOverlayMgr}.
+ * the {@link ngeo.map.FeatureOverlayMgr}.
  *
  * You can override the default component's template by setting the
  * value `gmfDisplayquerygridTemplateUrl`.
@@ -107,7 +111,7 @@ gmf.module.component('gmfDisplayquerygrid', gmf.displayquerygridComponent);
  * @param {!angular.Scope} $scope Angular scope.
  * @param {ngeox.QueryResult} ngeoQueryResult ngeo query result.
  * @param {ngeo.MapQuerent} ngeoMapQuerent ngeo map querent service.
- * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
+ * @param {ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *     overlay manager service.
  * @param {angular.$timeout} $timeout Angular timeout service.
  * @param {ngeo.CsvDownload} ngeoCsvDownload CSV download service.
@@ -234,7 +238,7 @@ gmf.DisplayquerygridController = function($injector, $scope, ngeoQueryResult, ng
   this.features_ = new ol.Collection();
 
   /**
-   * @type {ngeo.FeatureOverlay}
+   * @type {ngeo.map.FeatureOverlay}
    * @private
    */
   this.highlightFeatureOverlay_ = ngeoFeatureOverlayMgr.getFeatureOverlay();

--- a/contribs/gmf/src/directives/displayquerywindow.js
+++ b/contribs/gmf/src/directives/displayquerywindow.js
@@ -1,8 +1,6 @@
 goog.provide('gmf.displayquerywindowComponent');
 
 goog.require('gmf');
-goog.require('ngeo.FeatureOverlay');
-goog.require('ngeo.FeatureOverlayMgr');
 /** @suppress {extraRequire} - required for `ngeoQueryResult` */
 goog.require('ngeo.MapQuerent');
 /** @suppress {extraRequire} */
@@ -12,6 +10,12 @@ goog.require('ol.style.Circle');
 goog.require('ol.style.Fill');
 goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
+
+goog.require('ngeo.map.FeatureOverlayMgr');
+
+
+// In the future module declaration, don't forget to require:
+// - ngeo.map.FeatureOverlayMgr.module.name
 
 
 ngeo.module.value('gmfDisplayquerywindowTemplateUrl',
@@ -41,7 +45,7 @@ function gmfDisplayquerywindowTemplateUrl($element, $attrs, gmfDisplayquerywindo
 
 /**
  * Provide a component to display results of the {@link ngeo.queryResult}
- * and shows related features on the map using the {@link ngeo.FeatureOverlayMgr}.
+ * and shows related features on the map using the {@link ngeo.map.FeatureOverlayMgr}.
  *
  * You can override the default component's template by setting the
  * value `gmfDisplayquerywindowTemplateUrl`.
@@ -92,7 +96,7 @@ gmf.module.component('gmfDisplayquerywindow', gmf.displayquerywindowComponent);
  * @param {!angular.Scope} $scope Angular scope.
  * @param {!ngeox.QueryResult} ngeoQueryResult ngeo query result.
  * @param {!ngeo.MapQuerent} ngeoMapQuerent ngeo map querent service.
- * @param {!ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
+ * @param {!ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *     overlay manager service.
  * @constructor
  * @private
@@ -165,13 +169,13 @@ gmf.DisplayquerywindowController = function($element, $scope, ngeoQueryResult, n
   this.features_ = new ol.Collection();
 
   /**
-   * @type {!ngeo.FeatureOverlayMgr}
+   * @type {!ngeo.map.FeatureOverlayMgr}
    * @private
    */
   this.ngeoFeatureOverlayMgr_ = ngeoFeatureOverlayMgr;
 
   /**
-   * @type {ngeo.FeatureOverlay}
+   * @type {ngeo.map.FeatureOverlay}
    * @private
    */
   this.highlightFeatureOverlay_ = ngeoFeatureOverlayMgr.getFeatureOverlay();

--- a/contribs/gmf/src/directives/drawprofileline.js
+++ b/contribs/gmf/src/directives/drawprofileline.js
@@ -8,6 +8,12 @@ goog.require('ol.style.Style');
 goog.require('ol.style.Stroke');
 goog.require('ngeo.DecorateInteraction');
 
+goog.require('ngeo.map.FeatureOverlayMgr');
+
+
+// In the future module declaration, don't forget to require:
+// - ngeo.map.FeatureOverlayMgr.module.name
+
 
 /**
  * Simple directive that can be put on any element. The directive listen on
@@ -63,7 +69,7 @@ gmf.module.directive('gmfDrawprofileline', gmf.drawprofilelineDirective);
  * @param {!angular.Scope} $scope Scope.
  * @param {!angular.JQLite} $element Element.
  * @param {!angular.$timeout} $timeout Angular timeout service.
- * @param {!ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr Feature overlay
+ * @param {!ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr Feature overlay
  *     manager.
  * @param {!ngeo.DecorateInteraction} ngeoDecorateInteraction Decorate
  *     interaction service

--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -16,7 +16,7 @@ goog.require('ngeo.createfeatureDirective');
 goog.require('ngeo.DecorateInteraction');
 goog.require('ngeo.EventHelper');
 goog.require('ngeo.FeatureHelper');
-goog.require('ngeo.LayerHelper');
+goog.require('ngeo.map.LayerHelper');
 goog.require('ngeo.Menu');
 goog.require('ngeo.ToolActivate');
 goog.require('ngeo.interaction.Rotate');
@@ -105,7 +105,7 @@ gmf.module.directive(
  *     interaction service.
  * @param {ngeo.EventHelper} ngeoEventHelper Ngeo Event Helper.
  * @param {ngeo.FeatureHelper} ngeoFeatureHelper Ngeo feature helper service.
- * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
+ * @param {ngeo.map.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
  * @param {ngeo.ToolActivate.Mgr} ngeoToolActivateMgr Ngeo ToolActivate manager
  *     service.
  * @constructor
@@ -232,7 +232,7 @@ gmf.EditfeatureController = function($element, $q, $scope, $timeout,
   this.ngeoFeatureHelper_ = ngeoFeatureHelper;
 
   /**
-   * @type {ngeo.LayerHelper}
+   * @type {ngeo.map.LayerHelper}
    * @private
    */
   this.ngeoLayerHelper_ = ngeoLayerHelper;

--- a/contribs/gmf/src/directives/filterselector.js
+++ b/contribs/gmf/src/directives/filterselector.js
@@ -15,6 +15,12 @@ goog.require('ngeo.Notification');
 goog.require('ngeo.RuleHelper');
 goog.require('ol.events');
 
+goog.require('ngeo.map.FeatureOverlayMgr');
+
+
+// In the future module declaration, don't forget to require:
+// - ngeo.map.FeatureOverlayMgr.module.name
+
 
 /**
  * @private
@@ -33,7 +39,7 @@ gmf.FilterselectorController = class {
    * @param {gmf.SavedFilters} gmfSavedFilters Gmf saved filters service.
    * @param {gmfx.User} gmfUser User.
    * @param {ngeo.Notification} ngeoNotification Ngeo notification service.
-   * @param {!ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr Ngeo FeatureOverlay
+   * @param {!ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr Ngeo FeatureOverlay
    *     manager
    * @param {!ngeo.RuleHelper} ngeoRuleHelper Ngeo rule helper service.
    * @private
@@ -142,7 +148,7 @@ gmf.FilterselectorController = class {
     this.ngeoNotification_ = ngeoNotification;
 
     /**
-     * @type {!ngeo.FeatureOverlay}
+     * @type {!ngeo.map.FeatureOverlay}
      * @export
      */
     this.featureOverlay = goog.asserts.assert(

--- a/contribs/gmf/src/directives/layertree.js
+++ b/contribs/gmf/src/directives/layertree.js
@@ -11,7 +11,7 @@ goog.require('gmf.SyncLayertreeMap');
 goog.require('gmf.TreeManager');
 goog.require('ngeo.WMSTime');
 goog.require('ngeo.Popup');
-goog.require('ngeo.LayerHelper');
+goog.require('ngeo.map.LayerHelper');
 goog.require('ngeo.LayertreeController');
 /** @suppress {extraRequire} */
 goog.require('ngeo.layertreeDirective');
@@ -118,7 +118,7 @@ gmf.module.component('gmfLayertree', gmf.layertreeComponent);
  * @param {!angular.$sce} $sce Angular sce service.
  * @param {!angular.Scope} $scope Angular scope.
  * @param {!ngeo.Popup.Factory} ngeoCreatePopup Popup service.
- * @param {!ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
+ * @param {!ngeo.map.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
  * @param {gmf.datasource.DataSourceBeingFiltered} gmfDataSourceBeingFiltered
  *     The Gmf value service that determines the data source currently being
  *     filtered.
@@ -174,7 +174,7 @@ gmf.LayertreeController = function($element, $http, $sce, $scope,
   this.$sce_ = $sce;
 
   /**
-   * @type {!ngeo.LayerHelper}
+   * @type {!ngeo.map.LayerHelper}
    * @private
    */
   this.layerHelper_ = ngeoLayerHelper;

--- a/contribs/gmf/src/directives/map.js
+++ b/contribs/gmf/src/directives/map.js
@@ -3,7 +3,13 @@ goog.provide('gmf.mapDirective');
 goog.require('gmf');
 goog.require('gmf.Permalink');
 goog.require('gmf.Snapping');
-goog.require('ngeo.FeatureOverlayMgr');
+
+goog.require('ngeo.map.FeatureOverlayMgr');
+
+
+// In the future module declaration, don't forget to require:
+// - ngeo.map.FeatureOverlayMgr.module.name
+
 
 /**
  * This goog.require is needed because it provides 'ngeo-map' used in
@@ -50,7 +56,7 @@ gmf.module.directive('gmfMap', gmf.mapDirective);
 
 
 /**
- * @param {!ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
+ * @param {!ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  * @param {!gmf.Permalink} gmfPermalink The gmf permalink service.
  * @param {!gmf.Snapping} gmfSnapping The gmf snapping service.
  * @constructor
@@ -85,7 +91,7 @@ gmf.MapController = function(ngeoFeatureOverlayMgr, gmfPermalink, gmfSnapping) {
   // Injected properties
 
   /**
-   * @type {!ngeo.FeatureOverlayMgr}
+   * @type {!ngeo.map.FeatureOverlayMgr}
    * @private
    */
   this.ngeoFeatureOverlayMgr_ = ngeoFeatureOverlayMgr;

--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -10,7 +10,7 @@ goog.require('ngeo.FeatureHelper');
 goog.require('ngeo.geom');
 /** @suppress {extraRequire} */
 goog.require('ngeo.jstsExports');
-goog.require('ngeo.LayerHelper');
+goog.require('ngeo.map.LayerHelper');
 goog.require('ngeo.ToolActivate');
 goog.require('ngeo.utils');
 goog.require('ol.Collection');
@@ -103,8 +103,8 @@ gmf.module.component('gmfObjectediting', gmf.objecteditingComponent);
  * @param {!ngeo.DecorateInteraction} ngeoDecorateInteraction Decorate
  *     interaction service.
  * @param {!ngeo.FeatureHelper} ngeoFeatureHelper Ngeo feature helper service.
-goog.require('ngeo.LayerHelper');
- * @param {!ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
+goog.require('ngeo.map.LayerHelper');
+ * @param {!ngeo.map.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
  * @param {!ngeo.ToolActivate.Mgr} ngeoToolActivateMgr Ngeo ToolActivate manager
  *     service.
  * @constructor
@@ -229,7 +229,7 @@ gmf.ObjecteditingController = function($scope, $timeout, gettextCatalog,
   this.featureHasGeom;
 
   /**
-   * @type {!ngeo.LayerHelper}
+   * @type {!ngeo.map.LayerHelper}
    * @private
    */
   this.ngeoLayerHelper_ = ngeoLayerHelper;

--- a/contribs/gmf/src/directives/print.js
+++ b/contribs/gmf/src/directives/print.js
@@ -4,13 +4,18 @@ goog.require('gmf');
 /** @suppress {extraRequire} */
 goog.require('gmf.authenticationDirective');
 goog.require('ngeo.Print');
-goog.require('ngeo.FeatureOverlayMgr');
-goog.require('ngeo.map.LayerHelper');
 goog.require('ngeo.PrintUtils');
 goog.require('ol.Observable');
 goog.require('ol.math');
 goog.require('ol.Map');
 goog.require('ol.layer.Group');
+
+goog.require('ngeo.map.LayerHelper');
+goog.require('ngeo.map.FeatureOverlayMgr');
+
+// In the future module declaration, don't forget to require:
+// - ngeo.map.FeatureOverlayMgr.module.name
+// - ngeo.map.LayerHelper.module.name (extra from the map module)
 
 
 /**
@@ -156,7 +161,7 @@ gmf.PrintController = class {
    * @param {angular.$injector} $injector Main injector.
    * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
    * @param {ngeo.map.LayerHelper} ngeoLayerHelper The ngeo Layer Helper service.
-   * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr Ngeo Feature Overlay
+   * @param {ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr Ngeo Feature Overlay
    *     Manager service.
    * @param {ngeo.PrintUtils} ngeoPrintUtils The ngeo PrintUtils service.
    * @param {ngeo.CreatePrint} ngeoCreatePrint The ngeo Create Print function.

--- a/contribs/gmf/src/directives/print.js
+++ b/contribs/gmf/src/directives/print.js
@@ -5,7 +5,7 @@ goog.require('gmf');
 goog.require('gmf.authenticationDirective');
 goog.require('ngeo.Print');
 goog.require('ngeo.FeatureOverlayMgr');
-goog.require('ngeo.LayerHelper');
+goog.require('ngeo.map.LayerHelper');
 goog.require('ngeo.PrintUtils');
 goog.require('ol.Observable');
 goog.require('ol.math');
@@ -155,7 +155,7 @@ gmf.PrintController = class {
    * @param {angular.$q} $q The Angular $q service.
    * @param {angular.$injector} $injector Main injector.
    * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
-   * @param {ngeo.LayerHelper} ngeoLayerHelper The ngeo Layer Helper service.
+   * @param {ngeo.map.LayerHelper} ngeoLayerHelper The ngeo Layer Helper service.
    * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr Ngeo Feature Overlay
    *     Manager service.
    * @param {ngeo.PrintUtils} ngeoPrintUtils The ngeo PrintUtils service.
@@ -249,7 +249,7 @@ gmf.PrintController = class {
     this.gettextCatalog_ = gettextCatalog;
 
     /**
-     * @type {ngeo.LayerHelper}
+     * @type {ngeo.map.LayerHelper}
      * @private
      */
     this.ngeoLayerHelper_ = ngeoLayerHelper;

--- a/contribs/gmf/src/directives/profile.js
+++ b/contribs/gmf/src/directives/profile.js
@@ -2,7 +2,6 @@ goog.provide('gmf.profileComponent');
 
 goog.require('gmf');
 goog.require('ngeo.CsvDownload');
-goog.require('ngeo.FeatureOverlayMgr');
 /** @suppress {extraRequire} */
 goog.require('ngeo.profileDirective');
 goog.require('ol.events');
@@ -14,6 +13,12 @@ goog.require('ol.obj');
 goog.require('ol.style.Circle');
 goog.require('ol.style.Fill');
 goog.require('ol.style.Style');
+
+goog.require('ngeo.map.FeatureOverlayMgr');
+
+
+// In the future module declaration, don't forget to require:
+// - ngeo.map.FeatureOverlayMgr.module.name
 
 
 ngeo.module.value('gmfProfileTemplateUrl',
@@ -104,7 +109,7 @@ gmf.module.component('gmfProfile', gmf.profileComponent);
  * @param {angular.JQLite} $element Element.
  * @param {angular.$filter} $filter Angular filter
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
- * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr Feature overlay
+ * @param {ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr Feature overlay
  *     manager.
  * @param {string} gmfProfileJsonUrl URL of GMF service JSON profile.
  * @param {ngeo.CsvDownload} ngeoCsvDownload CSV Download service.
@@ -149,7 +154,7 @@ gmf.ProfileController = function($scope, $http, $element, $filter,
   this.gettextCatalog_ = gettextCatalog;
 
   /**
-   * @type {ngeo.FeatureOverlay}
+   * @type {ngeo.map.FeatureOverlay}
    * @private
    */
   this.pointHoverOverlay_ = ngeoFeatureOverlayMgr.getFeatureOverlay();

--- a/contribs/gmf/src/search/component.js
+++ b/contribs/gmf/src/search/component.js
@@ -4,8 +4,6 @@ goog.require('gmf');
 goog.require('gmf.Themes');
 goog.require('gmf.TreeManager');
 goog.require('ngeo.AutoProjection');
-goog.require('ngeo.FeatureOverlay');
-goog.require('ngeo.FeatureOverlayMgr');
 /** @suppress {extraRequire} */
 goog.require('ngeo.colorpickerDirective');
 /** @suppress {extraRequire} */
@@ -24,6 +22,7 @@ goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 goog.require('ol.uri');
 
+goog.require('ngeo.map.FeatureOverlayMgr');
 goog.require('ngeo.search.module');
 goog.require('gmf.search.FulltextSearch');
 
@@ -33,6 +32,7 @@ goog.require('gmf.search.FulltextSearch');
  */
 gmf.search.component = angular.module('gmfSearch', [
   ngeo.search.module.name,
+  ngeo.map.FeatureOverlayMgr.module.name,
   gmf.search.FulltextSearch.module.name
 ]);
 
@@ -68,9 +68,9 @@ function gmfSearchTemplateUrl($element, $attrs, gmfSearchTemplateUrl) {
  * It can search in multiple GeoJSON datasources.
  * It can filter and group results by a feature's property.
  *
- * This component uses the {@link ngeo.FeatureOverlayMgr} to create a
+ * This component uses the {@link ngeo.map.FeatureOverlayMgr} to create a
  * feature overlay for drawing features on the map. The application
- * is responsible to initialize the {@link ngeo.FeatureOverlayMgr}
+ * is responsible to initialize the {@link ngeo.map.FeatureOverlayMgr}
  * with the map.
  *
  * Example flat results:
@@ -182,7 +182,7 @@ gmf.search.component.SearchController_ = class {
    * @param {ngeo.AutoProjection} ngeoAutoProjection The ngeo coordinates service.
    * @param {ngeo.search.createGeoJSONBloodhound.Function} ngeoSearchCreateGeoJSONBloodhound The ngeo
    *     create GeoJSON Bloodhound service.
-   * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
+   * @param {ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
    *     overlay manager service.
    * @param {gmf.Themes} gmfThemes gmf Themes service.
    * @param {gmf.TreeManager} gmfTreeManager gmf Tree Manager service.
@@ -251,7 +251,7 @@ gmf.search.component.SearchController_ = class {
     this.ngeoSearchCreateGeoJSONBloodhound_ = ngeoSearchCreateGeoJSONBloodhound;
 
     /**
-     * @type {ngeo.FeatureOverlayMgr}
+     * @type {ngeo.map.FeatureOverlayMgr}
      * @private
      */
     this.ngeoFeatureOverlayMgr = ngeoFeatureOverlayMgr;
@@ -325,7 +325,7 @@ gmf.search.component.SearchController_ = class {
     this.coordinatesProjections;
 
     /**
-     * @type {ngeo.FeatureOverlay}
+     * @type {ngeo.map.FeatureOverlay}
      * @private
      */
     this.featureOverlay_ = ngeoFeatureOverlayMgr.getFeatureOverlay();

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -168,13 +168,13 @@ gmf.Permalink = function($q, $timeout, $rootScope, $injector, ngeoDebounce, ngeo
     $injector.get('ngeoBackgroundLayerMgr') : null;
 
   /**
-   * @type {?ngeo.FeatureOverlayMgr}
+   * @type {?ngeo.map.FeatureOverlayMgr}
    */
   const ngeoFeatureOverlayMgr = $injector.has('ngeoFeatureOverlayMgr') ?
     $injector.get('ngeoFeatureOverlayMgr') : null;
 
   /**
-   * @type {?ngeo.FeatureOverlay}
+   * @type {?ngeo.map.FeatureOverlay}
    * @private
    */
   this.featureOverlay_ = ngeoFeatureOverlayMgr ?

--- a/contribs/gmf/src/services/syncLayertreeMap.js
+++ b/contribs/gmf/src/services/syncLayertreeMap.js
@@ -13,7 +13,7 @@ goog.require('ol.layer.Tile');
  *
  * @constructor
  * @param {angular.Scope} $rootScope Angular rootScope.
- * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
+ * @param {ngeo.map.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
  * @param {ngeo.WMSTime} ngeoWMSTime wms time service.
  * @param {gmf.Themes} gmfThemes The gmf Themes service.
  * @ngInject
@@ -24,7 +24,7 @@ gmf.SyncLayertreeMap = function($rootScope, ngeoLayerHelper, ngeoWMSTime,
   gmfThemes) {
 
   /**
-   * @type {ngeo.LayerHelper}
+   * @type {ngeo.map.LayerHelper}
    * @private
    */
   this.layerHelper_ = ngeoLayerHelper;

--- a/contribs/gmf/src/services/themesservice.js
+++ b/contribs/gmf/src/services/themesservice.js
@@ -2,7 +2,7 @@ goog.provide('gmf.Themes');
 
 goog.require('goog.asserts');
 goog.require('gmf');
-goog.require('ngeo.LayerHelper');
+goog.require('ngeo.map.LayerHelper');
 goog.require('ol.array');
 goog.require('ol.Collection');
 goog.require('ol.events.EventTarget');
@@ -23,7 +23,7 @@ gmf.module.value('gmfThemesOptions', {});
  * @param {angular.$http} $http Angular http service.
  * @param {angular.$injector} $injector Main injector.
  * @param {angular.$q} $q Angular q service
- * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
+ * @param {ngeo.map.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @param {gmfx.ThemesOptions} gmfThemesOptions Themes options.
  * @ngInject
@@ -79,7 +79,7 @@ gmf.Themes = function($http, $injector, $q, ngeoLayerHelper, gettextCatalog, gmf
   }
 
   /**
-   * @type {ngeo.LayerHelper}
+   * @type {ngeo.map.LayerHelper}
    * @private
    */
   this.layerHelper_ = ngeoLayerHelper;

--- a/contribs/gmf/src/services/treemanager.js
+++ b/contribs/gmf/src/services/treemanager.js
@@ -24,7 +24,7 @@ goog.require('ol.events');
  * @struct
  * @param {angular.$timeout} $timeout Angular timeout service.
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
- * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
+ * @param {ngeo.map.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
  * @param {ngeo.Notification} ngeoNotification Ngeo notification service.
  * @param {gmf.Themes} gmfThemes gmf Themes service.
  * @param {ngeo.StateManager} ngeoStateManager The ngeo StateManager service.
@@ -48,7 +48,7 @@ gmf.TreeManager = function($timeout, gettextCatalog, ngeoLayerHelper,
   this.gettextCatalog_ = gettextCatalog;
 
   /**
-   * @type {ngeo.LayerHelper}
+   * @type {ngeo.map.LayerHelper}
    * @private
    */
   this.layerHelper_ = ngeoLayerHelper;

--- a/contribs/gmf/test/spec/services/permalinkservice.spec.js
+++ b/contribs/gmf/test/spec/services/permalinkservice.spec.js
@@ -1,7 +1,7 @@
 /* global themes */
 goog.require('gmf.Permalink');
 goog.require('gmf');
-goog.require('ngeo.LayerHelper');
+goog.require('ngeo.map.LayerHelper');
 goog.require('ngeo.StateManager');
 goog.require('ngeo.Location');
 goog.require('ol.Map');

--- a/examples/desktopgeolocation.js
+++ b/examples/desktopgeolocation.js
@@ -1,6 +1,5 @@
 goog.provide('app.desktopgeolocation');
 
-goog.require('ngeo.FeatureOverlayMgr');
 /** @suppress {extraRequire} */
 goog.require('ngeo.desktopGeolocationDirective');
 goog.require('ol.Map');
@@ -24,7 +23,7 @@ app.module = angular.module('app', [
 
 /**
  * @param {angular.Scope} $scope Scope.
- * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
+ * @param {ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *     overlay manager service.
  * @constructor
  * @ngInject

--- a/examples/googlestreetview.js
+++ b/examples/googlestreetview.js
@@ -1,6 +1,5 @@
 goog.provide('app.googlestreetview');
 
-goog.require('ngeo.FeatureOverlayMgr');
 /** @suppress {extraRequire} */
 goog.require('ngeo.googlestreetviewComponent');
 goog.require('ngeo.ToolActivate');
@@ -24,7 +23,7 @@ app.module = angular.module('app', [
 
 
 /**
- * @param {!ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr Ngeo FeatureOverlay
+ * @param {!ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr Ngeo FeatureOverlay
  *     manager.
  * @param {ngeo.ToolActivate.Mgr} ngeoToolActivateMgr Ngeo ToolActivate manager
  *     service.

--- a/examples/interactionbtngroup.js
+++ b/examples/interactionbtngroup.js
@@ -1,7 +1,6 @@
 goog.provide('app.interactionbtngroup');
 
 goog.require('ngeo.DecorateInteraction');
-goog.require('ngeo.FeatureOverlayMgr');
 /** @suppress {extraRequire} */
 goog.require('ngeo.btnDirective');
 goog.require('ol.Collection');
@@ -28,7 +27,7 @@ app.module = angular.module('app', [
 /**
  * @param {ngeo.DecorateInteraction} ngeoDecorateInteraction Decorate
  *     interaction service.
- * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr Feature overlay
+ * @param {ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr Feature overlay
  *     manager.
  * @constructor
  * @ngInject

--- a/examples/mobilegeolocation.js
+++ b/examples/mobilegeolocation.js
@@ -1,6 +1,5 @@
 goog.provide('app.mobilegeolocation');
 
-goog.require('ngeo.FeatureOverlayMgr');
 /** @suppress {extraRequire} */
 goog.require('ngeo.mobileGeolocationDirective');
 goog.require('ol.Map');
@@ -24,7 +23,7 @@ const module = angular.module('app', [
 
 /**
  * @param {angular.Scope} $scope Scope.
- * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
+ * @param {ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *     overlay manager service.
  * @constructor
  * @ngInject

--- a/examples/toolActivate.js
+++ b/examples/toolActivate.js
@@ -1,7 +1,6 @@
 goog.provide('app.toolActivate');
 
 goog.require('ngeo.DecorateInteraction');
-goog.require('ngeo.FeatureOverlayMgr');
 goog.require('ngeo.ToolActivate');
 /** @suppress {extraRequire} */
 goog.require('ngeo.btnDirective');
@@ -29,7 +28,7 @@ app.module = angular.module('app', [
 
 
 /**
- * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr Feature overlay
+ * @param {ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr Feature overlay
  *     manager.
  * @param {ngeo.ToolActivate.Mgr} ngeoToolActivateMgr ToolActivate manager.
  * @param {ngeo.DecorateInteraction} ngeoDecorateInteraction Interaction

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -252,6 +252,15 @@ ngeox.IssueGetFeaturesOptions.prototype.wfsCount;
 
 
 /**
+ * @typedef {{
+ *  styleFunction: ol.StyleFunction,
+ *  features: Object.<string, ol.Feature>
+ * }}
+ */
+ngeox.MapFeatureOverlayGroup;
+
+
+/**
  * A hash that contains 2 lists of queryable data sources: `wfs` and `wms`.
  * The same data source can only be in one of the two lists. The `wfs` list
  * has priority, i.e. if the data source supports WFS, it's put in the

--- a/src/datasource/wmsgroup.js
+++ b/src/datasource/wmsgroup.js
@@ -1,7 +1,7 @@
 goog.provide('ngeo.datasource.WMSGroup');
 
 goog.require('ngeo');
-goog.require('ngeo.LayerHelper');
+goog.require('ngeo.map.LayerHelper');
 goog.require('ngeo.datasource.OGCGroup');
 goog.require('ngeo.datasource.OGC');
 
@@ -35,7 +35,7 @@ ngeo.datasource.WMSGroup = class extends ngeo.datasource.OGCGroup {
     this.layer_;
 
     /**
-     * @type {!ngeo.LayerHelper}
+     * @type {!ngeo.map.LayerHelper}
      * @private
      */
     this.ngeoLayerHelper_ = injector.get('ngeoLayerHelper');

--- a/src/directives/desktopgeolocation.js
+++ b/src/directives/desktopgeolocation.js
@@ -1,14 +1,18 @@
 goog.provide('ngeo.desktopGeolocationDirective');
 
 goog.require('ngeo');
-goog.require('ngeo.FeatureOverlay');
-goog.require('ngeo.FeatureOverlayMgr');
 goog.require('ngeo.Notification');
 goog.require('ol.events');
 goog.require('ol.Feature');
 goog.require('ol.Geolocation');
 goog.require('ol.Map');
 goog.require('ol.geom.Point');
+
+goog.require('ngeo.map.FeatureOverlayMgr');
+
+
+// In futur module declaration, don't forget to require:
+// - ngeo.map.FeatureOverlayMgr.module.name
 
 
 /**
@@ -63,7 +67,7 @@ ngeo.module.directive('ngeoDesktopGeolocation',
  * @struct
  * @param {angular.Scope} $scope The directive's scope.
  * @param {angular.JQLite} $element Element.
- * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
+ * @param {ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *     overlay manager service.
  * @param {ngeo.Notification} ngeoNotification Ngeo notification service.
  * @ngInject
@@ -100,7 +104,7 @@ ngeo.DesktopGeolocationController = function($scope, $element,
   this.notification_ = ngeoNotification;
 
   /**
-   * @type {ngeo.FeatureOverlay}
+   * @type {ngeo.map.FeatureOverlay}
    * @private
    */
   this.featureOverlay_ = ngeoFeatureOverlayMgr.getFeatureOverlay();

--- a/src/directives/filter.js
+++ b/src/directives/filter.js
@@ -7,6 +7,12 @@ goog.require('ngeo.ruleComponent');
 goog.require('ngeo.RuleHelper');
 goog.require('ngeo.rule.Geometry');
 
+goog.require('ngeo.map.FeatureOverlay');
+
+
+// In futur module declaration, don't forget to require:
+// - ngeo.map.FeatureOverlay.module.name
+
 
 /**
  * @private
@@ -55,7 +61,7 @@ ngeo.FilterController = class {
     this.directedRules;
 
     /**
-     * @type {!ngeo.FeatureOverlay}
+     * @type {!ngeo.map.FeatureOverlay}
      * @export
      */
     this.featureOverlay;

--- a/src/directives/googlestreetview.js
+++ b/src/directives/googlestreetview.js
@@ -5,7 +5,12 @@ goog.require('ol.Feature');
 goog.require('ol.Observable');
 goog.require('ol.geom.Point');
 goog.require('ngeo');
-goog.require('ngeo.FeatureOverlayMgr');
+
+goog.require('ngeo.map.FeatureOverlayMgr');
+
+
+// In futur module declaration, don't forget to require:
+// - ngeo.map.FeatureOverlayMgr.module.name
 
 
 /**
@@ -16,7 +21,7 @@ ngeo.GooglestreetviewController = class {
   /**
    * @param {angular.JQLite} $element Element.
    * @param {!angular.Scope} $scope Scope.
-   * @param {!ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr Ngeo FeatureOverlay
+   * @param {!ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr Ngeo FeatureOverlay
    *     manager.
    * @private
    * @ngInject
@@ -77,7 +82,7 @@ ngeo.GooglestreetviewController = class {
     this.feature_ = new ol.Feature();
 
     /**
-     * @type {!ngeo.FeatureOverlay}
+     * @type {!ngeo.map.FeatureOverlay}
      * @private
      */
     this.featureOverlay_ = goog.asserts.assert(

--- a/src/directives/mobilegeolocation.js
+++ b/src/directives/mobilegeolocation.js
@@ -1,14 +1,18 @@
 goog.provide('ngeo.mobileGeolocationDirective');
 
 goog.require('ngeo');
-goog.require('ngeo.FeatureOverlay');
-goog.require('ngeo.FeatureOverlayMgr');
 goog.require('ngeo.Notification');
 goog.require('ol.events');
 goog.require('ol.Feature');
 goog.require('ol.Geolocation');
 goog.require('ol.Map');
 goog.require('ol.geom.Point');
+
+goog.require('ngeo.map.FeatureOverlayMgr');
+
+
+// In futur module declaration, don't forget to require:
+// - ngeo.map.FeatureOverlayMgr.module.name
 
 
 /**
@@ -62,7 +66,7 @@ ngeo.module.directive('ngeoMobileGeolocation', ngeo.mobileGeolocationDirective);
  * @param {angular.Scope} $scope The directive's scope.
  * @param {angular.JQLite} $element Element.
  * @param {angularGettext.Catalog} gettextCatalog Gettext service.
- * @param {ngeo.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
+ * @param {ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *     overlay manager service.
  * @param {ngeo.Notification} ngeoNotification Ngeo notification service.
  * @ngInject
@@ -99,7 +103,7 @@ ngeo.MobileGeolocationController = function($scope, $element,
   this.notification_ = ngeoNotification;
 
   /**
-   * @type {ngeo.FeatureOverlay}
+   * @type {ngeo.map.FeatureOverlay}
    * @private
    */
   this.featureOverlay_ = ngeoFeatureOverlayMgr.getFeatureOverlay();

--- a/src/directives/rule.js
+++ b/src/directives/rule.js
@@ -17,6 +17,12 @@ goog.require('ngeo.rule.Select');
 goog.require('ol.Collection');
 goog.require('ol.events');
 
+goog.require('ngeo.map.FeatureOverlay');
+
+
+// In futur module declaration, don't forget to require:
+// - ngeo.map.FeatureOverlay.module.name
+
 
 /**
  * @private
@@ -46,7 +52,7 @@ ngeo.RuleController = class {
     // Binding properties
 
     /**
-     * @type {!ngeo.FeatureOverlay}
+     * @type {!ngeo.map.FeatureOverlay}
      * @export
      */
     this.featureOverlay;

--- a/src/map/FeatureOverlay.js
+++ b/src/map/FeatureOverlay.js
@@ -1,31 +1,19 @@
-goog.provide('ngeo.FeatureOverlay');
+goog.provide('ngeo.map.FeatureOverlay');
 
 goog.require('ngeo');
 goog.require('ol');
 goog.require('ol.events');
-goog.require('ol.Collection');
-goog.require('ol.Feature');
-goog.require('ol.style.Style');
-
-
-/**
- * @typedef {{
- *  styleFunction: ol.StyleFunction,
- *  features: Object.<string, ol.Feature>
- * }}
- */
-ngeo.FeatureOverlayGroup;
 
 
 /**
  * @constructor
- * @param {ngeo.FeatureOverlayMgr} manager The feature overlay manager.
+ * @param {ngeo.map.FeatureOverlayMgr} manager The feature overlay manager.
  * @param {number} index This feature overlay's index.
  */
-ngeo.FeatureOverlay = function(manager, index) {
+ngeo.map.FeatureOverlay = function(manager, index) {
 
   /**
-   * @type {ngeo.FeatureOverlayMgr}
+   * @type {ngeo.map.FeatureOverlayMgr}
    * @private
    */
   this.manager_ = manager;
@@ -49,7 +37,7 @@ ngeo.FeatureOverlay = function(manager, index) {
  * @param {ol.Feature} feature The feature to add.
  * @export
  */
-ngeo.FeatureOverlay.prototype.addFeature = function(feature) {
+ngeo.map.FeatureOverlay.prototype.addFeature = function(feature) {
   this.manager_.addFeature(feature, this.index_);
 };
 
@@ -59,7 +47,7 @@ ngeo.FeatureOverlay.prototype.addFeature = function(feature) {
  * @param {ol.Feature} feature The feature to remove.
  * @export
  */
-ngeo.FeatureOverlay.prototype.removeFeature = function(feature) {
+ngeo.map.FeatureOverlay.prototype.removeFeature = function(feature) {
   this.manager_.removeFeature(feature, this.index_);
 };
 
@@ -68,7 +56,7 @@ ngeo.FeatureOverlay.prototype.removeFeature = function(feature) {
  * Remove all the features from the feature overlay.
  * @export
  */
-ngeo.FeatureOverlay.prototype.clear = function() {
+ngeo.map.FeatureOverlay.prototype.clear = function() {
   this.manager_.clear(this.index_);
 };
 
@@ -82,7 +70,7 @@ ngeo.FeatureOverlay.prototype.clear = function() {
  * @param {ol.Collection.<ol.Feature>} features Feature collection.
  * @export
  */
-ngeo.FeatureOverlay.prototype.setFeatures = function(features) {
+ngeo.map.FeatureOverlay.prototype.setFeatures = function(features) {
   if (this.features_ !== null) {
     this.features_.clear();
     ol.events.unlisten(this.features_, 'add', this.handleFeatureAdd_, this);
@@ -105,7 +93,7 @@ ngeo.FeatureOverlay.prototype.setFeatures = function(features) {
  * Style.
  * @export
  */
-ngeo.FeatureOverlay.prototype.setStyle = function(style) {
+ngeo.map.FeatureOverlay.prototype.setStyle = function(style) {
   this.manager_.setStyle(style, this.index_);
 };
 
@@ -114,7 +102,7 @@ ngeo.FeatureOverlay.prototype.setStyle = function(style) {
  * @param {ol.Collection.Event} evt Feature collection event.
  * @private
  */
-ngeo.FeatureOverlay.prototype.handleFeatureAdd_ = function(evt) {
+ngeo.map.FeatureOverlay.prototype.handleFeatureAdd_ = function(evt) {
   const feature = /** @type {ol.Feature} */ (evt.element);
   this.addFeature(feature);
 };
@@ -124,7 +112,13 @@ ngeo.FeatureOverlay.prototype.handleFeatureAdd_ = function(evt) {
  * @param {ol.Collection.Event} evt Feature collection event.
  * @private
  */
-ngeo.FeatureOverlay.prototype.handleFeatureRemove_ = function(evt) {
+ngeo.map.FeatureOverlay.prototype.handleFeatureRemove_ = function(evt) {
   const feature = /** @type {ol.Feature} */ (evt.element);
   this.removeFeature(feature);
 };
+
+/**
+ * @type {!angular.Module}
+ */
+ngeo.map.FeatureOverlay.module = angular.module('ngeoFeatureOverlay', []);
+ngeo.module.requires.push(ngeo.map.FeatureOverlay.module.name);

--- a/src/map/FeatureOverlayMgr.js
+++ b/src/map/FeatureOverlayMgr.js
@@ -1,15 +1,14 @@
-goog.provide('ngeo.FeatureOverlayMgr');
+goog.provide('ngeo.map.FeatureOverlayMgr');
 
 goog.require('ngeo');
-goog.require('ngeo.FeatureOverlay');
 goog.require('ol');
-goog.require('ol.Feature');
 goog.require('ol.layer.Vector');
 goog.require('ol.obj');
 goog.require('ol.source.Vector');
 goog.require('ol.style.Style');
 
 goog.require('goog.asserts');
+goog.require('ngeo.map.FeatureOverlay');
 
 
 /**
@@ -18,7 +17,7 @@ goog.require('goog.asserts');
  *  features: Object.<string, ol.Feature>
  * }}
  */
-ngeo.FeatureOverlayGroup;
+ngeo.map.FeatureOverlayGroup;
 
 
 /**
@@ -44,7 +43,7 @@ ngeo.FeatureOverlayGroup;
  * @ngdoc service
  * @ngname ngeoFeatureOverlayMgr
  */
-ngeo.FeatureOverlayMgr = function() {
+ngeo.map.FeatureOverlayMgr = function() {
 
   /**
    * @type {Object.<string, number>}
@@ -53,7 +52,7 @@ ngeo.FeatureOverlayMgr = function() {
   this.featureUidToGroupIndex_ = {};
 
   /**
-   * @type {Array.<ngeo.FeatureOverlayGroup>}
+   * @type {Array.<ngeo.map.FeatureOverlayGroup>}
    * @private
    */
   this.groups_ = [];
@@ -85,7 +84,7 @@ ngeo.FeatureOverlayMgr = function() {
  * @param {number} groupIndex The group groupIndex.
  * @export
  */
-ngeo.FeatureOverlayMgr.prototype.addFeature = function(feature, groupIndex) {
+ngeo.map.FeatureOverlayMgr.prototype.addFeature = function(feature, groupIndex) {
   goog.asserts.assert(groupIndex >= 0);
   goog.asserts.assert(groupIndex < this.groups_.length);
   const featureUid = ol.getUid(feature).toString();
@@ -100,7 +99,7 @@ ngeo.FeatureOverlayMgr.prototype.addFeature = function(feature, groupIndex) {
  * @param {number} groupIndex The group groupIndex.
  * @export
  */
-ngeo.FeatureOverlayMgr.prototype.removeFeature = function(feature, groupIndex) {
+ngeo.map.FeatureOverlayMgr.prototype.removeFeature = function(feature, groupIndex) {
   goog.asserts.assert(groupIndex >= 0);
   goog.asserts.assert(groupIndex < this.groups_.length);
   const featureUid = ol.getUid(feature).toString();
@@ -114,7 +113,7 @@ ngeo.FeatureOverlayMgr.prototype.removeFeature = function(feature, groupIndex) {
  * @param {number} groupIndex The group groupIndex.
  * @export
  */
-ngeo.FeatureOverlayMgr.prototype.clear = function(groupIndex) {
+ngeo.map.FeatureOverlayMgr.prototype.clear = function(groupIndex) {
   goog.asserts.assert(groupIndex >= 0);
   goog.asserts.assert(groupIndex < this.groups_.length);
   const group = this.groups_[groupIndex];
@@ -129,22 +128,22 @@ ngeo.FeatureOverlayMgr.prototype.clear = function(groupIndex) {
  * @return {ol.layer.Vector} The vector layer used internally.
  * @export
  */
-ngeo.FeatureOverlayMgr.prototype.getLayer = function() {
+ngeo.map.FeatureOverlayMgr.prototype.getLayer = function() {
   return this.layer_;
 };
 
 
 /**
- * @return {ngeo.FeatureOverlay} Feature overlay.
+ * @return {ngeo.map.FeatureOverlay} Feature overlay.
  * @export
  */
-ngeo.FeatureOverlayMgr.prototype.getFeatureOverlay = function() {
+ngeo.map.FeatureOverlayMgr.prototype.getFeatureOverlay = function() {
   const groupIndex = this.groups_.length;
   this.groups_.push({
     styleFunction: ol.style.Style.defaultFunction,
     features: {}
   });
-  return new ngeo.FeatureOverlay(this, groupIndex);
+  return new ngeo.map.FeatureOverlay(this, groupIndex);
 };
 
 
@@ -152,7 +151,7 @@ ngeo.FeatureOverlayMgr.prototype.getFeatureOverlay = function() {
  * @param {ol.Map} map Map.
  * @export
  */
-ngeo.FeatureOverlayMgr.prototype.init = function(map) {
+ngeo.map.FeatureOverlayMgr.prototype.init = function(map) {
   this.layer_.setMap(map);
 };
 
@@ -163,7 +162,7 @@ ngeo.FeatureOverlayMgr.prototype.init = function(map) {
  * @param {number} groupIndex Group index.
  * @export
  */
-ngeo.FeatureOverlayMgr.prototype.setStyle = function(style, groupIndex) {
+ngeo.map.FeatureOverlayMgr.prototype.setStyle = function(style, groupIndex) {
   goog.asserts.assert(groupIndex >= 0);
   goog.asserts.assert(groupIndex < this.groups_.length);
   this.groups_[groupIndex].styleFunction = style === null ?
@@ -177,7 +176,7 @@ ngeo.FeatureOverlayMgr.prototype.setStyle = function(style, groupIndex) {
  * @return {Array.<ol.style.Style>|ol.style.Style} Styles.
  * @private
  */
-ngeo.FeatureOverlayMgr.prototype.styleFunction_ = function(feature, resolution) {
+ngeo.map.FeatureOverlayMgr.prototype.styleFunction_ = function(feature, resolution) {
   const featureUid = ol.getUid(feature).toString();
   goog.asserts.assert(featureUid in this.featureUidToGroupIndex_);
   const groupIndex = this.featureUidToGroupIndex_[featureUid];
@@ -186,4 +185,11 @@ ngeo.FeatureOverlayMgr.prototype.styleFunction_ = function(feature, resolution) 
 };
 
 
-ngeo.module.service('ngeoFeatureOverlayMgr', ngeo.FeatureOverlayMgr);
+/**
+ * @type {!angular.Module}
+ */
+ngeo.map.FeatureOverlayMgr.module = angular.module('ngeoFeatureOverlayMgr', [
+  ngeo.map.FeatureOverlay.module.name
+]);
+ngeo.map.FeatureOverlayMgr.module.service('ngeoFeatureOverlayMgr', ngeo.map.FeatureOverlayMgr);
+ngeo.module.requires.push(ngeo.map.FeatureOverlayMgr.module.name);

--- a/src/map/FeatureOverlayMgr.js
+++ b/src/map/FeatureOverlayMgr.js
@@ -12,15 +12,6 @@ goog.require('ngeo.map.FeatureOverlay');
 
 
 /**
- * @typedef {{
- *  styleFunction: ol.StyleFunction,
- *  features: Object.<string, ol.Feature>
- * }}
- */
-ngeo.map.FeatureOverlayGroup;
-
-
-/**
  * Provides a service that wraps an "unmanaged" vector layer,
  * used as a shared vector layer across the application.
  *
@@ -52,7 +43,7 @@ ngeo.map.FeatureOverlayMgr = function() {
   this.featureUidToGroupIndex_ = {};
 
   /**
-   * @type {Array.<ngeo.map.FeatureOverlayGroup>}
+   * @type {Array.<ngeox.MapFeatureOverlayGroup>}
    * @private
    */
   this.groups_ = [];

--- a/src/map/LayerHelper.js
+++ b/src/map/LayerHelper.js
@@ -1,8 +1,7 @@
-goog.provide('ngeo.LayerHelper');
+goog.provide('ngeo.map.LayerHelper');
 
 goog.require('ngeo');
 goog.require('goog.asserts');
-goog.require('ol.Collection');
 goog.require('ol.array');
 goog.require('ol.format.WMTSCapabilities');
 goog.require('ol.layer.Group');
@@ -25,7 +24,7 @@ goog.require('ol.uri');
  * @ngname ngeoLayerHelper
  * @ngInject
  */
-ngeo.LayerHelper = function($q, $http) {
+ngeo.map.LayerHelper = function($q, $http) {
 
   /**
    * @type {angular.$q}
@@ -44,13 +43,13 @@ ngeo.LayerHelper = function($q, $http) {
 /**
  * @const
  */
-ngeo.LayerHelper.GROUP_KEY = 'groupName';
+ngeo.map.LayerHelper.GROUP_KEY = 'groupName';
 
 
 /**
  * @const
  */
-ngeo.LayerHelper.REFRESH_PARAM = 'random';
+ngeo.map.LayerHelper.REFRESH_PARAM = 'random';
 
 
 /**
@@ -68,7 +67,7 @@ ngeo.LayerHelper.REFRESH_PARAM = 'random';
  * @return {ol.layer.Image} WMS Layer.
  * @export
  */
-ngeo.LayerHelper.prototype.createBasicWMSLayer = function(sourceURL,
+ngeo.map.LayerHelper.prototype.createBasicWMSLayer = function(sourceURL,
   sourceLayersName, sourceFormat, opt_serverType, opt_time, opt_params, opt_crossOrigin) {
 
   const params = {
@@ -106,7 +105,7 @@ ngeo.LayerHelper.prototype.createBasicWMSLayer = function(sourceURL,
  * @return {ol.layer.Image} WMS Layer.
  * @export
  */
-ngeo.LayerHelper.prototype.createBasicWMSLayerFromDataSource = function(
+ngeo.map.LayerHelper.prototype.createBasicWMSLayerFromDataSource = function(
   dataSource, opt_crossOrigin
 ) {
   const url = dataSource.wmsUrl;
@@ -151,7 +150,7 @@ ngeo.LayerHelper.prototype.createBasicWMSLayerFromDataSource = function(
  *     no layer else.
  * @export
  */
-ngeo.LayerHelper.prototype.createWMTSLayerFromCapabilitites = function(capabilitiesURL, layerName, opt_dimensions) {
+ngeo.map.LayerHelper.prototype.createWMTSLayerFromCapabilitites = function(capabilitiesURL, layerName, opt_dimensions) {
   const parser = new ol.format.WMTSCapabilities();
   const layer = new ol.layer.Tile({
     preload: Infinity
@@ -197,7 +196,7 @@ ngeo.LayerHelper.prototype.createWMTSLayerFromCapabilitites = function(capabilit
  * @return {!ol.layer.Tile} WMTS layer
  * @export
  */
-ngeo.LayerHelper.prototype.createWMTSLayerFromCapabilititesObj = function(
+ngeo.map.LayerHelper.prototype.createWMTSLayerFromCapabilititesObj = function(
   capabilities, layerCap, opt_dimensions
 ) {
 
@@ -230,7 +229,7 @@ ngeo.LayerHelper.prototype.createWMTSLayerFromCapabilititesObj = function(
  * @return {ol.layer.Group} Layer group.
  * @export
  */
-ngeo.LayerHelper.prototype.createBasicGroup = function(opt_layers) {
+ngeo.map.LayerHelper.prototype.createBasicGroup = function(opt_layers) {
   const group = new ol.layer.Group();
   if (opt_layers) {
     group.setLayers(opt_layers);
@@ -249,11 +248,11 @@ ngeo.LayerHelper.prototype.createBasicGroup = function(opt_layers) {
  * @return {ol.layer.Group} The group corresponding to the given name.
  * @export
  */
-ngeo.LayerHelper.prototype.getGroupFromMap = function(map, groupName) {
+ngeo.map.LayerHelper.prototype.getGroupFromMap = function(map, groupName) {
   const groups = map.getLayerGroup().getLayers();
   let group;
   groups.getArray().some((existingGroup) => {
-    if (existingGroup.get(ngeo.LayerHelper.GROUP_KEY) === groupName) {
+    if (existingGroup.get(ngeo.map.LayerHelper.GROUP_KEY) === groupName) {
       group = /** @type {ol.layer.Group} */ (existingGroup);
       return true;
     } else {
@@ -262,7 +261,7 @@ ngeo.LayerHelper.prototype.getGroupFromMap = function(map, groupName) {
   });
   if (!group) {
     group = this.createBasicGroup();
-    group.set(ngeo.LayerHelper.GROUP_KEY, groupName);
+    group.set(ngeo.map.LayerHelper.GROUP_KEY, groupName);
     map.addLayer(group);
   }
   return group;
@@ -276,7 +275,7 @@ ngeo.LayerHelper.prototype.getGroupFromMap = function(map, groupName) {
  * @return {Array.<ol.layer.Layer>} Layers.
  * @export
  */
-ngeo.LayerHelper.prototype.getFlatLayers = function(layer) {
+ngeo.map.LayerHelper.prototype.getFlatLayers = function(layer) {
   return this.getFlatLayers_(layer, []);
 };
 
@@ -289,7 +288,7 @@ ngeo.LayerHelper.prototype.getFlatLayers = function(layer) {
  * @return {Array.<ol.layer.Layer>} Layers.
  * @private
  */
-ngeo.LayerHelper.prototype.getFlatLayers_ = function(layer, array) {
+ngeo.map.LayerHelper.prototype.getFlatLayers_ = function(layer, array) {
   if (layer instanceof ol.layer.Group) {
     const sublayers = layer.getLayers();
     sublayers.forEach(function(l) {
@@ -313,7 +312,7 @@ ngeo.LayerHelper.prototype.getFlatLayers_ = function(layer, array) {
  * @return {?ol.layer.Base} Layer.
  * @export
  */
-ngeo.LayerHelper.prototype.getLayerByName = function(layerName, layers) {
+ngeo.map.LayerHelper.prototype.getLayerByName = function(layerName, layers) {
   let found = null;
   layers.some(function(layer) {
     if (layer instanceof ol.layer.Group) {
@@ -336,7 +335,7 @@ ngeo.LayerHelper.prototype.getLayerByName = function(layerName, layers) {
  * @return {string|undefined} The legend URL or undefined.
  * @export
  */
-ngeo.LayerHelper.prototype.getWMTSLegendURL = function(layer) {
+ngeo.map.LayerHelper.prototype.getWMTSLegendURL = function(layer) {
   // FIXME case of multiple styles ?  case of multiple legendUrl ?
   let url;
   const styles = layer.get('capabilitiesStyles');
@@ -359,7 +358,7 @@ ngeo.LayerHelper.prototype.getWMTSLegendURL = function(layer) {
  * @return {string|undefined} The legend URL or undefined.
  * @export
  */
-ngeo.LayerHelper.prototype.getWMSLegendURL = function(url,
+ngeo.map.LayerHelper.prototype.getWMSLegendURL = function(url,
   layerName, opt_scale, opt_legendRule) {
   if (!url) {
     return undefined;
@@ -388,7 +387,7 @@ ngeo.LayerHelper.prototype.getWMSLegendURL = function(url,
  * @param {ol.Map} map Map.
  * @return {boolean} Is the layer currently visible?
  */
-ngeo.LayerHelper.prototype.isLayerVisible = function(layer, map) {
+ngeo.map.LayerHelper.prototype.isLayerVisible = function(layer, map) {
   if (!layer.getVisible()) {
     return false;
   }
@@ -403,7 +402,7 @@ ngeo.LayerHelper.prototype.isLayerVisible = function(layer, map) {
  * Force a WMS layer to refresh using a random value.
  * @param {ol.layer.Image|ol.layer.Tile} layer Layer to refresh.
  */
-ngeo.LayerHelper.prototype.refreshWMSLayer = function(layer) {
+ngeo.map.LayerHelper.prototype.refreshWMSLayer = function(layer) {
   const source_ = layer.getSource();
   goog.asserts.assert(
     source_ instanceof ol.source.ImageWMS ||
@@ -411,7 +410,7 @@ ngeo.LayerHelper.prototype.refreshWMSLayer = function(layer) {
   );
   const source = /** @type {ol.source.ImageWMS|ol.source.TileWMS} */ (source_);
   const params = source.getParams();
-  params[ngeo.LayerHelper.REFRESH_PARAM] = Math.random();
+  params[ngeo.map.LayerHelper.REFRESH_PARAM] = Math.random();
   source.updateParams(params);
 };
 
@@ -426,7 +425,7 @@ ngeo.LayerHelper.prototype.refreshWMSLayer = function(layer) {
  * in a ISO-8601 string datetime or time interval format
  * @export
  */
-ngeo.LayerHelper.prototype.updateWMSLayerState = function(layer, names, opt_time) {
+ngeo.map.LayerHelper.prototype.updateWMSLayerState = function(layer, names, opt_time) {
   // Don't send layer without parameters, hide layer instead;
   if (names.length <= 0) {
     layer.setVisible(false);
@@ -448,10 +447,15 @@ ngeo.LayerHelper.prototype.updateWMSLayerState = function(layer, names, opt_time
  *     the data source ids this layer is composed of.
  * @export
  */
-ngeo.LayerHelper.prototype.getQuerySourceIds = function(layer) {
+ngeo.map.LayerHelper.prototype.getQuerySourceIds = function(layer) {
   return /** @type {Array.<number>|undefined} */ (
     layer.get('querySourceIds'));
 };
 
 
-ngeo.module.service('ngeoLayerHelper', ngeo.LayerHelper);
+/**
+ * @type {!angular.Module}
+ */
+ngeo.map.LayerHelper.module = angular.module('ngeoLayerHelper', []);
+ngeo.map.LayerHelper.module.service('ngeoLayerHelper', ngeo.map.LayerHelper);
+ngeo.module.requires.push(ngeo.map.LayerHelper.module.name);

--- a/src/map/module.js
+++ b/src/map/module.js
@@ -6,13 +6,15 @@ goog.provide('ngeo.map.module');
 goog.require('ngeo');
 goog.require('ngeo.map.BackgroundLayerMgr');
 goog.require('ngeo.map.directive');
+goog.require('ngeo.map.FeatureOverlayMgr');
 goog.require('ngeo.map.recenter');
 goog.require('ngeo.map.resizemap');
 goog.require('ngeo.map.scaleselector');
 
 /**
- * Also related to the map but not included in the module (require it manually):
- *   - ngeo.map.LayerHelper
+ * Also related to the map but not included in the module:
+ *  - ngeo.map.LayerHelper (require it manually)
+ *  - ngeo.map.FeatureOverlay (already required by ngeo.map.FeatureOverlayMgr)
  *
  * @type {!angular.Module}
  */
@@ -20,6 +22,7 @@ ngeo.map.module = angular.module('ngeoMapModule', [
   ngeo.module.name, // Change me when all dependencies are in a module.
   ngeo.map.BackgroundLayerMgr.module.name,
   ngeo.map.directive.name,
+  ngeo.map.FeatureOverlayMgr.module.name,
   ngeo.map.recenter.name,
   ngeo.map.resizemap.name,
   ngeo.map.scaleselector.name

--- a/src/map/module.js
+++ b/src/map/module.js
@@ -11,6 +11,9 @@ goog.require('ngeo.map.resizemap');
 goog.require('ngeo.map.scaleselector');
 
 /**
+ * Also related to the map but not included in the module (require it manually):
+ *   - ngeo.map.LayerHelper
+ *
  * @type {!angular.Module}
  */
 ngeo.map.module = angular.module('ngeoMapModule', [

--- a/src/services/print.js
+++ b/src/services/print.js
@@ -2,7 +2,7 @@ goog.provide('ngeo.Print');
 
 
 goog.require('ngeo');
-goog.require('ngeo.LayerHelper');
+goog.require('ngeo.map.LayerHelper');
 goog.require('ngeo.utils');
 goog.require('ol.color');
 goog.require('ol.format.GeoJSON');
@@ -96,7 +96,7 @@ ngeo.PrintStyleTypes_ = {
  * @struct
  * @param {string} url URL to MapFish print web service.
  * @param {angular.$http} $http Angular $http service.
- * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper service.
+ * @param {ngeo.map.LayerHelper} ngeoLayerHelper Ngeo Layer Helper service.
  */
 ngeo.Print = function(url, $http, ngeoLayerHelper) {
   /**
@@ -112,7 +112,7 @@ ngeo.Print = function(url, $http, ngeoLayerHelper) {
   this.$http_ = $http;
 
   /**
-   * @type {ngeo.LayerHelper}
+   * @type {ngeo.map.LayerHelper}
    * @private
    */
   this.ngeoLayerHelper_ = ngeoLayerHelper;
@@ -898,7 +898,7 @@ ngeo.Print.prototype.getCapabilities = function(opt_httpConfig) {
 
 /**
  * @param {angular.$http} $http Angular $http service.
- * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
+ * @param {ngeo.map.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
  * @return {ngeo.CreatePrint} The function to create a print service.
  * @ngInject
  * @ngdoc service

--- a/src/services/query.js
+++ b/src/services/query.js
@@ -3,7 +3,7 @@
 goog.provide('ngeo.Query');
 
 goog.require('ngeo');
-goog.require('ngeo.LayerHelper');
+goog.require('ngeo.map.LayerHelper');
 goog.require('ol.format.WFS');
 goog.require('ol.format.WMSGetFeatureInfo');
 goog.require('ol.obj');
@@ -65,7 +65,7 @@ ngeo.QueryableSources;
  * @param {ngeox.QueryResult} ngeoQueryResult The ngeo query result service.
  * @param {ngeox.QueryOptions|undefined} ngeoQueryOptions The options to
  *     configure the ngeo query service with.
- * @param {ngeo.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
+ * @param {ngeo.map.LayerHelper} ngeoLayerHelper Ngeo Layer Helper.
  * @ngdoc service
  * @ngname ngeoQuery
  * @ngInject
@@ -130,7 +130,7 @@ ngeo.Query = function($http, $q, ngeoQueryResult, ngeoQueryOptions,
     options.geometryName : 'geom';
 
   /**
-   * @type {ngeo.LayerHelper}
+   * @type {ngeo.map.LayerHelper}
    * @private
    */
   this.ngeoLayerHelper_ = ngeoLayerHelper;

--- a/test/spec/services/featureoverlay.spec.js
+++ b/test/spec/services/featureoverlay.spec.js
@@ -1,6 +1,6 @@
-goog.require('ngeo.FeatureOverlayMgr');
+goog.require('ngeo.map.FeatureOverlayMgr');
 
-describe('ngeo.FeatureOverlayMgr', () => {
+describe('ngeo.map.FeatureOverlayMgr', () => {
   let ngeoFeatureOverlayMgr;
   let map;
   let layer;

--- a/test/spec/services/layerHelper.spec.js
+++ b/test/spec/services/layerHelper.spec.js
@@ -1,8 +1,8 @@
 /* global wmtsCapabilities */
-goog.require('ngeo.LayerHelper');
+goog.require('ngeo.map.LayerHelper');
 goog.require('ngeo.test.data.wmtsCapabilities');
 
-describe('ngeo.LayerHelper', () => {
+describe('ngeo.map.LayerHelper', () => {
   let ngeoLayerHelper;
   let layer;
   const wmtsSrc = 'http://fake/wmts/capabilities.xml';


### PR DESCRIPTION
For https://jira.camptocamp.com/browse/GSGMF-183

Lasts module to move to the ngeo Map module:
 - Service ngeo LayerHelper (as extra of the module)
 - Service ngeo FeatureOverlayMgr
 - Object ngeo FeatureOverlay 

@gberaudo I'll like to have confirmation on some things I choose to do about module requirements:
 1.  ngeo.map.FeatureOverlay not in the ngeo.map.module , cause it's already in required by the FeatureOverlayMgr. Work but that's not like the gmf.search.Fulltextsearch service that is also put in the module).
 1.  Requirement of ngeo.map.FeatureOverlayMgr in gmf directive that use this service. I think that's right, but I can also require the whole ngeo.map.module

And the test doesn't pass. I need help to fix them

With this PR, we will have a whole top-level module :smiley: 