### PR TITLE
Force user to change its password

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -103,7 +103,9 @@
                 {{'Login' | translate}}
                 <a class="btn close" ng-click="mainCtrl.loginActive = false">&times;</a>
               </div>
-              <gmf-authentication></gmf-authentication>
+              <gmf-authentication
+                  gmf-authentication-force-password-change="::true">
+              </gmf-authentication>
             </div>
           </div>
           <div ng-show="mainCtrl.printPanelActive" class="row">

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -131,7 +131,10 @@
                 {{'Login' | translate}}
                 <a class="btn close" ng-click="mainCtrl.loginActive = false">&times;</a>
               </div>
-              <gmf-authentication gmf-authentication-allow-password-reset="false" gmf-authentication-allow-password-change="false"></gmf-authentication>
+              <gmf-authentication
+                  gmf-authentication-allow-password-reset="::false"
+                  gmf-authentication-allow-password-change="::false">
+              </gmf-authentication>
             </div>
           </div>
           <div ng-show="mainCtrl.printPanelActive" class="row">


### PR DESCRIPTION
Fix: #3278 - Use of is_password_changed
 
Demo here: https://ger-benjamin.github.io/ngeo/is_password_change_func/examples/contribs/gmf/apps/desktop
You can try it with the user: demobern (please, don't change the password).

![selection_059](https://user-images.githubusercontent.com/1792111/34677121-62e55108-f48f-11e7-94fe-9359df44dbc2.png)
