### PR TITLE
Fix ngRepeat track by displayquerygird

### DIFF
--- a/contribs/gmf/src/directives/partials/displayquerygrid.html
+++ b/contribs/gmf/src/directives/partials/displayquerygrid.html
@@ -10,7 +10,7 @@
     role="tablist">
 
     <li
-      ng-repeat="gridSource in ctrl.getGridSources() track by gridSource.source.id"
+      ng-repeat="gridSource in ctrl.getGridSources() track by gridSource.source.label"
       role="presentation"
       ng-class="{'active' : ctrl.isSelected(gridSource)}"
       ng-click="ctrl.selectTab(gridSource)">
@@ -34,7 +34,7 @@
 
   <div class="tab-content">
     <div
-      ng-repeat="gridSource in ctrl.getGridSources() track by gridSource.source.id"
+      ng-repeat="gridSource in ctrl.getGridSources() track by gridSource.source.label"
       role="tabpanel"
       class="tab-pane"
       ng-class="{'active' : ctrl.isSelected(gridSource)}"


### PR DESCRIPTION
Fixes https://github.com/camptocamp/ngeo/issues/3462

The track by property from ngRepeat is breaking if we used the id, but works when using the label (as it was previously to my last PR fixing the component: https://github.com/camptocamp/ngeo/pull/3351).

The bug was related to layers using two wms sources displayed together (layer "Two layers" under the "OSM function mixed" group in "demo" theme). 