### PR TITLE
Debug gmf permalink (push gmf.theme requirments)

### DIFF
--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -30,6 +30,8 @@ goog.require('ol.style.Style');
 
 // FIXME remove lines right under and add me at the module dependencies:
 ngeo.module.requires.push(ngeo.statemanager.module.name);
+gmf.module.requires.push(gmf.theme.Themes.module.name);
+gmf.module.requires.push(gmf.theme.Manager.module.name);
 
 
 /**


### PR DESCRIPTION
It was not working anymore (and a lot of examples use the permalink)
 
Note that this code will be removed when the permalink will be in a module.