### PR TITLE
Force password change

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -103,8 +103,10 @@
                 {{'Login' | translate}}
                 <a class="btn close" ng-click="mainCtrl.loginActive = false">&times;</a>
               </div>
+              <!-- Use forcePasswordChange (instand directly a boolean) because this value is bound with
+                   a function that opens the login panel (require to display the change password modal) -->
               <gmf-authentication
-                  gmf-authentication-force-password-change="::true">
+                  gmf-authentication-force-password-change="::mainCtrl.forcePasswordChange">
               </gmf-authentication>
             </div>
           </div>

--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -103,11 +103,7 @@
                 {{'Login' | translate}}
                 <a class="btn close" ng-click="mainCtrl.loginActive = false">&times;</a>
               </div>
-              <!-- Use forcePasswordChange (instand directly a boolean) because this value is bound with
-                   a function that opens the login panel (require to display the change password modal) -->
-              <gmf-authentication
-                  gmf-authentication-force-password-change="::mainCtrl.forcePasswordChange">
-              </gmf-authentication>
+              <gmf-authentication></gmf-authentication>
             </div>
           </div>
           <div ng-show="mainCtrl.printPanelActive" class="row">
@@ -291,6 +287,21 @@
       </div>
       <ngeo-modal ng-model="mainCtrl.modalShareShown">
         <gmf-share gmf-share-email="true"/>
+      </ngeo-modal>
+      <ngeo-modal
+          ngeo-modal-closable="false"
+          ng-model="mainCtrl.userMustChangeItsPassword()"
+          ng-model-options="{getterSetter: true}">
+        <div class="modal-header">
+          <h4 class="modal-title">
+            {{'You must change your password' | translate}}
+          </h4>
+        </div>
+        <div class="modal-body" translate>
+          <gmf-authentication
+            gmf-authentication-force-password-change="::true">
+          </gmf-authentication>
+        </div>
       </ngeo-modal>
     </main>
     <footer>

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -309,10 +309,10 @@
           </div>
         </div>
       </div>
-      <ngeo-modal ng-model="mainCtrl.modalShareShown" ngeo-modal-destroy-content-on-hide="true">
+      <ngeo-modal ng-model="mainCtrl.modalShareShown">
         <gmf-share gmf-share-email="false"/>
       </ngeo-modal>
-      <ngeo-modal ng-model="disclaimerVisibility" ngeo-modal-destroy-content-on-hide="true">
+      <ngeo-modal ng-model="disclaimerVisibility">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
         </div>

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -165,6 +165,7 @@
         </ul>
       </div>
       <gmf-authentication id="login" class="gmf-mobile-nav-slide" data-header-title="{{'Login' | translate}}"
+        gmf-authentication-force-password-change="::mainCtrl.forcePasswordChange"
         gmf-mobile-nav-back="authCtrl.gmfUser.username !== null">
       </gmf-authentication>
     </nav>

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -165,10 +165,25 @@
         </ul>
       </div>
       <gmf-authentication id="login" class="gmf-mobile-nav-slide" data-header-title="{{'Login' | translate}}"
-        gmf-authentication-force-password-change="::mainCtrl.forcePasswordChange"
         gmf-mobile-nav-back="authCtrl.gmfUser.username !== null">
       </gmf-authentication>
     </nav>
+    <ngeo-modal
+        ngeo-modal-closable="false"
+        ng-model="mainCtrl.userMustChangeItsPassword()"
+        ng-model-options="{getterSetter: true}">
+      <div class="modal-header">
+        <h4 class="modal-title">
+          {{'You must change your password' | translate}}
+        </h4>
+      </div>
+      <div class="modal-body" translate>
+        <gmf-authentication
+          gmf-authentication-force-password-change="::true">
+        </gmf-authentication>
+      </div>
+    </ngeo-modal>
+
     <script src="../../../../node_modules/jquery/dist/jquery.js"></script>
     <script src="../../../../third-party/jquery-ui/jquery-ui.js"></script>
     <script src="../../../../node_modules/jquery-ui-touch-punch/jquery.ui.touch-punch.js"></script>

--- a/contribs/gmf/apps/oeview/index.html
+++ b/contribs/gmf/apps/oeview/index.html
@@ -112,7 +112,7 @@
           </div>
         </div>
       </div>
-      <ngeo-modal ng-model="mainCtrl.modalShareShown" ngeo-modal-destroy-content-on-hide="true">
+      <ngeo-modal ng-model="mainCtrl.modalShareShown">
         <gmf-share gmf-share-email="true"/>
       </ngeo-modal>
     </main>

--- a/contribs/gmf/examples/authentication.html
+++ b/contribs/gmf/examples/authentication.html
@@ -12,6 +12,6 @@
       This example shows how to use the <code>gmf-authentication</code>
       directive to insert an authentication panel in a GeoMapFish page.
     </p>
-    <gmf-authentication gmf-authentication-force-password-change="true"></gmf-authentication>
+    <gmf-authentication gmf-authentication-password-validator="ctrl.passwordValidator"></gmf-authentication>
   </body>
 </html>

--- a/contribs/gmf/examples/authentication.js
+++ b/contribs/gmf/examples/authentication.js
@@ -20,10 +20,33 @@ gmfapp.authentication.module.constant('angularLocaleScript', '../build/angular-l
 
 
 /**
+ * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @constructor
  * @ngInject
  */
-gmfapp.authentication.MainController = function() {};
+gmfapp.authentication.MainController = function(gettextCatalog) {
+  /**
+   * A password validator that check if the password as:
+   *  - A minimal length of 8 characteres.
+   *  - At least one lowercase letter.
+   *  - At least one Uppercase letter.
+   *  - At least one digit.
+   *  - At least one special character.
+   * @type {gmfx.PasswordValidator} the password validator
+   * @export
+   */
+  this.passwordValidator = {
+    isPasswordValid: function(value) {
+      return (
+        value.length > 8 && /\d/.test(value) &&
+        /[a-z]/.test(value) && /[A-Z]/.test(value) &&
+        /\W/.test(value)
+      );
+    },
+    notValidMessage: gettextCatalog.getString('The new password must have at least 8 characters,'
+                             + 'including capital letter, small letter, digit and special character.')
+  };
+};
 
 
 gmfapp.authentication.module.controller('MainController', gmfapp.authentication.MainController);

--- a/contribs/gmf/options/gmfx.js
+++ b/contribs/gmf/options/gmfx.js
@@ -180,6 +180,17 @@ gmfx.ObjectEditingToolsOptions.prototype.regularPolygonRadius;
 
 
 /**
+ * Password validator function with an error message.
+ * Configuration options for the permalink service.
+ * @typedef {{
+ *     isPasswordValid: function(string): string,
+ *     notValidMessage: string
+ * }}
+ */
+gmfx.PasswordValidator;
+
+
+/**
  * Configuration options for the permalink service.
  * @typedef {{
  *     crosshairStyle: (Array<(null|ol.style.Style)>|null|ol.FeatureStyleFunction|ol.style.Style|undefined),

--- a/contribs/gmf/src/authentication/Service.js
+++ b/contribs/gmf/src/authentication/Service.js
@@ -21,11 +21,12 @@ gmf.authentication.Service = class extends ol.events.EventTarget {
 
   /**
    * @param {angular.$http} $http Angular http service.
+   * @param {angular.Scope} $rootScope The directive's scope.
    * @param {string} authenticationBaseUrl URL to "authentication" web service.
    * @param {gmfx.User} gmfUser User.
    * @ngInject
    */
-  constructor($http, authenticationBaseUrl, gmfUser) {
+  constructor($http, $rootScope, authenticationBaseUrl, gmfUser) {
 
     super();
 
@@ -34,6 +35,12 @@ gmf.authentication.Service = class extends ol.events.EventTarget {
      * @private
      */
     this.$http_ = $http;
+
+    /**
+     * @type {angular.Scope}
+     * @private
+     */
+    this.$rootScope_ = $rootScope;
 
     /**
      * The authentication url without trailing slash
@@ -80,7 +87,10 @@ gmf.authentication.Service = class extends ol.events.EventTarget {
     }), {
       headers: {'Content-Type': 'application/x-www-form-urlencoded'},
       withCredentials: true
-    });
+    }).then(((response) => {
+      this.user_.is_password_changed = true;
+      this.$rootScope_.$digest();
+    }).bind(this));
   }
 
   /**

--- a/contribs/gmf/src/authentication/component.html
+++ b/contribs/gmf/src/authentication/component.html
@@ -69,14 +69,20 @@
           type="button"
           class="form-control btn btn-default"
           value="{{'Cancel' | translate}}"
+          ng-if="!$ctrl.userMustChangeItsPassword()"
           ng-click="$ctrl.changePasswordReset()" />
+      <input
+          type="button"
+          class="form-control btn btn-default"
+          value="{{'Logout' | translate}}"
+          ng-if="$ctrl.userMustChangeItsPassword()"
+          ng-click="$ctrl.logout()" />
     </div>
   </form>
 
   <div ng-show="$ctrl.error" class="gmf-authentication-error help-block"></div>
 
   <ngeo-modal
-      ngeo-modal-destroy-content-on-hide="true"
       ng-model="$ctrl.changePasswordModalShown">
     <div class="modal-header">
       <button type="button"
@@ -98,64 +104,6 @@
               data-dismiss="modal">{{'OK' | translate}}</button>
     </div>
   </ngeo-modal>
-
-  <ngeo-modal
-      ngeo-modal-destroy-content-on-hide="true"
-      ng-model="$ctrl.userMustChangeItsPassword()"
-      ng-model-options="{getterSetter: true}">
-    <div class="modal-header">
-      <h4 class="modal-title">
-        {{'You must change your password.' | translate}}
-      </h4>
-    </div>
-    <div class="modal-body">
-      <form
-          name="changePasswordForm"
-          role="form"
-          ng-submit="$ctrl.changePassword()"
-          ng-controller="GmfAuthenticationController"
-          ng-class="{'has-error': $ctrl.error}">
-        <div class="form-group">
-          <input
-              type="password"
-              class="form-control"
-              name="oldpassword"
-              ng-model="$ctrl.oldPwdVal"
-              ng-attr-placeholder="{{'Old password' | translate}}"/>
-        </div>
-        <div class="form-group">
-          <input
-              type="password"
-              class="form-control"
-              name="newpassword"
-              ng-model="$ctrl.newPwdVal"
-              ng-attr-placeholder="{{'New password' | translate}}"/>
-        </div>
-        <div class="form-group">
-          <input
-              type="password"
-              class="form-control"
-              name="newpasswordconfirm"
-              ng-model="$ctrl.newPwdConfVal"
-              ng-attr-placeholder="{{'Confirm new password' | translate}}"/>
-        </div>
-        <div class="form-group">
-          <input
-              type="submit"
-              class="form-control btn btn-primary"
-              value="{{'Change password' | translate}}" />
-        </div>
-        <input
-            type="button"
-            class="form-control btn btn-default"
-            value="{{'Logout' | translate}}"
-            ng-click="$ctrl.logout()" />
-        </div>
-      </form>
-      <div ng-show="$ctrl.error" class="gmf-authentication-error help-block"></div>
-    </div>
-  </ngeo-modal>
-
 </div>
 
 <div ng-if="!$ctrl.gmfUser.username">
@@ -196,7 +144,6 @@
   <div ng-show="$ctrl.error" class="gmf-authentication-error help-block"></div>
 
   <ngeo-modal
-      ngeo-modal-destroy-content-on-hide="true"
       ng-model="$ctrl.resetPasswordModalShown">
     <div class="modal-header">
       <button type="button"

--- a/contribs/gmf/src/authentication/component.html
+++ b/contribs/gmf/src/authentication/component.html
@@ -17,9 +17,6 @@
           class="form-control btn btn-primary"
           value="{{'Logout' | translate}}" />
     </div>
-    <span
-        ng-show="$ctrl.error"
-        class="gmf-authentication-error help-block"></span>
     <div class="form-group">
     <input
         ng-show="$ctrl.allowPasswordChange"
@@ -68,15 +65,15 @@
           value="{{'Change password' | translate}}" />
     </div>
     <div class="form-group">
-      <span ng-show="$ctrl.error"
-            class="gmf-authentication-error help-block"></span>
-    <input
-        type="button"
-        class="form-control btn btn-default"
-        value="{{'Cancel' | translate}}"
-        ng-click="$ctrl.changePasswordReset()" />
+      <input
+          type="button"
+          class="form-control btn btn-default"
+          value="{{'Cancel' | translate}}"
+          ng-click="$ctrl.changePasswordReset()" />
     </div>
   </form>
+
+  <div ng-show="$ctrl.error" class="gmf-authentication-error help-block"></div>
 
   <ngeo-modal
       ngeo-modal-destroy-content-on-hide="true"
@@ -99,6 +96,63 @@
       <button type="button"
               class="btn btn-default"
               data-dismiss="modal">{{'OK' | translate}}</button>
+    </div>
+  </ngeo-modal>
+
+  <ngeo-modal
+      ngeo-modal-destroy-content-on-hide="true"
+      ng-model="$ctrl.userMustChangeItsPassword()"
+      ng-model-options="{getterSetter: true}">
+    <div class="modal-header">
+      <h4 class="modal-title">
+        {{'You must change your password.' | translate}}
+      </h4>
+    </div>
+    <div class="modal-body">
+      <form
+          name="changePasswordForm"
+          role="form"
+          ng-submit="$ctrl.changePassword()"
+          ng-controller="GmfAuthenticationController"
+          ng-class="{'has-error': $ctrl.error}">
+        <div class="form-group">
+          <input
+              type="password"
+              class="form-control"
+              name="oldpassword"
+              ng-model="$ctrl.oldPwdVal"
+              ng-attr-placeholder="{{'Old password' | translate}}"/>
+        </div>
+        <div class="form-group">
+          <input
+              type="password"
+              class="form-control"
+              name="newpassword"
+              ng-model="$ctrl.newPwdVal"
+              ng-attr-placeholder="{{'New password' | translate}}"/>
+        </div>
+        <div class="form-group">
+          <input
+              type="password"
+              class="form-control"
+              name="newpasswordconfirm"
+              ng-model="$ctrl.newPwdConfVal"
+              ng-attr-placeholder="{{'Confirm new password' | translate}}"/>
+        </div>
+        <div class="form-group">
+          <input
+              type="submit"
+              class="form-control btn btn-primary"
+              value="{{'Change password' | translate}}" />
+        </div>
+        <input
+            type="button"
+            class="form-control btn btn-default"
+            value="{{'Logout' | translate}}"
+            ng-click="$ctrl.logout()" />
+        </div>
+      </form>
+      <div ng-show="$ctrl.error" class="gmf-authentication-error help-block"></div>
     </div>
   </ngeo-modal>
 
@@ -133,14 +187,13 @@
         class="form-control btn btn-primary"
         value="{{'Connect' | translate}}" />
     </div>
-    <span
-        ng-show="$ctrl.error"
-        class="gmf-authentication-error help-block"></span>
     <div ng-show="$ctrl.allowPasswordReset" class="form-group">
       <a ng-click="$ctrl.resetPassword()"
          href="">{{'Password forgotten?' | translate}}</a>
     </div>
   </form>
+
+  <div ng-show="$ctrl.error" class="gmf-authentication-error help-block"></div>
 
   <ngeo-modal
       ngeo-modal-destroy-content-on-hide="true"

--- a/contribs/gmf/src/authentication/component.js
+++ b/contribs/gmf/src/authentication/component.js
@@ -79,8 +79,27 @@ function gmfAuthenticationTemplateUrl($element, $attrs, gmfAuthenticationTemplat
  *     it you must also allow the user to change its password.
  * @htmlAttribute {boolean} gmf-authentication-force-password-change Force the
  *     user to change its password. Default to false. If you set it to true, you
- *     should also allow the user to change its password and you must ensure that the modal can be
- *     displayed (if your login panel is hidden, display it).
+ *     should also allow the user to change its password. Don't add this option alone, use
+ *     it in a dedicated authentication component, in a ngeo-modal, directly in
+ *     your index.html (see example 2.)
+ *
+ * Example 2:
+ *
+ *     <ngeo-modal
+ *         ngeo-modal-closable="false"
+ *         ng-model="mainCtrl.userMustChangeItsPassword()"
+ *         ng-model-options="{getterSetter: true}">
+ *       <div class="modal-header">
+ *         <h4 class="modal-title">
+ *           {{'You must change your password' | translate}}
+ *         </h4>
+ *       </div>
+ *       <div class="modal-body" translate>
+ *         <gmf-authentication
+ *           gmf-authentication-force-password-change="::true">
+ *         </gmf-authentication>
+ *       </div>
+ *     </ngeo-modal>
  *
  * @ngdoc component
  * @ngname gmfAuthentication
@@ -108,6 +127,7 @@ gmf.authentication.component.component('gmfAuthentication', gmf.authentication.c
 gmf.authentication.component.AuthenticationController_ = class {
   /**
    * @private
+   * @param {!angular.JQLite} $element Element.
    * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
    * @param {gmf.authentication.Service} gmfAuthenticationService GMF Authentication service
    * @param {gmfx.User} gmfUser User.
@@ -116,7 +136,13 @@ gmf.authentication.component.AuthenticationController_ = class {
    * @ngdoc controller
    * @ngname GmfAuthenticationController
    */
-  constructor(gettextCatalog, gmfAuthenticationService, gmfUser, ngeoNotification) {
+  constructor($element, gettextCatalog, gmfAuthenticationService, gmfUser, ngeoNotification) {
+
+    /**
+     * @type {!angular.JQLite}
+     * @private
+     */
+    this.$element_ = $element;
 
     /**
      * @type {gmfx.User}
@@ -232,6 +258,9 @@ gmf.authentication.component.AuthenticationController_ = class {
     this.allowPasswordReset = this.allowPasswordReset !== false;
     this.allowPasswordChange = this.allowPasswordChange !== false;
     this.forcePasswordChange = this.forcePasswordChange === true;
+    if (this.forcePasswordChange) {
+      this.changingPassword = true;
+    }
   }
 
 
@@ -371,10 +400,9 @@ gmf.authentication.component.AuthenticationController_ = class {
     this.newPwdConfVal = '';
   }
 
-
   /**
-   * @return {boolean} True if the modal must be shown to force the user to change its
-   *     password. False Otherwise.
+   * @return {boolean} True if the user must change is password and if the "forcePasswordChange" option of
+   *    this component is set to true.
    * @export
    */
   userMustChangeItsPassword() {
@@ -392,7 +420,7 @@ gmf.authentication.component.AuthenticationController_ = class {
 
     this.error = true;
 
-    const container = angular.element('.gmf-authentication-error');
+    const container = this.$element_.find('.gmf-authentication-error');
 
     if (!Array.isArray(errors)) {
       errors = [errors];

--- a/contribs/gmf/src/controllers/AbstractAppController.js
+++ b/contribs/gmf/src/controllers/AbstractAppController.js
@@ -310,12 +310,6 @@ gmf.controllers.AbstractAppController = function(config, $scope, $injector) {
   this.gmfUser = $injector.get('gmfUser');
 
   /**
-   * @type {gmfx.User}
-   * @export
-   */
-  this.forcePasswordChange = true;
-
-  /**
    * @type {ngeox.miscGetBrowserLanguage}
    */
   this.getBrowserLanguage = $injector.get('ngeoGetBrowserLanguage');
@@ -580,6 +574,16 @@ gmf.controllers.AbstractAppController = function(config, $scope, $injector) {
    * @export
    */
   this.displaywindowWidth = null;
+};
+
+
+/**
+ * @return {boolean} Return true if a user exists and its 'is_password_changed' value is explicitely set
+ *     to false.
+ * @export
+ */
+gmf.controllers.AbstractAppController.prototype.userMustChangeItsPassword = function() {
+  return this.gmfUser.is_password_changed === false;
 };
 
 

--- a/contribs/gmf/src/controllers/AbstractAppController.js
+++ b/contribs/gmf/src/controllers/AbstractAppController.js
@@ -309,12 +309,11 @@ gmf.controllers.AbstractAppController = function(config, $scope, $injector) {
    */
   this.gmfUser = $injector.get('gmfUser');
 
-  // close right nave on successful login
-  $scope.$watch(() => this.gmfUser.username, (newVal) => {
-    if (newVal !== null && this.navIsVisible) {
-      this.rightNavVisible = false;
-    }
-  });
+  /**
+   * @type {gmfx.User}
+   * @export
+   */
+  this.forcePasswordChange = true;
 
   /**
    * @type {ngeox.miscGetBrowserLanguage}

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -210,12 +210,21 @@ gmf.controllers.AbstractDesktopController = function(config, $scope, $injector) 
 
   gmf.controllers.AbstractAppController.call(this, config, $scope, $injector);
 
-  // close the login panel on successful login
+  // Close the login panel on successful login.
   $scope.$watch(() => this.gmfUser.username, (newVal) => {
     if (newVal !== null && this.loginActive) {
       this.loginActive = false;
     }
   });
+
+  // Open login panel if user must change it's password.
+  if (this.forcePasswordChange) {
+    $scope.$watch(() => this.gmfUser.is_password_changed, (newVal) => {
+      if (newVal === false && !this.loginActive) {
+        this.loginActive = true;
+      }
+    });
+  }
 
 };
 ol.inherits(gmf.controllers.AbstractDesktopController, gmf.controllers.AbstractAppController);

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -216,16 +216,6 @@ gmf.controllers.AbstractDesktopController = function(config, $scope, $injector) 
       this.loginActive = false;
     }
   });
-
-  // Open login panel if user must change it's password.
-  if (this.forcePasswordChange) {
-    $scope.$watch(() => this.gmfUser.is_password_changed, (newVal) => {
-      if (newVal === false && !this.loginActive) {
-        this.loginActive = true;
-      }
-    });
-  }
-
 };
 ol.inherits(gmf.controllers.AbstractDesktopController, gmf.controllers.AbstractAppController);
 

--- a/contribs/gmf/src/controllers/AbstractMobileController.js
+++ b/contribs/gmf/src/controllers/AbstractMobileController.js
@@ -127,6 +127,23 @@ gmf.controllers.AbstractMobileController = function(config, $scope, $injector) {
 
   this.manageResize = true;
   this.resizeTransition = 500;
+
+  // Close right nave on successful login.
+  $scope.$watch(() => this.gmfUser.username, (newVal) => {
+    if (newVal !== null && this.navIsVisible()) {
+      this.rightNavVisible = false;
+    }
+  });
+
+  // Open login panel if user must change it's password.
+  if (this.forcePasswordChange) {
+    $scope.$watch(() => this.gmfUser.is_password_changed, (newVal) => {
+      if (newVal === false && !this.rightNavVisible) {
+        this.rightNavVisible = true;
+      }
+    });
+  }
+
 };
 ol.inherits(gmf.controllers.AbstractMobileController, gmf.controllers.AbstractAppController);
 

--- a/contribs/gmf/src/controllers/AbstractMobileController.js
+++ b/contribs/gmf/src/controllers/AbstractMobileController.js
@@ -140,6 +140,7 @@ gmf.controllers.AbstractMobileController = function(config, $scope, $injector) {
     $scope.$watch(() => this.gmfUser.is_password_changed, (newVal) => {
       if (newVal === false && !this.rightNavVisible) {
         this.rightNavVisible = true;
+        this.openNavMenu('#login');
       }
     });
   }
@@ -209,6 +210,22 @@ gmf.controllers.AbstractMobileController.prototype.leftNavIsVisible = function()
  */
 gmf.controllers.AbstractMobileController.prototype.rightNavIsVisible = function() {
   return this.rightNavVisible;
+};
+
+
+/**
+ * Open the menu with corresponding to the data-target attribute value.
+ * @param {string} target the data-target value.
+ * @export
+ */
+gmf.controllers.AbstractMobileController.prototype.openNavMenu = function(target) {
+  const navElements = document.getElementsByClassName('gmf-mobile-nav-button');
+  for (const key in navElements) {
+    const element = navElements[key];
+    if (element.dataset && element.dataset.target === target) {
+      element.click();
+    }
+  }
 };
 
 

--- a/contribs/gmf/src/controllers/AbstractMobileController.js
+++ b/contribs/gmf/src/controllers/AbstractMobileController.js
@@ -134,17 +134,6 @@ gmf.controllers.AbstractMobileController = function(config, $scope, $injector) {
       this.rightNavVisible = false;
     }
   });
-
-  // Open login panel if user must change it's password.
-  if (this.forcePasswordChange) {
-    $scope.$watch(() => this.gmfUser.is_password_changed, (newVal) => {
-      if (newVal === false && !this.rightNavVisible) {
-        this.rightNavVisible = true;
-        this.openNavMenu('#login');
-      }
-    });
-  }
-
 };
 ol.inherits(gmf.controllers.AbstractMobileController, gmf.controllers.AbstractAppController);
 

--- a/src/message/modalcomponent.js
+++ b/src/message/modalcomponent.js
@@ -38,6 +38,8 @@ ngeo.message.modalComponent = angular.module('ngeoModal', []);
  *
  * @htmlAttribute {boolean} ngeo-modal-resizable Whether the modal can be
  *     resized or not. Defaults to `false`.
+ * @htmlAttribute {boolean} ngeo-modal-closable Whether the modal can be
+ *     closed by clicking outside it or by hiting the `escape` keyboard key. Defaults to `true`.
  * @ngdoc component
  * @ngname ngeoModal
  * @type {!angular.Component}
@@ -56,7 +58,8 @@ ngeo.message.modalComponent.component_ = {
   transclude: true,
   controller: 'ngeoModalController',
   bindings: {
-    'resizable': '<ngeoModalResizable'
+    'resizable': '<ngeoModalResizable',
+    'closable': '<ngeoModalClosable'
   }
 };
 
@@ -91,6 +94,12 @@ ngeo.message.modalComponent.Controller_ = class {
      * @export
      * @type {boolean}
      */
+    this.closable = true;
+
+    /**
+     * @export
+     * @type {boolean}
+     */
     this.resizable;
 
     /**
@@ -101,7 +110,13 @@ ngeo.message.modalComponent.Controller_ = class {
   }
 
   $onInit() {
+
     this.modal_ = this.$element_.children();
+
+    if (this.closable === false) {
+      this.modal_.attr('data-keyboard', false);
+      this.modal_.attr('data-backdrop', 'static');
+    }
 
     this.resizable = !!this.resizable;
 
@@ -118,9 +133,7 @@ ngeo.message.modalComponent.Controller_ = class {
     this.modal_.on('shown.bs.modal hidden.bs.modal', (e) => {
       const type = e.type;
       goog.asserts.assert(type == 'shown' || type == 'hidden');
-      this.$scope_.$apply(() => {
-        this.ngModel.$setViewValue(type == 'shown');
-      });
+      this.ngModel.$setViewValue(type == 'shown');
     });
   }
 


### PR DESCRIPTION
For https://jira.camptocamp.com/projects/GEO/queues/custom/52/GEO-712

(/!\ New dev, no webpack / es6 thing)

IT:
- Force user to change it's password via a modal (that we can't dismiss).
- Add a possibility to use a function to validate that the password fulfill some requirements
- Add possibility to  keep modal open.

Added in desktop and mobile.

(What a headheach :unamused: But work well now)