### PR TITLE
Backgroundlayerselector opacityslider

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -222,7 +222,6 @@
               <img src="image/background-layer-button.png" alt="" />
             </button>
             <gmf-backgroundlayerselector
-              gmf-backgroundlayerselector-dimensions="::mainCtrl.dimensions"
               gmf-backgroundlayerselector-map="::mainCtrl.map"
               class="dropdown-menu">
             </gmf-backgroundlayerselector>

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -254,6 +254,7 @@
             </button>
             <gmf-backgroundlayerselector
               gmf-backgroundlayerselector-map="::mainCtrl.map"
+              gmf-backgroundlayer-opacity-options="::mainCtrl.bgOpacityOptions"
               class="dropdown-menu">
             </gmf-backgroundlayerselector>
           </div>

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -253,7 +253,6 @@
               <img src="image/background-layer-button.png" alt="" />
             </button>
             <gmf-backgroundlayerselector
-              gmf-backgroundlayerselector-dimensions="::mainCtrl.dimensions"
               gmf-backgroundlayerselector-map="::mainCtrl.map"
               class="dropdown-menu">
             </gmf-backgroundlayerselector>

--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -139,7 +139,7 @@ app.AlternativeDesktopController = function($scope, $injector, ngeoFile, gettext
    * @type {string}
    * @export
    */
-  this.bgOpacityOptions = 'OSM map WMS';
+  this.bgOpacityOptions = 'Test aus Olten';
 
   /**
    * @export

--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -136,6 +136,12 @@ app.AlternativeDesktopController = function($scope, $injector, ngeoFile, gettext
   gettextCatalog.getString('Add a layer');
 
   /**
+   * @type {string}
+   * @export
+   */
+  this.bgOpacityOptions = 'OSM map WMS';
+
+  /**
    * @export
    */
   this.importOptions = new app.GmfImportHelper(this.map, $scope, gettext, ngeoFile, $q).createOptions();

--- a/contribs/gmf/apps/mobile/index.html
+++ b/contribs/gmf/apps/mobile/index.html
@@ -107,7 +107,6 @@
         id="background"
         class="gmf-mobile-nav-slide"
         data-header-title="{{'Background' | translate}}"
-        gmf-backgroundlayerselector-dimensions="::mainCtrl.dimensions"
         gmf-backgroundlayerselector-map="::mainCtrl.map"
         gmf-backgroundlayerselector-select="mainCtrl.hideNav()">
       </gmf-backgroundlayerselector>

--- a/contribs/gmf/apps/mobile_alt/index.html
+++ b/contribs/gmf/apps/mobile_alt/index.html
@@ -110,7 +110,6 @@
         id="background"
         class="gmf-mobile-nav-slide"
         data-header-title="{{'Background' | translate}}"
-        gmf-backgroundlayerselector-dimensions="::mainCtrl.dimensions"
         gmf-backgroundlayerselector-map="::mainCtrl.map"
         gmf-backgroundlayerselector-select="mainCtrl.hideNav()">
       </gmf-backgroundlayerselector>

--- a/contribs/gmf/examples/backgroundlayerselector.html
+++ b/contribs/gmf/examples/backgroundlayerselector.html
@@ -49,7 +49,6 @@
     directive to select the map background layer.</p>
     <div>
         <gmf-backgroundlayerselector
-          gmf-backgroundlayerselector-dimensions="::ctrl.dimensions"
           gmf-backgroundlayerselector-map="::ctrl.map">
         </gmf-backgroundlayerselector>
     </div>

--- a/contribs/gmf/examples/backgroundlayerselector.js
+++ b/contribs/gmf/examples/backgroundlayerselector.js
@@ -31,12 +31,6 @@ gmfapp.MainController = function(gmfThemes) {
   gmfThemes.loadThemes();
 
   /**
-   * @type {Object.<string, string>}
-   * @export
-   */
-  this.dimensions = {};
-
-  /**
    * @type {ol.Map}
    * @export
    */

--- a/contribs/gmf/less/map.less
+++ b/contribs/gmf/less/map.less
@@ -95,7 +95,7 @@ button[ngeo-mobile-geolocation] {
     }
 
     &.gmf-backgroundlayerselector-disabled{
-      border-color: red;
+      border-top-color: @map-tools-color;
       pointer-events: none;
     }
 

--- a/contribs/gmf/less/map.less
+++ b/contribs/gmf/less/map.less
@@ -103,7 +103,7 @@ button[ngeo-mobile-geolocation] {
       &::after {
         width: (18em / 14);
         font-family: FontAwesome;
-        content: @fa-var-check-circle-o;
+        content: @fa-var-check;
         text-align: center;
       }
     }

--- a/contribs/gmf/less/map.less
+++ b/contribs/gmf/less/map.less
@@ -93,6 +93,20 @@ button[ngeo-mobile-geolocation] {
         content: @fa-var-check;
       }
     }
+
+    &.gmf-backgroundlayerselector-disabled{
+      border-color: red;
+      pointer-events: none;
+    }
+
+    span.gmf-backgroundlayerselector-opacity-check {
+      &::after {
+        width: (18em / 14);
+        font-family: FontAwesome;
+        content: @fa-var-check-circle-o;
+        text-align: center;
+      }
+    }
   }
 
   .gmf-text {
@@ -105,6 +119,12 @@ button[ngeo-mobile-geolocation] {
   .gmf-thumb {
     height: @map-tools-size;
     margin: 0 @half-app-margin;
+  }
+
+  input.gmf-backgroundlayerselector-opacity-slider {
+    margin: 1rem 0 2rem 0;
+    padding-left: @half-app-margin !important;
+    padding-right: @half-app-margin !important;
   }
 }
 

--- a/contribs/gmf/src/directives/backgroundlayerselector.js
+++ b/contribs/gmf/src/directives/backgroundlayerselector.js
@@ -140,6 +140,12 @@ gmf.BackgroundlayerselectorController = function($scope, ngeoBackgroundLayerMgr,
    */
   this.backgroundLayerMgr_ = ngeoBackgroundLayerMgr;
 
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.isThemeLoadedOnce_ = false;
+
   this.listenerKeys_.push(ol.events.listen(
     this.backgroundLayerMgr_,
     ngeo.BackgroundEventType.CHANGE,
@@ -170,7 +176,11 @@ gmf.BackgroundlayerselectorController.prototype.handleThemesChange_ = function()
   this.gmfThemes_.getBgLayers().then((layers) => {
     this.bgLayers = layers;
 
-    if (this.opacityOptions !== undefined) {
+    if (this.opacityOptions !== undefined && !this.isThemeLoadedOnce_) {
+      // Angular initialize twice the component, this limit to set
+      // only once the background layer used by opacity slider
+      this.isThemeLoadedOnce_ = true;
+
       const opacityLayer = layers.find(layer => layer.get('label') === this.opacityOptions);
       if (opacityLayer !== undefined) {
         this.setOpacityBgLayer(opacityLayer);
@@ -190,7 +200,7 @@ gmf.BackgroundlayerselectorController.prototype.handleThemesChange_ = function()
  * @param {?number} val The opacity.
  * @returns {number} The background layer opacity.
  */
-gmf.BackgroundlayerselectorController.prototype.getSetOpacityBgLayer = function(val) {
+gmf.BackgroundlayerselectorController.prototype.getSetBgLayerOpacity = function(val) {
   if (val) {
     this.opacityLayer.setOpacity(val);
   }

--- a/contribs/gmf/src/directives/backgroundlayerselector.js
+++ b/contribs/gmf/src/directives/backgroundlayerselector.js
@@ -4,7 +4,6 @@ goog.require('gmf');
 goog.require('gmf.Themes');
 goog.require('ngeo.BackgroundEventType');
 goog.require('ngeo.BackgroundLayerMgr');
-goog.require('ngeo.DecorateLayer');
 
 
 gmf.module.value('gmfBackgroundlayerselectorTemplateUrl',
@@ -77,12 +76,11 @@ gmf.module.component('gmfBackgroundlayerselector', gmf.backgroundlayerselectorCo
  * @param {!angular.Scope} $scope Angular scope.
  * @param {!ngeo.BackgroundLayerMgr} ngeoBackgroundLayerMgr Background layer manager.
  * @param {!gmf.Themes} gmfThemes Themes service.
- * @param {ngeo.DecorateLayer} ngeoDecorateLayer layer decorator service.
  * @ngInject
  * @ngdoc controller
  * @ngname GmfBackgroundlayerselectorController
  */
-gmf.BackgroundlayerselectorController = function($scope, ngeoBackgroundLayerMgr, gmfThemes, ngeoDecorateLayer) {
+gmf.BackgroundlayerselectorController = function($scope, ngeoBackgroundLayerMgr, gmfThemes) {
 
   /**
    * @type {?ol.Map}
@@ -120,12 +118,6 @@ gmf.BackgroundlayerselectorController = function($scope, ngeoBackgroundLayerMgr,
    * @export
    */
   this.opacityLayer;
-
-  /**
-   * @type {ngeo.DecorateLayer}
-   * @private
-   */
-  this.ngeoDecorateLayer_ = ngeoDecorateLayer;
 
   /**
    * @type {!gmf.Themes}
@@ -182,11 +174,7 @@ gmf.BackgroundlayerselectorController.prototype.handleThemesChange_ = function()
       const opacityLayer = layers.find(layer => layer.get('label') === this.opacityOptions);
       if (opacityLayer !== undefined) {
         this.setOpacityBgLayer(opacityLayer);
-        this.ngeoDecorateLayer_(opacityLayer);
-
-        // Set the opacity layer and default opacity
         this.opacityLayer = opacityLayer;
-        /** @type{number} */ (this.opacityLayer.opacity) = opacityLayer.getOpacity();
 
         // Reorder the bgArray with the opacity layer at the end
         const indexOpa = this.bgLayers.findIndex(layer => layer === this.opacityLayer);
@@ -197,6 +185,17 @@ gmf.BackgroundlayerselectorController.prototype.handleThemesChange_ = function()
   });
 };
 
+/**
+ * Getter/setter for background layer opacity.
+ * @param {?number} val The opacity.
+ * @returns {number} The background layer opacity.
+ */
+gmf.BackgroundlayerselectorController.prototype.getSetOpacityBgLayer = function(val) {
+  if (val) {
+    this.opacityLayer.setOpacity(val);
+  }
+  return this.opacityLayer.getOpacity();
+};
 
 /**
  * @param {ol.layer.Base} layer Layer.

--- a/contribs/gmf/src/directives/backgroundlayerselector.js
+++ b/contribs/gmf/src/directives/backgroundlayerselector.js
@@ -39,7 +39,6 @@ function gmfBackgroundlayerselectorTemplateUrl($element, $attrs, gmfBackgroundla
  * Example:
  *
  *      <gmf-backgroundlayerselector
- *        gmf-backgroundlayerselector-dimensions="::ctrl.dimensions"
  *        gmf-backgroundlayerselector-map="::ctrl.map"
  *        gmf-backgroundlayerselector-select="onBackgroundSelected()">
  *      </gmf-backgroundlayerselector>
@@ -48,8 +47,6 @@ function gmfBackgroundlayerselectorTemplateUrl($element, $attrs, gmfBackgroundla
  *
  *  * thumbnail: The URL used for the icon.
  *
- * @htmlAttribute {Object.<string, string>} gmf-backgroundlayerselector-dimensions
- *     The dimensions.
  * @htmlAttribute {ol.Map=} gmf-backgroundlayerselector-map The map.
  * @htmlAttribute {Function} gmf-backgroundlayerselector-select Function called
  *     when a layer was selected by the user.
@@ -60,7 +57,6 @@ function gmfBackgroundlayerselectorTemplateUrl($element, $attrs, gmfBackgroundla
 gmf.backgroundlayerselectorComponent = {
   controller: 'GmfBackgroundlayerselectorController as ctrl',
   bindings: {
-    'dimensions': '=gmfBackgroundlayerselectorDimensions',
     'map': '=gmfBackgroundlayerselectorMap',
     'select': '&?gmfBackgroundlayerselectorSelect'
   },
@@ -83,12 +79,6 @@ gmf.module.component('gmfBackgroundlayerselector', gmf.backgroundlayerselectorCo
  * @ngname GmfBackgroundlayerselectorController
  */
 gmf.BackgroundlayerselectorController = function($scope, ngeoBackgroundLayerMgr, gmfThemes) {
-
-  /**
-   * @type {!Object.<string, string>}
-   * @export
-   */
-  this.dimensions;
 
   /**
    * @type {?ol.Map}
@@ -154,7 +144,6 @@ gmf.module.controller('GmfBackgroundlayerselectorController',
  * Initialise the controller.
  */
 gmf.BackgroundlayerselectorController.prototype.$onInit = function() {
-  goog.asserts.assert(this.dimensions, 'The dimensions object is required');
   this.handleThemesChange_();
 };
 

--- a/contribs/gmf/src/directives/backgroundlayerselector.js
+++ b/contribs/gmf/src/directives/backgroundlayerselector.js
@@ -40,6 +40,7 @@ function gmfBackgroundlayerselectorTemplateUrl($element, $attrs, gmfBackgroundla
  *
  *      <gmf-backgroundlayerselector
  *        gmf-backgroundlayerselector-map="::ctrl.map"
+ *        gmf-backgroundlayer-opacity-options="::ctrl.bgOpacityOptions"
  *        gmf-backgroundlayerselector-select="onBackgroundSelected()">
  *      </gmf-backgroundlayerselector>
  *
@@ -48,6 +49,7 @@ function gmfBackgroundlayerselectorTemplateUrl($element, $attrs, gmfBackgroundla
  *  * thumbnail: The URL used for the icon.
  *
  * @htmlAttribute {ol.Map=} gmf-backgroundlayerselector-map The map.
+ * @htmlAttribute {string} gmf-backgroundlayer-opacity-options The opacity slider options.
  * @htmlAttribute {Function} gmf-backgroundlayerselector-select Function called
  *     when a layer was selected by the user.
  *
@@ -58,6 +60,7 @@ gmf.backgroundlayerselectorComponent = {
   controller: 'GmfBackgroundlayerselectorController as ctrl',
   bindings: {
     'map': '=gmfBackgroundlayerselectorMap',
+    'opacityOptions': '=gmfBackgroundlayerOpacityOptions',
     'select': '&?gmfBackgroundlayerselectorSelect'
   },
   templateUrl: gmfBackgroundlayerselectorTemplateUrl
@@ -85,6 +88,12 @@ gmf.BackgroundlayerselectorController = function($scope, ngeoBackgroundLayerMgr,
    * @export
    */
   this.map;
+
+  /**
+   * @type {?string}
+   * @export
+   */
+  this.opacityOptions;
 
   /**
    * Function called when a layer was selected by the user.
@@ -155,6 +164,20 @@ gmf.BackgroundlayerselectorController.prototype.$onInit = function() {
 gmf.BackgroundlayerselectorController.prototype.handleThemesChange_ = function() {
   this.gmfThemes_.getBgLayers().then((layers) => {
     this.bgLayers = layers;
+
+    if (this.opacityOptions !== undefined) {
+      const opacityLayer = layers.find(layer => layer.get('label') === this.opacityOptions);
+      if (opacityLayer !== undefined) {
+        // Set the opacity layer and default opacity
+        this.opacityLayer = opacityLayer;
+        this.opacityLayer.opacity = 0;
+
+        // Reorder the bgArray with the opacity layer at the end
+        const indexOpa = this.bgLayers.findIndex(layer => layer === this.opacityLayer);
+        this.bgLayers.splice(indexOpa, 1);
+        this.bgLayers.push(opacityLayer);
+      }
+    }
   });
 };
 

--- a/contribs/gmf/src/directives/backgroundlayerselector.js
+++ b/contribs/gmf/src/directives/backgroundlayerselector.js
@@ -1,6 +1,5 @@
 goog.provide('gmf.backgroundlayerselectorComponent');
 
-goog.require('goog.asserts');
 goog.require('gmf');
 goog.require('gmf.Themes');
 goog.require('ngeo.BackgroundEventType');
@@ -117,6 +116,12 @@ gmf.BackgroundlayerselectorController = function($scope, ngeoBackgroundLayerMgr,
   this.bgLayers;
 
   /**
+   * @type {ol.layer.Base}
+   * @export
+   */
+  this.opacityLayer;
+
+  /**
    * @type {ngeo.DecorateLayer}
    * @private
    */
@@ -181,7 +186,7 @@ gmf.BackgroundlayerselectorController.prototype.handleThemesChange_ = function()
 
         // Set the opacity layer and default opacity
         this.opacityLayer = opacityLayer;
-        this.opacityLayer.opacity = opacityLayer.getOpacity();
+        /** @type{number} */ (this.opacityLayer.opacity) = opacityLayer.getOpacity();
 
         // Reorder the bgArray with the opacity layer at the end
         const indexOpa = this.bgLayers.findIndex(layer => layer === this.opacityLayer);

--- a/contribs/gmf/src/directives/backgroundlayerselector.js
+++ b/contribs/gmf/src/directives/backgroundlayerselector.js
@@ -89,7 +89,7 @@ gmf.BackgroundlayerselectorController = function($scope, ngeoBackgroundLayerMgr,
   this.map;
 
   /**
-   * @type {?string}
+   * @type {!string|undefined}
    * @export
    */
   this.opacityOptions;
@@ -140,12 +140,6 @@ gmf.BackgroundlayerselectorController = function($scope, ngeoBackgroundLayerMgr,
    */
   this.backgroundLayerMgr_ = ngeoBackgroundLayerMgr;
 
-  /**
-   * @type {boolean}
-   * @private
-   */
-  this.isThemeLoadedOnce_ = false;
-
   this.listenerKeys_.push(ol.events.listen(
     this.backgroundLayerMgr_,
     ngeo.BackgroundEventType.CHANGE,
@@ -176,17 +170,14 @@ gmf.BackgroundlayerselectorController.prototype.handleThemesChange_ = function()
   this.gmfThemes_.getBgLayers().then((layers) => {
     this.bgLayers = layers;
 
-    if (this.opacityOptions !== undefined && !this.isThemeLoadedOnce_) {
-      // Angular initialize twice the component, this limit to set
-      // only once the background layer used by opacity slider
-      this.isThemeLoadedOnce_ = true;
-
+    if (this.opacityOptions !== undefined) {
       const opacityLayer = layers.find(layer => layer.get('label') === this.opacityOptions);
       if (opacityLayer !== undefined) {
         this.setOpacityBgLayer(opacityLayer);
         this.opacityLayer = opacityLayer;
 
-        // Reorder the bgArray with the opacity layer at the end
+        // Reorder for the UI the bgArray copy with the opacity layer at the end
+        this.bgLayers = this.bgLayers.slice();
         const indexOpa = this.bgLayers.findIndex(layer => layer === this.opacityLayer);
         this.bgLayers.splice(indexOpa, 1);
         this.bgLayers.push(opacityLayer);
@@ -196,7 +187,7 @@ gmf.BackgroundlayerselectorController.prototype.handleThemesChange_ = function()
 };
 
 /**
- * Getter/setter for background layer opacity.
+ * Getter/setter for background layer overlay, used by opacity slider.
  * @param {?number} val The opacity.
  * @returns {number} The background layer opacity.
  */
@@ -221,7 +212,7 @@ gmf.BackgroundlayerselectorController.prototype.setLayer = function(layer, opt_s
 };
 
 /**
- * Set a background layer used by the opacity slider.
+ * Set a background layer overlay, used by the opacity slider.
  * @param {ol.layer.Base} layer The opacity background layer.
  */
 gmf.BackgroundlayerselectorController.prototype.setOpacityBgLayer = function(layer) {

--- a/contribs/gmf/src/directives/backgroundlayerselector.js
+++ b/contribs/gmf/src/directives/backgroundlayerselector.js
@@ -5,6 +5,7 @@ goog.require('gmf');
 goog.require('gmf.Themes');
 goog.require('ngeo.BackgroundEventType');
 goog.require('ngeo.BackgroundLayerMgr');
+goog.require('ngeo.DecorateLayer');
 
 
 gmf.module.value('gmfBackgroundlayerselectorTemplateUrl',
@@ -77,11 +78,12 @@ gmf.module.component('gmfBackgroundlayerselector', gmf.backgroundlayerselectorCo
  * @param {!angular.Scope} $scope Angular scope.
  * @param {!ngeo.BackgroundLayerMgr} ngeoBackgroundLayerMgr Background layer manager.
  * @param {!gmf.Themes} gmfThemes Themes service.
+ * @param {ngeo.DecorateLayer} ngeoDecorateLayer layer decorator service.
  * @ngInject
  * @ngdoc controller
  * @ngname GmfBackgroundlayerselectorController
  */
-gmf.BackgroundlayerselectorController = function($scope, ngeoBackgroundLayerMgr, gmfThemes) {
+gmf.BackgroundlayerselectorController = function($scope, ngeoBackgroundLayerMgr, gmfThemes, ngeoDecorateLayer) {
 
   /**
    * @type {?ol.Map}
@@ -113,6 +115,12 @@ gmf.BackgroundlayerselectorController = function($scope, ngeoBackgroundLayerMgr,
    * @export
    */
   this.bgLayers;
+
+  /**
+   * @type {ngeo.DecorateLayer}
+   * @private
+   */
+  this.ngeoDecorateLayer_ = ngeoDecorateLayer;
 
   /**
    * @type {!gmf.Themes}
@@ -168,9 +176,12 @@ gmf.BackgroundlayerselectorController.prototype.handleThemesChange_ = function()
     if (this.opacityOptions !== undefined) {
       const opacityLayer = layers.find(layer => layer.get('label') === this.opacityOptions);
       if (opacityLayer !== undefined) {
+        this.setOpacityBgLayer(opacityLayer);
+        this.ngeoDecorateLayer_(opacityLayer);
+
         // Set the opacity layer and default opacity
         this.opacityLayer = opacityLayer;
-        this.opacityLayer.opacity = 0;
+        this.opacityLayer.opacity = opacityLayer.getOpacity();
 
         // Reorder the bgArray with the opacity layer at the end
         const indexOpa = this.bgLayers.findIndex(layer => layer === this.opacityLayer);
@@ -195,6 +206,13 @@ gmf.BackgroundlayerselectorController.prototype.setLayer = function(layer, opt_s
   }
 };
 
+/**
+ * Set a background layer used by the opacity slider.
+ * @param {ol.layer.Base} layer The opacity background layer.
+ */
+gmf.BackgroundlayerselectorController.prototype.setOpacityBgLayer = function(layer) {
+  this.backgroundLayerMgr_.setOpacityBgLayer(this.map, layer);
+};
 
 /**
  * @private

--- a/contribs/gmf/src/directives/partials/backgroundlayerselector.html
+++ b/contribs/gmf/src/directives/partials/backgroundlayerselector.html
@@ -15,6 +15,6 @@
          min="0"
          max="1"
          step="0.01"
-         ng-model="ctrl.getSetOpacityBgLayer"
+         ng-model="ctrl.getSetBgLayerOpacity"
          ng-model-options="{getterSetter: true}">
 </ul>

--- a/contribs/gmf/src/directives/partials/backgroundlayerselector.html
+++ b/contribs/gmf/src/directives/partials/backgroundlayerselector.html
@@ -14,6 +14,7 @@
          type="range"
          min="0"
          max="1"
-         step="0.05"
-         ng-model="ctrl.opacityLayer.opacity">
+         step="0.01"
+         ng-model="ctrl.getSetOpacityBgLayer"
+         ng-model-options="{getterSetter: true}">
 </ul>

--- a/contribs/gmf/src/directives/partials/backgroundlayerselector.html
+++ b/contribs/gmf/src/directives/partials/backgroundlayerselector.html
@@ -1,9 +1,16 @@
 <ul class="gmf-backgroundlayerselector">
   <li ng-repeat="layer in ctrl.bgLayers"
       ng-click="ctrl.setLayer(layer)"
-      ng-class="{'gmf-backgroundlayerselector-active': ctrl.bgLayer == layer}">
+      ng-class="{'gmf-backgroundlayerselector-active': ctrl.bgLayer == layer, 'gmf-backgroundlayerselector-disabled': ctrl.opacityLayer == layer}">
     <img class="gmf-thumb"
          ng-src="{{::layer.get('metadata')['thumbnail']}}" />
     <span class="gmf-text">{{layer.get("label") | translate}}</span>
+    <span ng-class="{'gmf-backgroundlayerselector-opacity-check': ctrl.opacityLayer == layer}"></span>
   </li>
+
+  <input ng-if="ctrl.opacityLayer"
+         class="input-action gmf-backgroundlayerselector-opacity-slider"
+         name="bg-layer-opacity"
+         type="range" min="0" max="1" step="0.01"
+         ng-model="ctrl.opacityLayer.opacity">
 </ul>

--- a/contribs/gmf/src/directives/partials/backgroundlayerselector.html
+++ b/contribs/gmf/src/directives/partials/backgroundlayerselector.html
@@ -11,6 +11,9 @@
   <input ng-if="ctrl.opacityLayer"
          class="input-action gmf-backgroundlayerselector-opacity-slider"
          name="bg-layer-opacity"
-         type="range" min="0" max="1" step="0.01"
+         type="range"
+         min="0"
+         max="1"
+         step="0.05"
          ng-model="ctrl.opacityLayer.opacity">
 </ul>

--- a/contribs/gmf/src/gmf.js
+++ b/contribs/gmf/src/gmf.js
@@ -40,6 +40,11 @@ gmf.module.config(['$animateProvider',
  */
 gmf.baseTemplateUrl = 'gmf';
 
+/**
+ * @const
+ * @export
+ */
+gmf.BACKGROUNDLAYERGROUP_NAME = 'background';
 
 /**
  * @const

--- a/src/services/backgroundlayermgr.js
+++ b/src/services/backgroundlayermgr.js
@@ -163,6 +163,18 @@ ngeo.BackgroundLayerMgr.prototype.set = function(map, layer) {
 };
 
 /**
+ * Return the current opacity background layer of a given map. `null` is returned if
+ * the map does not have an opacity background layer.
+ * @param {ol.Map} map Map.
+ * @return {ol.layer.Base} layer The opacity background layer.
+ * @export
+ */
+ngeo.BackgroundLayerMgr.prototype.getOpacityBgLayer = function(map) {
+  const mapUid = ol.getUid(map).toString();
+  return mapUid in this.mapUids_ ? this.ngeoLayerHelper_.getGroupFromMap(map, gmf.BACKGROUNDLAYERGROUP_NAME).getLayers().item(1) : null;
+};
+
+/**
  * Set a background layer used by the opacity slider.
  * @param {ol.Map} map The map.
  * @param {ol.layer.Base} layer The opacity background layer.

--- a/src/services/backgroundlayermgr.js
+++ b/src/services/backgroundlayermgr.js
@@ -141,7 +141,9 @@ ngeo.BackgroundLayerMgr.prototype.get = function(map) {
 ngeo.BackgroundLayerMgr.prototype.set = function(map, layer) {
   const mapUid = ol.getUid(map).toString();
   const previous = this.get(map);
-  layer.setZIndex(-200);
+  if (layer !== null) {
+    layer.setZIndex(-200);
+  }
 
   const bgGroup = this.ngeoLayerHelper_.getGroupFromMap(map, gmf.BACKGROUNDLAYERGROUP_NAME);
 

--- a/src/services/backgroundlayermgr.js
+++ b/src/services/backgroundlayermgr.js
@@ -104,6 +104,13 @@ ngeo.BackgroundLayerMgr = function() {
    * @private
    */
   this.mapUids_ = {};
+
+  /**
+   * A status for the opacity layer group 'set' operation
+   * @type {boolean}
+   * @private
+   */
+  this.switchStatus_ = false;
 };
 ol.inherits(ngeo.BackgroundLayerMgr, ol.Observable);
 
@@ -148,6 +155,25 @@ ngeo.BackgroundLayerMgr.prototype.set = function(map, layer) {
   this.dispatchEvent(new ngeo.BackgroundEvent(ngeo.BackgroundEventType.CHANGE,
     layer, previous));
   return previous;
+};
+
+/**
+ * Set a background layer used by the opacity slider.
+ * @param {ol.Map} map The map.
+ * @param {ol.layer.Base} layer The opacity background layer.
+ */
+ngeo.BackgroundLayerMgr.prototype.setOpacityBgLayer = function(map, layer) {
+  layer.setOpacity(0);
+  layer.setVisible(true);
+
+  // Switch order to make the opacity layer first
+  const data = map.getLayers().getArray()[0];
+  if (map.getLayers().getArray().length > 0 && !this.switchStatus_) {
+    map.getLayers().removeAt(0);
+    map.getLayers().setAt(0, layer);
+    map.getLayers().setAt(1, data);
+    this.switchStatus_ = true;
+  }
 };
 
 /**

--- a/src/services/backgroundlayermgr.js
+++ b/src/services/backgroundlayermgr.js
@@ -172,6 +172,12 @@ ngeo.BackgroundLayerMgr.prototype.setOpacityBgLayer = function(map, layer) {
   layer.setVisible(true);
   const bgGroup = this.ngeoLayerHelper_.getGroupFromMap(map, gmf.BACKGROUNDLAYERGROUP_NAME);
   bgGroup.getLayers().insertAt(1, layer);
+
+  // To make sure the group are correctly sorted,
+  // We remove the background group at index 1 and
+  // add it back at index 0 (then index 1 is data group)
+  map.getLayers().pop();
+  map.getLayers().insertAt(0, bgGroup);
 };
 
 /**

--- a/src/services/backgroundlayermgr.js
+++ b/src/services/backgroundlayermgr.js
@@ -141,6 +141,7 @@ ngeo.BackgroundLayerMgr.prototype.get = function(map) {
 ngeo.BackgroundLayerMgr.prototype.set = function(map, layer) {
   const mapUid = ol.getUid(map).toString();
   const previous = this.get(map);
+  layer.setZIndex(-200);
 
   const bgGroup = this.ngeoLayerHelper_.getGroupFromMap(map, gmf.BACKGROUNDLAYERGROUP_NAME);
 
@@ -163,8 +164,8 @@ ngeo.BackgroundLayerMgr.prototype.set = function(map, layer) {
 };
 
 /**
- * Return the current opacity background layer of a given map. `null` is returned if
- * the map does not have an opacity background layer.
+ * Return the current background layer overlay of a given map, used by the opacity slider.
+ * `null` is returned if the map does not have an opacity background layer.
  * @param {ol.Map} map Map.
  * @return {ol.layer.Base} layer The opacity background layer.
  * @export
@@ -175,21 +176,20 @@ ngeo.BackgroundLayerMgr.prototype.getOpacityBgLayer = function(map) {
 };
 
 /**
- * Set a background layer used by the opacity slider.
+ * Set an background layer overlay, used by the opacity slider.
  * @param {ol.Map} map The map.
  * @param {ol.layer.Base} layer The opacity background layer.
  */
 ngeo.BackgroundLayerMgr.prototype.setOpacityBgLayer = function(map, layer) {
   layer.setOpacity(0);
+  layer.setZIndex(-100);
   layer.setVisible(true);
   const bgGroup = this.ngeoLayerHelper_.getGroupFromMap(map, gmf.BACKGROUNDLAYERGROUP_NAME);
-  bgGroup.getLayers().insertAt(1, layer);
 
-  // To make sure the group are correctly sorted,
-  // We remove the background group at index 1 and
-  // add it back at index 0 (then index 1 is data group)
-  map.getLayers().pop();
-  map.getLayers().insertAt(0, bgGroup);
+  const index = bgGroup.getLayers().getArray().indexOf(layer);
+  if (index === -1) {
+    bgGroup.getLayers().push(layer);
+  }
 };
 
 /**

--- a/test/spec/services/backgroundlayermgr.spec.js
+++ b/test/spec/services/backgroundlayermgr.spec.js
@@ -78,6 +78,20 @@ describe('ngeo.BackgroundLayerMgr', () => {
       const layer = ngeoBackgroundLayerMgr.get(map);
       expect(layer).toBe(expectedLayer);
     });
+
+    it('returns `null` if no opacity background layer', () => {
+      const layer = ngeoBackgroundLayerMgr.getOpacityBgLayer(map);
+      expect(layer).toBe(null);
+    });
+
+    it('returns the current opacity background layer', () => {
+      const activeBgLayer = new ol.layer.Tile();
+      ngeoBackgroundLayerMgr.set(map, activeBgLayer);
+      const opacityBgLayer = new ol.layer.Tile();
+      ngeoBackgroundLayerMgr.setOpacityBgLayer(map, opacityBgLayer);
+      const layer = ngeoBackgroundLayerMgr.getOpacityBgLayer(map);
+      expect(layer).toBe(opacityBgLayer);
+    });
   });
 
 });

--- a/test/spec/services/backgroundlayermgr.spec.js
+++ b/test/spec/services/backgroundlayermgr.spec.js
@@ -1,12 +1,16 @@
 goog.require('ngeo.BackgroundLayerMgr');
+goog.require('ngeo.LayerHelper');
 
 describe('ngeo.BackgroundLayerMgr', () => {
   let ngeoBackgroundLayerMgr;
+  let ngeoLayerHelper;
   let map;
+  const BACKGROUNDLAYERGROUP_NAME = 'background';
 
   beforeEach(() => {
     inject(($injector) => {
       ngeoBackgroundLayerMgr = $injector.get('ngeoBackgroundLayerMgr');
+      ngeoLayerHelper = $injector.get('ngeoLayerHelper');
     });
 
     map = new ol.Map({});
@@ -17,15 +21,17 @@ describe('ngeo.BackgroundLayerMgr', () => {
     it('sets the background layer #1', () => {
       const layer = new ol.layer.Tile();
       ngeoBackgroundLayerMgr.set(map, layer);
-      expect(map.getLayers().item(0)).toBe(layer);
+      const bgGroup = ngeoLayerHelper.getGroupFromMap(map, BACKGROUNDLAYERGROUP_NAME);
+      expect(bgGroup.getLayers().item(0)).toBe(layer);
     });
 
     it('sets the background layer #2', () => {
-      map.addLayer(new ol.layer.Tile());
       const layer = new ol.layer.Tile();
       ngeoBackgroundLayerMgr.set(map, layer);
-      expect(map.getLayers().getLength()).toBe(2);
-      expect(map.getLayers().item(0)).toBe(layer);
+      const bgGroup = ngeoLayerHelper.getGroupFromMap(map, BACKGROUNDLAYERGROUP_NAME);
+      bgGroup.getLayers().setAt(1, new ol.layer.Tile());
+      expect(bgGroup.getLayers().getLength()).toBe(2);
+      expect(bgGroup.getLayers().item(0)).toBe(layer);
     });
 
     it('sets the background layer #3', () => {
@@ -33,15 +39,28 @@ describe('ngeo.BackgroundLayerMgr', () => {
       ngeoBackgroundLayerMgr.set(map, layer1);
       const layer2 = new ol.layer.Tile();
       ngeoBackgroundLayerMgr.set(map, layer2);
-      expect(map.getLayers().getLength()).toBe(1);
-      expect(map.getLayers().item(0)).toBe(layer2);
+      const bgGroup = ngeoLayerHelper.getGroupFromMap(map, BACKGROUNDLAYERGROUP_NAME);
+      expect(bgGroup.getLayers().getLength()).toBe(1);
+      expect(bgGroup.getLayers().item(0)).toBe(layer2);
+    });
+
+    it('sets the opacity background layer', () => {
+      const layer1 = new ol.layer.Tile();
+      ngeoBackgroundLayerMgr.set(map, layer1);
+      const layer2 = new ol.layer.Tile();
+      ngeoBackgroundLayerMgr.setOpacityBgLayer(map, layer2);
+      const bgGroup = ngeoLayerHelper.getGroupFromMap(map, BACKGROUNDLAYERGROUP_NAME);
+      expect(bgGroup.getLayers().getLength()).toBe(2);
+      expect(bgGroup.getLayers().item(0)).toBe(layer1);
+      expect(bgGroup.getLayers().item(1)).toBe(layer2);
     });
 
     it('unsets the background layer', () => {
       const layer = new ol.layer.Tile();
       ngeoBackgroundLayerMgr.set(map, layer);
       ngeoBackgroundLayerMgr.set(map, null);
-      expect(map.getLayers().getLength()).toBe(0);
+      const bgGroup = ngeoLayerHelper.getGroupFromMap(map, BACKGROUNDLAYERGROUP_NAME);
+      expect(bgGroup.getLayers().getLength()).toBe(0);
     });
 
   });


### PR DESCRIPTION
Add a way to get a static background layer linked to an opacity slider, via a parameter to include in the interface. I.E:
```
  /**
   * @type {string}
   * @export
   */
  this.bgOpacityOptions = 'Test aus Olten';
```
The string is the layer label (WMS name from admin interface).

The component is defined as follow in the html:
```
<gmf-backgroundlayerselector
    gmf-backgroundlayerselector-map="::mainCtrl.map"
    gmf-backgroundlayer-opacity-options="::mainCtrl.bgOpacityOptions"
    class="dropdown-menu">
</gmf-backgroundlayerselector> 
```
`gmf-backgroundlayer-opacity-options` is facultative and if ignored, the application will just set as it was without the feature.

First commit is remove correctly the dimension used in the past but not done completly.
The app now use a group containing the active layer and the one used as overlay for the opacity slider. This group is called "background" and is always index 0 with group "data" at index 1.
Tests are updated to this new structures.