### PR TITLE
Allow print symbols rotation in gmf projects

### DIFF
--- a/src/services/print.js
+++ b/src/services/print.js
@@ -216,19 +216,11 @@ ngeo.Print.prototype.encodeMap_ = function(map, scale, object) {
   object.layers = [];
 
   const mapLayerGroup = map.getLayerGroup();
-  goog.asserts.assert(mapLayerGroup !== null);
+  goog.asserts.assert(mapLayerGroup);
+  this.printNativeAngle_ = !(mapLayerGroup.get('printNativeAngle') !== false);
   let layers = this.ngeoLayerHelper_.getFlatLayers(mapLayerGroup);
   layers = layers.slice().reverse();
 
-  // (1.) We loop on every layers and if one of them doesn't use native angle,
-  // this set the global value to use for the print (default is true)
-  layers.forEach((layer) => {
-    if (layer.get('printNativeAngle') === false) {
-      this.printNativeAngle_ = false;
-    }
-  });
-
-  // (2.) We encode the layers
   layers.forEach((layer) => {
     if (layer.getVisible()) {
       goog.asserts.assert(viewResolution !== undefined);

--- a/src/services/print.js
+++ b/src/services/print.js
@@ -125,6 +125,12 @@ ngeo.Print = function(url, $http, ngeoLayerHelper) {
    * @private
    */
   this.ngeoLayerHelper_ = ngeoLayerHelper;
+
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.printNativeAngle_ = true;
 };
 
 
@@ -214,6 +220,15 @@ ngeo.Print.prototype.encodeMap_ = function(map, scale, object) {
   let layers = this.ngeoLayerHelper_.getFlatLayers(mapLayerGroup);
   layers = layers.slice().reverse();
 
+  // (1.) We loop on every layers and if one of them doesn't use native angle,
+  // this set the global value to use for the print (default is true)
+  layers.forEach((layer) => {
+    if (layer.getProperties()['printNativeAngle'] === false) {
+      this.printNativeAngle_ = false;
+    }
+  });
+
+  // (2.) We encode the layers
   layers.forEach((layer) => {
     if (layer.getVisible()) {
       goog.asserts.assert(viewResolution !== undefined);
@@ -308,7 +323,7 @@ ngeo.Print.prototype.encodeWmsLayer_ = function(arr, opacity, url, params) {
     type: 'wms',
     opacity,
     version: params['VERSION'],
-    useNativeAngle: false
+    useNativeAngle: this.printNativeAngle_
   });
   arr.push(object);
 };

--- a/src/services/print.js
+++ b/src/services/print.js
@@ -217,7 +217,7 @@ ngeo.Print.prototype.encodeMap_ = function(map, scale, object) {
 
   const mapLayerGroup = map.getLayerGroup();
   goog.asserts.assert(mapLayerGroup);
-  this.printNativeAngle_ = !(mapLayerGroup.get('printNativeAngle') !== false);
+  this.printNativeAngle_ = !(mapLayerGroup.get('printNativeAngle') === false);
   let layers = this.ngeoLayerHelper_.getFlatLayers(mapLayerGroup);
   layers = layers.slice().reverse();
 

--- a/src/services/print.js
+++ b/src/services/print.js
@@ -223,7 +223,7 @@ ngeo.Print.prototype.encodeMap_ = function(map, scale, object) {
   // (1.) We loop on every layers and if one of them doesn't use native angle,
   // this set the global value to use for the print (default is true)
   layers.forEach((layer) => {
-    if (layer.getProperties()['printNativeAngle'] === false) {
+    if (layer.get('printNativeAngle') === false) {
       this.printNativeAngle_ = false;
     }
   });

--- a/src/services/print.js
+++ b/src/services/print.js
@@ -307,7 +307,8 @@ ngeo.Print.prototype.encodeWmsLayer_ = function(arr, opacity, url, params) {
     serverType: params['SERVERTYPE'],
     type: 'wms',
     opacity,
-    version: params['VERSION']
+    version: params['VERSION'],
+    useNativeAngle: false
   });
   arr.push(object);
 };

--- a/test/spec/services/print.spec.js
+++ b/test/spec/services/print.spec.js
@@ -113,7 +113,8 @@ describe('ngeo.CreatePrint', () => {
                 type: 'wms',
                 opacity: 1,
                 serverType: undefined,
-                version: undefined
+                version: undefined,
+                useNativeAngle: true
               }]
             },
             foo: 'fooval',
@@ -170,7 +171,8 @@ describe('ngeo.CreatePrint', () => {
                 type: 'wms',
                 opacity: 1,
                 serverType: undefined,
-                version: undefined
+                version: undefined,
+                useNativeAngle: true
               }]
             },
             foo: 'fooval',


### PR DESCRIPTION
This was the old behavior for 2.1 (icons were rotating with the map).
Adding parameter 'useNativeAngle' to 'false' fixes the issue in 2.2.