### PR TITLE
Update print mask manually on scale selection

### DIFF
--- a/contribs/gmf/src/directives/print.js
+++ b/contribs/gmf/src/directives/print.js
@@ -1115,6 +1115,8 @@ gmf.PrintController.prototype.getSetScale = function(opt_scale) {
     const res = this.ngeoPrintUtils_.getOptimalResolution(mapSize, this.paperSize_, opt_scale);
     const contrainRes = this.map.getView().constrainResolution(res, 0, 1);
     this.map.getView().setResolution(contrainRes);
+    // Render the map to update the postcompose mask manually
+    this.map.render();
     this.scaleManuallySelected_ = true;
   }
   return this.layoutInfo.scale;


### PR DESCRIPTION
For GEO-1051  (fix the fix) 

If the scale was already adapted, the map was not updated and so, the mask neither.