### PR TITLE
Fix ngeo examples

### DIFF
--- a/buildtools/webpack.ngeoexamples.js
+++ b/buildtools/webpack.ngeoexamples.js
@@ -26,11 +26,18 @@ for (const filename of ls('examples/*.html')) {
 
 // move data folder
 plugins.push(new CopyWebpackPlugin(
-  [{
-    from: 'examples/data/*',
-    to: 'data',
-    flatten: true
-  }]
+  [
+    {
+      from: 'examples/data/*',
+      to: 'data',
+      flatten: true
+    },
+    {
+      from: 'examples/partials/*',
+      to: 'partials',
+      flatten: true
+    }
+  ]
 ));
 
 module.exports = {

--- a/buildtools/webpack.ngeoexamples.js
+++ b/buildtools/webpack.ngeoexamples.js
@@ -2,6 +2,7 @@ const path = require('path');
 const ls = require('ls');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const plugins = [];
 const entry = {};
@@ -19,9 +20,18 @@ for (const filename of ls('examples/*.html')) {
       chunksSortMode: 'manual',
       filename: name + '.html',
       chunks: ['commons', name],
-    }),
+    })
   );
 }
+
+// move data folder
+plugins.push(new CopyWebpackPlugin(
+  [{
+    from: 'examples/data/*',
+    to: 'data',
+    flatten: true
+  }]
+));
 
 module.exports = {
   output: {

--- a/examples/animation.js
+++ b/examples/animation.js
@@ -1,7 +1,6 @@
 goog.provide('app.animation');
 
 // webpack: import './animation.css';
-// webpack: import './common_dependencies.js';
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Tile');
@@ -11,6 +10,7 @@ goog.require('ngeo.map.module');
 
 /** @type {!angular.Module} */
 app.animation.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name
 ]);
 

--- a/examples/asitvd.js
+++ b/examples/asitvd.js
@@ -1,7 +1,6 @@
 goog.provide('app.asitvd');
 
 // webpack: import './asitvd.css';
-// webpack: import './common_dependencies.js';
 goog.require('ngeo.source.AsitVD');
 goog.require('ol.Map');
 goog.require('ol.View');
@@ -11,6 +10,7 @@ goog.require('ngeo.map.module');
 
 /** @type {!angular.Module} */
 app.asitvd.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name
 ]);
 

--- a/examples/attributes.js
+++ b/examples/attributes.js
@@ -1,6 +1,5 @@
 goog.provide('app.attributes');
 
-// webpack: import './common_dependencies.js';
 goog.require('ngeo.format.XSDAttribute');
 /** @suppress {extraRequire} */
 goog.require('ngeo.editing.attributesComponent');
@@ -10,6 +9,7 @@ goog.require('ngeo.map.module');
 
 /** @type {!angular.Module} */
 app.attributes.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name,
   ngeo.editing.attributesComponent.name,
 ]);

--- a/examples/backgroundlayer.js
+++ b/examples/backgroundlayer.js
@@ -1,7 +1,6 @@
 goog.provide('app.backgroundlayer');
 
 // webpack: import './backgroundlayer.css';
-// webpack: import './common_dependencies.js';
 goog.require('ngeo.source.AsitVD');
 const EPSG21781 = goog.require('ngeo.proj.EPSG21781');
 goog.require('ol.Map');
@@ -14,6 +13,7 @@ goog.require('ngeo.map.module');
 
 /** @type {!angular.Module} **/
 app.backgroundlayer.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name
 ]);
 

--- a/examples/backgroundlayerdropdown.js
+++ b/examples/backgroundlayerdropdown.js
@@ -1,7 +1,6 @@
 goog.provide('app.backgroundlayerdropdown');
 
 // webpack: import './backgroundlayerdropdown.css';
-// webpack: import './common_dependencies.js';
 goog.require('ngeo.source.AsitVD');
 const EPSG21781 = goog.require('ngeo.proj.EPSG21781');
 goog.require('ol.Map');
@@ -14,6 +13,7 @@ goog.require('ngeo.map.module');
 
 /** @type {!angular.Module} **/
 app.backgroundlayerdropdown.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name
 ]);
 

--- a/examples/bboxquery.js
+++ b/examples/bboxquery.js
@@ -1,7 +1,6 @@
 goog.provide('app.bboxquery');
 
 // webpack: import './bboxquery.css';
-// webpack: import './common_dependencies.js';
 const EPSG21781 = goog.require('ngeo.proj.EPSG21781');
 goog.require('ngeo.datasource.DataSources');
 goog.require('ngeo.datasource.OGC');
@@ -19,6 +18,7 @@ goog.require('ol.source.OSM');
 
 /** @type {!angular.Module} */
 app.bboxquery.module = angular.module('app', [
+  'gettext',
   ngeo.datasource.DataSources.module.name,
   ngeo.map.module.name,
   ngeo.misc.btnComponent.name,

--- a/examples/colorpicker.js
+++ b/examples/colorpicker.js
@@ -1,12 +1,12 @@
 goog.provide('app.colorpicker');
 
 // webpack: import './colorpicker.css';
-// webpack: import './common_dependencies.js';
 /** @suppress {extraRequire} */
 goog.require('ngeo.misc.colorpickerComponent');
 
 /** @type {!angular.Module} **/
 app.colorpicker.module = angular.module('app', [
+  'gettext',
   ngeo.misc.colorpickerComponent.name,
 ]);
 

--- a/examples/control.js
+++ b/examples/control.js
@@ -1,7 +1,6 @@
 goog.provide('app.control');
 
 // webpack: import './control.css';
-// webpack: import './common_dependencies.js';
 goog.require('ngeo.map.module');
 /** @suppress {extraRequire} */
 goog.require('ngeo.misc.controlComponent');
@@ -14,6 +13,7 @@ goog.require('ol.source.OSM');
 
 /** @type {!angular.Module} **/
 app.control.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name,
   ngeo.misc.controlComponent.name,
 ]);

--- a/examples/createfeature.js
+++ b/examples/createfeature.js
@@ -1,7 +1,6 @@
 goog.provide('app.createfeature');
 
 // webpack: import './createfeature.css';
-// webpack: import './common_dependencies.js';
 /** @suppress {extraRequire} */
 goog.require('ngeo.editing.createfeatureComponent');
 goog.require('ngeo.GeometryType');
@@ -21,6 +20,7 @@ goog.require('ngeo.map.module');
 
 /** @type {!angular.Module} **/
 app.createfeature.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name,
   ngeo.misc.btnComponent.name,
   ngeo.misc.ToolActivateMgr.module.name,

--- a/examples/datepicker.js
+++ b/examples/datepicker.js
@@ -1,7 +1,6 @@
 goog.provide('app.datepicker');
 
 // webpack: import './datepicker.css';
-// webpack: import './common_dependencies.js';
 /** @suppress {extraRequire} */
 goog.require('ngeo.misc.datepickerComponent');
 goog.require('ngeo.misc.Time');
@@ -9,6 +8,7 @@ goog.require('ngeo.misc.Time');
 
 /** @type {!angular.Module} **/
 app.datepicker.module = angular.module('app', [
+  'gettext',
   ngeo.misc.datepickerComponent.name,
   ngeo.misc.Time.module.name,
 ]);

--- a/examples/datetimepicker.js
+++ b/examples/datetimepicker.js
@@ -1,12 +1,12 @@
 goog.provide('app.datetimepicker');
 
 // webpack: import './datetimepicker.css';
-// webpack: import './common_dependencies.js';
 goog.require('ngeo.misc.datetimepickerComponent');
 
 
 /** @type {!angular.Module} **/
 app.datetimepicker.module = angular.module('app', [
+  'gettext',
   ngeo.misc.datetimepickerComponent.name,
 ]);
 

--- a/examples/desktopgeolocation.js
+++ b/examples/desktopgeolocation.js
@@ -1,7 +1,6 @@
 goog.provide('app.desktopgeolocation');
 
 // webpack: import './desktopgeolocation.css';
-// webpack: import './common_dependencies.js';
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Tile');
@@ -16,6 +15,7 @@ goog.require('ngeo.geolocation.desktop');
 
 /** @type {!angular.Module} **/
 app.desktopgeolocation.module = angular.module('app', [
+  'gettext',
   ngeo.geolocation.desktop.name,
   ngeo.map.module.name
 ]);

--- a/examples/disclaimer.js
+++ b/examples/disclaimer.js
@@ -1,7 +1,6 @@
 goog.provide('app.disclaimer');
 
 // webpack: import './disclaimer.css';
-// webpack: import './common_dependencies.js';
 // webpack: import 'jquery-ui/ui/widgets/tooltip.js';
 goog.require('ngeo.message.Disclaimer');
 goog.require('ngeo.message.Message');
@@ -14,6 +13,7 @@ goog.require('ngeo.map.module');
 
 /** @type {!angular.Module} **/
 app.disclaimer.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name,
   ngeo.message.Disclaimer.module.name,
 ]);

--- a/examples/drawfeature.js
+++ b/examples/drawfeature.js
@@ -1,7 +1,6 @@
 goog.provide('app.drawfeature');
 
 // webpack: import './drawfeature.css';
-// webpack: import './common_dependencies.js';
 goog.require('ngeo.draw.module');
 goog.require('ngeo.map.module');
 goog.require('ngeo.misc.ToolActivate');
@@ -16,6 +15,7 @@ goog.require('ol.source.Vector');
 
 /** @type {!angular.Module} **/
 app.drawfeature.module = angular.module('app', [
+  'gettext',
   ngeo.draw.module.name,
   ngeo.map.module.name,
   ngeo.misc.ToolActivateMgr.module.name,

--- a/examples/elevationProfile.js
+++ b/examples/elevationProfile.js
@@ -1,7 +1,6 @@
 goog.provide('app.elevationProfile');
 
 // webpack: import './elevationProfile.css';
-// webpack: import './common_dependencies.js';
 const EPSG21781 = goog.require('ngeo.proj.EPSG21781');
 goog.require('ol.Feature');
 goog.require('ol.Map');
@@ -18,6 +17,7 @@ goog.require('ngeo.profile.elevationComponent');
 
 /** @type {!angular.Module} **/
 app.elevationProfile.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name,
   ngeo.profile.elevationComponent.name,
 ]);

--- a/examples/googlestreetview.js
+++ b/examples/googlestreetview.js
@@ -1,7 +1,6 @@
 goog.provide('app.googlestreetview');
 
 // webpack: import './googlestreetview.css';
-// webpack: import './common_dependencies.js';
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Tile');
@@ -18,6 +17,7 @@ goog.require('ngeo.misc.ToolActivateMgr');
 
 /** @type {!angular.Module} **/
 app.googlestreetview.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name,
   ngeo.googlestreetview.module.name,
   ngeo.misc.ToolActivateMgr.module.name

--- a/examples/grid.js
+++ b/examples/grid.js
@@ -1,13 +1,13 @@
 goog.provide('app.grid');
 
 // webpack: import './grid.css';
-// webpack: import './common_dependencies.js';
 goog.require('ngeo.grid.Config');
 goog.require('ngeo.grid.module');
 
 
 /** @type {!angular.Module} **/
 app.grid.module = angular.module('app', [
+  'gettext',
   ngeo.grid.module.name
 ]);
 

--- a/examples/importfeatures.js
+++ b/examples/importfeatures.js
@@ -1,7 +1,6 @@
 goog.provide('app.importfeatures');
 
 // webpack: import './importfeatures.css';
-// webpack: import './common_dependencies.js';
 goog.require('ngeo.map.module');
 /** @suppress {extraRequire} */
 goog.require('ngeo.misc.filereaderComponent');
@@ -17,6 +16,7 @@ goog.require('ol.source.Vector');
 
 /** @type {!angular.Module} **/
 app.importfeatures.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name,
   ngeo.misc.filereaderComponent.name,
 ]);

--- a/examples/interactionbtngroup.js
+++ b/examples/interactionbtngroup.js
@@ -1,7 +1,6 @@
 goog.provide('app.interactionbtngroup');
 
 // webpack: import './interactionbtngroup.css';
-// webpack: import './common_dependencies.js';
 goog.require('ngeo.map.module');
 /** @suppress {extraRequire} */
 goog.require('ngeo.misc.btnComponent');
@@ -20,6 +19,7 @@ goog.require('ol.style.Style');
 
 /** @type {!angular.Module} **/
 app.interactionbtngroup.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name,
   ngeo.misc.btnComponent.name,
 ]);

--- a/examples/layerorder.js
+++ b/examples/layerorder.js
@@ -1,7 +1,6 @@
 goog.provide('app.layerorder');
 
 // webpack: import './layerorder.css';
-// webpack: import './common_dependencies.js';
 goog.require('ngeo.map.module');
 /** @suppress {extraRequire} */
 goog.require('ngeo.misc.sortableComponent');
@@ -16,6 +15,7 @@ goog.require('ol.source.TileWMS');
 
 /** @type {!angular.Module} **/
 app.layerorder.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name,
   ngeo.misc.sortableComponent.name,
 ]);

--- a/examples/layertree.js
+++ b/examples/layertree.js
@@ -6,7 +6,6 @@
 goog.provide('app.layertree');
 
 // webpack: import './layertree.css';
-// webpack: import './common_dependencies.js';
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Tile');
@@ -19,6 +18,7 @@ goog.require('ngeo.message.Popup');
 
 /** @type {!angular.Module} **/
 app.layertree.module = angular.module('app', [
+  'gettext',
   ngeo.layertree.module.name,
   ngeo.map.module.name,
   ngeo.message.Popup.module.name,

--- a/examples/locationsearch.js
+++ b/examples/locationsearch.js
@@ -1,7 +1,6 @@
 goog.provide('app.locationsearch');
 
 // webpack: import './locationsearch.css';
-// webpack: import './common_dependencies.js';
 goog.require('goog.asserts');
 goog.require('ngeo.map.module');
 goog.require('ngeo.search.module');
@@ -14,6 +13,7 @@ goog.require('ol.source.OSM');
 
 /** @type {!angular.Module} **/
 const module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name,
   ngeo.search.module.name
 ]);

--- a/examples/locationsearch.js
+++ b/examples/locationsearch.js
@@ -12,7 +12,7 @@ goog.require('ol.source.OSM');
 
 
 /** @type {!angular.Module} **/
-const module = angular.module('app', [
+const appmodule = angular.module('app', [
   'gettext',
   ngeo.map.module.name,
   ngeo.search.module.name
@@ -35,7 +35,7 @@ app.locationsearch.locationSearchComponent = {
 };
 
 
-module.component('appLocationSearch', app.locationsearch.locationSearchComponent);
+appmodule.component('appLocationSearch', app.locationsearch.locationSearchComponent);
 
 
 /**
@@ -140,7 +140,7 @@ app.locationsearch.SearchController.select_ = function(event, suggestion, datase
 };
 
 
-module.controller('AppSearchController', app.locationsearch.SearchController);
+appmodule.controller('AppSearchController', app.locationsearch.SearchController);
 
 
 /**
@@ -167,4 +167,4 @@ app.locationsearch.MainController = function() {
 };
 
 
-module.controller('MainController', app.locationsearch.MainController);
+appmodule.controller('MainController', app.locationsearch.MainController);

--- a/examples/mapfishprint.js
+++ b/examples/mapfishprint.js
@@ -1,7 +1,6 @@
 goog.provide('app.mapfishprint');
 
 // webpack: import './mapfishprint.css';
-// webpack: import './common_dependencies.js';
 const EPSG21781 = goog.require('ngeo.proj.EPSG21781');
 goog.require('ngeo.print.Service');
 goog.require('ngeo.print.Utils');
@@ -17,6 +16,7 @@ goog.require('ngeo.map.module');
 
 /** @type {!angular.Module} **/
 const module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name,
   ngeo.print.Service.module.name,
   ngeo.print.Utils.modle.name,

--- a/examples/mapfishprint.js
+++ b/examples/mapfishprint.js
@@ -15,11 +15,11 @@ goog.require('ngeo.map.module');
 
 
 /** @type {!angular.Module} **/
-const module = angular.module('app', [
+const appmodule = angular.module('app', [
   'gettext',
   ngeo.map.module.name,
   ngeo.print.Service.module.name,
-  ngeo.print.Utils.modle.name,
+  ngeo.print.Utils.module.name,
 ]);
 
 
@@ -267,4 +267,4 @@ app.mapfishprint.MainController.prototype.handleGetStatusError_ = function(resp)
 };
 
 
-module.controller('MainController', app.mapfishprint.MainController);
+appmodule.controller('MainController', app.mapfishprint.MainController);

--- a/examples/mapquery.js
+++ b/examples/mapquery.js
@@ -1,7 +1,6 @@
 goog.provide('app.mapquery');
 
 // webpack: import './mapquery.css';
-// webpack: import './common_dependencies.js';
 const EPSG21781 = goog.require('ngeo.proj.EPSG21781');
 goog.require('ngeo.datasource.DataSources');
 goog.require('ngeo.datasource.OGC');
@@ -21,6 +20,7 @@ goog.require('ol.source.OSM');
 
 /** @type {!angular.Module} **/
 app.mapquery.module = angular.module('app', [
+  'gettext',
   ngeo.datasource.DataSources.module.name,
   ngeo.map.module.name,
   ngeo.misc.btnComponent.name,

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -1,7 +1,6 @@
 goog.provide('app.measure');
 
 // webpack: import './measure.css';
-// webpack: import './common_dependencies.js';
 goog.require('ngeo.interaction.MeasureArea');
 goog.require('ngeo.interaction.MeasureAzimut');
 goog.require('ngeo.interaction.MeasureLength');
@@ -24,6 +23,7 @@ goog.require('ol.style.Fill');
 
 /** @type {!angular.Module} **/
 app.measure.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name,
   ngeo.misc.btnComponent.name,
   ngeo.misc.filters.name,

--- a/examples/mobilegeolocation.js
+++ b/examples/mobilegeolocation.js
@@ -1,7 +1,6 @@
 goog.provide('app.mobilegeolocation');
 
 // webpack: import './mobilegeolocation.css';
-// webpack: import './common_dependencies.js';
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Tile');
@@ -16,6 +15,7 @@ goog.require('ngeo.geolocation.mobile');
 
 /** @type {!angular.Module} **/
 const module = angular.module('app', [
+  'gettext',
   ngeo.geolocation.mobile.name,
   ngeo.map.module.name
 ]);

--- a/examples/mobilegeolocation.js
+++ b/examples/mobilegeolocation.js
@@ -14,7 +14,7 @@ goog.require('ngeo.geolocation.mobile');
 
 
 /** @type {!angular.Module} **/
-const module = angular.module('app', [
+const appmodule = angular.module('app', [
   'gettext',
   ngeo.geolocation.mobile.name,
   ngeo.map.module.name
@@ -74,4 +74,4 @@ app.mobilegeolocation.MainController = function($scope, ngeoFeatureOverlayMgr) {
 };
 
 
-module.controller('MainController', app.mobilegeolocation.MainController);
+appmodule.controller('MainController', app.mobilegeolocation.MainController);

--- a/examples/modal.js
+++ b/examples/modal.js
@@ -1,13 +1,13 @@
 goog.provide('app.modal');
 
 // webpack: import './modal.css';
-// webpack: import './common_dependencies.js';
 /** @suppress {extraRequire} */
 goog.require('ngeo.message.modalComponent');
 
 
 /** @type {!angular.Module} **/
 app.modal.module = angular.module('app', [
+  'gettext',
   ngeo.message.modalComponent.name,
 ]);
 

--- a/examples/modifycircle.js
+++ b/examples/modifycircle.js
@@ -1,7 +1,6 @@
 goog.provide('app.modifycircle');
 
 // webpack: import './modifycircle.css';
-// webpack: import './common_dependencies.js';
 goog.require('ngeo.format.FeatureProperties');
 goog.require('ngeo.interaction.ModifyCircle');
 goog.require('ol.Map');
@@ -19,6 +18,7 @@ goog.require('ngeo.map.module');
 
 /** @type {!angular.Module} **/
 const module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name
 ]);
 

--- a/examples/modifycircle.js
+++ b/examples/modifycircle.js
@@ -17,7 +17,7 @@ goog.require('ngeo.map.module');
 
 
 /** @type {!angular.Module} **/
-const module = angular.module('app', [
+const appmodule = angular.module('app', [
   'gettext',
   ngeo.map.module.name
 ]);
@@ -93,4 +93,4 @@ app.modifycircle.MainController = function() {
 };
 
 
-module.controller('MainController', app.modifycircle.MainController);
+appmodule.controller('MainController', app.modifycircle.MainController);

--- a/examples/modifyrectangle.js
+++ b/examples/modifyrectangle.js
@@ -1,7 +1,6 @@
 goog.provide('app.modifyrectangle');
 
 // webpack: import './modifyrectangle.css';
-// webpack: import './common_dependencies.js';
 goog.require('ngeo.interaction.ModifyRectangle');
 goog.require('ol.Map');
 goog.require('ol.View');
@@ -21,6 +20,7 @@ goog.require('ngeo.map.module');
 
 /** @type {!angular.Module} **/
 const module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name
 ]);
 

--- a/examples/modifyrectangle.js
+++ b/examples/modifyrectangle.js
@@ -19,7 +19,7 @@ goog.require('ngeo.map.module');
 
 
 /** @type {!angular.Module} **/
-const module = angular.module('app', [
+const appmodule = angular.module('app', [
   'gettext',
   ngeo.map.module.name
 ]);
@@ -136,4 +136,4 @@ app.modifyrectangle.MainController = function() {
 };
 
 
-module.controller('MainController', app.modifyrectangle.MainController);
+appmodule.controller('MainController', app.modifyrectangle.MainController);

--- a/examples/notification.js
+++ b/examples/notification.js
@@ -1,7 +1,6 @@
 goog.provide('app.notification');
 
 // webpack: import './notification.css';
-// webpack: import './common_dependencies.js';
 // webpack: import 'jquery-ui/ui/widgets/tooltip.js';
 goog.require('ngeo.message.Message');
 goog.require('ngeo.message.Notification');
@@ -9,6 +8,7 @@ goog.require('ngeo.message.Notification');
 
 /** @type {!angular.Module} **/
 app.notification.module = angular.module('app', [
+  'gettext',
   ngeo.message.Notification.module.name,
 ]);
 

--- a/examples/permalink.js
+++ b/examples/permalink.js
@@ -1,7 +1,6 @@
 goog.provide('app.permalink');
 
 // webpack: import './permalink.css';
-// webpack: import './common_dependencies.js';
 goog.require('ngeo.format.FeatureHash');
 goog.require('ngeo.map.module');
 goog.require('ngeo.misc.debounce');
@@ -19,6 +18,7 @@ goog.require('ol.style.Style');
 
 /** @type {!angular.Module} **/
 app.permalink.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name,
   ngeo.misc.debounce.name,
   ngeo.statemanager.module.name,

--- a/examples/popover.js
+++ b/examples/popover.js
@@ -1,12 +1,12 @@
 goog.provide('app.popover');
 
 // webpack: import './popover.css';
-// webpack: import './common_dependencies.js';
 /** @suppress {extraRequire} */
 goog.require('ngeo.message.popoverComponent');
 
 
 /** @type {!angular.Module} **/
 app.popover.module = angular.module('app', [
+  'gettext',
   ngeo.message.popoverComponent.name,
 ]);

--- a/examples/popupservice.js
+++ b/examples/popupservice.js
@@ -1,13 +1,13 @@
 goog.provide('app.popupservice');
 
 // webpack: import './popupservice.css';
-// webpack: import './common_dependencies.js';
 // webpack: import 'jquery-ui/ui/widgets/tooltip.js';
 goog.require('ngeo.message.Popup');
 
 
 /** @type {!angular.Module} **/
 app.popupservice.module = angular.module('app', [
+  'gettext',
   ngeo.message.Popup.module.name,
 ]);
 

--- a/examples/recenter.js
+++ b/examples/recenter.js
@@ -1,7 +1,6 @@
 goog.provide('app.recenter');
 
 // webpack: import './recenter.css';
-// webpack: import './common_dependencies.js';
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Tile');
@@ -11,6 +10,7 @@ goog.require('ngeo.map.module');
 
 /** @type {!angular.Module} **/
 const module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name
 ]);
 

--- a/examples/recenter.js
+++ b/examples/recenter.js
@@ -9,7 +9,7 @@ goog.require('ngeo.map.module');
 
 
 /** @type {!angular.Module} **/
-const module = angular.module('app', [
+const appmodule = angular.module('app', [
   'gettext',
   ngeo.map.module.name
 ]);
@@ -39,4 +39,4 @@ app.recenter.MainController = function() {
 };
 
 
-module.controller('MainController', app.recenter.MainController);
+appmodule.controller('MainController', app.recenter.MainController);

--- a/examples/rotate.js
+++ b/examples/rotate.js
@@ -1,7 +1,6 @@
 goog.provide('app.rotate');
 
 // webpack: import './rotate.css';
-// webpack: import './common_dependencies.js';
 goog.require('ngeo.interaction.Rotate');
 goog.require('ol.Collection');
 goog.require('ol.Feature');
@@ -22,6 +21,7 @@ goog.require('ngeo.map.module');
 
 /** @type {!angular.Module} **/
 app.rotate.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name
 ]);
 

--- a/examples/rotate.js
+++ b/examples/rotate.js
@@ -27,7 +27,7 @@ app.rotate.module = angular.module('app', [
 
 
 /** @type {!angular.Module} **/
-const module = angular.module('app', ['ngeo']);
+const appmodule = angular.module('app', ['ngeo']);
 
 
 /**
@@ -144,4 +144,4 @@ app.rotate.MainController = function() {
 };
 
 
-module.controller('MainController', app.rotate.MainController);
+appmodule.controller('MainController', app.rotate.MainController);

--- a/examples/scaleselector.js
+++ b/examples/scaleselector.js
@@ -1,7 +1,6 @@
 goog.provide('app.scaleselector');
 
 // webpack: import './scaleselector.css';
-// webpack: import './common_dependencies.js';
 goog.require('ngeo.misc.filters');
 goog.require('ol.Map');
 goog.require('ol.View');
@@ -12,6 +11,7 @@ goog.require('ngeo.map.module');
 
 /** @type {!angular.Module} **/
 app.scaleselector.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name,
   ngeo.misc.filters.name,
 ]);

--- a/examples/search.js
+++ b/examples/search.js
@@ -1,7 +1,6 @@
 goog.provide('app.search');
 
 // webpack: import './search.css';
-// webpack: import './common_dependencies.js';
 goog.require('goog.asserts');
 goog.require('ngeo.map.module');
 const EPSG21781 = goog.require('ngeo.proj.EPSG21781');
@@ -17,6 +16,7 @@ goog.require('ol.source.Vector');
 
 /** @type {!angular.Module} **/
 app.search.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name,
   ngeo.search.module.name
 ]);

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,7 +1,6 @@
 goog.provide('app.simple');
 
 // webpack: import './simple.css';
-// webpack: import './common_dependencies.js';
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Tile');
@@ -11,6 +10,7 @@ goog.require('ngeo.map.module');
 
 /** @type {!angular.Module} **/
 app.simple.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name
 ]);
 

--- a/examples/simple3d.js
+++ b/examples/simple3d.js
@@ -1,7 +1,6 @@
 goog.provide('app.simple3d');
 
 // webpack: import './simple3d.css';
-// webpack: import './common_dependencies.js';
 /** @suppress {extraRequire} */
 goog.require('ol.Map');
 goog.require('ol.View');
@@ -14,6 +13,7 @@ goog.require('ngeo.olcs.Manager');
 
 /** @type {!angular.Module} **/
 app.simple3d.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name,
   ngeo.olcs.olcsModule.name
 ]);

--- a/examples/toolActivate.js
+++ b/examples/toolActivate.js
@@ -1,7 +1,6 @@
 goog.provide('app.toolActivate');
 
 // webpack: import './toolActivate.css';
-// webpack: import './common_dependencies.js';
 goog.require('ngeo.map.module');
 /** @suppress {extraRequire} */
 goog.require('ngeo.misc.btnComponent');
@@ -22,6 +21,7 @@ goog.require('ol.style.Style');
 
 /** @type {!angular.Module} **/
 app.toolActivate.module = angular.module('app', [
+  'gettext',
   ngeo.map.module.name,
   ngeo.misc.btnComponent.name,
   ngeo.misc.ToolActivateMgr.module.name,

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "clean-css-cli": "4.1.11",
     "commander": "2.15.0",
     "console-control-strings": "1.1.0",
+    "copy-webpack-plugin": "4.4.2",
     "corejs-typeahead": "1.2.1",
     "coveralls": "3.0.0",
     "css-loader": "0.28.10",

--- a/src/misc/sortableComponent.js
+++ b/src/misc/sortableComponent.js
@@ -1,5 +1,6 @@
 goog.provide('ngeo.misc.sortableComponent');
 
+// webpack: import 'jquery-ui/ui/widgets/sortable.js';
 goog.require('goog.asserts');
 
 


### PR DESCRIPTION
To be fixed later:

- asitvd.html: no layers for me (probably Olten-Problem)
- backgroundlayerdropdown.html: missing bootstrap
- colorpicker.html: (was broken before)
- datepicker.html: missing css import
- drawfeature.html: Draw Circle + DrawAzimut broken
- googlestreetview.html: google streetmap api is not loaded, need external loader like https://github.com/yuanqing/load-google-maps-api
- layerorder.html: sortable handles have a width of 0, no way to grab them. Current release broken as well.
- modifyrectangle.html: runtime error
- modifycircle.js: ol_geom_Polygon.fromCircle is not a function (despite ol/geom/Polygon.js being imported)
- simple3d.html: cesium import