### PR TITLE
Add z-index to popover

### DIFF
--- a/contribs/gmf/less/popover.less
+++ b/contribs/gmf/less/popover.less
@@ -6,6 +6,7 @@
 
 .popover {
   border-radius: 0;
+  z-index: @above-content-index;
   .popover-content {
     ul {
       margin-bottom: 0;


### PR DESCRIPTION
Fixes https://github.com/camptocamp/ngeo/issues/3494

Maybe with 2.3 using movable elements, some adjustements will nee to be done.
Tested that the popover is on top of the contextual menu.