### PR TITLE
Add require of goog.assert

### DIFF
--- a/buildtools/webpack-migration
+++ b/buildtools/webpack-migration
@@ -6,6 +6,7 @@ function jscodeshift {
     rm /tmp/jscodeshift.log
 }
 
+rm -f src/jstsexports.js
 node node_modules/googshift/filename-case-from-module.js src '*.js'
 node node_modules/googshift/filename-case-from-module.js contribs/gmf/src '*.js'
 node node_modules/googshift/filename-case-from-module.js contribs/gmf/apps '*.js'
@@ -31,6 +32,7 @@ sed '/app:/d' -i .eslintrc.yaml
 sed '/gmfapp:/d' -i .eslintrc.yaml
 sed '/proj4:/d' -i .eslintrc.yaml
 sed '/d3:/d' -i .eslintrc.yaml
+sed '/goog:/d' -i .eslintrc.yaml
 sed '/jsts:/d' -i .eslintrc.yaml
 sed '/moment:/d' -i .eslintrc.yaml
 sed '/saveAs:/d' -i .eslintrc.yaml

--- a/contribs/gmf/examples/drawfeature.js
+++ b/contribs/gmf/examples/drawfeature.js
@@ -6,6 +6,7 @@ goog.require('gmf');
 /** @suppress {extraRequire} */
 goog.require('gmf.map.component');
 goog.require('gmf.drawing.module');
+goog.require('goog.asserts');
 goog.require('ngeo.format.FeatureProperties');
 goog.require('ngeo.map.module');
 goog.require('ngeo.misc.FeatureHelper');

--- a/contribs/gmf/examples/featurestyle.js
+++ b/contribs/gmf/examples/featurestyle.js
@@ -6,6 +6,7 @@ goog.require('gmf');
 goog.require('gmf.drawing.featureStyleComponent');
 /** @suppress {extraRequire} */
 goog.require('gmf.map.component');
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ngeo.format.FeatureProperties');
 goog.require('ngeo.misc.FeatureHelper');

--- a/contribs/gmf/src/contextualdata/component.js
+++ b/contribs/gmf/src/contextualdata/component.js
@@ -2,6 +2,7 @@ goog.provide('gmf.contextualdata.component');
 
 goog.require('gmf');
 goog.require('gmf.raster.RasterService');
+goog.require('goog.asserts');
 goog.require('ol.Overlay');
 goog.require('ol.proj');
 goog.require('ol.events');

--- a/contribs/gmf/src/controllers/AbstractAppController.js
+++ b/contribs/gmf/src/controllers/AbstractAppController.js
@@ -21,6 +21,7 @@ goog.require('gmf.theme.Manager');
 goog.require('gmf.theme.Themes');
 /** @suppress {extraRequire} */
 goog.require('gmf.theme.selectorComponent');
+goog.require('goog.asserts');
 /** @suppress {extraRequire} */
 goog.require('ngeo.filters');
 /** @suppress {extraRequire} */

--- a/contribs/gmf/src/datasource/ExternalDataSourcesManager.js
+++ b/contribs/gmf/src/datasource/ExternalDataSourcesManager.js
@@ -5,6 +5,7 @@ goog.provide('gmf.datasource.ExternalDataSourcesManager');
 
 goog.require('gmf');
 /** @suppress {extraRequire} */
+goog.require('goog.asserts');
 goog.require('ngeo.utils.File');
 goog.require('ngeo.datasource.DataSources');
 goog.require('ngeo.datasource.File');

--- a/contribs/gmf/src/datasource/Manager.js
+++ b/contribs/gmf/src/datasource/Manager.js
@@ -6,6 +6,7 @@ goog.require('gmf.datasource.WFSAliases');
 goog.require('gmf.layertree.SyncLayertreeMap');
 goog.require('gmf.layertree.TreeManager');
 goog.require('gmf.theme.Themes');
+goog.require('goog.asserts');
 /** @suppress {extraRequire} */
 goog.require('ngeo.datasource.DataSources');
 goog.require('ngeo.datasource.OGC');

--- a/contribs/gmf/src/disclaimer/component.js
+++ b/contribs/gmf/src/disclaimer/component.js
@@ -5,6 +5,7 @@ goog.require('ol.events');
 goog.require('ol.layer.Base');
 goog.require('ol.layer.Group');
 goog.require('gmf');
+goog.require('goog.asserts');
 goog.require('ngeo.message.Message');
 goog.require('ngeo.message.Disclaimer');
 goog.require('ngeo.misc.EventHelper');

--- a/contribs/gmf/src/drawing/drawFeatureComponent.js
+++ b/contribs/gmf/src/drawing/drawFeatureComponent.js
@@ -3,6 +3,7 @@ goog.provide('gmf.drawing.drawFeatureComponent');
 goog.require('gmf');
 /** @suppress {extraRequire} */
 goog.require('gmf.drawing.featureStyleComponent');
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ngeo.GeometryType');
 goog.require('ngeo.Menu');

--- a/contribs/gmf/src/drawing/featureStyleComponent.js
+++ b/contribs/gmf/src/drawing/featureStyleComponent.js
@@ -1,6 +1,7 @@
 goog.provide('gmf.drawing.featureStyleComponent');
 
 goog.require('gmf');
+goog.require('goog.asserts');
 goog.require('ol.events');
 goog.require('ol.Object');
 goog.require('ngeo');

--- a/contribs/gmf/src/editing/Snapping.js
+++ b/contribs/gmf/src/editing/Snapping.js
@@ -3,6 +3,7 @@ goog.provide('gmf.editing.Snapping');
 goog.require('gmf');
 goog.require('gmf.layertree.TreeManager');
 goog.require('gmf.theme.Themes');
+goog.require('goog.asserts');
 goog.require('ngeo.layertree.Controller');
 goog.require('ol');
 goog.require('ol.events');

--- a/contribs/gmf/src/editing/editFeatureComponent.js
+++ b/contribs/gmf/src/editing/editFeatureComponent.js
@@ -7,6 +7,7 @@ goog.require('gmf.editing.EditFeature');
 goog.require('gmf.editing.Snapping');
 goog.require('gmf.editing.XSDAttributes');
 goog.require('gmf.layertree.SyncLayertreeMap');
+goog.require('goog.asserts');
 goog.require('ngeo');
 /** @suppress {extraRequire} */
 goog.require('ngeo.editing.attributesComponent');

--- a/contribs/gmf/src/filters/SavedFilters.js
+++ b/contribs/gmf/src/filters/SavedFilters.js
@@ -1,6 +1,7 @@
 goog.provide('gmf.filters.SavedFilters');
 
 goog.require('gmf');
+goog.require('goog.asserts');
 goog.require('ol.array');
 
 

--- a/contribs/gmf/src/filters/filterselectorcomponent.js
+++ b/contribs/gmf/src/filters/filterselectorcomponent.js
@@ -8,6 +8,7 @@ goog.require('gmf.datasource.DataSourceBeingFiltered');
 goog.require('gmf.datasource.Helper');
 goog.require('gmf.datasource.OGC');
 goog.require('gmf.filters.SavedFilters');
+goog.require('goog.asserts');
 /** @suppress {extraRequire} */
 goog.require('ngeo.message.modalComponent');
 goog.require('ngeo.message.Notification');

--- a/contribs/gmf/src/import/importdatasourceComponent.js
+++ b/contribs/gmf/src/import/importdatasourceComponent.js
@@ -7,6 +7,7 @@ goog.require('gmf.datasource.ExternalDataSourcesManager');
 goog.require('gmf.import.wmsCapabilityLayertreeComponent');
 /** @suppress {extraRequire} */
 goog.require('gmf.import.wmtsCapabilityLayertreeComponent');
+goog.require('goog.asserts');
 goog.require('ngeo.query.Querent');
 goog.require('ngeo.datasource.OGC');
 

--- a/contribs/gmf/src/layertree/SyncLayertreeMap.js
+++ b/contribs/gmf/src/layertree/SyncLayertreeMap.js
@@ -2,6 +2,7 @@ goog.provide('gmf.layertree.SyncLayertreeMap');
 
 goog.require('gmf');
 goog.require('gmf.theme.Themes');
+goog.require('goog.asserts');
 goog.require('ngeo.layertree.Controller');
 goog.require('ngeo.misc.WMSTime');
 goog.require('ol');

--- a/contribs/gmf/src/layertree/TreeManager.js
+++ b/contribs/gmf/src/layertree/TreeManager.js
@@ -2,6 +2,7 @@ goog.provide('gmf.layertree.TreeManager');
 
 goog.require('gmf');
 goog.require('gmf.theme.Themes');
+goog.require('goog.asserts');
 goog.require('ngeo.layertree.Controller');
 goog.require('ngeo.message.Message');
 goog.require('ngeo.message.Notification');

--- a/contribs/gmf/src/layertree/component.js
+++ b/contribs/gmf/src/layertree/component.js
@@ -9,6 +9,7 @@ goog.require('gmf.layertree.datasourceGroupTreeComponent');
 goog.require('gmf.layertree.SyncLayertreeMap');
 goog.require('gmf.layertree.TreeManager');
 goog.require('gmf.theme.Themes');
+goog.require('goog.asserts');
 goog.require('ngeo.datasource.OGC');
 /** @suppress {extraRequire} */
 goog.require('ngeo.layertree.component');

--- a/contribs/gmf/src/map/mousepositionComponent.js
+++ b/contribs/gmf/src/map/mousepositionComponent.js
@@ -1,6 +1,7 @@
 goog.provide('gmf.map.mousepositionComponent');
 
 goog.require('gmf');
+goog.require('goog.asserts');
 goog.require('ngeo');
 /** @suppress {extraRequire} */
 goog.require('ngeo.filters');

--- a/contribs/gmf/src/mobile/measure/pointComponent.js
+++ b/contribs/gmf/src/mobile/measure/pointComponent.js
@@ -2,6 +2,7 @@ goog.provide('gmf.mobile.measure.pointComponent');
 
 goog.require('gmf');
 goog.require('gmf.raster.RasterService');
+goog.require('goog.asserts');
 goog.require('ngeo.interaction.MeasurePointMobile');
 goog.require('ngeo.interaction.MobileDraw');
 

--- a/contribs/gmf/src/objectediting/component.js
+++ b/contribs/gmf/src/objectediting/component.js
@@ -9,7 +9,8 @@ goog.require('gmf.objectediting.Query');
 /** @suppress {extraRequire} */
 goog.require('gmf.objectediting.toolsComponent');
 /** @suppress {extraRequire} */
-goog.require('ngeo.jstsExports');
+goog.require('goog.asserts');
+goog.require('ngeo.jstsExports'); // nowebpack
 goog.require('ngeo.map.LayerHelper');
 goog.require('ngeo.misc.decorate');
 goog.require('ngeo.misc.FeatureHelper');

--- a/contribs/gmf/src/print/component.js
+++ b/contribs/gmf/src/print/component.js
@@ -4,6 +4,7 @@ goog.require('gmf');
 /** @suppress {extraRequire} */
 goog.require('gmf.authentication.Service');
 goog.require('gmf.theme.Themes');
+goog.require('goog.asserts');
 goog.require('ngeo.map.LayerHelper');
 goog.require('ngeo.map.FeatureOverlayMgr');
 goog.require('ngeo.misc.FeatureHelper');

--- a/contribs/gmf/src/profile/component.js
+++ b/contribs/gmf/src/profile/component.js
@@ -1,6 +1,7 @@
 goog.provide('gmf.profile.component');
 
 goog.require('gmf');
+goog.require('goog.asserts');
 goog.require('ol.events');
 goog.require('ol.Feature');
 goog.require('ol.Observable');

--- a/contribs/gmf/src/profile/drawLineComponent.js
+++ b/contribs/gmf/src/profile/drawLineComponent.js
@@ -1,6 +1,7 @@
 goog.provide('gmf.profile.drawLineComponent');
 
 goog.require('gmf');
+goog.require('goog.asserts');
 goog.require('ol.Collection');
 goog.require('ol.interaction.Draw');
 goog.require('ol.Map');

--- a/contribs/gmf/src/query/gridComponent.js
+++ b/contribs/gmf/src/query/gridComponent.js
@@ -1,6 +1,7 @@
 goog.provide('gmf.query.gridComponent');
 
 goog.require('gmf');
+goog.require('goog.asserts');
 /** @suppress {extraRequire} */
 goog.require('ngeo.download.Csv');
 /** @suppress {extraRequire} */

--- a/contribs/gmf/src/query/windowComponent.js
+++ b/contribs/gmf/src/query/windowComponent.js
@@ -1,6 +1,7 @@
 goog.provide('gmf.query.windowComponent');
 
 goog.require('gmf');
+goog.require('goog.asserts');
 goog.require('ngeo.map.FeatureOverlayMgr');
 goog.require('ngeo.misc.FeatureHelper');
 /** @suppress {extraRequire} */

--- a/contribs/gmf/src/raster/component.js
+++ b/contribs/gmf/src/raster/component.js
@@ -2,6 +2,7 @@ goog.provide('gmf.raster.component');
 
 goog.require('gmf');
 goog.require('gmf.raster.RasterService');
+goog.require('goog.asserts');
 /** @suppress {extraRequire} */
 goog.require('ngeo.misc.debounce');
 goog.require('ol.events');

--- a/contribs/gmf/src/search/component.js
+++ b/contribs/gmf/src/search/component.js
@@ -4,6 +4,7 @@ goog.require('gmf');
 goog.require('gmf.layertree.TreeManager');
 goog.require('gmf.search.FulltextSearch');
 goog.require('gmf.theme.Themes');
+goog.require('goog.asserts');
 goog.require('ngeo.map.FeatureOverlayMgr');
 goog.require('ngeo.misc.AutoProjection');
 /** @suppress {extraRequire} */

--- a/examples/locationsearch.js
+++ b/examples/locationsearch.js
@@ -2,17 +2,16 @@ goog.provide('app.locationsearch');
 
 // webpack: import './locationsearch.css';
 // webpack: import './common_dependencies.js';
+goog.require('goog.asserts');
+goog.require('ngeo');
+goog.require('ngeo.map.module');
+goog.require('ngeo.search.module');
 goog.require('ol');
 goog.require('ol.proj');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Tile');
 goog.require('ol.source.OSM');
-goog.require('goog.asserts');
-
-goog.require('ngeo');
-goog.require('ngeo.map.module');
-goog.require('ngeo.search.module');
 
 
 /** @type {!angular.Module} **/

--- a/examples/search.js
+++ b/examples/search.js
@@ -2,8 +2,12 @@ goog.provide('app.search');
 
 // webpack: import './search.css';
 // webpack: import './common_dependencies.js';
+goog.require('goog.asserts');
+goog.require('ngeo');
+goog.require('ngeo.map.module');
 /** @suppress {extraRequire} */
 goog.require('ngeo.proj.EPSG21781');
+goog.require('ngeo.search.module');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Tile');
@@ -11,11 +15,6 @@ goog.require('ol.layer.Vector');
 goog.require('ol.proj');
 goog.require('ol.source.OSM');
 goog.require('ol.source.Vector');
-goog.require('goog.asserts');
-
-goog.require('ngeo');
-goog.require('ngeo.map.module');
-goog.require('ngeo.search.module');
 
 
 /** @type {!angular.Module} **/

--- a/src/datasource/DataSources.js
+++ b/src/datasource/DataSources.js
@@ -1,12 +1,12 @@
 goog.provide('ngeo.datasource.DataSources');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ngeo.datasource.DataSource');
 goog.require('ol.Collection');
 goog.require('ol.events');
 goog.require('ol.Observable');
 goog.require('ol.View');
-goog.require('goog.asserts');
 
 
 ngeo.datasource.DataSources = class {

--- a/src/datasource/FileGroup.js
+++ b/src/datasource/FileGroup.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.datasource.FileGroup');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ngeo.datasource.File');
 goog.require('ngeo.datasource.Group');

--- a/src/datasource/Group.js
+++ b/src/datasource/Group.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.datasource.Group');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ol.Collection');
 

--- a/src/datasource/Helper.js
+++ b/src/datasource/Helper.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.datasource.Helper');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ngeo.datasource.DataSource');
 goog.require('ngeo.datasource.DataSources');

--- a/src/datasource/WMSGroup.js
+++ b/src/datasource/WMSGroup.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.datasource.WMSGroup');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ngeo.map.LayerHelper');
 goog.require('ngeo.datasource.OGCGroup');

--- a/src/draw/Controller.js
+++ b/src/draw/Controller.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.draw.Controller');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 /** @suppress {extraRequire} */
 goog.require('ngeo.draw.features');

--- a/src/editing/createfeaturecomponent.js
+++ b/src/editing/createfeaturecomponent.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.editing.createfeatureComponent');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 /** @suppress {extraRequire} */
 goog.require('ngeo.filters');

--- a/src/filter/RuleHelper.js
+++ b/src/filter/RuleHelper.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.filter.RuleHelper');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ngeo.filter.Condition');
 goog.require('ngeo.format.AttributeType');

--- a/src/filter/component.js
+++ b/src/filter/component.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.filter.component');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ngeo.query.MapQuerent');
 goog.require('ngeo.filter.Condition');

--- a/src/filter/rulecomponent.js
+++ b/src/filter/rulecomponent.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.filter.ruleComponent');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ngeo.Menu');
 goog.require('ngeo.draw.component');

--- a/src/format/wfsattribute.js
+++ b/src/format/wfsattribute.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.format.WFSAttribute');
 
+goog.require('goog.asserts');
 goog.require('ngeo.format.Attribute');
 goog.require('ngeo.format.AttributeType');
 

--- a/src/format/xsdattribute.js
+++ b/src/format/xsdattribute.js
@@ -1,11 +1,11 @@
 goog.provide('ngeo.format.XSDAttribute');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ngeo.format.Attribute');
 goog.require('ngeo.format.AttributeType');
 goog.require('ol');
 goog.require('ol.format.XML');
-goog.require('goog.asserts');
 
 
 /**

--- a/src/geolocation/desktop.js
+++ b/src/geolocation/desktop.js
@@ -1,14 +1,14 @@
 goog.provide('ngeo.geolocation.desktop');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
+goog.require('ngeo.map.FeatureOverlayMgr');
 goog.require('ngeo.message.Notification');
 goog.require('ol.events');
 goog.require('ol.Feature');
 goog.require('ol.Geolocation');
 goog.require('ol.Map');
 goog.require('ol.geom.Point');
-
-goog.require('ngeo.map.FeatureOverlayMgr');
 
 
 /**

--- a/src/geolocation/mobile.js
+++ b/src/geolocation/mobile.js
@@ -1,6 +1,8 @@
 goog.provide('ngeo.geolocation.mobile');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
+goog.require('ngeo.map.FeatureOverlayMgr');
 goog.require('ngeo.message.Notification');
 goog.require('ol.easing');
 goog.require('ol.events');
@@ -8,9 +10,6 @@ goog.require('ol.Feature');
 goog.require('ol.Geolocation');
 goog.require('ol.Map');
 goog.require('ol.geom.Point');
-
-goog.require('ngeo.map.FeatureOverlayMgr');
-
 
 /**
  * @type {!angular.Module}

--- a/src/goog.asserts.js_
+++ b/src/goog.asserts.js_
@@ -136,9 +136,9 @@ exports.fail = function(opt_message, var_args) {
  * @throws {goog.asserts.AssertionError} When the value is not a number.
  */
 exports.assertNumber = function(value, opt_message, var_args) {
-  if (exports.ENABLE_ASSERTS && !goog.isNumber(value)) {
+  if (exports.ENABLE_ASSERTS && typeof value != 'number') {
     exports.doAssertFailure_(
-      'Expected number but got %s: %s.', [goog.typeOf(value), value],
+      'Expected number but got %s: %s.', [typeof value, value],
       opt_message, Array.prototype.slice.call(arguments, 2));
   }
   return /** @type {number} */ (value);
@@ -154,9 +154,9 @@ exports.assertNumber = function(value, opt_message, var_args) {
  * @throws {goog.asserts.AssertionError} When the value is not a string.
  */
 exports.assertString = function(value, opt_message, var_args) {
-  if (exports.ENABLE_ASSERTS && !goog.isString(value)) {
+  if (exports.ENABLE_ASSERTS && typeof value != 'string') {
     exports.doAssertFailure_(
-      'Expected string but got %s: %s.', [goog.typeOf(value), value],
+      'Expected string but got %s: %s.', [typeof value, value],
       opt_message, Array.prototype.slice.call(arguments, 2));
   }
   return /** @type {string} */ (value);
@@ -173,9 +173,9 @@ exports.assertString = function(value, opt_message, var_args) {
  * @throws {goog.asserts.AssertionError} When the value is not a function.
  */
 exports.assertFunction = function(value, opt_message, var_args) {
-  if (exports.ENABLE_ASSERTS && !goog.isFunction(value)) {
+  if (exports.ENABLE_ASSERTS && typeof value != 'function') {
     exports.doAssertFailure_(
-      'Expected function but got %s: %s.', [goog.typeOf(value), value],
+      'Expected function but got %s: %s.', [typeof value, value],
       opt_message, Array.prototype.slice.call(arguments, 2));
   }
   return /** @type {!Function} */ (value);
@@ -191,9 +191,11 @@ exports.assertFunction = function(value, opt_message, var_args) {
  * @throws {goog.asserts.AssertionError} When the value is not an object.
  */
 exports.assertObject = function(value, opt_message, var_args) {
-  if (exports.ENABLE_ASSERTS && !goog.isObject(value)) {
+  if (exports.ENABLE_ASSERTS &&
+      (value === null || typeof value != 'object' ||
+      Array.isArray(value) || typeof value == 'function')) {
     exports.doAssertFailure_(
-      'Expected object but got %s: %s.', [goog.typeOf(value), value],
+      'Expected object but got %s: %s.', [typeof value, value],
       opt_message, Array.prototype.slice.call(arguments, 2));
   }
   return /** @type {!Object} */ (value);
@@ -209,9 +211,9 @@ exports.assertObject = function(value, opt_message, var_args) {
  * @throws {goog.asserts.AssertionError} When the value is not an array.
  */
 exports.assertArray = function(value, opt_message, var_args) {
-  if (exports.ENABLE_ASSERTS && !goog.isArray(value)) {
+  if (exports.ENABLE_ASSERTS && !Array.isArray(value)) {
     exports.doAssertFailure_(
-      'Expected array but got %s: %s.', [goog.typeOf(value), value],
+      'Expected array but got %s: %s.', [typeof value, value],
       opt_message, Array.prototype.slice.call(arguments, 2));
   }
   return /** @type {!Array<?>} */ (value);
@@ -228,9 +230,9 @@ exports.assertArray = function(value, opt_message, var_args) {
  * @throws {goog.asserts.AssertionError} When the value is not a boolean.
  */
 exports.assertBoolean = function(value, opt_message, var_args) {
-  if (exports.ENABLE_ASSERTS && !goog.isBoolean(value)) {
+  if (exports.ENABLE_ASSERTS && typeof value != 'boolean') {
     exports.doAssertFailure_(
-      'Expected boolean but got %s: %s.', [goog.typeOf(value), value],
+      'Expected boolean but got %s: %s.', [typeof value, value],
       opt_message, Array.prototype.slice.call(arguments, 2));
   }
   return /** @type {boolean} */ (value);
@@ -248,9 +250,11 @@ exports.assertBoolean = function(value, opt_message, var_args) {
  */
 exports.assertElement = function(value, opt_message, var_args) {
   if (exports.ENABLE_ASSERTS &&
-      (!goog.isObject(value) || value.nodeType != goog.dom.NodeType.ELEMENT)) {
+      (value === null || typeof value != 'object' ||
+      Array.isArray(value) || typeof value == 'function' ||
+      value.nodeType == undefined)) {
     exports.doAssertFailure_(
-      'Expected Element but got %s: %s.', [goog.typeOf(value), value],
+      'Expected Element but got %s: %s.', [typeof value, value],
       opt_message, Array.prototype.slice.call(arguments, 2));
   }
   return /** @type {!Element} */ (value);

--- a/src/googlestreetview/component.js
+++ b/src/googlestreetview/component.js
@@ -1,14 +1,14 @@
 goog.provide('ngeo.googlestreetview.component');
 
+goog.require('goog.asserts');
+goog.require('ngeo');
+goog.require('ngeo.map.FeatureOverlayMgr');
 goog.require('ol.array');
 goog.require('ol.events');
 goog.require('ol.proj');
 goog.require('ol.Feature');
 goog.require('ol.Observable');
 goog.require('ol.geom.Point');
-goog.require('ngeo');
-
-goog.require('ngeo.map.FeatureOverlayMgr');
 
 
 /**

--- a/src/grid/component.js
+++ b/src/grid/component.js
@@ -1,11 +1,11 @@
 goog.provide('ngeo.grid.component');
 
-goog.require('ngeo');
-goog.require('ol.has');
 goog.require('goog.asserts');
+goog.require('ngeo');
 /** @suppress {extraRequire} */
 goog.require('ngeo.filters');
 goog.require('ngeo.grid.Config');
+goog.require('ol.has');
 // webpack: import 'floatthead';
 
 

--- a/src/interaction/drawregularpolygonfromclick.js
+++ b/src/interaction/drawregularpolygonfromclick.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.interaction.DrawRegularPolygonFromClick');
 
+goog.require('goog.asserts');
 goog.require('ol');
 goog.require('ol.events');
 goog.require('ol.Feature');

--- a/src/interaction/measure.js
+++ b/src/interaction/measure.js
@@ -1,8 +1,8 @@
 goog.provide('ngeo.interaction.Measure');
 
+goog.require('goog.asserts');
 goog.require('ngeo.CustomEvent');
 goog.require('ngeo.interaction.MeasureBaseOptions');
-goog.require('goog.asserts');
 goog.require('ol');
 goog.require('ol.dom');
 goog.require('ol.proj');

--- a/src/interaction/measurearea.js
+++ b/src/interaction/measurearea.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.interaction.MeasureArea');
 
+goog.require('goog.asserts');
 goog.require('ngeo.interaction.Measure');
 goog.require('ol');
 goog.require('ol.geom.Polygon');

--- a/src/interaction/measurelength.js
+++ b/src/interaction/measurelength.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.interaction.MeasureLength');
 
+goog.require('goog.asserts');
 goog.require('ngeo.interaction.Measure');
 goog.require('ol');
 goog.require('ol.geom.LineString');

--- a/src/interaction/measurepointmobile.js
+++ b/src/interaction/measurepointmobile.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.interaction.MeasurePointMobile');
 
+goog.require('goog.asserts');
 goog.require('ngeo.interaction.Measure');
 goog.require('ngeo.interaction.MobileDraw');
 goog.require('ol');

--- a/src/interaction/mobiledraw.js
+++ b/src/interaction/mobiledraw.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.interaction.MobileDraw');
 
+goog.require('goog.asserts');
 goog.require('ol');
 goog.require('ol.events');
 goog.require('ol.Feature');

--- a/src/interaction/modify.js
+++ b/src/interaction/modify.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.interaction.Modify');
 
+goog.require('goog.asserts');
 goog.require('ngeo.utils');
 goog.require('ngeo.format.FeatureProperties');
 goog.require('ngeo.interaction.ModifyCircle');

--- a/src/interaction/rotate.js
+++ b/src/interaction/rotate.js
@@ -1,7 +1,7 @@
 goog.provide('ngeo.interaction.Rotate');
 
-goog.require('ngeo.CustomEvent');
 goog.require('goog.asserts');
+goog.require('ngeo.CustomEvent');
 goog.require('ol');
 goog.require('ol.extent');
 goog.require('ol.Collection');

--- a/src/interaction/translate.js
+++ b/src/interaction/translate.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.interaction.Translate');
 
+goog.require('goog.asserts');
 goog.require('ol');
 goog.require('ol.Feature');
 goog.require('ol.events');

--- a/src/layertree/Controller.js
+++ b/src/layertree/Controller.js
@@ -1,11 +1,12 @@
 goog.provide('ngeo.layertree.Controller');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
+goog.require('ngeo.misc.decorate');
 goog.require('ol');
 goog.require('ol.events');
 goog.require('ol.layer.Group');
 goog.require('ol.layer.Layer');
-goog.require('ngeo.misc.decorate');
 
 
 /**

--- a/src/map/FeatureOverlayMgr.js
+++ b/src/map/FeatureOverlayMgr.js
@@ -1,14 +1,13 @@
 goog.provide('ngeo.map.FeatureOverlayMgr');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
+goog.require('ngeo.map.FeatureOverlay');
 goog.require('ol');
 goog.require('ol.layer.Vector');
 goog.require('ol.obj');
 goog.require('ol.source.Vector');
 goog.require('ol.style.Style');
-
-goog.require('goog.asserts');
-goog.require('ngeo.map.FeatureOverlay');
 
 
 /**

--- a/src/map/LayerHelper.js
+++ b/src/map/LayerHelper.js
@@ -1,7 +1,7 @@
 goog.provide('ngeo.map.LayerHelper');
 
-goog.require('ngeo');
 goog.require('goog.asserts');
+goog.require('ngeo');
 goog.require('ol.array');
 goog.require('ol.format.WMTSCapabilities');
 goog.require('ol.layer.Group');

--- a/src/map/scaleselector.js
+++ b/src/map/scaleselector.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.map.scaleselector');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ol.array');
 goog.require('ol.Map');

--- a/src/menu.js
+++ b/src/menu.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.Menu');
 
+goog.require('goog.asserts');
 goog.require('ngeo.CustomEvent');
 goog.require('ol');
 goog.require('ol.events');

--- a/src/message/Popup.js
+++ b/src/message/Popup.js
@@ -1,7 +1,7 @@
 goog.provide('ngeo.message.Popup');
 
-goog.require('ngeo');
 goog.require('goog.asserts');
+goog.require('ngeo');
 
 /**
  * This goog.require is needed because of 'ngeo-popup' used in

--- a/src/misc/FeatureHelper.js
+++ b/src/misc/FeatureHelper.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.misc.FeatureHelper');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 /** @suppress {extraRequire} */
 goog.require('ngeo.filters');

--- a/src/misc/ToolActivateMgr.js
+++ b/src/misc/ToolActivateMgr.js
@@ -1,7 +1,7 @@
 goog.provide('ngeo.misc.ToolActivateMgr');
 
-goog.require('ngeo');
 goog.require('goog.asserts');
+goog.require('ngeo');
 goog.require('ngeo.misc.ToolActivate');
 
 

--- a/src/misc/WMSTime.js
+++ b/src/misc/WMSTime.js
@@ -1,8 +1,8 @@
 goog.provide('ngeo.misc.WMSTime');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ngeo.misc.Time');
-goog.require('goog.asserts');
 goog.require('ol');
 
 

--- a/src/misc/sortableComponent.js
+++ b/src/misc/sortableComponent.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.misc.sortableComponent');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 
 

--- a/src/olcs/Service.js
+++ b/src/olcs/Service.js
@@ -1,5 +1,6 @@
 goog.module('ngeo.olcs.Service');
 
+goog.require('goog.asserts');
 goog.require('ngeo.misc.debounce');
 goog.require('ngeo.statemanager.Location');
 goog.require('ngeo.olcs.constants');

--- a/src/olcs/controls3d.js
+++ b/src/olcs/controls3d.js
@@ -1,6 +1,7 @@
 goog.module('ngeo.olcs.controls3d');
 goog.module.declareLegacyNamespace();
 
+goog.require('goog.asserts');
 goog.require('ol.easing');
 goog.require('olcs.core');
 goog.require('ngeo');

--- a/src/print/Service.js
+++ b/src/print/Service.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.print.Service');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ngeo.print.VectorEncoder');
 goog.require('ngeo.map.LayerHelper');

--- a/src/print/VectorEncoder.js
+++ b/src/print/VectorEncoder.js
@@ -1,5 +1,7 @@
 goog.provide('ngeo.print.VectorEncoder');
 
+goog.require('goog.asserts');
+goog.require('ngeo.utils');
 goog.require('ol');
 goog.require('ol.format.GeoJSON');
 goog.require('ol.source.Vector');
@@ -8,8 +10,6 @@ goog.require('ol.math');
 goog.require('ol.style.Icon');
 goog.require('ol.style.Circle');
 goog.require('ol.color');
-goog.require('goog.asserts');
-goog.require('ngeo.utils');
 
 
 /**

--- a/src/query/MapQuerent.js
+++ b/src/query/MapQuerent.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.query.MapQuerent');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ngeo.query.Querent');
 goog.require('ngeo.datasource.DataSources');

--- a/src/query/Querent.js
+++ b/src/query/Querent.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.query.Querent');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ngeo.datasource.OGC');
 goog.require('ngeo.filter.RuleHelper');

--- a/src/query/Service.js
+++ b/src/query/Service.js
@@ -2,6 +2,7 @@
 
 goog.provide('ngeo.query.Service');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ngeo.map.LayerHelper');
 goog.require('ol.format.WFS');

--- a/src/rule/geometry.js
+++ b/src/rule/geometry.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.rule.Geometry');
 
+goog.require('goog.asserts');
 goog.require('ngeo.format.AttributeType');
 goog.require('ngeo.rule.Rule');
 goog.require('ol.Object');

--- a/src/rule/rule.js
+++ b/src/rule/rule.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.rule.Rule');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ol.Observable');
 

--- a/src/statemanager/Location.js
+++ b/src/statemanager/Location.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.statemanager.Location');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ngeo.utils');
 

--- a/src/statemanager/Wfspermalink.js
+++ b/src/statemanager/Wfspermalink.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.statemanager.WfsPermalink');
 
+goog.require('goog.asserts');
 goog.require('ngeo');
 goog.require('ol.extent');
 goog.require('ol.format.filter');


### PR DESCRIPTION
It will still fail because of:

Case 1: goog.exportSymbol
https://github.com/camptocamp/ngeo/blob/master/src/jstsexports.js#L14
Any idea ?

Case 2: goog.<type>
https://github.com/camptocamp/ngeo/blob/master/src/goog.asserts.js_#L139 (and brothers)
Can I use `typeof(value) === "number"` ?

What should I do ?
