### PR TITLE
Add printNativeAngle parameter to the gmf-created print LayerGroup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1021,7 +1021,7 @@ transifex-init: .build/python-venv/bin/tx \
 .PRECIOUS: .build/locale/%/LC_MESSAGES/demo.po
 .build/locale/%/LC_MESSAGES/demo.po:
 	mkdir -p $(dir $@)
-	wget -O $@ https://raw.githubusercontent.com/camptocamp/demo_geomapfish/master/demo/locale/$*/LC_MESSAGES/demo-client.po
+	wget -O $@ https://raw.githubusercontent.com/camptocamp/demo_geomapfish/2.2/demo/locale/$*/LC_MESSAGES/demo-client.po
 
 contribs/gmf/build/gmf-%.json: \
 		.build/locale/%/LC_MESSAGES/ngeo.po \

--- a/contribs/gmf/externs/gmf-themes.js
+++ b/contribs/gmf/externs/gmf-themes.js
@@ -487,6 +487,14 @@ gmfThemes.GmfMetaData.prototype.isChecked;
  */
 gmfThemes.GmfMetaData.prototype.isExpanded;
 
+/**
+ * Whether the print should rotate the symbols.
+ * Default to true.
+ * For layer groups (only).
+ * @type {boolean|undefined}
+ */
+gmfThemes.GmfMetaData.prototype.printNativeAngle;
+
 
 /**
  * Whether the legend is expanded by default.

--- a/contribs/gmf/src/directives/print.js
+++ b/contribs/gmf/src/directives/print.js
@@ -767,6 +767,7 @@ gmf.PrintController.prototype.print = function(format) {
   map.setView(this.map.getView());
   const ol_layers = this.ngeoLayerHelper_.getFlatLayers(this.map.getLayerGroup());
   const new_ol_layers = [];
+  let print_native_angle = true;
   for (let i = 0, ii = ol_layers.length; i < ii; i++) {
     let layer = ol_layers[i];
     const metadata = layer.get('metadata');
@@ -787,10 +788,17 @@ gmf.PrintController.prototype.print = function(format) {
         }
       }
     }
+
+    // Get the print native angle parameter for WMS layers
+    if (layer instanceof ol.layer.Image) {
+      print_native_angle = layer.get('printNativeAngle');
+    }
+
     new_ol_layers.push(layer);
   }
   map.setLayerGroup(new ol.layer.Group({
-    layers: new_ol_layers
+    layers: new_ol_layers,
+    'printNativeAngle': print_native_angle
   }));
 
   const spec = this.ngeoPrint_.createSpec(map, scale, this.layoutInfo.dpi,

--- a/contribs/gmf/src/services/syncLayertreeMap.js
+++ b/contribs/gmf/src/services/syncLayertreeMap.js
@@ -163,6 +163,11 @@ gmf.SyncLayertreeMap.prototype.createGroup_ = function(treeCtrl, map,
   let layer = null;
   const isFirstLevelGroup = treeCtrl.parent.isRoot;
 
+  let printNativeAngle = true;
+  if (groupNode.metadata.printNativeAngle !== undefined) {
+    printNativeAngle = groupNode.metadata.printNativeAngle;
+  }
+
   if (isFirstLevelGroup) { // First level group
     layer = this.createLayerFromGroup_(treeCtrl, !!groupNode.mixed);
     // Insert the layer at the right place
@@ -178,6 +183,8 @@ gmf.SyncLayertreeMap.prototype.createGroup_ = function(treeCtrl, map,
       layerGroup.getLayers().insertAt(0, layer);
     }
   }
+
+  layer.set('printNativeAngle', printNativeAngle);
   return layer;
 };
 


### PR DESCRIPTION
I set the parameter this way in a project controller via metadata 'printNativeAngle' in the admin interface applied to the layer group I want.

printNativeAngle value was not sent to the ngeo print component because gmf did not retrieve the original layerGroup but create a new one just before sending it to ngeo.

Desktop_alt updated to test this use case.