### PR TITLE
Extract unlistener for mobile measure tool

### DIFF
--- a/src/ol-ext/interaction/measure.js
+++ b/src/ol-ext/interaction/measure.js
@@ -439,14 +439,19 @@ ngeo.interaction.Measure.prototype.onDrawEnd_ = function(evt) {
   this.dispatchEvent(new ngeo.MeasureEvent(ngeo.MeasureEventType.MEASUREEND,
     this.sketchFeature));
   this.sketchFeature = null;
-  goog.asserts.assert(this.changeEventKey_ !== null);
-  goog.asserts.assert(this.postcomposeEventKey_ !== null);
+  this.unlistenerEvent_();
+};
+
+/**
+ * Handle unlistener events for 'end of drawing' interaction
+ * @private
+ */
+ngeo.interaction.Measure.prototype.unlistenerEvent_ = function() {
   ol.events.unlistenByKey(this.changeEventKey_);
   ol.events.unlistenByKey(this.postcomposeEventKey_);
   this.changeEventKey_ = null;
   this.postcomposeEventKey_ = null;
 };
-
 
 /**
  * Creates a new help tooltip
@@ -537,6 +542,7 @@ ngeo.interaction.Measure.prototype.updateState_ = function() {
     this.getMap().removeOverlay(this.measureTooltipOverlay_);
     this.removeMeasureTooltip_();
     this.removeHelpTooltip_();
+    this.unlistenerEvent_();
   }
 };
 

--- a/src/ol-ext/interaction/measure.js
+++ b/src/ol-ext/interaction/measure.js
@@ -447,10 +447,12 @@ ngeo.interaction.Measure.prototype.onDrawEnd_ = function(evt) {
  * @private
  */
 ngeo.interaction.Measure.prototype.unlistenerEvent_ = function() {
-  ol.events.unlistenByKey(this.changeEventKey_);
-  ol.events.unlistenByKey(this.postcomposeEventKey_);
-  this.changeEventKey_ = null;
-  this.postcomposeEventKey_ = null;
+  if (this.changeEventKey_ !== null && this.postcomposeEventKey_ !== null) {
+    ol.events.unlistenByKey(this.changeEventKey_);
+    ol.events.unlistenByKey(this.postcomposeEventKey_);
+    this.changeEventKey_ = null;
+    this.postcomposeEventKey_ = null;
+  }
 };
 
 /**


### PR DESCRIPTION
Fixes the unlistener to be correctly executed at end of drawing interaction.

I extracted the unlisteners to have a similar behavior for the mobile measure tool, which were already used in drawing features on desktop apps.