### PR TITLE
Fix title value to be correctly set in object editing pages

### DIFF
--- a/contribs/gmf/src/directives/partials/editfeature.html
+++ b/contribs/gmf/src/directives/partials/editfeature.html
@@ -92,7 +92,7 @@
               class="close"
               ng-click="efCtrl.cancel()"
               ng-disabled="efCtrl.pending"
-              title="{{'Cancel modifications | translate'}}"
+              title="{{'Cancel modifications' | translate}}"
               href>&times;</a>
           </div>
         </div>
@@ -107,19 +107,19 @@
           class="btn btn-sm btn-default gmf-editfeature-btn-save"
           ng-click="form.$valid && efCtrl.save()"
           ng-disabled="!efCtrl.dirty || efCtrl.pending"
-          title="{{'Save modifications | translate'}}"></input>
+          title="{{'Save modifications' | translate}}"></input>
         <a
           class="btn btn-sm btn-default gmf-editfeature-btn-cancel"
           ng-click="efCtrl.confirmCancel()"
           ng-disabled="efCtrl.pending"
-          title="{{'Cancel modifications | translate'}}"
+          title="{{'Cancel modifications' | translate}}"
           href>{{'Cancel' | translate}}</a>
         <button
           class="btn btn-sm btn-link gmf-editfeature-btn-delete"
           ng-click="efCtrl.delete()"
           ng-disabled="efCtrl.pending"
           ng-show="efCtrl.featureId"
-          title="{{'Delete this feature | translate'}}">
+          title="{{'Delete this feature' | translate}}">
           <span class="fa fa-trash"></span>
           {{'Delete' | translate}}
         </button>

--- a/contribs/gmf/src/directives/partials/objectediting.html
+++ b/contribs/gmf/src/directives/partials/objectediting.html
@@ -37,17 +37,17 @@
     class="btn btn-sm btn-default gmf-objectediting-btn-save"
     ng-click="form.$valid && oeCtrl.save()"
     ng-disabled="!oeCtrl.dirty || oeCtrl.pending || !oeCtrl.featureHasGeom"
-    title="{{'Save modifications | translate'}}"></input>
+    title="{{'Save modifications' | translate}}"></input>
   <a
     class="btn btn-sm btn-link gmf-objectediting-btn-undo"
     ng-click="oeCtrl.undo()"
     ng-disabled="!oeCtrl.dirty || oeCtrl.pending"
-    title="{{'Undo latest modifications | translate'}}"
+    title="{{'Undo latest modifications' | translate}}"
     href>{{'Undo' | translate}}</a>
   <a
     class="btn btn-sm btn-link gmf-objectediting-btn-delete"
     ng-click="oeCtrl.delete()"
     ng-disabled="oeCtrl.isStateInsert() || oeCtrl.pending"
-    title="{{'Delete the feature | translate'}}"
+    title="{{'Delete the feature' | translate}}"
     href>{{'Delete' | translate}}</a>
 </form>


### PR DESCRIPTION
Fixes a small issue I caught in EPFL: some of the tooltips were incorrectly set as the " | translate" was visibile in the interface.

I grepped on " | translate' " to make sure there were no file left wrapping the pipe and following anymore.