### PR TITLE
Set content-type header for WFS requests

### DIFF
--- a/src/services/querent.js
+++ b/src/services/querent.js
@@ -472,6 +472,7 @@ ngeo.Querent = class {
           featureCountRequest,
           {
             params,
+            headers: {'Content-Type': 'text/xml; charset=UTF-8'},
             timeout: canceler.promise
           }
         ).then(((response) => {
@@ -510,6 +511,7 @@ ngeo.Querent = class {
             featureRequest,
             {
               params,
+              headers: {'Content-Type': 'text/xml; charset=UTF-8'},
               timeout: canceler.promise
             }
           ).then((response) => {


### PR DESCRIPTION
Fixes https://jira.camptocamp.com/servicedesk/customer/portal/6/GEO-865

Currently the WFS requests are sent with header 'content-type': 'application/json', but we always send a xml payload to Mapserver. Issue is on one of baselstadt instance (integration), this behaviour did redirect the request for some reasons ... Setting the correct content-type header to 'text/xml'.

More generally, outside this use case, the content-type should have been 'text/xml' anyways.