### PR TITLE
Fix the circle label in Draw & Measure

### DIFF
--- a/contribs/gmf/src/directives/partials/featurestyle.html
+++ b/contribs/gmf/src/directives/partials/featurestyle.html
@@ -7,7 +7,7 @@
         class="form-control"/>
   </div>
   <div
-      ng-if="fsCtrl.type !== 'Text' && fsCtrl.type !== 'Circle'"
+      ng-if="fsCtrl.type !== 'Text'"
       class="form-group">
         <input
           id="gmf-featurestyle-showlabel"

--- a/src/services/featurehelper.js
+++ b/src/services/featurehelper.js
@@ -343,7 +343,7 @@ ngeo.FeatureHelper.prototype.getPolygonStyle_ = function(feature) {
     })
   })];
   if (showMeasure || showLabel) {
-    if (azimut !== undefined) {
+    if (showMeasure && azimut !== undefined) {
       // Radius style:
       const line = this.getRadiusLine(feature, azimut);
       const length = ngeo.interaction.Measure.getFormattedLength(
@@ -374,6 +374,17 @@ ngeo.FeatureHelper.prototype.getPolygonStyle_ = function(feature) {
           offsetY: Math.sin((azimut - 90) * Math.PI / 180) * 20
         })
       }));
+
+      //Label Style
+      if (showLabel) {
+        styles.push(new ol.style.Style({
+          text: this.createTextStyle_({
+            text: this.getNameProperty(feature),
+            offsetY: -8,
+            exceedLength: true
+          })
+        }));
+      }
     } else {
       //Label Style
       const textLabelValues = [];
@@ -389,7 +400,6 @@ ngeo.FeatureHelper.prototype.getPolygonStyle_ = function(feature) {
         styles.push(new ol.style.Style({
           text: this.createTextStyle_({
             text: textLabelValue,
-            offsetY: -(8 / 2 + 4),
             exceedLength: true
           })
         }));


### PR DESCRIPTION
Fixes https://jira.camptocamp.com/browse/GEO-1118 for 2.2
Allow circle to get the geometry name label active as well as azimuth (previously the label was hidden as it would show the same infos as the azimuth for circles).