### PR TITLE
Set the background layer from the them at page load

### DIFF
--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -151,9 +151,6 @@ gmf.AbstractController = function(config, $scope, $injector) {
     this.gmfThemeManager.setThemeName('', true);
     if (evt.type !== gmf.AuthenticationEventType.READY) {
       this.updateCurrentTheme_(previousThemeName);
-    } else {
-      // initialize default background layer
-      this.setDefaultBackground_(null, true);
     }
     // Reload themes when login status changes.
     this.gmfThemes_.loadThemes(roleId);
@@ -416,7 +413,7 @@ gmf.AbstractController = function(config, $scope, $injector) {
   $scope.$root.$on(gmf.ThemeManagerEventType.THEME_NAME_SET, (event, name) => {
     this.gmfThemes_.getThemeObject(name).then((theme) => {
       if (theme) {
-        this.setDefaultBackground_(theme, false);
+        this.setDefaultBackground_(theme);
       }
     });
   });
@@ -590,31 +587,31 @@ gmf.AbstractController.prototype.initLanguage = function() {
 
 /**
  * @param {gmfThemes.GmfTheme} theme Theme.
- * @param {boolean} use_permalink Get background from the permalink.
  * @private
  */
-gmf.AbstractController.prototype.setDefaultBackground_ = function(theme, use_permalink) {
+gmf.AbstractController.prototype.setDefaultBackground_ = function(theme) {
   this.gmfThemes_.getBgLayers(this.dimensions).then((layers) => {
     let layer;
 
-    if (use_permalink) {
-      // get the background from the permalink
-      layer = this.permalink_.getBackgroundLayer(layers);
-    }
+    // get the background from the permalink
+    layer = this.permalink_.getBackgroundLayer(layers);
+
     if (!layer) {
       // get the background from the user settings
       layer = gmf.AbstractController.getLayerByLabels(layers, this.gmfUser.functionalities.default_basemap);
-      if (!layer && theme) {
-        // get the background from the theme
-        layer = gmf.AbstractController.getLayerByLabels(layers, theme.functionalities.default_basemap);
-      }
-      if (!layer) {
-        // fallback to the layers list, use the second one because the first is the blank layer.
-        layer = layers[1];
-      }
     }
-    goog.asserts.assert(layer);
 
+    if (!layer) {
+      // get the background from the theme
+      layer = gmf.AbstractController.getLayerByLabels(layers, theme.functionalities.default_basemap);
+    }
+
+    if (!layer) {
+      // fallback to the layers list, use the second one because the first is the blank layer.
+      layer = layers[1];
+    }
+
+    goog.asserts.assert(layer);
     this.backgroundLayerMgr_.set(this.map, layer);
   });
 };

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -411,7 +411,7 @@ gmf.Permalink = function($timeout, $rootScope, $injector, ngeoDebounce,
 
   if (this.gmfThemeManager_) {
     this.rootScope_.$on(gmf.ThemeManagerEventType.THEME_NAME_SET, (event, name) => {
-      this.setThemeInUrl_();
+      this.setThemeInUrl_(name);
     });
   }
 
@@ -835,10 +835,10 @@ gmf.Permalink.prototype.themeInUrl_ = function(pathElements) {
 
 
 /**
+ * @param {string} themeName Theme name.
  * @private
  */
-gmf.Permalink.prototype.setThemeInUrl_ = function() {
-  const themeName = this.gmfThemeManager_ ? this.gmfThemeManager_.getThemeName() : null;
+gmf.Permalink.prototype.setThemeInUrl_ = function(themeName) {
   if (themeName) {
     const pathElements = this.ngeoLocation_.getPath().split('/');
     goog.asserts.assert(pathElements.length > 1);
@@ -920,10 +920,10 @@ gmf.Permalink.prototype.initLayers_ = function() {
   }
   this.gmfThemes_.getThemesObject().then((themes) => {
     const themeName = this.defaultThemeName();
+    goog.asserts.assert(themeName !== null);
 
     if (this.gmfThemeManager_ && this.gmfThemeManager_.modeFlush) {
-      // Set theme in stealth mode, we just want to set the theme name, not more.
-      this.gmfThemeManager_.setThemeName(`${themeName}`, true);
+      this.gmfThemeManager_.setThemeName(themeName);
     }
 
     /**

--- a/contribs/gmf/src/services/thememanager.js
+++ b/contribs/gmf/src/services/thememanager.js
@@ -128,12 +128,11 @@ gmf.ThemeManager.prototype.isLoading = function() {
 
 /**
  * @param {string} name The new theme name.
- * @param {boolean=} opt_stealth Don't emit an event is true
- * @export
+ * @param {boolean=} opt_silent Don't emit a theme change event, default is false.
  */
-gmf.ThemeManager.prototype.setThemeName = function(name, opt_stealth) {
+gmf.ThemeManager.prototype.setThemeName = function(name, opt_silent) {
   this.themeName_ = name;
-  if (!opt_stealth) {
+  if (!opt_silent) {
     this.$rootScope_.$emit(gmf.ThemeManagerEventType.THEME_NAME_SET, name);
   }
 };


### PR DESCRIPTION
Correctly set the background layer at page load.

Change: at page load, the theme name is directly set to the url; it was not the case previously.
