### PR TITLE
Accepte multiple enumerate attributes (filters)

### DIFF
--- a/contribs/gmf/src/services/enumerateattribute.js
+++ b/contribs/gmf/src/services/enumerateattribute.js
@@ -33,7 +33,7 @@ gmf.EnumerateAttribute = class {
     this.baseUrl_ = gmfLayersUrl;
 
     /**
-     * @type {Object.<number, !angular.$q.Promise>}
+     * @type {Object.<string, !angular.$q.Promise>}
      * @private
      */
     this.promises_ = {};
@@ -45,14 +45,14 @@ gmf.EnumerateAttribute = class {
    * @return {angular.$q.Promise} Promise.
    */
   getAttributeValues(dataSource, attribute) {
-    const id = dataSource.id;
+    const promiseId = `${dataSource.id}_${attribute}`;
     const name = dataSource.name;
-    if (!this.promises_[id]) {
+    if (!this.promises_[promiseId]) {
       const url = `${this.baseUrl_}/${name}/values/${attribute}`;
-      this.promises_[id] = this.http_.get(url).then(
+      this.promises_[promiseId] = this.http_.get(url).then(
         this.handleGetAttributeValues_.bind(this));
     }
-    return this.promises_[id];
+    return this.promises_[promiseId];
   }
 
   /**


### PR DESCRIPTION
Fix: #3365
Now we query each attributes to get their "description" and so, we can filter on multiple enumerated attributes (tested locally).

Note that for that, we need:
 - (mapfile) That the column is given by the sql request and "exported" via the gml_include_items.
 - (vars file) That each attribute is listed in the layers->enum-><layer>->attributes section
 - (admin) That the layer has a enumeratedAttributes metadata with the value "column1,column2,etc"
 - (Column can't have alias ! )