### PR TITLE
Document usage of old buildtools scripts

### DIFF
--- a/buildtools/build.js
+++ b/buildtools/build.js
@@ -1,4 +1,8 @@
 "use strict";
+
+// This file and related ones should be kept for projects that based their build chain
+// on the one from ngeo.
+
 /**
  * This task builds OpenLayers with the Closure Compiler.
  */


### PR DESCRIPTION
Document we are going to keep the old buildtools scripts for projects that depended on it. This may be temporary though, and these files finally cleaned out.