### PR TITLE
Edition - Checkbox with 'false' value are also valid

### DIFF
--- a/src/directives/partials/attributes.html
+++ b/src/directives/partials/attributes.html
@@ -15,7 +15,6 @@
           <label>
             <input
                 name="{{::attribute.name}}"
-                ng-required="attribute.required"
                 ng-model="attrCtrl.properties[attribute.name]"
                 ng-change="attrCtrl.handleInputChange(attribute.name);"
                 type="checkbox">


### PR DESCRIPTION
Fix #3212

For now, a "false" value is considered as not set and is not valid (you cannot save)

The easier way to fix it.
What does it mean "required" on a boolean field ?
  