### PR TITLE
Change type of binding to allow changes to mergetabs during runtime

### DIFF
--- a/contribs/gmf/src/directives/displayquerygrid.js
+++ b/contribs/gmf/src/directives/displayquerygrid.js
@@ -90,7 +90,7 @@ gmf.displayquerygridComponent = {
     'removeEmptyColumnsFn': '&?gmfDisplayquerygridRemoveemptycolumns',
     'maxResultsFn': '&?gmfDisplayquerygridMaxresults',
     'maxRecenterZoomFn': '&?gmfDisplayquerygridMaxrecenterzoom',
-    'mergeTabsFn': '&?gmfDisplayquerygridMergetabs'
+    'mergeTabs': '=?gmfDisplayquerygridMergetabs'
   },
   templateUrl: gmfDisplayquerygridTemplateUrl
 };
@@ -274,7 +274,7 @@ gmf.DisplayquerygridController = function($injector, $scope, ngeoQueryResult, ng
 gmf.DisplayquerygridController.prototype.$onInit = function() {
   this.removeEmptyColumns_ = this['removeEmptyColumnsFn'] ? this['removeEmptyColumnsFn']() === true : false;
   this.maxRecenterZoom = this['maxRecenterZoomFn'] ? this['maxRecenterZoomFn']() : undefined;
-  this.mergeTabs_ = this['mergeTabsFn'] ? this['mergeTabsFn']() : {};
+  this.mergeTabs_ = this['mergeTabs'] ? this['mergeTabs'] : {};
 
   const featuresOverlay = this.ngeoFeatureOverlayMgr_.getFeatureOverlay();
   featuresOverlay.setFeatures(this.features_);

--- a/contribs/gmf/src/directives/displayquerygrid.js
+++ b/contribs/gmf/src/directives/displayquerygrid.js
@@ -90,7 +90,7 @@ gmf.displayquerygridComponent = {
     'removeEmptyColumnsFn': '&?gmfDisplayquerygridRemoveemptycolumns',
     'maxResultsFn': '&?gmfDisplayquerygridMaxresults',
     'maxRecenterZoomFn': '&?gmfDisplayquerygridMaxrecenterzoom',
-    'mergeTabs': '=?gmfDisplayquerygridMergetabs'
+    'mergeTabs': '<?gmfDisplayquerygridMergetabs'
   },
   templateUrl: gmfDisplayquerygridTemplateUrl
 };
@@ -212,9 +212,8 @@ gmf.DisplayquerygridController = function($injector, $scope, ngeoQueryResult, ng
 
   /**
    * @type {!gmfx.GridMergeTabs}
-   * @private
    */
-  this.mergeTabs_ = {};
+  this.mergeTabs = {};
 
   /**
    * A mapping between row uid and the corresponding feature for each
@@ -274,7 +273,6 @@ gmf.DisplayquerygridController = function($injector, $scope, ngeoQueryResult, ng
 gmf.DisplayquerygridController.prototype.$onInit = function() {
   this.removeEmptyColumns_ = this['removeEmptyColumnsFn'] ? this['removeEmptyColumnsFn']() === true : false;
   this.maxRecenterZoom = this['maxRecenterZoomFn'] ? this['maxRecenterZoomFn']() : undefined;
-  this.mergeTabs_ = this['mergeTabs'] ? this['mergeTabs'] : {};
 
   const featuresOverlay = this.ngeoFeatureOverlayMgr_.getFeatureOverlay();
   featuresOverlay.setFeatures(this.features_);
@@ -339,7 +337,7 @@ gmf.DisplayquerygridController.prototype.updateData_ = function() {
   this.pending = false;
   let sources = this.ngeoQueryResult.sources;
   // merge sources if requested
-  if (Object.keys(this.mergeTabs_).length > 0) {
+  if (Object.keys(this.mergeTabs).length > 0) {
     sources = this.getMergedSources_(sources);
   }
 
@@ -456,8 +454,8 @@ gmf.DisplayquerygridController.prototype.getMergedSources_ = function(sources) {
 gmf.DisplayquerygridController.prototype.getMergedSource_ = function(source, mergedSources) {
   let mergeSourceId = null;
 
-  for (const currentMergeSourceId in this.mergeTabs_) {
-    const sourceLabels = this.mergeTabs_[currentMergeSourceId];
+  for (const currentMergeSourceId in this.mergeTabs) {
+    const sourceLabels = this.mergeTabs[currentMergeSourceId];
     const containsSource = sourceLabels.some(sourceLabel => sourceLabel == source.label);
     if (containsSource) {
       mergeSourceId = currentMergeSourceId;

--- a/contribs/gmf/test/spec/directives/displayquerygrid.spec.js
+++ b/contribs/gmf/test/spec/directives/displayquerygrid.spec.js
@@ -398,7 +398,7 @@ describe('gmf.displayquerygridComponent', () => {
         queried: true
       }];
 
-      queryGridController.mergeTabs_ = {
+      queryGridController.mergeTabs = {
         'merged_source': ['Test 1', 'Test 2']
       };
 
@@ -491,7 +491,7 @@ describe('gmf.displayquerygridComponent', () => {
         queried: true
       }];
 
-      queryGridController.mergeTabs_ = {
+      queryGridController.mergeTabs = {
         'merged_source': ['Test 1', 'Test 2']
       };
 


### PR DESCRIPTION
see: GEO-977

Tested with desktop_alt. Changes to the bound object during runtime will be reflected in a new search.
This should not break existing code as long the feature is used like in the desktop_alt.