### PR TITLE
Add maxzoom for permalink search

### DIFF
--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -22,8 +22,6 @@ goog.require('gmf.mapDirective');
 /** @suppress {extraRequire} */
 goog.require('gmf.searchDirective');
 /** @suppress {extraRequire} */
-goog.require('gmf.FulltextSearchService');
-/** @suppress {extraRequire} */
 goog.require('gmf.themeselectorDirective');
 /** @suppress {extraRequire} */
 goog.require('ngeo.BackgroundLayerMgr');
@@ -513,17 +511,6 @@ gmf.AbstractController = function(config, $scope, $injector) {
   cgxp.tools.openInfoWindow = function(url, title, opt_width, opt_height) {
     gmfx.openIframePopup(url, title, opt_width, opt_height);
   };
-
-  /**
-   * @private
-   */
-  this.fullTextSearch_ = $injector.get('gmfFulltextSearchService');
-
-  const searchQuery = this.ngeoLocation.getParam('search');
-  if (searchQuery) {
-    const overlay = ngeoFeatureOverlayMgr.getFeatureOverlay();
-    this.search_(searchQuery, overlay);
-  }
 };
 
 
@@ -630,24 +617,6 @@ gmf.AbstractController.prototype.updateCurrentTheme_ = function(fallbackThemeNam
       this.gmfThemeManager.setThemeName(fallbackThemeName);
     }
   });
-};
-
-/**
- * Performs a full-text search and centers the map on the first search result.
- * @param {string} query Search query.
- * @param {ngeo.FeatureOverlay} overlay Feature overlay to add the feature if found.
- * @private
- */
-gmf.AbstractController.prototype.search_ = function(query, overlay) {
-  this.fullTextSearch_.search(query, {'limit': 1})
-    .then((data) => {
-      if (data && data.features[0]) {
-        const format = new ol.format.GeoJSON();
-        const feature = format.readFeature(data.features[0]);
-        overlay.addFeature(feature);
-        this.map.getView().fit(feature.getGeometry().getExtent());
-      }
-    });
 };
 
 gmf.module.controller('AbstractController', gmf.AbstractController);

--- a/contribs/gmf/src/directives/search.js
+++ b/contribs/gmf/src/directives/search.js
@@ -477,6 +477,9 @@ gmf.SearchController.prototype.$onInit = function() {
       if (this.ngeoLocation_.getParam('search-select-index')) {
         resultIndex = parseInt(this.ngeoLocation_.getParam('search-select-index'), 10);
       }
+      if (this.ngeoLocation_.getParam('search-maxzoom')) {
+        this.maxZoom = parseInt(this.ngeoLocation_.getParam('search-maxzoom'), 10) || 16;
+      }
       this.fulltextsearch_(searchQuery, resultIndex);
     }
   }
@@ -899,8 +902,7 @@ gmf.SearchController.prototype.selectFromGMF_ = function(event, feature, dataset
     }
   }
 
-  const size = this.map_.getSize();
-  if (featureGeometry && size) {
+  if (featureGeometry && this.map_.getSize()) {
     const view = this.map_.getView();
     this.featureOverlay_.clear();
     this.featureOverlay_.addFeature(feature);
@@ -908,7 +910,7 @@ gmf.SearchController.prototype.selectFromGMF_ = function(event, feature, dataset
     const fitArray = featureGeometry.getType() === 'GeometryCollection' ?
       featureGeometry.getExtent() : featureGeometry;
     view.fit(fitArray, {
-      size,
+      size: this.map_.getSize(),
       maxZoom: this.maxZoom});
   }
   this.leaveSearch_();
@@ -982,7 +984,10 @@ gmf.SearchController.prototype.fulltextsearch_ = function(query, resultIndex) {
         const format = new ol.format.GeoJSON();
         const feature = format.readFeature(data.features[resultIndex - 1]);
         this.featureOverlay_.addFeature(feature);
-        this.map_.getView().fit(feature.getGeometry().getExtent());
+        this.map_.getView().fit(feature.getGeometry().getExtent(), {
+          size: this.map_.getSize(),
+          maxZoom: this.maxZoom
+        });
         this.inputValue = /** @type {string} */ (feature.get('label'));
       }
     });


### PR DESCRIPTION
Fixes #3551

Add a new permalink parameter "search-maxzoom" that takes a integer. It does the same behavior as using the gmf-search-maxzoom from the directive, but for permalink. Also remove conflicts with the directive in abstract.js.