### PR TITLE
Update swisstopo WMTS URL for EPSG:2056

### DIFF
--- a/src/source/swisstopo.js
+++ b/src/source/swisstopo.js
@@ -62,7 +62,7 @@ const swisstopoTileGrids = {
  */
 const swisstopoCreateUrl = function(projection, format) {
   if (projection === 'EPSG:2056') {
-    return `${'https://wmts{10-14}.geo.admin.ch/1.0.0/{Layer}/default/{Time}' +
+    return `${'https://wmts{20-24}.geo.admin.ch/1.0.0/{Layer}/default/{Time}' +
       '/2056/{TileMatrix}/{TileCol}/{TileRow}.'}${format}`;
   } else if (projection === 'EPSG:21781') {
     return `${'https://wmts{5-9}.geo.admin.ch/1.0.0/{Layer}/default/{Time}' +


### PR DESCRIPTION
Change URL to hosts wmts{20-24}.geo.admin.ch, which is what the current
documentation recommends:

http://api3.geo.admin.ch/services/sdiservices.html#other-projections