### PR TITLE
Fix IE11 wrongly generated DOM

### DIFF
--- a/contribs/gmf/apps/desktop/index.html
+++ b/contribs/gmf/apps/desktop/index.html
@@ -296,7 +296,7 @@
         </div>
       </div>
       <ngeo-modal ng-model="mainCtrl.modalShareShown">
-        <gmf-share gmf-share-email="true"/>
+        <gmf-share gmf-share-email="true"></gmf-share>
       </ngeo-modal>
       <ngeo-modal
           ngeo-modal-closable="false"

--- a/contribs/gmf/apps/desktop_alt/index.html
+++ b/contribs/gmf/apps/desktop_alt/index.html
@@ -310,7 +310,7 @@
         </div>
       </div>
       <ngeo-modal ng-model="mainCtrl.modalShareShown">
-        <gmf-share gmf-share-email="false"/>
+        <gmf-share gmf-share-email="false"></gmf-share>
       </ngeo-modal>
       <ngeo-modal ng-model="disclaimerVisibility">
         <div class="modal-header">


### PR DESCRIPTION
Fix GSGMF-402 and GSGMF-404

If a tag is self-closing and is not part of the HTML5 standard, IE11 seems to not know how to handle it (especially as it is custom tags used with directive components). This fixes the issue and allow the DOM to be generated correctly.