### PR TITLE
Re-enable WFS permalink for desktop_alt

### DIFF
--- a/contribs/gmf/apps/desktop_alt/js/controller.js
+++ b/contribs/gmf/apps/desktop_alt/js/controller.js
@@ -10,6 +10,7 @@ goog.require('app');
 goog.require('gmf.controllers.AbstractDesktopController');
 goog.require('gmf.import.module');
 goog.require('ngeo.googlestreetview.module');
+goog.require('ngeo.statemanager.WfsPermalink');
 goog.require('ngeo.proj.EPSG2056');
 goog.require('ngeo.proj.EPSG21781');
 goog.require('ol');
@@ -20,6 +21,7 @@ app.desktop_alt.module = angular.module('AppDesktopAlt', [
   gmf.controllers.AbstractDesktopController.module.name,
   gmf.import.module.name,
   ngeo.googlestreetview.module.name,
+  ngeo.statemanager.WfsPermalink.module.name,
 ]);
 
 


### PR DESCRIPTION
Fix GSGMF-382

Put back the WFS permalink to the desktop_alt app