### PR TITLE
Fix gmf printNativeAngle when more than one group in the layer tree

### DIFF
--- a/contribs/gmf/src/directives/print.js
+++ b/contribs/gmf/src/directives/print.js
@@ -789,9 +789,10 @@ gmf.PrintController.prototype.print = function(format) {
       }
     }
 
-    // Get the print native angle parameter for WMS layers
-    if (layer instanceof ol.layer.Image) {
-      print_native_angle = layer.get('printNativeAngle');
+    // Get the print native angle parameter for WMS layers when set to not use default value
+    // Is applied only once when the value is overridden with a metadata from administration
+    if (layer instanceof ol.layer.Image && layer.get('printNativeAngle') === false) {
+      print_native_angle = false;
     }
 
     new_ol_layers.push(layer);


### PR DESCRIPTION
Was working with a single group in the layer tree with 'false' as value. 

If only one of many groups in the layer tree is set to use the printNativeAngle, the variable would be set back to 'true' because the next group iterated would have the value 'true', thus no icons orientation would works even if the value needed was 'false'...