### PR TITLE
Allow vertex deletation on single click

### DIFF
--- a/contribs/gmf/src/directives/editfeature.js
+++ b/contribs/gmf/src/directives/editfeature.js
@@ -17,6 +17,7 @@ goog.require('ngeo.DecorateInteraction');
 goog.require('ngeo.EventHelper');
 goog.require('ngeo.FeatureHelper');
 goog.require('ngeo.LayerHelper');
+goog.require('ngeo.utils');
 goog.require('ngeo.Menu');
 goog.require('ngeo.ToolActivate');
 goog.require('ngeo.ToolActivateMgr');
@@ -449,6 +450,7 @@ gmf.EditfeatureController.prototype.$onInit = function() {
 
   // (1.2) Create, set and initialize interactions
   this.modify_ = new ol.interaction.Modify({
+    deleteCondition: ngeo.utils.deleteCondition,
     features: this.features,
     style: this.ngeoFeatureHelper_.getVertexStyle(false)
   });

--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -360,6 +360,7 @@ gmf.ObjecteditingController = function($scope, $timeout, gettextCatalog,
    * @private
    */
   this.modify_ = new ol.interaction.Modify({
+    deleteCondition: ngeo.utils.deleteCondition,
     features: this.features_,
     style: ngeoFeatureHelper.getVertexStyle(false)
   });

--- a/src/ol-ext/interaction/modify.js
+++ b/src/ol-ext/interaction/modify.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.interaction.Modify');
 
+goog.require('ngeo.utils');
 goog.require('ngeo.interaction.ModifyCircle');
 goog.require('ngeo.interaction.ModifyRectangle');
 goog.require('ol.functions');
@@ -59,6 +60,7 @@ ngeo.interaction.Modify = function(options) {
   this.otherFeatures_ = new ol.Collection();
 
   this.interactions_.push(new ol.interaction.Modify({
+    deleteCondition: ngeo.utils.deleteCondition,
     features: this.otherFeatures_,
     pixelTolerance: options.pixelTolerance,
     style: options.style,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.utils');
 
+goog.require('ol.events.condition');
 goog.require('ol.geom.LineString');
 goog.require('ol.geom.MultiPoint');
 goog.require('ol.geom.MultiLineString');
@@ -103,4 +104,14 @@ ngeo.utils.encodeQueryString = function(queryData) {
     queryItem.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`);
   }
   return queryItem.join('&');
+};
+
+
+/**
+ * Delete condition passed to the modify interaction
+ * @param {ol.MapBrowserEvent} event Browser event.
+ * @return {boolean} The result.
+ */
+ngeo.utils.deleteCondition = function(event) {
+  return ol.events.condition.noModifierKeys(event) && ol.events.condition.singleClick(event);
 };


### PR DESCRIPTION
Instead of alt + single click, see:
https://github.com/openlayers/openlayers/blob/master/changelog/upgrade-notes.md#olinteractionmodify-deletes-with-alt-key-only


fixes #3413 