### PR TITLE
Add rollup to fix missing ol.ext dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@camptocamp/cesium": "1.39",
     "phantomjs-prebuilt": "2.1.14",
     "proj4": "2.4.3",
+    "rollup-plugin-commonjs": "8.4.1",
     "svg2ttf": "4.1.0",
     "temp": "0.8.3",
     "ttf2eot": "2.0.0",


### PR DESCRIPTION
To be able to use ngeo 2.2 again.

Problem was: 
````
ngeo/node_modules/@camptocamp/closure-util/lib/manager.js:186
              throw new Error('Unsatisfied dependency "' + require + '" ' +
              ^

Error: Unsatisfied dependency "ol.ext.pixelworks.Processor" in script: ngeo/node_modules/openlayers/src/ol/source/raster.js

````