### PR TITLE
Fix binding for clearButton

### DIFF
--- a/contribs/gmf/src/search/component.js
+++ b/contribs/gmf/src/search/component.js
@@ -162,7 +162,7 @@ gmf.search.component.component_ = {
     'datasources': '<gmfSearchDatasources',
     'typeaheadOptions': '<?gmfSearchOptions',
     'featuresStyles': '<?gmfSearchStyles',
-    'clearButton': '=gmfSearchClearbutton',
+    'clearButton': '=?gmfSearchClearbutton',
     'colorChooser': '<gmfSearchColorchooser',
     'coordinatesProjections': '<?gmfSearchCoordinatesprojections',
     'additionalListeners': '<gmfSearchListeners',


### PR DESCRIPTION
Small missing binding change after cleanup done here: https://github.com/camptocamp/ngeo/pull/3672
The cleanup should give a default value if there is none provided, however if there is none provided it was sending the following error:
```
angular.js:14800 Error: [$compile:nonassign] Expression 'undefined' in attribute 'gmfSearchClearbutton' used with directive 'gmfSearch' is non-assignable!
http://errors.angularjs.org/1.6.9/$compile/nonassign?p0=undefined&p1=gmfSearchClearbutton&p2=gmfSearch
    at angular.js:116
    at parentSet (angular.js:10693)
    at parentValueWatch (angular.js:10706)
    at regularInterceptedExpression (angular.js:16777)
    at Scope.$digest (angular.js:18372)
    at Scope.$apply (angular.js:18649)
    at done (angular.js:12627)
    at completeRequest (angular.js:12871)
    at XMLHttpRequest.requestLoaded (angular.js:12788)
```
This fix makes that attribute as optional.

Fixes GSGMF-393