### PR TITLE
Escape sourceLabel ids when invalid characters are present

### DIFF
--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -407,6 +407,9 @@
               defaultFeatureNS: 'http://mapserver.gis.umn.edu/mapserver',
               defaultFeaturePrefix: 'feature'
             }));
+        module.constant('ngeoQueryOptions', {
+          limit: 50
+        })
       })();
     </script>
   </body>

--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -114,13 +114,13 @@ app.AlternativeDesktopController = function($scope, $injector, ngeoFile, gettext
    * @export
    */
   this.gridMergeTabs = {
-    'OSM time merged': ['osm_time', 'osm_time2']
+    'OSM_time_merged': ['osm_time', 'osm_time2']
   };
 
   // Allow angular-gettext-tools to collect the strings to translate
   /** @type {angularGettext.Catalog} */
   const gettextCatalog = $injector.get('gettextCatalog');
-  gettextCatalog.getString('OSM time merged');
+  gettextCatalog.getString('OSM_time_merged');
   gettextCatalog.getString('Add a theme');
   gettextCatalog.getString('Add a sub theme');
   gettextCatalog.getString('Add a layer');

--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -114,13 +114,17 @@ app.AlternativeDesktopController = function($scope, $injector, ngeoFile, gettext
    * @export
    */
   this.gridMergeTabs = {
-    'OSM_time_merged': ['osm_time', 'osm_time2']
+    'OSM_time_merged': ['osm_time', 'osm_time2'],
+    'transport (merged)': ['fuel', 'parking'],
+    'Learning [merged]': ['information', 'bus_stop']
   };
 
   // Allow angular-gettext-tools to collect the strings to translate
   /** @type {angularGettext.Catalog} */
   const gettextCatalog = $injector.get('gettextCatalog');
   gettextCatalog.getString('OSM_time_merged');
+  gettextCatalog.getString('OSM_time (merged)');
+  gettextCatalog.getString('Learning [merged]');
   gettextCatalog.getString('Add a theme');
   gettextCatalog.getString('Add a sub theme');
   gettextCatalog.getString('Add a layer');

--- a/contribs/gmf/src/directives/displayquerygrid.js
+++ b/contribs/gmf/src/directives/displayquerygrid.js
@@ -693,9 +693,20 @@ gmf.DisplayquerygridController.prototype.selectTab = function(gridSource) {
  * @param {string|number} sourceLabel Id of the source that should be refreshed.
  */
 gmf.DisplayquerygridController.prototype.reflowGrid_ = function(sourceLabel) {
-  // this is a "work-around" to make sure that the grid is rendered correctly.
-  // when a pane is activated by setting `this.selectedTab`, the class `active`
-  // is not yet set on the pane. that's why the class is set manually, and
+  // This escapes the sourceLabel id if there is some unauthorized values.
+  // Replace the id to be a valid selector. This work-around allows all
+  // tabs to work if it is not set correctly in the ctrl.mergeTabs array,
+  // in example: value with spaces, brackets, parentheses, etc.
+  const toEscape = /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\ |]/g;
+  if (sourceLabel.match(toEscape) !== null) {
+    const escapedSourceLabel = sourceLabel.replace(toEscape, '_');
+    this.$element_.find(`div.tab-pane[id='${sourceLabel}']`).attr('id', escapedSourceLabel);
+    sourceLabel = escapedSourceLabel;
+  }
+
+  // This is a "work-around" to make sure that the grid is rendered correctly.
+  // When a pane is activated by setting `this.selectedTab`, the class `active`
+  // is not yet set on the pane. That's why the class is set manually, and
   // after the pane is shown (in the next digest loop), the grid table can
   // be refreshed.
   const activePane = this.$element_.find(`div.tab-pane#${sourceLabel}`);

--- a/contribs/gmf/src/directives/displayquerygrid.js
+++ b/contribs/gmf/src/directives/displayquerygrid.js
@@ -389,13 +389,13 @@ gmf.DisplayquerygridController.prototype.hasOneWithTooManyResults_ = function() 
  * @private
  */
 gmf.DisplayquerygridController.prototype.escapeValue_ = function(value) {
-  if (Number.isInteger(value)) {
+  // Work-around for Number.isInteger() when not always getting a number ...
+  if (Number.isInteger(/** @type {number} */ (value))) {
     return value;
   } else {
     const toEscape = /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\ |]/g;
     if (value.match(toEscape) !== null) {
-      const escapedValue = value.replace(toEscape, '_');
-      return escapedValue;
+      return value.replace(toEscape, '_');
     } else {
       return value;
     }

--- a/contribs/gmf/src/directives/displayquerygrid.js
+++ b/contribs/gmf/src/directives/displayquerygrid.js
@@ -382,6 +382,12 @@ gmf.DisplayquerygridController.prototype.hasOneWithTooManyResults_ = function() 
   return this.ngeoQueryResult.sources.some(source => source.tooManyResults);
 };
 
+/**
+ * Returns an escaped value.
+ * @param {string|number} value A value to escape.
+ * @returns {string|number} value An escaped value.
+ * @private
+ */
 gmf.DisplayquerygridController.prototype.escapeValue_ = function(value) {
   if (Number.isInteger(value)) {
     return value;

--- a/contribs/gmf/src/directives/partials/displayquerygrid.html
+++ b/contribs/gmf/src/directives/partials/displayquerygrid.html
@@ -10,15 +10,15 @@
     role="tablist">
 
     <li
-      ng-repeat="gridSource in ctrl.getGridSources() track by gridSource.source.label"
+      ng-repeat="gridSource in ctrl.getGridSources() track by gridSource.source.id"
       role="presentation"
       ng-class="{'active' : ctrl.isSelected(gridSource)}"
       ng-click="ctrl.selectTab(gridSource)">
 
       <a
-        href="#{{gridSource.source.label}}"
-        data-target="#{{gridSource.source.label}}"
-        aria-controls="{{gridSource.source.label}}"
+        href="#{{gridSource.source.id}}"
+        data-target="#{{gridSource.source.id}}"
+        aria-controls="{{gridSource.source.id}}"
         role="tab"
         data-toggle="tab">
 
@@ -34,11 +34,11 @@
 
   <div class="tab-content">
     <div
-      ng-repeat="gridSource in ctrl.getGridSources() track by gridSource.source.label"
+      ng-repeat="gridSource in ctrl.getGridSources() track by gridSource.source.id"
       role="tabpanel"
       class="tab-pane"
       ng-class="{'active' : ctrl.isSelected(gridSource)}"
-      id="{{gridSource.source.label}}">
+      id="{{gridSource.source.id}}">
 
       <ngeo-grid
         ngeo-grid-configuration="gridSource.configuration"


### PR DESCRIPTION
Fixes #3273.

With this fix, we escape the IDs (generated from the value in ctrl.mergeTabs for merged tabs or OL datasource). If an invalid value would result in an invalid ID selector (css), then the value is stripped from unauthorized characters. Other change is the use of the datasource IDs for the HTML ids instead of the label value that contained spaces, etc.

Ideally ids defined in the ctrl.mergeTabs should have no spaces, or any specific characters such as parentheses, brackets, etc. This fix allow all project to work without changing ids manually, but if possible having a correct value is just best practice...

In that context I changed the value in our desktop example, while the fix was tested on the previous value, 'OSM time merged'.
  