### PR TITLE
Allow bloodhound rateLimitWait params to be settable in gmf

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -209,6 +209,7 @@
           gmf-search-coordinatesprojections="mainCtrl.searchCoordinatesProjections"
           gmf-search-colorchooser="false"
           gmf-search-placeholder="{{'Search…'|translate}}"
+          gmf-search-delay="mainCtrl.searchDelay"
           gmf-search-clearbutton="true">
         </gmf-search>
         <div class="gmf-app-map-bottom-controls">

--- a/contribs/gmf/apps/desktop/js/controller.js
+++ b/contribs/gmf/apps/desktop/js/controller.js
@@ -40,6 +40,12 @@ app.DesktopController = function($scope, $injector) {
   }, $scope, $injector);
 
   /**
+   * @type {number}
+   * @export
+   */
+  this.searchDelay = 50;
+
+  /**
    * @type {Array.<string>}
    * @export
    */

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -239,6 +239,7 @@
           gmf-search-coordinatesprojections="mainCtrl.searchCoordinatesProjections"
           gmf-search-colorchooser="true"
           gmf-search-placeholder="{{'Search…'|translate}}"
+          gmf-search-delay="mainCtrl.searchDelay"
           gmf-search-clearbutton="true">
         </gmf-search>
         <div class="gmf-app-map-bottom-controls">

--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -66,6 +66,12 @@ app.AlternativeDesktopController = function($scope, $injector, ngeoFile, gettext
   this.searchCoordinatesProjections = ['EPSG:21781', 'EPSG:2056', 'EPSG:4326'];
 
   /**
+   * @type {number}
+   * @export
+   */
+  this.searchDelay = 500;
+
+  /**
    * @type {boolean}
    * @export
    */

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -56,7 +56,8 @@
         gmf-search-clearbutton="true"
         gmf-search-placeholder="{{'Search…'|translate}}"
         gmf-search-coordinatesprojections="mainCtrl.searchCoordinatesProjections"
-        gmf-search-listeners="::mainCtrl.searchListeners">
+        gmf-search-listeners="::mainCtrl.searchListeners"
+        gmf-search-delay="mainCtrl.searchDelay">
       </gmf-search>
       <button class="gmf-mobile-nav-trigger gmf-mobile-nav-right-trigger"
         ng-click="mainCtrl.toggleRightNavVisibility()">

--- a/contribs/gmf/apps/mobile/js/controller.js
+++ b/contribs/gmf/apps/mobile/js/controller.js
@@ -46,6 +46,12 @@ app.MobileController = function($scope, $injector) {
   ];
 
   /**
+   * @type {number}
+   * @export
+   */
+  this.searchDelay = 50;
+
+  /**
    * @type {Array.<string>}
    * @export
    */

--- a/contribs/gmf/apps/mobile_alt/index.html
+++ b/contribs/gmf/apps/mobile_alt/index.html
@@ -56,7 +56,8 @@
         gmf-search-clearbutton="true"
         gmf-search-placeholder="{{'Search…'|translate}}"
         gmf-search-coordinatesprojections="mainCtrl.searchCoordinatesProjections"
-        gmf-search-listeners="::mainCtrl.searchListeners">
+        gmf-search-listeners="::mainCtrl.searchListeners"
+        gmf-search-delay="mainCtrl.searchDelay">
       </gmf-search>
       <button class="gmf-mobile-nav-trigger gmf-mobile-nav-right-trigger"
         ng-click="mainCtrl.toggleRightNavVisibility()">

--- a/contribs/gmf/apps/mobile_alt/js/controller.js
+++ b/contribs/gmf/apps/mobile_alt/js/controller.js
@@ -46,6 +46,12 @@ app.AlternativeMobileController = function($scope, $injector) {
   ];
 
   /**
+   * @type {number}
+   * @export
+   */
+  this.searchDelay = 50;
+
+  /**
    * @type {Array.<string>}
    * @export
    */

--- a/contribs/gmf/examples/search.html
+++ b/contribs/gmf/examples/search.html
@@ -163,7 +163,8 @@
         gmf-search-colorchooser="true"
         gmf-search-placeholder="Search for « Laus » for example…"
         gmf-search-clearbutton="true"
-        gmf-search-on-init="ctrl.searchIsReady()">
+        gmf-search-on-init="ctrl.searchIsReady()"
+        gmf-search-delay="50">
       </gmf-search>
       <p id="desc">This example shows how to use the <code>gmf-search</code> directive, which
       is based on Twitter's <code>typeahead</code> component.</p>
@@ -192,6 +193,7 @@
       var gmfModule = angular.module('gmf');
       gmfModule.constant('defaultTheme', 'Demo');
       gmfModule.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
+      gmfModule.constant('fulltextsearchUrl', 'https://geomapfish-demo.camptocamp.net/2.2/wsgi/fulltextsearch?limit=30&partitionlimit=5&interface=desktop');
     </script>
   </body>
 </html>

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -59,6 +59,7 @@ gmf.module.value('gmfSearchTemplateUrl',
  *        gmf-search-styles="ctrl.searchStyles"
  *        gmf-search-datasources="ctrl.searchDatasources"
  *        gmf-search-coordinatesprojections="ctrl.searchCoordinatesProjections"
+ *        gmf-search-delay="mainCtrl.searchDelay"
  *        gmf-search-clearbutton="true">
  *      </gmf-search>
  *      <script>
@@ -81,7 +82,8 @@ gmf.module.value('gmfSearchTemplateUrl',
  *        gmf-search-styles="ctrl.searchStyles"
  *        gmf-search-datasources="ctrl.searchDatasources"
  *        gmf-search-coordinatesprojections="ctrl.searchCoordinatesProjections"
- *        gmf-search-clearbutton="true">
+ *        gmf-search-clearbutton="true"
+ *        gmf-search-delay="mainCtrl.searchDelay"
  *        gmf-search-colorchooser="true">
  *      </gmf-search>
  *      <script>
@@ -110,6 +112,7 @@ gmf.module.value('gmfSearchTemplateUrl',
  *      defined in ol3). If not provided, only the map's view projection
  *      format will be supported.
  * @htmlAttribute {boolean} gmf-search-clearbutton The clear button.
+ * @htmlAttribute {boolean} gmf-search-delay The bloodhound request delay.
  * @htmlAttribute {boolean} gmf-search-colorchooser Whether to let the user
  *      change the style of the feature on the map. Default is false.
  * @htmlAttribute {ngeox.SearchDirectiveListeners} gmf-search-listeners
@@ -138,6 +141,7 @@ gmf.searchDirective = function(gmfSearchTemplateUrl) {
       'coordinatesProjections': '=?gmfSearchCoordinatesprojections',
       'additionalListeners': '=gmfSearchListeners',
       'maxZoom': '<gmfSearchMaxzoom',
+      'delay': '<gmfSearchDelay',
       'onInitCallback': '&?gmfSearchOnInit'
     },
     controller: 'GmfSearchController as ctrl',
@@ -297,6 +301,12 @@ gmf.SearchController = function($scope, $compile, $timeout, $injector, gettextCa
    * @export
    */
   this.placeholder;
+
+  /**
+   * @type {string}
+   * @export
+   */
+  this.delay = parseInt(this.scope_['delay'], 10) || 50;
 
   /**
    * The maximum zoom we will zoom on result.
@@ -635,7 +645,7 @@ gmf.SearchController.prototype.createAndInitBloodhound_ = function(config,
 gmf.SearchController.prototype.getBloodhoudRemoteOptions_ = function() {
   const gettextCatalog = this.gettextCatalog_;
   return {
-    rateLimitWait: 50,
+    rateLimitWait: this.delay,
     prepare(query, settings) {
       const url = settings.url;
       const lang = gettextCatalog.currentLanguage;

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -303,7 +303,7 @@ gmf.SearchController = function($scope, $compile, $timeout, $injector, gettextCa
   this.placeholder;
 
   /**
-   * @type {string}
+   * @type {number}
    * @export
    */
   this.delay = parseInt(this.scope_['delay'], 10) || 50;


### PR DESCRIPTION
This PR allow the rateLimitWait parameter, that is used with the Bloodhound engine for debouncing fulltext-search requests, to be set up. That allow as well to set different values for each interfaces. Like mobile could get a higher value in order to get less request / bandwidth used with the backend for fulltext-search.

If the value is not set from the directive html, or not existing in the interface controller, the search component is going to set it to the default value: 50 ms. This was the value we previously hard-coded. There should be no issue for project that have outdated html for the search component as the component is going to initialize the value correctly in any cases.

I updated every interface, only desktop_alt have a different value that the default one.
Fixed the gmf example as well.