### PR TITLE
Update url-loader to 1.0.1 and adapt webpack build config

### DIFF
--- a/buildtools/webpack.prod.js
+++ b/buildtools/webpack.prod.js
@@ -17,7 +17,7 @@ const resourcesRule = {
 const fontRule = {
   test: /\.(eot|ttf|woff|woff2)$/,
   use: {
-    loader: 'url-loader',
+    loader: 'file-loader',
     options: {
       name: 'build/[name].[hash:20].[ext]'
     }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "ttf2woff": "2.0.1",
     "uglify-js": "3.3.21",
     "uglifyjs-webpack-plugin": "1.2.4",
-    "url-loader": "1.0.0",
+    "url-loader": "1.0.1",
     "url-polyfill": "1.0.13",
     "walk": "2.3.13",
     "webpack": "4.6.0",


### PR DESCRIPTION
Fixes the two issues with webpack build we have on EPFL project.

Dependency update from url-loader 1.0.0 to 1.0.1 fixes an issue with urls being processed as [Object object] instead of the wanted base64 inlined data strings.

Use of file-loader instead of url-loader allow the production css file to have static relative urls instead of base64 inlined strings for the png, svg, eot, woff and woff2 files format. This change allowed in EPFL to reduce css from 2 Megabytes to 250 Kilobytes.

I'm not sure if we should do it for .cur files, probably it is not a huge gain as there is only 2 files and probably not many added in projects...