### PR TITLE
Just ignore the 0.13 versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ Mako==1.0.7
 pip==9.0.3
 requests==2.18.4
 setuptools==39.0.1
-transifex-client==0.12.5  # rq.filter: <0.13
+transifex-client==0.12.5  # rq.filter: >=0.14
 urllib3==1.22


### PR DESCRIPTION
Better Transifex version filter