### PR TITLE
Mouse position translation

### DIFF
--- a/contribs/gmf/src/directives/mouseposition.js
+++ b/contribs/gmf/src/directives/mouseposition.js
@@ -37,7 +37,8 @@ gmf.module.component('gmfMouseposition', gmf.mousepositionComponent);
 
 /**
  * @param {!angular.JQLite} $element Element.
- * @param {!angular.$filter} $filter Angular filter
+ * @param {!angular.$filter} $filter Angular filter.
+ * @param {!angular.Scope} $scope Angular scope.
  * @param {!angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @constructor
  * @private
@@ -45,7 +46,7 @@ gmf.module.component('gmfMouseposition', gmf.mousepositionComponent);
  * @ngdoc controller
  * @ngname gmfMousepositionController
  */
-gmf.MousepositionController = function($element, $filter, gettextCatalog) {
+gmf.MousepositionController = function($element, $filter, $scope, gettextCatalog) {
   /**
    * @type {!ol.Map}
    * @export
@@ -63,6 +64,12 @@ gmf.MousepositionController = function($element, $filter, gettextCatalog) {
    * @export
    */
   this.projection;
+
+  /**
+   * @type {angular.Scope}
+   * @private
+   */
+  this.$scope_ = $scope;
 
   /**
    * @type {angularGettext.Catalog}
@@ -98,17 +105,24 @@ gmf.MousepositionController.prototype.$onInit = function() {
     return filter.apply(this, args);
   };
 
-  const gettextCatalog_ = this.gettextCatalog_;
-  this.control = new ol.control.MousePosition({
-    className: 'gmf-mouseposition-control',
-    coordinateFormat: formatFn.bind(this),
-    target: angular.element('.gmf-mouseposition-control-target', this.$element_)[0],
-    undefinedHTML: gettextCatalog_.getString('Coordinates')
+  this.control = null;
+  this.$scope_.$on('gettextLanguageChanged', () => {
+    if (this.control !== null) {
+      this.map.removeControl(this.control);
+    }
+
+    const gettextCatalog = this.gettextCatalog_;
+    this.control = new ol.control.MousePosition({
+      className: 'gmf-mouseposition-control',
+      coordinateFormat: formatFn.bind(this),
+      target: angular.element('.gmf-mouseposition-control-target', this.$element_)[0],
+      undefinedHTML: gettextCatalog.getString('Coordinates')
+    });
+
+    this.setProjection(this.projections[0]);
+
+    this.map.addControl(this.control);
   });
-
-  this.setProjection(this.projections[0]);
-
-  this.map.addControl(this.control);
 };
 
 

--- a/contribs/gmf/src/directives/mouseposition.js
+++ b/contribs/gmf/src/directives/mouseposition.js
@@ -70,22 +70,17 @@ gmf.MousepositionController = function($element, $filter, gettextCatalog) {
    */
   this.gettextCatalog_ = gettextCatalog;
 
-  // function that apply the filter.
-  const formatFn = function(coordinates) {
-    const filterAndArgs = this.projection.filter.split(':');
-    const filter = $filter(filterAndArgs.shift());
-    goog.asserts.assertFunction(filter);
-    const args = filterAndArgs;
-    args.unshift(coordinates);
-    return filter.apply(this, args);
-  };
+  /**
+   * @type {angular.JQLite}
+   * @private
+   */
+  this.$element_ = $element;
 
-  this.control = new ol.control.MousePosition({
-    className: 'gmf-mouseposition-control',
-    coordinateFormat: formatFn.bind(this),
-    target: angular.element('.gmf-mouseposition-control-target', $element)[0],
-    undefinedHTML: this.gettextCatalog_.getString('Coordinates')
-  });
+  /**
+   * @type {angular.$filter}
+   * @private
+   */
+  this.$filter_ = $filter;
 };
 
 
@@ -93,6 +88,24 @@ gmf.MousepositionController = function($element, $filter, gettextCatalog) {
  * Initialise the controller.
  */
 gmf.MousepositionController.prototype.$onInit = function() {
+  // function that apply the filter.
+  const formatFn = function(coordinates) {
+    const filterAndArgs = this.projection.filter.split(':');
+    const filter = this.$filter_(filterAndArgs.shift());
+    goog.asserts.assertFunction(filter);
+    const args = filterAndArgs;
+    args.unshift(coordinates);
+    return filter.apply(this, args);
+  };
+
+  const gettextCatalog_ = this.gettextCatalog_;
+  this.control = new ol.control.MousePosition({
+    className: 'gmf-mouseposition-control',
+    coordinateFormat: formatFn.bind(this),
+    target: angular.element('.gmf-mouseposition-control-target', this.$element_)[0],
+    undefinedHTML: gettextCatalog_.getString('Coordinates')
+  });
+
   this.setProjection(this.projections[0]);
 
   this.map.addControl(this.control);

--- a/contribs/gmf/src/directives/mouseposition.js
+++ b/contribs/gmf/src/directives/mouseposition.js
@@ -64,6 +64,12 @@ gmf.MousepositionController = function($element, $filter, gettextCatalog) {
    */
   this.projection;
 
+  /**
+   * @type {angularGettext.Catalog}
+   * @private
+   */
+  this.gettextCatalog_ = gettextCatalog;
+
   // function that apply the filter.
   const formatFn = function(coordinates) {
     const filterAndArgs = this.projection.filter.split(':');
@@ -78,7 +84,7 @@ gmf.MousepositionController = function($element, $filter, gettextCatalog) {
     className: 'gmf-mouseposition-control',
     coordinateFormat: formatFn.bind(this),
     target: angular.element('.gmf-mouseposition-control-target', $element)[0],
-    undefinedHTML: gettextCatalog.getString('Coordinates')
+    undefinedHTML: this.gettextCatalog_.getString('Coordinates')
   });
 };
 


### PR DESCRIPTION
Fixes #3344 

This fixes the translation issue with the mouse position OL control. Now we wait for gettextCatalog to fire an event that the language is loaded/changed to create the component with the correct language string.