### PR TITLE
Fix UI overlapping on iOS 10 (Safari)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -636,7 +636,7 @@ node_modules/angular/angular.min.js: .build/node_modules.timestamp
 		-e '/\/node_modules\//d' \
 		-e '/\/third-party\//d' \
 		-e '/default\.js/d' \
-		-e '|utils/ios-overlap-fix\.js|d' \
+		-e 'utils/ios-overlap-fix\.js/d' \
 		-e "s/var cacheVersion = '0';/var cacheVersion = '`git rev-parse HEAD`';/g" \
 		-e 's|utils/watchwatchers\.js|lib/watchwatchers.js|' \
 		-e 's|/@?main=$*/js/controller\.js|../../build/$*.js|' $< > $@

--- a/Makefile
+++ b/Makefile
@@ -636,7 +636,7 @@ node_modules/angular/angular.min.js: .build/node_modules.timestamp
 		-e '/\/node_modules\//d' \
 		-e '/\/third-party\//d' \
 		-e '/default\.js/d' \
-		-e 'utils/ios-overlap-fix\.js/d' \
+		-e '/utils\/ios-overlap-fix\.js/d' \
 		-e "s/var cacheVersion = '0';/var cacheVersion = '`git rev-parse HEAD`';/g" \
 		-e 's|utils/watchwatchers\.js|lib/watchwatchers.js|' \
 		-e 's|/@?main=$*/js/controller\.js|../../build/$*.js|' $< > $@

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ GMF_APPS_LIBS_JS_FILES += \
 	node_modules/url-polyfill/url-polyfill.js \
 	third-party/jquery-ui/jquery-ui.js \
 	node_modules/jquery-ui-touch-punch/jquery.ui.touch-punch.min.js \
-	node_modules/google-closure-library/closure/goog/transpile.js
+	node_modules/google-closure-library/closure/goog/transpile.js \
+	utils/ios-overlap-fix.js
 else
 GMF_APPS_LIBS_JS_FILES += \
 	examples/https.js \
@@ -73,7 +74,8 @@ GMF_APPS_LIBS_JS_FILES += \
 	node_modules/moment/min/moment.min.js \
 	node_modules/url-polyfill/url-polyfill.min.js \
 	third-party/jquery-ui/jquery-ui.min.js \
-	node_modules/jquery-ui-touch-punch/jquery.ui.touch-punch.min.js
+	node_modules/jquery-ui-touch-punch/jquery.ui.touch-punch.min.js \
+	utils/ios-overlap-fix.js
 endif
 
 BUILD_EXAMPLES_CHECK_TIMESTAMP_FILES := $(patsubst examples/%.html,.build/%.check.timestamp,$(EXAMPLES_HTML_FILES)) \
@@ -464,6 +466,10 @@ dist/gmf.js.map: dist/gmf.js
 	mkdir -p $(dir $@)
 	cp $< $@
 
+.build/examples-hosted/lib/ios-overlap-fix.js: utils/ios-overlap-fix.js
+	mkdir -p $(dir $@)
+	cp $< $@
+
 .build/examples-hosted/lib/typeahead.bundle.min.js: node_modules/corejs-typeahead/dist/typeahead.bundle.min.js
 	mkdir -p $(dir $@)
 	cp $< $@
@@ -619,6 +625,7 @@ node_modules/angular/angular.min.js: .build/node_modules.timestamp
 		.build/examples-hosted/contribs/gmf/build/%.js \
 		.build/examples-hosted/contribs/gmf/build/%.css \
 		.build/examples-hosted/lib/watchwatchers.js \
+		.build/examples-hosted/lib/ios-overlap-fix.js \
 		$(addprefix .build/examples-hosted/contribs/gmf/build/gmf-, $(addsuffix .json, $(LANGUAGES))) \
 		$(addprefix .build/examples-hosted/contribs/gmf/build/angular-locale_, $(addsuffix .js, $(LANGUAGES))) \
 		$(addprefix .build/examples-hosted/contribs/gmf/fonts/fontawesome-webfont., eot ttf woff woff2) \

--- a/Makefile
+++ b/Makefile
@@ -636,6 +636,7 @@ node_modules/angular/angular.min.js: .build/node_modules.timestamp
 		-e '/\/node_modules\//d' \
 		-e '/\/third-party\//d' \
 		-e '/default\.js/d' \
+		-e '|utils/ios-overlap-fix\.js|d' \
 		-e "s/var cacheVersion = '0';/var cacheVersion = '`git rev-parse HEAD`';/g" \
 		-e 's|utils/watchwatchers\.js|lib/watchwatchers.js|' \
 		-e 's|/@?main=$*/js/controller\.js|../../build/$*.js|' $< > $@

--- a/contribs/gmf/apps/ios-overlap-fix.js
+++ b/contribs/gmf/apps/ios-overlap-fix.js
@@ -1,0 +1,29 @@
+      // Hack for ios Safari browser (UI overlapping on iOS 10)
+      var userAgent = window.navigator.userAgent;
+      var regEx = /iP(hone|od|ad)/;
+      var iOS = regEx.test(userAgent);
+      var webkit = /WebKit/i.test(userAgent);
+      var criOS = /CriOS/i.test(userAgent);
+      var platform = regEx.test(window.navigator.platform);
+
+      if(iOS && webkit && platform && !criOS && !window.MSStream) {
+        function iosChecker() {
+          var v = (window.navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
+          return [parseInt(v[1], 10), parseInt(v  [2], 10), parseInt(v[3] || 0, 10)];
+        }
+
+        var iosVersion = iosChecker()[0];
+        if (iosVersion >= 10) {
+          var interval = setInterval(function () {
+            if($('div.ol-zoom').get(0)) {
+              clearInterval(interval);
+              $('button.gmf-mobile-nav-left-trigger').addClass('ios-margin-top');
+              $('button.gmf-mobile-nav-right-trigger').addClass('ios-margin-top');
+              $('gmf-search').addClass('ios-margin-top');
+              $('div.ol-zoom').addClass('ios-zoom-btn');
+              $('div.ol-rotate').addClass('ios-rotate-btn');
+              $('button[ngeo-mobile-geolocation]').addClass('ios-geolocation-btn');
+            }
+          }, 100);
+        }
+      }

--- a/contribs/gmf/apps/ios-overlap-fix.js
+++ b/contribs/gmf/apps/ios-overlap-fix.js
@@ -1,29 +1,36 @@
-      // Hack for ios Safari browser (UI overlapping on iOS 10)
-      var userAgent = window.navigator.userAgent;
-      var regEx = /iP(hone|od|ad)/;
-      var iOS = regEx.test(userAgent);
-      var webkit = /WebKit/i.test(userAgent);
-      var criOS = /CriOS/i.test(userAgent);
-      var platform = regEx.test(window.navigator.platform);
+// Hack for ios Safari browser (UI overlapping on iOS 10)
+const userAgent = window.navigator.userAgent;
+const regEx = /iP(hone|od|ad)/;
+const iOS = regEx.test(userAgent);
+const webkit = /WebKit/i.test(userAgent);
+const chromeiOS = /(Chrome|CriOS|OPiOS)/i.test(userAgent);
+const platform = regEx.test(window.navigator.platform);
 
-      if(iOS && webkit && platform && !criOS && !window.MSStream) {
-        function iosChecker() {
-          var v = (window.navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
-          return [parseInt(v[1], 10), parseInt(v  [2], 10), parseInt(v[3] || 0, 10)];
-        }
+const iosChecker = function() {
+  const v = (window.navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
+  return [parseInt(v[1], 10), parseInt(v  [2], 10), parseInt(v[3] || 0, 10)];
+};
 
-        var iosVersion = iosChecker()[0];
-        if (iosVersion >= 10) {
-          var interval = setInterval(function () {
-            if($('div.ol-zoom').get(0)) {
-              clearInterval(interval);
-              $('button.gmf-mobile-nav-left-trigger').addClass('ios-margin-top');
-              $('button.gmf-mobile-nav-right-trigger').addClass('ios-margin-top');
-              $('gmf-search').addClass('ios-margin-top');
-              $('div.ol-zoom').addClass('ios-zoom-btn');
-              $('div.ol-rotate').addClass('ios-rotate-btn');
-              $('button[ngeo-mobile-geolocation]').addClass('ios-geolocation-btn');
-            }
-          }, 100);
-        }
+/**
+* iOS is true on iOS or emulators (user-agent)
+* webkit is true on Safari/Chrome, etc
+* platform is true on iOS, not emulator (platform)
+* chromeiOS is true on other browsers (chrome/opera)
+* MSStream is true on IE
+*/
+if (iOS && webkit && platform && !chromeiOS && !window.MSStream) {
+  const iosVersion = iosChecker()[0];
+  if (iosVersion >= 10) {
+    const interval = setInterval(() => {
+      if ($('div.ol-zoom').get(0)) {
+        clearInterval(interval);
+        $('button.gmf-mobile-nav-left-trigger').addClass('ios-margin-top');
+        $('button.gmf-mobile-nav-right-trigger').addClass('ios-margin-top');
+        $('gmf-search').addClass('ios-margin-top');
+        $('div.ol-zoom').addClass('ios-zoom-btn');
+        $('div.ol-rotate').addClass('ios-rotate-btn');
+        $('button[ngeo-mobile-geolocation]').addClass('ios-geolocation-btn');
       }
+    }, 100);
+  }
+}

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -190,7 +190,7 @@
     <script src="../../../../node_modules/url-polyfill/url-polyfill.js"></script>
     <script src="/@?main=mobile/js/controller.js"></script>
     <script src="../default.js"></script>
-    <script src="../ios-overlap-fix.js"></script>
+    <script src="../../../../utils/ios-overlap-fix.js"></script>
     <script src="../../../../utils/watchwatchers.js"></script>
     <script>
       (function() {

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -194,15 +194,16 @@
     <script>
       // Hack for ios Safari browser (UI overlapping on iOS 10)
       var userAgent = window.navigator.userAgent;
-      var iOS = !!userAgent.match(/iP(hone|od|ad)/i);
-      var webkit = !!userAgent.match(/WebKit/i);
+      var regEx = /iP(hone|od|ad)/;
+      var iOS = regEx.test(userAgent);
+      var webkit = /WebKit/i.test(userAgent);
+      var criOS = /CriOS/i.test(userAgent);
+      var platform = regEx.test(window.navigator.platform);
 
-      if(iOS && webkit && !userAgent.match(/CriOS/i)) {
+      if(iOS && webkit && platform && !criOS && !window.MSStream) {
         function iosChecker() {
-          if (/iP(hone|od|ad)/.test(window.navigator.platform)) {
-            var v = (window.navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
-            return [parseInt(v[1], 10), parseInt(v  [2], 10), parseInt(v[3] || 0, 10)];
-          }
+          var v = (window.navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
+          return [parseInt(v[1], 10), parseInt(v  [2], 10), parseInt(v[3] || 0, 10)];
         }
 
         var iosVersion = iosChecker()[0];

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -192,8 +192,12 @@
     <script src="../default.js"></script>
     <script src="../../../../utils/watchwatchers.js"></script>
     <script>
-      // Hack for ios Safari browser (UI overlapping on iOS 11)
-      if(window.navigator.userAgent.match(/iP(hone|od|ad)/i)) {
+      // Hack for ios Safari browser (UI overlapping on iOS 10)
+      var userAgent = window.navigator.userAgent;
+      var iOS = !!userAgent.match(/iP(hone|od|ad)/i);
+      var webkit = !!userAgent.match(/WebKit/i);
+
+      if(iOS && webkit && !userAgent.match(/CriOS/i)) {
         function iosChecker() {
           if (/iP(hone|od|ad)/.test(window.navigator.platform)) {
             var v = (window.navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
@@ -202,11 +206,7 @@
         }
 
         var iosVersion = iosChecker()[0];
-        var userAgent = window.navigator.userAgent;
-        var webkit = !!userAgent.match(/WebKit/i);
-        var ios11Safari = webkit && !userAgent.match(/CriOS/i) && iosVersion >= 11;
-
-        if (ios11Safari) {
+        if (iosVersion >= 10) {
           var interval = setInterval(function () {
             if($('div.ol-zoom').get(0)) {
               clearInterval(interval);

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -192,24 +192,35 @@
     <script src="../default.js"></script>
     <script src="../../../../utils/watchwatchers.js"></script>
     <script>
-      (function() {
-        var cacheVersion = '0';
-        var urlElements = window.location.pathname.split('/');
+      // Hack for ios Safari browser (UI overlapping on iOS 11)
+      let userAgent = navigator.userAgent || navigator.vendor || window.opera;
+      let isIos = /iPad|iPhone|iPod/.test(userAgent) && !window.MSStream;
 
-        var angularLocaleScriptUrlElements = urlElements.slice(0, urlElements.length - 3);
+      if (isIos) {
+        $('button.gmf-mobile-nav-left-trigger').addClass('ios-margin-top');
+        $('button.gmf-mobile-nav-right-trigger').addClass('ios-margin-top');
+        $('gmf-search').addClass('ios-margin-top');
+      }
+    </script>
+    <script>
+      (function() {
+        let cacheVersion = '0';
+        let urlElements = window.location.pathname.split('/');
+
+        let angularLocaleScriptUrlElements = urlElements.slice(0, urlElements.length - 3);
         angularLocaleScriptUrlElements.push('build', 'angular-locale_{{locale}}.js?cache_version=' + cacheVersion);
 
-        var gmfModule = angular.module('gmf');
+        let gmfModule = angular.module('gmf');
         gmfModule.constant('angularLocaleScript', angularLocaleScriptUrlElements.join('/'));
 
-        var langUrls = {};
+        let langUrls = {};
         ['en', 'fr', 'de'].forEach(function(lang) {
-            var langUrlElements = urlElements.slice(0, urlElements.length - 3);
-            langUrlElements.push('build', 'gmf-' + lang + '.json?cache_version=' + cacheVersion)
-            langUrls[lang] = langUrlElements.join('/')
+          let langUrlElements = urlElements.slice(0, urlElements.length - 3);
+          langUrlElements.push('build', 'gmf-' + lang + '.json?cache_version=' + cacheVersion)
+          langUrls[lang] = langUrlElements.join('/')
         });
 
-        var module = angular.module('app');
+        let module = angular.module('app');
         module.constant('defaultTheme', 'Demo');
         module.constant('defaultLang', 'en');
         module.constant('langUrls', langUrls);

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -193,10 +193,12 @@
     <script src="../../../../utils/watchwatchers.js"></script>
     <script>
       // Hack for ios Safari browser (UI overlapping on iOS 11)
-      let userAgent = navigator.userAgent || navigator.vendor || window.opera;
-      let isIos = /iPad|iPhone|iPod/.test(userAgent) && !window.MSStream;
+      let userAgent = window.navigator.userAgent;
+      let iOS = !!userAgent.match(/iP(ad|hone)/i);
+      let webkit = !!userAgent.match(/WebKit/i);
+      let iOSSafari = iOS && webkit && !userAgent.match(/CriOS/i);
 
-      if (isIos) {
+      if (iOSSafari) {
         $('button.gmf-mobile-nav-left-trigger').addClass('ios-margin-top');
         $('button.gmf-mobile-nav-right-trigger').addClass('ios-margin-top');
         $('gmf-search').addClass('ios-margin-top');

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -193,10 +193,10 @@
     <script src="../../../../utils/watchwatchers.js"></script>
     <script>
       // Hack for ios Safari browser (UI overlapping on iOS 11)
-      let userAgent = window.navigator.userAgent;
-      let iOS = !!userAgent.match(/iP(ad|hone)/i);
-      let webkit = !!userAgent.match(/WebKit/i);
-      let iOSSafari = iOS && webkit && !userAgent.match(/CriOS/i);
+      var userAgent = window.navigator.userAgent;
+      var iOS = !!userAgent.match(/iP(ad|hone)/i);
+      var webkit = !!userAgent.match(/WebKit/i);
+      var iOSSafari = iOS && webkit && !userAgent.match(/CriOS/i);
 
       if (iOSSafari) {
         $('button.gmf-mobile-nav-left-trigger').addClass('ios-margin-top');
@@ -206,23 +206,23 @@
     </script>
     <script>
       (function() {
-        let cacheVersion = '0';
-        let urlElements = window.location.pathname.split('/');
+        var cacheVersion = '0';
+        var urlElements = window.location.pathname.split('/');
 
-        let angularLocaleScriptUrlElements = urlElements.slice(0, urlElements.length - 3);
+        var angularLocaleScriptUrlElements = urlElements.slice(0, urlElements.length - 3);
         angularLocaleScriptUrlElements.push('build', 'angular-locale_{{locale}}.js?cache_version=' + cacheVersion);
 
-        let gmfModule = angular.module('gmf');
+        var gmfModule = angular.module('gmf');
         gmfModule.constant('angularLocaleScript', angularLocaleScriptUrlElements.join('/'));
 
-        let langUrls = {};
+        var langUrls = {};
         ['en', 'fr', 'de'].forEach(function(lang) {
-          let langUrlElements = urlElements.slice(0, urlElements.length - 3);
+          var langUrlElements = urlElements.slice(0, urlElements.length - 3);
           langUrlElements.push('build', 'gmf-' + lang + '.json?cache_version=' + cacheVersion)
           langUrls[lang] = langUrlElements.join('/')
         });
 
-        let module = angular.module('app');
+        var module = angular.module('app');
         module.constant('defaultTheme', 'Demo');
         module.constant('defaultLang', 'en');
         module.constant('langUrls', langUrls);

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -190,38 +190,8 @@
     <script src="../../../../node_modules/url-polyfill/url-polyfill.js"></script>
     <script src="/@?main=mobile/js/controller.js"></script>
     <script src="../default.js"></script>
+    <script src="../ios-overlap-fix.js"></script>
     <script src="../../../../utils/watchwatchers.js"></script>
-    <script>
-      // Hack for ios Safari browser (UI overlapping on iOS 10)
-      var userAgent = window.navigator.userAgent;
-      var regEx = /iP(hone|od|ad)/;
-      var iOS = regEx.test(userAgent);
-      var webkit = /WebKit/i.test(userAgent);
-      var criOS = /CriOS/i.test(userAgent);
-      var platform = regEx.test(window.navigator.platform);
-
-      if(iOS && webkit && platform && !criOS && !window.MSStream) {
-        function iosChecker() {
-          var v = (window.navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
-          return [parseInt(v[1], 10), parseInt(v  [2], 10), parseInt(v[3] || 0, 10)];
-        }
-
-        var iosVersion = iosChecker()[0];
-        if (iosVersion >= 10) {
-          var interval = setInterval(function () {
-            if($('div.ol-zoom').get(0)) {
-              clearInterval(interval);
-              $('button.gmf-mobile-nav-left-trigger').addClass('ios-margin-top');
-              $('button.gmf-mobile-nav-right-trigger').addClass('ios-margin-top');
-              $('gmf-search').addClass('ios-margin-top');
-              $('div.ol-zoom').addClass('ios-zoom-btn');
-              $('div.ol-rotate').addClass('ios-rotate-btn');
-              $('button[ngeo-mobile-geolocation]').addClass('ios-geolocation-btn');
-            }
-          }, 100);
-        }
-      }
-    </script>
     <script>
       (function() {
         var cacheVersion = '0';

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -193,15 +193,32 @@
     <script src="../../../../utils/watchwatchers.js"></script>
     <script>
       // Hack for ios Safari browser (UI overlapping on iOS 11)
-      var userAgent = window.navigator.userAgent;
-      var iOS = !!userAgent.match(/iP(ad|hone)/i);
-      var webkit = !!userAgent.match(/WebKit/i);
-      var iOSSafari = iOS && webkit && !userAgent.match(/CriOS/i);
+      if(window.navigator.userAgent.match(/iP(hone|od|ad)/i)) {
+        function iosChecker() {
+          if (/iP(hone|od|ad)/.test(window.navigator.platform)) {
+            var v = (window.navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
+            return [parseInt(v[1], 10), parseInt(v  [2], 10), parseInt(v[3] || 0, 10)];
+          }
+        }
 
-      if (iOSSafari) {
-        $('button.gmf-mobile-nav-left-trigger').addClass('ios-margin-top');
-        $('button.gmf-mobile-nav-right-trigger').addClass('ios-margin-top');
-        $('gmf-search').addClass('ios-margin-top');
+        var iosVersion = iosChecker()[0];
+        var userAgent = window.navigator.userAgent;
+        var webkit = !!userAgent.match(/WebKit/i);
+        var ios11Safari = webkit && !userAgent.match(/CriOS/i) && iosVersion >= 11;
+
+        if (ios11Safari) {
+          var interval = setInterval(function () {
+            if($('div.ol-zoom').get(0)) {
+              clearInterval(interval);
+              $('button.gmf-mobile-nav-left-trigger').addClass('ios-margin-top');
+              $('button.gmf-mobile-nav-right-trigger').addClass('ios-margin-top');
+              $('gmf-search').addClass('ios-margin-top');
+              $('div.ol-zoom').addClass('ios-zoom-btn');
+              $('div.ol-rotate').addClass('ios-rotate-btn');
+              $('button[ngeo-mobile-geolocation]').addClass('ios-geolocation-btn');
+            }
+          }, 100);
+        }
       }
     </script>
     <script>

--- a/contribs/gmf/apps/mobile_alt/index.html
+++ b/contribs/gmf/apps/mobile_alt/index.html
@@ -190,6 +190,7 @@
     <script src="../../../../node_modules/url-polyfill/url-polyfill.js"></script>
     <script src="/@?main=mobile_alt/js/controller.js"></script>
     <script src="../default.js"></script>
+    <script src="../ios-overlap-fix.js"></script>
     <script src="../../../../utils/watchwatchers.js"></script>
     <script>
       (function() {

--- a/contribs/gmf/apps/mobile_alt/index.html
+++ b/contribs/gmf/apps/mobile_alt/index.html
@@ -190,7 +190,7 @@
     <script src="../../../../node_modules/url-polyfill/url-polyfill.js"></script>
     <script src="/@?main=mobile_alt/js/controller.js"></script>
     <script src="../default.js"></script>
-    <script src="../ios-overlap-fix.js"></script>
+    <script src="../../../../utils/ios-overlap-fix.js"></script>
     <script src="../../../../utils/watchwatchers.js"></script>
     <script>
       (function() {

--- a/contribs/gmf/less/iphone.less
+++ b/contribs/gmf/less/iphone.less
@@ -1,0 +1,6 @@
+// Hack for ios Safari browser (UI overlapping on iOS 11)
+@media all and (orientation: portrait) {
+  .ios-margin-top {
+    margin-top: 5rem;
+  }
+}

--- a/contribs/gmf/less/iphone.less
+++ b/contribs/gmf/less/iphone.less
@@ -1,6 +1,20 @@
 // Hack for ios Safari browser (UI overlapping on iOS 11)
 @media all and (orientation: landscape) {
+  @ios-margin: 5rem;
+
   .ios-margin-top {
-    margin-top: 4rem;
+    margin-top: @ios-margin;
+  }
+
+  .ios-zoom-btn {
+    top: (@app-margin + @map-tools-size + @app-margin) + @ios-margin !important;
+  }
+
+  .ios-rotate-btn {
+    top: (4 * @map-tools-size + 2 * @app-margin + 3 * @micro-app-margin) + @ios-margin !important;
+  }
+
+  .ios-geolocation-btn {
+    top: (3 * @map-tools-size + 2 * @app-margin + 2 * @micro-app-margin) + @ios-margin !important;
   }
 }

--- a/contribs/gmf/less/iphone.less
+++ b/contribs/gmf/less/iphone.less
@@ -2,19 +2,23 @@
 @media all and (orientation: landscape) {
   @ios-margin: 5rem;
 
-  .ios-margin-top {
-    margin-top: @ios-margin;
-  }
+  body.ios-margin {
+    button.gmf-mobile-nav-left-trigger,
+    button.gmf-mobile-nav-right-trigger,
+    gmf-search {
+      margin-top: @ios-margin;
+    }
 
-  .ios-zoom-btn {
-    top: (@app-margin + @map-tools-size + @app-margin) + @ios-margin !important;
-  }
+    div.ol-zoom {
+      top: (@app-margin + @map-tools-size + @app-margin) + @ios-margin;
+    }
 
-  .ios-rotate-btn {
-    top: (4 * @map-tools-size + 2 * @app-margin + 3 * @micro-app-margin) + @ios-margin !important;
-  }
+    div.ol-rotate {
+      top: (4 * @map-tools-size + 2 * @app-margin + 3 * @micro-app-margin) + @ios-margin;
+    }
 
-  .ios-geolocation-btn {
-    top: (3 * @map-tools-size + 2 * @app-margin + 2 * @micro-app-margin) + @ios-margin !important;
+    button[ngeo-mobile-geolocation] {
+      top: (3 * @map-tools-size + 2 * @app-margin + 2 * @micro-app-margin) + @ios-margin;
+    }
   }
 }

--- a/contribs/gmf/less/iphone.less
+++ b/contribs/gmf/less/iphone.less
@@ -1,4 +1,4 @@
-// Hack for ios Safari browser (UI overlapping on iOS 11)
+// Hack for ios Safari browser (UI overlapping on iOS 10)
 @media all and (orientation: landscape) {
   @ios-margin: 5rem;
 
@@ -7,14 +7,14 @@
   }
 
   .ios-zoom-btn {
-    top: (@app-margin + @map-tools-size + @app-margin) + @ios-margin !important;
+    top: (@app-margin + @map-tools-size + @app-margin) + @ios-margin;
   }
 
   .ios-rotate-btn {
-    top: (4 * @map-tools-size + 2 * @app-margin + 3 * @micro-app-margin) + @ios-margin !important;
+    top: (4 * @map-tools-size + 2 * @app-margin + 3 * @micro-app-margin) + @ios-margin;
   }
 
   .ios-geolocation-btn {
-    top: (3 * @map-tools-size + 2 * @app-margin + 2 * @micro-app-margin) + @ios-margin !important;
+    top: (3 * @map-tools-size + 2 * @app-margin + 2 * @micro-app-margin) + @ios-margin;
   }
 }

--- a/contribs/gmf/less/iphone.less
+++ b/contribs/gmf/less/iphone.less
@@ -1,6 +1,6 @@
 // Hack for ios Safari browser (UI overlapping on iOS 11)
-@media all and (orientation: portrait) {
+@media all and (orientation: landscape) {
   .ios-margin-top {
-    margin-top: 5rem;
+    margin-top: 4rem;
   }
 }

--- a/contribs/gmf/less/iphone.less
+++ b/contribs/gmf/less/iphone.less
@@ -7,14 +7,14 @@
   }
 
   .ios-zoom-btn {
-    top: (@app-margin + @map-tools-size + @app-margin) + @ios-margin;
+    top: (@app-margin + @map-tools-size + @app-margin) + @ios-margin !important;
   }
 
   .ios-rotate-btn {
-    top: (4 * @map-tools-size + 2 * @app-margin + 3 * @micro-app-margin) + @ios-margin;
+    top: (4 * @map-tools-size + 2 * @app-margin + 3 * @micro-app-margin) + @ios-margin !important;
   }
 
   .ios-geolocation-btn {
-    top: (3 * @map-tools-size + 2 * @app-margin + 2 * @micro-app-margin) + @ios-margin;
+    top: (3 * @map-tools-size + 2 * @app-margin + 2 * @micro-app-margin) + @ios-margin !important;
   }
 }

--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -14,7 +14,7 @@
 @import 'displaywindow.less';
 @import 'mobiledisplaywindow.less';
 
-// Hack for ios Safari browser (UI overlapping on iOS 11)
+// Hack for ios Safari browser (UI overlapping on iOS 10)
 @import 'iphone.less';
 
 /**

--- a/contribs/gmf/less/mobile.less
+++ b/contribs/gmf/less/mobile.less
@@ -14,6 +14,9 @@
 @import 'displaywindow.less';
 @import 'mobiledisplaywindow.less';
 
+// Hack for ios Safari browser (UI overlapping on iOS 11)
+@import 'iphone.less';
+
 /**
  * Mobile specific css only !
  * Please, use shared less files to describe desktop-mobile shared css

--- a/utils/ios-overlap-fix.js
+++ b/utils/ios-overlap-fix.js
@@ -16,13 +16,15 @@ const iosChecker = function() {
 * webkit is true on Safari/Chrome, etc
 * platform is true on iOS, not emulator (platform)
 * chromeiOS is true on other browsers (chrome/opera)
-* MSStream is true on IE
 */
-if (iOS && webkit && platform && !chromeiOS && !window.MSStream) {
+if (iOS && webkit && platform && !chromeiOS) {
   const iosVersion = iosChecker()[0];
-  if (iosVersion >= 10) {
+  console.log('iOS version: ', iosVersion);
+  if (iosVersion > 10) {
     const interval = setInterval(() => {
+      console.log('interval');
       if ($('div.ol-zoom').get(0)) {
+        console.log('stop interval');
         clearInterval(interval);
         $('button.gmf-mobile-nav-left-trigger').addClass('ios-margin-top');
         $('button.gmf-mobile-nav-right-trigger').addClass('ios-margin-top');

--- a/utils/ios-overlap-fix.js
+++ b/utils/ios-overlap-fix.js
@@ -19,12 +19,9 @@ const iosChecker = function() {
 */
 if (iOS && webkit && platform && !chromeiOS) {
   const iosVersion = iosChecker()[0];
-  console.log('iOS version: ', iosVersion);
   if (iosVersion >= 10) {
     const interval = setInterval(() => {
-      console.log('interval');
       if ($('div.ol-zoom').get(0)) {
-        console.log('stop interval');
         clearInterval(interval);
         $('body').addClass('ios-margin');
       }

--- a/utils/ios-overlap-fix.js
+++ b/utils/ios-overlap-fix.js
@@ -1,30 +1,32 @@
-// Hack for ios Safari browser (UI overlapping on iOS 10)
-const userAgent = window.navigator.userAgent;
-const regEx = /iP(hone|od|ad)/;
-const iOS = regEx.test(userAgent);
-const webkit = /WebKit/i.test(userAgent);
-const chromeiOS = /(Chrome|CriOS|OPiOS)/i.test(userAgent);
-const platform = regEx.test(window.navigator.platform);
+(function() {
+  // Hack for ios Safari browser (UI overlapping on iOS 10)
+  var userAgent = window.navigator.userAgent;
+  var regEx = /iP(hone|od|ad)/;
+  var iOS = regEx.test(userAgent);
+  var webkit = /WebKit/i.test(userAgent);
+  var chromeiOS = /(Chrome|CriOS|OPiOS)/i.test(userAgent);
+  var platform = regEx.test(window.navigator.platform);
 
-const iosChecker = function() {
-  const v = (window.navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
-  return [parseInt(v[1], 10), parseInt(v  [2], 10), parseInt(v[3] || 0, 10)];
-};
+  var iosChecker = function() {
+    var v = (window.navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
+    return [parseInt(v[1], 10), parseInt(v  [2], 10), parseInt(v[3] || 0, 10)];
+  };
 
-/**
-* iOS is true on iOS or emulators (user-agent)
-* webkit is true on Safari/Chrome, etc
-* platform is true on iOS, not emulator (platform)
-* chromeiOS is true on other browsers (chrome/opera)
-*/
-if (iOS && webkit && platform && !chromeiOS) {
-  const iosVersion = iosChecker()[0];
-  if (iosVersion >= 10) {
-    const interval = setInterval(() => {
-      if ($('div.ol-zoom').get(0)) {
-        clearInterval(interval);
-        $('body').addClass('ios-margin');
-      }
-    }, 100);
+  /**
+  * iOS is true on iOS or emulators (user-agent)
+  * webkit is true on Safari/Chrome, etc
+  * platform is true on iOS, not emulator (platform)
+  * chromeiOS is true on other browsers (chrome/opera)
+  */
+  if (iOS && webkit && platform && !chromeiOS) {
+    var iosVersion = iosChecker()[0];
+    if (iosVersion >= 10) {
+      var interval = setInterval(function() {
+        if ($('div.ol-zoom').get(0)) {
+          clearInterval(interval);
+          $('body').addClass('ios-margin');
+        }
+      }, 100);
+    }
   }
-}
+})();

--- a/utils/ios-overlap-fix.js
+++ b/utils/ios-overlap-fix.js
@@ -20,7 +20,7 @@ const iosChecker = function() {
 if (iOS && webkit && platform && !chromeiOS) {
   const iosVersion = iosChecker()[0];
   console.log('iOS version: ', iosVersion);
-  if (iosVersion > 10) {
+  if (iosVersion >= 10) {
     const interval = setInterval(() => {
       console.log('interval');
       if ($('div.ol-zoom').get(0)) {

--- a/utils/ios-overlap-fix.js
+++ b/utils/ios-overlap-fix.js
@@ -26,12 +26,7 @@ if (iOS && webkit && platform && !chromeiOS) {
       if ($('div.ol-zoom').get(0)) {
         console.log('stop interval');
         clearInterval(interval);
-        $('button.gmf-mobile-nav-left-trigger').addClass('ios-margin-top');
-        $('button.gmf-mobile-nav-right-trigger').addClass('ios-margin-top');
-        $('gmf-search').addClass('ios-margin-top');
-        $('div.ol-zoom').addClass('ios-zoom-btn');
-        $('div.ol-rotate').addClass('ios-rotate-btn');
-        $('button[ngeo-mobile-geolocation]').addClass('ios-geolocation-btn');
+        $('body').addClass('ios-margin');
       }
     }, 100);
   }


### PR DESCRIPTION
Fixes #2695

This PR introduce a iOS less file that take specific classes. Then in the interface, the ios user-agent is checked to know if it is an iOS device and its version. If true and egal to iOS 10, it applies the classes to the HTML elements.

TODO:
- [x] (maybe) exlude iOS 9 and below
- [x] Test on real devices
- [x] Fix build (IE load the file on any interfaces)

Known issues:
- Overlap on the botton of the screen (it is possible to get the screen scrolled with a focus on the search field and drag at the bottom)
- ~Code is not minified/transpiled in the build (so may break on IE ?)~

Demo:
https://camptocamp.github.io/ngeo/ios-overlap-fix/examples/contribs/gmf/apps/mobile/