### PR TITLE
Add the import datasource module to desktop interface

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -84,6 +84,10 @@
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Street View'|translate}}">
               <span class="fa fa-street-view"></span>
             </button>
+            <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.importDataSourceActive"
+                    data-toggle="tooltip" data-placement="left" data-original-title="{{'Import Layer'|translate}}">
+              <span class="fa fa-upload"></span>
+            </button>
           </div>
           <br/>
           <br/>
@@ -198,6 +202,17 @@
                   feature-style="mainCtrl.googleStreetViewStyle"
                   map="mainCtrl.map">
               </ngeo-googlestreetview>
+            </div>
+          </div>
+          <div ng-show="mainCtrl.importDataSourceActive" class="row">
+            <div class="col-sm-12">
+              <div class="gmf-app-tools-content-heading">
+                {{'Import Layer'|translate}}
+                <a class="btn close" ng-click="mainCtrl.importDataSource = false">&times;</a>
+              </div>
+              <gmf-importdatasource
+                      map="mainCtrl.map">
+              </gmf-importdatasource>
             </div>
           </div>
         </div>

--- a/contribs/gmf/apps/desktop/js/controller.js
+++ b/contribs/gmf/apps/desktop/js/controller.js
@@ -8,6 +8,7 @@ goog.provide('app.desktop.Controller');
 
 goog.require('app');
 goog.require('gmf.controllers.AbstractDesktopController');
+goog.require('gmf.import.module');
 goog.require('ngeo.proj.EPSG2056');
 goog.require('ngeo.proj.EPSG21781');
 goog.require('ol');
@@ -15,8 +16,22 @@ goog.require('ol');
 app.desktop.module = angular.module('AppDesktop', [
   app.module.name,
   gmf.controllers.AbstractDesktopController.module.name,
+  gmf.import.module.name,
 ]);
 
+app.desktop.module.value('gmfExternalOGCServers', [{
+  'name': 'Swiss Topo WMS',
+  'type': 'WMS',
+  'url': 'https://wms.geo.admin.ch/?lang=fr'
+}, {
+  'name': 'ASIT VD',
+  'type': 'WMTS',
+  'url': 'https://ows.asitvd.ch/wmts/1.0.0/WMTSCapabilities.xml'
+}, {
+  'name': 'Swiss Topo WMTS',
+  'type': 'WMTS',
+  'url': 'https://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml?lang=fr'
+}]);
 
 /**
  * @param {angular.Scope} $scope Scope.

--- a/contribs/gmf/apps/desktop/less/main.less
+++ b/contribs/gmf/apps/desktop/less/main.less
@@ -1,1 +1,2 @@
 @import '../../../less/desktop.less';
+@import '../../../less/importdatasource.less';


### PR DESCRIPTION
Fixes GSGMF-386

Was only present in desktop_alt, but it is a standard feature, so I added it to desktop.