### PR TITLE
Fix ogc server encoding for IE11/Edge

### DIFF
--- a/src/services/print.js
+++ b/src/services/print.js
@@ -131,6 +131,12 @@ ngeo.Print = function(url, $http, ngeoLayerHelper) {
    * @private
    */
   this.printNativeAngle_ = true;
+
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.isMs = new URL('http://_/?a=+').searchParams.get('a') == '+';
 };
 
 
@@ -287,7 +293,11 @@ ngeo.Print.prototype.encodeImageWmsLayer_ = function(arr, layer) {
  * @private
  */
 ngeo.Print.prototype.encodeWmsLayer_ = function(arr, opacity, url, params) {
-  const url_url = new URL(url);
+  let url_url = new URL(url);
+  // work-around to normalize IE11 & Edge ogcserver encoding issue
+  if (this.isMs && url_url.search.indexOf('+')) {
+    url_url = new URL(url_url.origin + url_url.pathname + url_url.search.replace(/\+/g, '%20'));
+  }
   const customParams = {'TRANSPARENT': true};
   if (url_url.searchParams) {
     for (const element of url_url.searchParams) {


### PR DESCRIPTION
It seems that the ogcserver sent by IE11 and Edge is the following:
"ogcserver": "Main+PNG"

while the correct format sent by Chrome and Firefox is:
"ogcserver: "Main PNG"

The wrong format causes the plus sign to be encoded into %2B, and breaks the print request.
The condition I add is not doing anything in the cases when Chrome and Firefox are sending the right value.