### PR TITLE
Remove unused vars 3

### DIFF
--- a/contribs/gmf/apps/desktop/js/controller.js
+++ b/contribs/gmf/apps/desktop/js/controller.js
@@ -10,9 +10,6 @@ goog.require('app');
 goog.require('gmf.controllers.AbstractDesktopController');
 goog.require('ngeo.proj.EPSG2056');
 goog.require('ngeo.proj.EPSG21781');
-
-/** @suppress {extraRequire} */
-goog.require('ngeo.googlestreetview.component');
 goog.require('ol');
 
 app.desktop.module = angular.module('AppDesktop', [

--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -9,13 +9,16 @@ goog.provide('app.desktop_alt.Controller');
 goog.require('app');
 goog.require('gmf.controllers.AbstractDesktopController');
 /** @suppress {extraRequire} */
-goog.require('gmf.import.importdatasourceComponent');
+goog.require('gmf.import.module');
+/** @suppress {extraRequire} */
+goog.require('ngeo.googlestreetview.module');
 goog.require('ngeo.proj.EPSG2056');
 goog.require('ngeo.proj.EPSG21781');
-
-/** @suppress {extraRequire} */
-goog.require('ngeo.googlestreetview.component');
 goog.require('ol');
+
+// Add me in module dependencies:
+// gmf.import.module.name,
+// ngeo.googlestreetview.module.name
 
 
 app.module.value('ngeoQueryOptions', {

--- a/contribs/gmf/apps/mobile_alt/js/controller.js
+++ b/contribs/gmf/apps/mobile_alt/js/controller.js
@@ -11,6 +11,9 @@ goog.require('gmf.controllers.AbstractMobileController');
 goog.require('ngeo.proj.EPSG2056');
 goog.require('ngeo.proj.EPSG21781');
 goog.require('ol');
+goog.require('ol.style.Fill');
+goog.require('ol.style.RegularShape');
+goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 
 

--- a/contribs/gmf/src/authentication/component.js
+++ b/contribs/gmf/src/authentication/component.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.authentication.component');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 goog.require('gmf.authentication.Service');
 goog.require('ngeo.message.Message');
 goog.require('ngeo.message.Notification');

--- a/contribs/gmf/src/backgroundlayerselector/component.js
+++ b/contribs/gmf/src/backgroundlayerselector/component.js
@@ -1,7 +1,7 @@
 goog.provide('gmf.backgroundlayerselector.component');
 
+goog.require('gmf'); // nowebpack
 goog.require('goog.asserts');
-goog.require('gmf');
 goog.require('gmf.theme.Themes');
 goog.require('ngeo.map.BackgroundLayerMgr');
 goog.require('ol.events');

--- a/contribs/gmf/src/datasource/ExternalDataSourcesManager.js
+++ b/contribs/gmf/src/datasource/ExternalDataSourcesManager.js
@@ -5,6 +5,7 @@ goog.provide('gmf.datasource.ExternalDataSourcesManager');
 
 goog.require('gmf');
 goog.require('goog.asserts');
+goog.require('ngeo.map.LayerHelper');
 goog.require('ngeo.misc.File');
 goog.require('ngeo.datasource.DataSources');
 goog.require('ngeo.datasource.File');
@@ -380,7 +381,7 @@ gmf.datasource.ExternalDataSourcesManager = class {
         injector: this.injector_,
         title: service['Title'],
         url: url
-      });
+      }, this.ngeoLayerHelper_);
       this.addLayer_(wmsGroup.layer);
       this.addWMSGroup_(wmsGroup);
       this.dataSources_.push(dataSource);
@@ -666,6 +667,7 @@ gmf.datasource.ExternalDataSourcesManager.getId = function(layer) {
 
 
 gmf.datasource.ExternalDataSourcesManager.module = angular.module('gmfExternalDataSourcesManager', [
+  ngeo.map.LayerHelper.module.name,
   ngeo.misc.File.module.name,
   ngeo.datasource.DataSources.module.name,
 ]);

--- a/contribs/gmf/src/drawing/drawFeatureComponent.js
+++ b/contribs/gmf/src/drawing/drawFeatureComponent.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.drawing.drawFeatureComponent');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 /** @suppress {extraRequire} */
 goog.require('gmf.drawing.featureStyleComponent');
 goog.require('goog.asserts');

--- a/contribs/gmf/src/drawing/featureStyleComponent.js
+++ b/contribs/gmf/src/drawing/featureStyleComponent.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.drawing.featureStyleComponent');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 goog.require('goog.asserts');
 goog.require('ol.events');
 goog.require('ol.Object');

--- a/contribs/gmf/src/editing/editFeatureComponent.js
+++ b/contribs/gmf/src/editing/editFeatureComponent.js
@@ -1,7 +1,6 @@
 goog.provide('gmf.editing.editFeatureComponent');
 
-
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 goog.require('gmf.editing.EditFeature');
 /** @suppress {extraRequire} */
 goog.require('gmf.editing.Snapping');

--- a/contribs/gmf/src/editing/editFeatureSelectorComponent.js
+++ b/contribs/gmf/src/editing/editFeatureSelectorComponent.js
@@ -1,7 +1,7 @@
 goog.provide('gmf.editing.editFeatureSelectorComponent');
 
+goog.require('gmf'); // nowebpack
 goog.require('goog.asserts');
-goog.require('gmf');
 /** @suppress {extraRequire} */
 goog.require('gmf.editing.editFeatureComponent');
 goog.require('gmf.layertree.TreeManager');

--- a/contribs/gmf/src/filters/filterselectorcomponent.js
+++ b/contribs/gmf/src/filters/filterselectorcomponent.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.filters.filterselectorComponent');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 /** @suppress {extraRequire} */
 goog.require('gmf.authentication.Service');
 goog.require('gmf.datasource.DataSourceBeingFiltered');

--- a/contribs/gmf/src/import/importdatasourceComponent.js
+++ b/contribs/gmf/src/import/importdatasourceComponent.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.import.importdatasourceComponent');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 /** @suppress {extraRequire} */
 goog.require('gmf.datasource.ExternalDataSourcesManager');
 /** @suppress {extraRequire} */

--- a/contribs/gmf/src/import/wmsCapabilityLayertreeComponent.js
+++ b/contribs/gmf/src/import/wmsCapabilityLayertreeComponent.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.import.wmsCapabilityLayertreeComponent');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 /** @suppress {extraRequire} */
 goog.require('gmf.datasource.ExternalDataSourcesManager');
 /** @suppress {extraRequire} */

--- a/contribs/gmf/src/import/wmtsCapabilityLayertreeComponent.js
+++ b/contribs/gmf/src/import/wmtsCapabilityLayertreeComponent.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.import.wmtsCapabilityLayertreeComponent');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 /** @suppress {extraRequire} */
 goog.require('gmf.datasource.ExternalDataSourcesManager');
 /** @suppress {extraRequire} */

--- a/contribs/gmf/src/layertree/datasourceGroupTreeComponent.js
+++ b/contribs/gmf/src/layertree/datasourceGroupTreeComponent.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.layertree.datasourceGroupTreeComponent');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 goog.require('ngeo.datasource.DataSources');
 goog.require('ol');
 

--- a/contribs/gmf/src/layertree/timesliderComponent.js
+++ b/contribs/gmf/src/layertree/timesliderComponent.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.layertree.timeSliderComponent');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 goog.require('ngeo.misc.WMSTime');
 // webpack: import 'jquery-ui/widgets/slider.js';
 // webpack: import 'angular-ui-slider';

--- a/contribs/gmf/src/map/component.js
+++ b/contribs/gmf/src/map/component.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.map.component');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 goog.require('gmf.permalink.Permalink');
 goog.require('gmf.editing.Snapping');
 goog.require('ngeo.map.component');

--- a/contribs/gmf/src/map/mousepositionComponent.js
+++ b/contribs/gmf/src/map/mousepositionComponent.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.map.mousepositionComponent');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 goog.require('goog.asserts');
 goog.require('ngeo.misc.filters');
 goog.require('ol.control.MousePosition');

--- a/contribs/gmf/src/mobile/measure/lengthComponent.js
+++ b/contribs/gmf/src/mobile/measure/lengthComponent.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.mobile.measure.lengthComponent');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 goog.require('ngeo.misc.filters');
 goog.require('ngeo.interaction.MeasureLengthMobile');
 goog.require('ngeo.misc.decorate');

--- a/contribs/gmf/src/mobile/measure/pointComponent.js
+++ b/contribs/gmf/src/mobile/measure/pointComponent.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.mobile.measure.pointComponent');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 goog.require('gmf.raster.RasterService');
 goog.require('goog.asserts');
 goog.require('ngeo.interaction.MeasurePointMobile');

--- a/contribs/gmf/src/objectediting/component.js
+++ b/contribs/gmf/src/objectediting/component.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.objectediting.component');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 goog.require('gmf.editing.EditFeature');
 goog.require('gmf.layertree.SyncLayertreeMap');
 goog.require('gmf.layertree.TreeManager');

--- a/contribs/gmf/src/objectediting/toolsComponent.js
+++ b/contribs/gmf/src/objectediting/toolsComponent.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.objectediting.toolsComponent');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 /** @suppress {extraRequire} */
 goog.require('gmf.objectediting.getWMSFeatureComponent');
 /** @suppress {extraRequire} */

--- a/contribs/gmf/src/permalink/Permalink.js
+++ b/contribs/gmf/src/permalink/Permalink.js
@@ -9,8 +9,6 @@ goog.require('ngeo.Popover');
 goog.require('ngeo.draw.features');
 goog.require('ngeo.datasource.Group');
 goog.require('ngeo.datasource.OGC');
-/** @suppress {extraRequire} */
-goog.require('ngeo.datasource.WMSGroup');
 goog.require('ngeo.olcs.constants');
 goog.require('ngeo.format.FeatureHash');
 goog.require('ngeo.format.FeatureProperties');

--- a/contribs/gmf/src/permalink/shareComponent.js
+++ b/contribs/gmf/src/permalink/shareComponent.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.permalink.shareComponent');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 goog.require('gmf.permalink.ShareService');
 
 

--- a/contribs/gmf/src/profile/component.js
+++ b/contribs/gmf/src/profile/component.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.profile.component');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 goog.require('goog.asserts');
 goog.require('ol.events');
 goog.require('ol.Feature');

--- a/contribs/gmf/src/query/gridComponent.js
+++ b/contribs/gmf/src/query/gridComponent.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.query.gridComponent');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 goog.require('goog.asserts');
 /** @suppress {extraRequire} */
 goog.require('ngeo.download.Csv');

--- a/contribs/gmf/src/query/windowComponent.js
+++ b/contribs/gmf/src/query/windowComponent.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.query.windowComponent');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 goog.require('goog.asserts');
 goog.require('ngeo.map.FeatureOverlayMgr');
 goog.require('ngeo.misc.FeatureHelper');

--- a/contribs/gmf/src/raster/component.js
+++ b/contribs/gmf/src/raster/component.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.raster.component');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 goog.require('gmf.raster.RasterService');
 goog.require('goog.asserts');
 /** @suppress {extraRequire} */

--- a/contribs/gmf/src/theme/selectorComponent.js
+++ b/contribs/gmf/src/theme/selectorComponent.js
@@ -1,6 +1,6 @@
 goog.provide('gmf.theme.selectorComponent');
 
-goog.require('gmf');
+goog.require('gmf'); // nowebpack
 goog.require('gmf.theme.Manager');
 goog.require('gmf.theme.Themes');
 goog.require('ol.events');

--- a/src/datasource/WMSGroup.js
+++ b/src/datasource/WMSGroup.js
@@ -1,7 +1,6 @@
 goog.provide('ngeo.datasource.WMSGroup');
 
 goog.require('goog.asserts');
-goog.require('ngeo.map.LayerHelper');
 goog.require('ngeo.datasource.OGCGroup');
 goog.require('ngeo.datasource.OGC');
 goog.require('ol.array');
@@ -19,8 +18,9 @@ ngeo.datasource.WMSGroup = class extends ngeo.datasource.OGCGroup {
    *
    * @struct
    * @param {ngeox.datasource.WMSGroupOptions} options Options.
+   * @param {!ngeo.map.LayerHelper} ngeoLayerHelper the ngeo map LayerHelper service.
    */
-  constructor(options) {
+  constructor(options, ngeoLayerHelper) {
 
     super(options);
 
@@ -39,7 +39,7 @@ ngeo.datasource.WMSGroup = class extends ngeo.datasource.OGCGroup {
      * @type {!ngeo.map.LayerHelper}
      * @private
      */
-    this.ngeoLayerHelper_ = injector.get('ngeoLayerHelper');
+    this.ngeoLayerHelper_ = ngeoLayerHelper;
 
     /**
      * @type {!angular.Scope}

--- a/test/spec/services/decoratelayer.spec.js
+++ b/test/spec/services/decoratelayer.spec.js
@@ -1,5 +1,4 @@
 goog.require('ngeo.misc.decorate');
-goog.require('ol.Map');
 goog.require('ol.layer.Tile');
 goog.require('ol.source.OSM');
 

--- a/test/spec/services/decoratelayerloading.spec.js
+++ b/test/spec/services/decoratelayerloading.spec.js
@@ -2,7 +2,6 @@ goog.require('ngeo.misc.decorate');
 goog.require('ol.layer.Image');
 goog.require('ol.layer.Group');
 goog.require('ol.source.Image');
-goog.require('ol.Collection');
 
 
 describe('ngeo.misc.DecorateLayerLoading test suite', () => {


### PR DESCRIPTION
For https://jira.camptocamp.com/browse/GSGMF-261

Still to fix (in a next PR):

90% -> Requires in the tests files,
10% -> Some require in apps (will be easy when apps will be transformed into modules)
~39 / 300+ warnings left


Then there is also some warnings (~20) in the "make lint" result without webpack.