### PR TITLE
Add new npm script to serve the examples and apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "2.3.0-dev.2",
   "description": "AngularJS OpenLayers Library",
   "scripts": {
-    "prepublish": "make -f npm.mk install"
+    "prepublish": "make -f npm.mk install",
+    "serve-ngeo-examples": "NODE_ENV=dev TARGET=ngeo-examples webpack --watch & serve .build/examples-hosted/",
+    "serve-gmf-examples": "NODE_ENV=dev TARGET=gmf-examples webpack --watch & serve .build/examples-hosted/contribs/gmf/",
+    "serve-gmf-apps": "NODE_ENV=dev TARGET=gmf-apps webpack --watch & serve .build/contribs-gmf-apps/"
   },
   "repository": {
     "type": "git",
@@ -88,6 +91,7 @@
     "phantomjs-polyfill-string-includes": "1.0.0",
     "phantomjs-prebuilt": "2.1.16",
     "proj4": "2.4.4",
+    "serve": "6.4.9",
     "svg2ttf": "4.1.0",
     "temp": "0.8.3",
     "ttf2eot": "2.0.0",
@@ -98,7 +102,6 @@
     "url-polyfill": "1.0.11",
     "walk": "2.3.9",
     "webpack": "3.11.0",
-    "webpack-dev-server": "2.11.1",
     "webpack-merge": "4.1.1"
   },
   "dependencies": {}


### PR DESCRIPTION
work in progress

As npm scripts but this can moved into the Makefile is needed.
webpack-dev-server is not developed anymore