### PR TITLE
Lux 3dpermalink

### DIFF
--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -15,6 +15,7 @@ goog.require('ngeo.FeatureHelper');
 goog.require('ngeo.Features');
 goog.require('ngeo.FeatureOverlay');
 goog.require('ngeo.FeatureOverlayMgr');
+goog.require('ngeo.olcs.constants');
 goog.require('ngeo.Popover');
 goog.require('ngeo.StateManager');
 goog.require('ngeo.format.FeatureHash');
@@ -695,13 +696,16 @@ gmf.Permalink.prototype.registerMap_ = function(map, oeFeature) {
     goog.asserts.assert(size);
     view.fit(oeFeature.getGeometry().getExtent(), size);
   } else {
-    center = this.getMapCenter();
-    if (center) {
-      view.setCenter(center);
-    }
-    const zoom = this.getMapZoom();
-    if (zoom !== undefined) {
-      view.setZoom(zoom);
+    const enabled3d = this.ngeoStateManager_.getInitialBooleanValue(ngeo.olcs.constants.Permalink3dParam.ENABLED);
+    if (!enabled3d) {
+      center = this.getMapCenter();
+      if (center) {
+        view.setCenter(center);
+      }
+      const zoom = this.getMapZoom();
+      if (zoom !== undefined) {
+        view.setZoom(zoom);
+      }
     }
   }
 

--- a/examples/simple3d.html
+++ b/examples/simple3d.html
@@ -31,7 +31,11 @@
     <p id="desc">
       This example shows how to use <code>ngeo.olcs.Manager</code> and the
       <code><a href="../apidoc/ngeo.olcs.ngeoOlcsControls3d.html" title="Read our documentation">ngeo-olcs-controls3d</a></code>
-      component to control an 3D view.
+      component to control an 3D view.<br>
+      It also shows how 3d navigation interacts with permalink.
+      <br><br>
+      Here an example of permalink format: <code>?3d_enabled=true&3d_lon=26.81533&3d_lat=-21.85790&3d_elevation=1274213&3d_heading=360.000&3d_pitch=-63.995</code><br>
+      3d permalink is managed in <code><a href="../apidoc/ngeo.olcs.ngeoOlcsService.html" title="Read our documentation">ngeo-olcs-service</a></code>.
     </p>
     <script src="../node_modules/jquery/dist/jquery.js"></script>
     <script src="../node_modules/angular/angular.js"></script>

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ngeo-build": "buildtools/build.js"
   },
   "devDependencies": {
+    "@camptocamp/cesium": "1.39",
     "angular": "1.6.5",
     "angular-animate": "1.6.5",
     "angular-dynamic-locale": "0.1.32",
@@ -33,7 +34,7 @@
     "async": "2.5.0",
     "bootstrap": "3.3.7",
     "clean-css-cli": "4.1.6",
-    "closure-util": "camptocamp/closure-util#487fac6",
+    "closure-util": "github:camptocamp/closure-util#487fac6",
     "console-control-strings": "1.1.0",
     "corejs-typeahead": "1.1.1",
     "coveralls": "2.13.1",
@@ -59,9 +60,8 @@
     "less-plugin-clean-css": "1.5.1",
     "moment": "2.18.1",
     "nomnom": "1.8.1",
+    "ol-cesium": "github:openlayers/ol-cesium#ae925e6ca346381a5e7dba224d09894894bbd854",
     "openlayers": "openlayers/openlayers#4a6317d",
-    "ol-cesium": "openlayers/ol-cesium#3014d02de4",
-    "@camptocamp/cesium": "1.39",
     "phantomjs-prebuilt": "2.1.14",
     "proj4": "2.4.3",
     "svg2ttf": "4.1.0",

--- a/src/modules/olcs/Service.js
+++ b/src/modules/olcs/Service.js
@@ -51,7 +51,7 @@ const Service = class {
     });
 
     if (this.ngeoStateManager_.getInitialBooleanValue('3d_enabled')) {
-        this.initialStateToCamera_();
+      this.initialStateToCamera_();
     }
   }
 
@@ -65,6 +65,7 @@ const Service = class {
 
   /**
    * @private
+   * @return {Promise<undefined>} A promise after load & enabled.
    */
   initialStateToCamera_() {
     const stateManager = this.ngeoStateManager_;
@@ -75,6 +76,9 @@ const Service = class {
     const heading = stateManager.getInitialNumberValue('3d_heading') || 0;
     const pitch = stateManager.getInitialNumberValue('3d_pitch') || 0;
 
+    goog.asserts.assert(lon !== undefined);
+    goog.asserts.assert(lat !== undefined);
+    goog.asserts.assert(elevation !== undefined);
     return this.manager_.set3dWithView(lon, lat, elevation, heading, pitch);
   }
 

--- a/src/modules/olcs/Service.js
+++ b/src/modules/olcs/Service.js
@@ -2,6 +2,7 @@ goog.module('ngeo.olcs.Service');
 
 goog.require('ngeo.Debounce');
 goog.require('ngeo.Location');
+goog.require('ngeo.olcs.constants');
 goog.require('ngeo.StateManager');
 
 const Service = class {
@@ -70,11 +71,11 @@ const Service = class {
   initialStateToCamera_() {
     const stateManager = this.ngeoStateManager_;
 
-    const lon = stateManager.getInitialNumberValue('3d_lon');
-    const lat = stateManager.getInitialNumberValue('3d_lat');
-    const elevation = stateManager.getInitialNumberValue('3d_elevation');
-    const heading = stateManager.getInitialNumberValue('3d_heading') || 0;
-    const pitch = stateManager.getInitialNumberValue('3d_pitch') || 0;
+    const lon = stateManager.getInitialNumberValue(ngeo.olcs.constants.Permalink3dParam.LON);
+    const lat = stateManager.getInitialNumberValue(ngeo.olcs.constants.Permalink3dParam.LAT);
+    const elevation = stateManager.getInitialNumberValue(ngeo.olcs.constants.Permalink3dParam.ELEVATION);
+    const heading = stateManager.getInitialNumberValue(ngeo.olcs.constants.Permalink3dParam.HEADING) || 0;
+    const pitch = stateManager.getInitialNumberValue(ngeo.olcs.constants.Permalink3dParam.PITCH) || 0;
 
     goog.asserts.assert(lon !== undefined);
     goog.asserts.assert(lat !== undefined);
@@ -93,12 +94,12 @@ const Service = class {
     camera.moveEnd.addEventListener(this.ngeoDebounce_(() => {
       const position = camera.positionCartographic;
       this.ngeoStateManager_.updateState({
-        '3d_enabled': true,
-        '3d_lon': Cesium.Math.toDegrees(position.longitude).toFixed(5),
-        '3d_lat': Cesium.Math.toDegrees(position.latitude).toFixed(5),
-        '3d_elevation': position.height.toFixed(0),
-        '3d_heading': Cesium.Math.toDegrees(camera.heading).toFixed(3),
-        '3d_pitch': Cesium.Math.toDegrees(camera.pitch).toFixed(3)
+        [ngeo.olcs.constants.Permalink3dParam.ENABLED]: true,
+        [ngeo.olcs.constants.Permalink3dParam.LON]: Cesium.Math.toDegrees(position.longitude).toFixed(5),
+        [ngeo.olcs.constants.Permalink3dParam.LAT]: Cesium.Math.toDegrees(position.latitude).toFixed(5),
+        [ngeo.olcs.constants.Permalink3dParam.ELEVATION]: position.height.toFixed(0),
+        [ngeo.olcs.constants.Permalink3dParam.HEADING]: Cesium.Math.toDegrees(camera.heading).toFixed(3),
+        [ngeo.olcs.constants.Permalink3dParam.PITCH]: Cesium.Math.toDegrees(camera.pitch).toFixed(3)
       });
     }, 1000, true));
 
@@ -113,7 +114,7 @@ const Service = class {
    * @private
    */
   remove3dState_() {
-    this.ngeoLocation_.getParamKeysWithPrefix('3d_').forEach((key) => {
+    this.ngeoLocation_.getParamKeysWithPrefix(ngeo.olcs.constants.Permalink3dParam.PREFIX).forEach((key) => {
       this.ngeoStateManager_.deleteParam(key);
     });
   }

--- a/src/modules/olcs/Service.js
+++ b/src/modules/olcs/Service.js
@@ -90,7 +90,7 @@ const Service = class {
    */
   cameraFromPermalink_() {
     const manager = this.manager_;
-    const scene = manager.ol3d.getCesiumScene();
+    const scene = manager.getOl3d().getCesiumScene();
     const camera = scene.camera;
 
     const lon = this.ngeoLocation_.getParamAsFloat('3d_lon');
@@ -116,9 +116,9 @@ const Service = class {
    */
   setupPermalink_() {
     const manager = this.manager_;
-    const scene = manager.ol3d.getCesiumScene();
+    const scene = manager.getOl3d().getCesiumScene();
     const camera = scene.camera;
-    const is3DCurrentlyEnabled = manager.ol3d.getEnabled();
+    const is3DCurrentlyEnabled = manager.getOl3d().getEnabled();
 
     camera.moveEnd.addEventListener(this.ngeoDebounce_(() => {
       if (is3DCurrentlyEnabled) {
@@ -133,6 +133,30 @@ const Service = class {
         });
       }
     }, 1000, true));
+
+    this.$rootScope.$watch(
+      () => this.manager_.getOl3d().getEnabled(),
+      this.on3dToggle_.bind(this)
+    );
+  }
+
+  /**
+   * @private
+   */
+  teardownPermalink_() {
+    this.ngeoLocation_.getParamKeysWithPrefix('3d_').forEach((key) => {
+      this.ngeoLocation_.deleteParam(key);
+    });
+  }
+
+  /**
+   * @private
+   * @param {boolean} enabled Is 3d active or not.
+   */
+  on3dToggle_(enabled) {
+    if (!enabled) {
+      this.teardownPermalink_();
+    }
   }
 
 };

--- a/src/modules/olcs/Service.js
+++ b/src/modules/olcs/Service.js
@@ -51,9 +51,7 @@ const Service = class {
     });
 
     if (this.ngeoStateManager_.getInitialBooleanValue('3d_enabled')) {
-      this.manager_.toggle3d().then(() => {
         this.initialStateToCamera_();
-      });
     }
   }
 
@@ -69,27 +67,15 @@ const Service = class {
    * @private
    */
   initialStateToCamera_() {
-    const manager = this.manager_;
     const stateManager = this.ngeoStateManager_;
-    const scene = manager.getOl3d().getCesiumScene();
-    const camera = scene.camera;
 
     const lon = stateManager.getInitialNumberValue('3d_lon');
     const lat = stateManager.getInitialNumberValue('3d_lat');
     const elevation = stateManager.getInitialNumberValue('3d_elevation');
-    const destination = Cesium.Cartesian3.fromDegrees(lon, lat, elevation);
+    const heading = stateManager.getInitialNumberValue('3d_heading') || 0;
+    const pitch = stateManager.getInitialNumberValue('3d_pitch') || 0;
 
-    const heading = Cesium.Math.toRadians(
-      stateManager.getInitialNumberValue('3d_heading') || 0);
-    const pitch = Cesium.Math.toRadians(
-      stateManager.getInitialNumberValue('3d_pitch') || 0);
-    const roll = 0;
-    const orientation = {heading, pitch, roll};
-
-    camera.setView({
-      destination,
-      orientation
-    });
+    return this.manager_.set3dWithView(lon, lat, elevation, heading, pitch);
   }
 
   /**

--- a/src/modules/olcs/Service.js
+++ b/src/modules/olcs/Service.js
@@ -1,12 +1,42 @@
 goog.module('ngeo.olcs.Service');
 
+goog.require('ngeo.Debounce');
+goog.require('ngeo.Location');
+goog.require('ngeo.StateManager');
+
 const Service = class {
-  constructor() {
+
+  /**
+   * @ngInject
+   * @param {angular.Scope} $rootScope Angular root scope.
+   * @param {!ngeo.Debounce} ngeoDebounce ngeo debounce service.
+   * @param {ngeo.Location} ngeoLocation ngeo location service.
+   */
+  constructor($rootScope, ngeoDebounce, ngeoLocation) {
     /**
      * @private
      * @type {olcs.contrib.Manager|undefined}
      */
     this.manager_;
+
+    /**
+     * @private
+     * @type {angular.Scope}
+     */
+    this.$rootScope = $rootScope;
+
+    /**
+     * @private
+     * @type {ngeo.Location}
+     */
+    this.ngeoDebounce_ = ngeoDebounce;
+
+    /**
+     * @private
+     * @type {ngeo.Debounce}
+     */
+    this.ngeoLocation_ = ngeoLocation;
+
   }
 
   /**
@@ -15,6 +45,19 @@ const Service = class {
    */
   initialize(manager) {
     this.manager_ = manager;
+
+    const unWatchFn = this.$rootScope.$watch(
+      () => this.manager_.getOl3d(),
+      (ol3d) => {
+        if (ol3d) {
+          if(this.ngeoLocation_.hasParam('3d_enabled')) {
+            this.cameraFromPermalink_();
+          }
+          this.setupPermalink_();
+          unWatchFn();
+        }
+      }
+    );
   }
 
   /**
@@ -24,6 +67,74 @@ const Service = class {
   getManager() {
     return this.manager_;
   }
+
+  /**
+   * @export
+   * @return {number} the min tilt.
+   */
+  getMinTilt() {
+    return 0;
+  }
+
+  /**
+   * @export
+   * Almost Pi / 2
+   * @return {number} the max tilt.
+   */
+  getMaxTilt() {
+    return 7 * Math.PI / 16;
+  }
+
+  /**
+   * @private
+   */
+  cameraFromPermalink_() {
+    const manager = this.manager_;
+    const scene = manager.ol3d.getCesiumScene();
+    const camera = scene.camera;
+
+    const lon = this.ngeoLocation_.getParamAsFloat('3d_lon');
+    const lat = this.ngeoLocation_.getParamAsFloat('3d_lat');
+    const elevation = this.ngeoLocation_.getParamAsInt('3d_elevation');
+    const destination = Cesium.Cartesian3.fromDegrees(lon, lat, elevation);
+
+    const heading = Cesium.Math.toRadians(
+      this.ngeoLocation_.getParamAsFloat('3d_heading') || 0);
+    const pitch = Cesium.Math.toRadians(
+      this.ngeoLocation_.getParamAsFloat('3d_pitch') || 0);
+    const roll = 0;
+    const orientation = {heading, pitch, roll};
+
+    camera.setView({
+      destination,
+      orientation
+    });
+  }
+
+  /**
+   * @private
+   */
+  setupPermalink_() {
+    const manager = this.manager_;
+    const scene = manager.ol3d.getCesiumScene();
+    const camera = scene.camera;
+    const is3DCurrentlyEnabled = manager.ol3d.getEnabled();
+
+    camera.moveEnd.addEventListener(this.ngeoDebounce_(() => {
+      if (is3DCurrentlyEnabled) {
+        const position = camera.positionCartographic;
+        this.ngeoLocation_.updateParams({
+          '3d_enabled': true,
+          '3d_lon': Cesium.Math.toDegrees(position.longitude).toFixed(5),
+          '3d_lat': Cesium.Math.toDegrees(position.latitude).toFixed(5),
+          '3d_elevation': position.height.toFixed(0),
+          '3d_heading': Cesium.Math.toDegrees(camera.heading).toFixed(3),
+          '3d_pitch': Cesium.Math.toDegrees(camera.pitch).toFixed(3)
+        });
+      }
+    }, 1000, true));
+  }
+
 };
 
 const name = 'ngeoOlcsService';

--- a/src/modules/olcs/Service.js
+++ b/src/modules/olcs/Service.js
@@ -11,8 +11,9 @@ const Service = class {
    * @param {angular.Scope} $rootScope Angular root scope.
    * @param {!ngeo.Debounce} ngeoDebounce ngeo debounce service.
    * @param {ngeo.Location} ngeoLocation ngeo location service.
+   * @param {ngeo.StateManager} ngeoStateManager The ngeo StateManager service.
    */
-  constructor($rootScope, ngeoDebounce, ngeoLocation) {
+  constructor($rootScope, ngeoDebounce, ngeoLocation, ngeoStateManager) {
     /**
      * @private
      * @type {olcs.contrib.Manager|undefined}
@@ -27,15 +28,21 @@ const Service = class {
 
     /**
      * @private
-     * @type {ngeo.Location}
+     * @type {ngeo.Debounce}
      */
     this.ngeoDebounce_ = ngeoDebounce;
 
     /**
      * @private
-     * @type {ngeo.Debounce}
+     * @type {ngeo.Location}
      */
     this.ngeoLocation_ = ngeoLocation;
+
+    /**
+     * @private
+     * @type {ngeo.StateManager}
+     */
+    this.ngeoStateManager_ = ngeoStateManager;
 
   }
 
@@ -50,7 +57,7 @@ const Service = class {
       () => this.manager_.getOl3d(),
       (ol3d) => {
         if (ol3d) {
-          if(this.ngeoLocation_.hasParam('3d_enabled')) {
+          if (this.ngeoStateManager_.getInitialBooleanValue('3d_enabled')) {
             this.cameraFromPermalink_();
           }
           this.setupPermalink_();
@@ -58,6 +65,10 @@ const Service = class {
         }
       }
     );
+
+    if (this.ngeoStateManager_.getInitialBooleanValue('3d_enabled')) {
+      this.manager_.toggle3d();
+    }
   }
 
   /**
@@ -90,18 +101,19 @@ const Service = class {
    */
   cameraFromPermalink_() {
     const manager = this.manager_;
+    const stateManager = this.ngeoStateManager_;
     const scene = manager.getOl3d().getCesiumScene();
     const camera = scene.camera;
 
-    const lon = this.ngeoLocation_.getParamAsFloat('3d_lon');
-    const lat = this.ngeoLocation_.getParamAsFloat('3d_lat');
-    const elevation = this.ngeoLocation_.getParamAsInt('3d_elevation');
+    const lon = stateManager.getInitialNumberValue('3d_lon');
+    const lat = stateManager.getInitialNumberValue('3d_lat');
+    const elevation = stateManager.getInitialNumberValue('3d_elevation');
     const destination = Cesium.Cartesian3.fromDegrees(lon, lat, elevation);
 
     const heading = Cesium.Math.toRadians(
-      this.ngeoLocation_.getParamAsFloat('3d_heading') || 0);
+      stateManager.getInitialNumberValue('3d_heading') || 0);
     const pitch = Cesium.Math.toRadians(
-      this.ngeoLocation_.getParamAsFloat('3d_pitch') || 0);
+      stateManager.getInitialNumberValue('3d_pitch') || 0);
     const roll = 0;
     const orientation = {heading, pitch, roll};
 
@@ -123,7 +135,7 @@ const Service = class {
     camera.moveEnd.addEventListener(this.ngeoDebounce_(() => {
       if (is3DCurrentlyEnabled) {
         const position = camera.positionCartographic;
-        this.ngeoLocation_.updateParams({
+        this.ngeoStateManager_.updateState({
           '3d_enabled': true,
           '3d_lon': Cesium.Math.toDegrees(position.longitude).toFixed(5),
           '3d_lat': Cesium.Math.toDegrees(position.latitude).toFixed(5),
@@ -145,7 +157,7 @@ const Service = class {
    */
   teardownPermalink_() {
     this.ngeoLocation_.getParamKeysWithPrefix('3d_').forEach((key) => {
-      this.ngeoLocation_.deleteParam(key);
+      this.ngeoStateManager_.deleteParam(key);
     });
   }
 

--- a/src/modules/olcs/constants.js
+++ b/src/modules/olcs/constants.js
@@ -1,0 +1,47 @@
+/**
+ * @module ngeo olcs constants
+ */
+goog.module('ngeo.olcs.constants');
+goog.module.declareLegacyNamespace();
+
+/**
+ * @enum {string}
+ * @export
+ */
+exports.Permalink3dParam = {
+  /**
+   * @type {string}
+   * @export
+   */
+  ENABLED: '3d_enabled',
+  /**
+   * @type {string}
+   * @export
+   */
+  LON: '3d_lon',
+  /**
+   * @type {string}
+   * @export
+   */
+  LAT: '3d_lat',
+  /**
+   * @type {string}
+   * @export
+   */
+  ELEVATION: '3d_elevation',
+  /**
+   * @type {string}
+   * @export
+   */
+  HEADING: '3d_heading',
+  /**
+   * @type {string}
+   * @export
+   */
+  PITCH: '3d_pitch',
+  /**
+   * @type {string}
+   * @export
+   */
+  PREFIX: '3d_'
+};

--- a/src/modules/olcs/olcsmodule.js
+++ b/src/modules/olcs/olcsmodule.js
@@ -4,6 +4,10 @@
 goog.module('ngeo.olcs.olcsModule');
 goog.module.declareLegacyNamespace();
 
+goog.require('ngeo.Debounce');
+goog.require('ngeo.Location');
+goog.require('ngeo.StateManager');
+
 const Service = goog.require('ngeo.olcs.Service');
 const control = goog.require('ngeo.olcs.controls3d');
 

--- a/src/modules/olcs/olcsmodule.js
+++ b/src/modules/olcs/olcsmodule.js
@@ -4,10 +4,6 @@
 goog.module('ngeo.olcs.olcsModule');
 goog.module.declareLegacyNamespace();
 
-goog.require('ngeo.Debounce');
-goog.require('ngeo.Location');
-goog.require('ngeo.StateManager');
-
 const Service = goog.require('ngeo.olcs.Service');
 const control = goog.require('ngeo.olcs.controls3d');
 


### PR DESCRIPTION
Manage 3d permalink if cesium is active.

Here the params used 
```
3d_enabled=true
3d_lon=23.49043
3d_lat=-40.49055
3d_elevation=993992
3d_heading=360.000
3d_pitch=-42.408
```

- [x] Load camera from permalink
- [x] Enable 3d if `3d_enabled` set in permalink
- [x] Update permalink from camera move
- [x] Add an example
- [x] Remove 3d permalink params when back to 2d
- [x] Update permalink when switch to 3d
- [x] Use ngeoStateManager
