### PR TITLE
Fix closable attribute in modalcomponent

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -299,6 +299,7 @@
         <gmf-share gmf-share-email="true"/>
       </ngeo-modal>
       <ngeo-modal
+          ngeo-modal-closable="false"
           ng-model="mainCtrl.userMustChangeItsPassword()"
           ng-model-options="{getterSetter: true}">
         <div class="modal-header">

--- a/src/message/modalcomponent.js
+++ b/src/message/modalcomponent.js
@@ -110,7 +110,7 @@ ngeo.message.modalComponent.Controller_ = class {
   }
 
   $onInit() {
-    this.closable = this.closable === true;
+    this.closable = this.closable !== false;
 
     this.modal_ = this.$element_.children();
 


### PR DESCRIPTION
Now the default value when nothing is provided will always allow to close a modal from the "close button" or clicking outside the modal.