### PR TITLE
Background group name use a variable

### DIFF
--- a/contribs/gmf/src/gmf.js
+++ b/contribs/gmf/src/gmf.js
@@ -10,12 +10,6 @@ gmf.baseModuleTemplateUrl = 'gmf'; // nowebpack
  * @const
  * @export
  */
-gmf.BACKGROUNDLAYERGROUP_NAME = 'background';
-
-/**
- * @const
- * @export
- */
 gmf.DATALAYERGROUP_NAME = 'data';
 
 /**

--- a/src/map/Backgroundlayermgr.js
+++ b/src/map/Backgroundlayermgr.js
@@ -74,10 +74,6 @@ ngeo.map.BackgroundLayerMgr = function(ngeoLayerHelper) {
    */
   this.ngeoLayerHelper_ = ngeoLayerHelper;
 
-  /**
-   * @type {string}
-   */
-  this.BACKGROUNDLAYERGROUP_NAME = 'background';
 };
 ol.inherits(ngeo.map.BackgroundLayerMgr, ol.Observable);
 
@@ -91,7 +87,8 @@ ol.inherits(ngeo.map.BackgroundLayerMgr, ol.Observable);
  */
 ngeo.map.BackgroundLayerMgr.prototype.get = function(map) {
   const mapUid = ol.getUid(map).toString();
-  return mapUid in this.mapUids_ ? this.ngeoLayerHelper_.getGroupFromMap(map, this.BACKGROUNDLAYERGROUP_NAME).getLayers().item(0) : null;
+  return mapUid in this.mapUids_ ? this.ngeoLayerHelper_.getGroupFromMap(map,
+    ngeo.map.BackgroundLayerMgr.BACKGROUNDLAYERGROUP_NAME).getLayers().item(0) : null;
 };
 
 
@@ -112,7 +109,7 @@ ngeo.map.BackgroundLayerMgr.prototype.set = function(map, layer) {
     this.ngeoLayerHelper_.setZIndexToFirstLevelChildren(layer, ZIndex);
   }
 
-  const bgGroup = this.ngeoLayerHelper_.getGroupFromMap(map, this.BACKGROUNDLAYERGROUP_NAME);
+  const bgGroup = this.ngeoLayerHelper_.getGroupFromMap(map, ngeo.map.BackgroundLayerMgr.BACKGROUNDLAYERGROUP_NAME);
 
   if (previous !== null) {
     goog.asserts.assert(mapUid in this.mapUids_);
@@ -145,7 +142,8 @@ ngeo.map.BackgroundLayerMgr.prototype.set = function(map, layer) {
  */
 ngeo.map.BackgroundLayerMgr.prototype.getOpacityBgLayer = function(map) {
   const mapUid = ol.getUid(map).toString();
-  return mapUid in this.mapUids_ ? this.ngeoLayerHelper_.getGroupFromMap(map, this.BACKGROUNDLAYERGROUP_NAME).getLayers().item(1) : null;
+  return mapUid in this.mapUids_ ? this.ngeoLayerHelper_.getGroupFromMap(map,
+    ngeo.map.BackgroundLayerMgr.BACKGROUNDLAYERGROUP_NAME).getLayers().item(1) : null;
 };
 
 /**
@@ -159,7 +157,7 @@ ngeo.map.BackgroundLayerMgr.prototype.setOpacityBgLayer = function(map, layer) {
   layer.setVisible(true);
   layer.setZIndex(ZIndex);
   this.ngeoLayerHelper_.setZIndexToFirstLevelChildren(layer, ZIndex);
-  const bgGroup = this.ngeoLayerHelper_.getGroupFromMap(map, this.BACKGROUNDLAYERGROUP_NAME);
+  const bgGroup = this.ngeoLayerHelper_.getGroupFromMap(map, ngeo.map.BackgroundLayerMgr.BACKGROUNDLAYERGROUP_NAME);
 
   const index = bgGroup.getLayers().getArray().indexOf(layer);
   if (index === -1) {
@@ -213,3 +211,8 @@ ngeo.map.BackgroundLayerMgr.prototype.updateDimensions = function(map, dimension
  */
 ngeo.map.BackgroundLayerMgr.module = angular.module('ngeoBackgroundLayerMgr', []);
 ngeo.map.BackgroundLayerMgr.module.service('ngeoBackgroundLayerMgr', ngeo.map.BackgroundLayerMgr);
+
+/**
+ * @const
+ */
+ngeo.map.BackgroundLayerMgr.BACKGROUNDLAYERGROUP_NAME = 'background';


### PR DESCRIPTION
This PR remove the hardcoded group name introduce temporery in the #3651 merge
Instead of moving the component in gmf as discussed for #3651, use a inner file variable for the background group name. 

This allows Luxembourg to not break...
https://github.com/camptocamp/luxembourg_geoportailv3/blob/3d/geoportailv3/static/js/backgroundlayer/backgroundlayerdirective.js#L23
