### PR TITLE
Improve filter buttons activation

### DIFF
--- a/src/directives/filter.js
+++ b/src/directives/filter.js
@@ -198,6 +198,15 @@ ngeo.FilterController = class {
 
 
   /**
+   * @return {boolean} True if at least one rule is currently defined.
+   * @export
+   */
+  hasARule() {
+    return [].concat(this.customRules, this.directedRules).length > 0;
+  }
+
+
+  /**
    * Loop in all directed and custom rules. Apply the rules that have a proper
    * value inside the data source, in the `filterRules` property.
    * @export

--- a/src/directives/partials/filter.html
+++ b/src/directives/partials/filter.html
@@ -88,8 +88,8 @@
 <a
     class="btn btn-link"
     type="button"
-    ng-click="!filterCtrl.aRuleIsActive && filterCtrl.apply()"
-    ng-disabled="filterCtrl.aRuleIsActive">
+    ng-click="filterCtrl.apply()"
+    ng-disabled="filterCtrl.hasARule() === false || filterCtrl.datasource.visible === false">
   <span class="fa fa-check"></span>
   <span translate>Apply filter</span>
 </a>
@@ -97,8 +97,8 @@
 <a
     class="btn btn-link"
     type="button"
-    ng-click="!filterCtrl.aRuleIsActive && filterCtrl.getData()"
-    ng-disabled="filterCtrl.aRuleIsActive">
+    ng-click="filterCtrl.getData()"
+    ng-disabled="filterCtrl.hasARule() === false || filterCtrl.datasource.visible === false">
   <span class="fa fa-chevron-right"></span>
   <span translate>Get data</span>
 </a>


### PR DESCRIPTION
For GEO-1053

Example (tmp): https://gmf-test.sig.cloud.camptocamp.net/bge
 - Open theme "filters"
 - (keep only one group, otherwise, it's hard to know which layer is currently active)
 - Open panel filters, choose one layer.

Then, new with this PR:
Buttons "Apply filter" and "Get Data" are enable only on the following condition: "at least one rule exist" and "the layer is activated". Otherwise there are, and look, disable.