### PR TITLE
Debug login errors and force-password-change message

### DIFF
--- a/contribs/gmf/examples/authentication.html
+++ b/contribs/gmf/examples/authentication.html
@@ -22,7 +22,7 @@
       This example shows how to use the <code>gmf-authentication</code>
       directive to insert an authentication panel in a GeoMapFish page.
     </p>
-    <gmf-authentication></gmf-authentication>
+    <gmf-authentication gmf-authentication-force-password-change="true"></gmf-authentication>
     <script src="../../../node_modules/jquery/dist/jquery.js"></script>
     <script src="../../../third-party/jquery-ui/jquery-ui.min.js"></script>
     <script src="../../../node_modules/angular/angular.js"></script>

--- a/contribs/gmf/src/directives/authenticationdirective.js
+++ b/contribs/gmf/src/directives/authenticationdirective.js
@@ -193,7 +193,7 @@ gmf.AuthenticationController = function(gettextCatalog, $scope,
   this.newPwdConfVal = '';
 
   ol.events.listen(gmfAuthentication, gmf.AuthenticationEventType.READY,
-    this.onLoginReady_.bind(this));
+    this.onUserChange_.bind(this));
 };
 
 
@@ -280,7 +280,10 @@ gmf.AuthenticationController.prototype.login = function() {
   } else {
     const error = gettextCatalog.getString('Incorrect username or password.');
     this.gmfAuthentication_.login(this.loginVal, this.pwdVal).then(
-      this.resetError_.bind(this),
+      () => {
+        this.resetError_();
+        this.onUserChange_();
+      },
       this.setError_.bind(this, error));
   }
 };
@@ -345,11 +348,10 @@ gmf.AuthenticationController.prototype.changePasswordReset = function() {
 
 
 /**
- * @param {gmf.AuthenticationEvent} e GMF Authentification event.
  * @private
  */
-gmf.AuthenticationController.prototype.onLoginReady_ = function(e) {
-  if (e.user.is_password_changed === false && this.forcePasswordChange) {
+gmf.AuthenticationController.prototype.onUserChange_ = function() {
+  if (this.gmfUser.is_password_changed === false && this.forcePasswordChange) {
     const gettextCatalog = this.gettextCatalog;
     const msg = gettextCatalog.getString('You must change your password.');
     this.notification_.notify({

--- a/contribs/gmf/src/directives/partials/authentication.html
+++ b/contribs/gmf/src/directives/partials/authentication.html
@@ -78,7 +78,9 @@
     </div>
   </form>
 
-  <ngeo-modal ng-model="authCtrl.changePasswordModalShown">
+  <ngeo-modal
+      ngeo-modal-destroy-content-on-hide="true"
+      ng-model="authCtrl.changePasswordModalShown">
     <div class="modal-header">
       <button type="button"
               class="close"
@@ -140,7 +142,9 @@
     </div>
   </form>
 
-  <ngeo-modal ng-model="authCtrl.resetPasswordModalShown">
+  <ngeo-modal
+      ngeo-modal-destroy-content-on-hide="true"
+      ng-model="authCtrl.resetPasswordModalShown">
     <div class="modal-header">
       <button type="button"
               class="close"


### PR DESCRIPTION
First commit fix a $compile:multiling Linking Element Multiple Times angular error.

Second commit fix: https://github.com/camptocamp/ngeo/issues/3278
~~The problem is that the READY event was not emitted on login (but I need it, and it looks not problematic to emit it at the same time as the LOGIN event.) Then, the problem is that the "soft" reload of the page remove the notification, I've used a timeout to avoid this problem. If you know a better method...~~
