### PR TITLE
Add headers to wfs permalink request

### DIFF
--- a/src/services/wfspermalink.js
+++ b/src/services/wfspermalink.js
@@ -205,7 +205,10 @@ ngeo.WfsPermalink.prototype.issueRequest_ = function(wfsType, filter, map, showF
   });
 
   const featureRequest = new XMLSerializer().serializeToString(featureRequestXml);
-  this.$http_.post(this.url_, featureRequest).then((response) => {
+  const config = {
+    headers: {'Content-Type': 'text/xml; charset=UTF-8'}
+  };
+  this.$http_.post(this.url_, featureRequest, config).then((response) => {
     const features = wfsFormat.readFeatures(response.data);
     if (features.length == 0) {
       return;


### PR DESCRIPTION
Fixes https://jira.camptocamp.com/servicedesk/customer/portal/6/GEO-1030

Add missing headers for wfs permalink requests.