### PR TITLE
Add missing webpack import for dropdown

### DIFF
--- a/contribs/gmf/src/drawing/drawFeatureComponent.js
+++ b/contribs/gmf/src/drawing/drawFeatureComponent.js
@@ -27,6 +27,7 @@ goog.require('ol.Collection');
 goog.require('ol.style.Fill');
 goog.require('ol.style.Style');
 goog.require('ol.style.Text');
+// webpack: import 'bootstrap/js/dropdown.js';
 
 
 /**

--- a/contribs/gmf/src/filters/filterselectorcomponent.js
+++ b/contribs/gmf/src/filters/filterselectorcomponent.js
@@ -20,6 +20,7 @@ goog.require('ol.events');
 goog.require('ol.array');
 
 goog.require('ngeo.map.FeatureOverlayMgr');
+// webpack: import 'bootstrap/js/dropdown.js';
 
 
 gmf.filters.filterselectorComponent = angular.module('gmfFilterselector', [

--- a/contribs/gmf/src/map/mousepositionComponent.js
+++ b/contribs/gmf/src/map/mousepositionComponent.js
@@ -5,6 +5,7 @@ goog.require('goog.asserts');
 goog.require('ngeo.misc.filters');
 goog.require('ol.control.MousePosition');
 goog.require('ol.proj');
+// webpack: import 'bootstrap/js/dropdown.js';
 
 
 /**

--- a/contribs/gmf/src/print/component.js
+++ b/contribs/gmf/src/print/component.js
@@ -18,6 +18,7 @@ goog.require('ol.layer.Tile');
 goog.require('ol.layer.Group');
 goog.require('ol.Map');
 goog.require('ol.math');
+// webpack: import 'bootstrap/js/dropdown.js';
 
 
 /**

--- a/contribs/gmf/src/profile/component.js
+++ b/contribs/gmf/src/profile/component.js
@@ -16,6 +16,7 @@ goog.require('ngeo.download.Csv');
 goog.require('ngeo.map.FeatureOverlayMgr');
 /** @suppress {extraRequire} */
 goog.require('ngeo.profile.elevationComponent');
+// webpack: import 'bootstrap/js/dropdown.js';
 
 
 /**

--- a/contribs/gmf/src/query/gridComponent.js
+++ b/contribs/gmf/src/query/gridComponent.js
@@ -19,6 +19,7 @@ goog.require('ol.style.Circle');
 goog.require('ol.style.Fill');
 goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
+// webpack: import 'bootstrap/js/dropdown.js';
 
 
 /**

--- a/contribs/gmf/src/query/windowComponent.js
+++ b/contribs/gmf/src/query/windowComponent.js
@@ -18,6 +18,7 @@ goog.require('ol.style.Style');
 // webpack: import 'angular-animate';
 // webpack: import 'angular-touch';
 // webpack: import 'bootstrap/js/collapse.js';
+// webpack: import 'bootstrap/js/dropdown.js';
 
 
 /**

--- a/contribs/gmf/src/raster/component.js
+++ b/contribs/gmf/src/raster/component.js
@@ -6,6 +6,7 @@ goog.require('goog.asserts');
 /** @suppress {extraRequire} */
 goog.require('ngeo.misc.debounce');
 goog.require('ol.events');
+// webpack: import 'bootstrap/js/dropdown.js';
 
 
 /**

--- a/contribs/gmf/src/theme/selectorComponent.js
+++ b/contribs/gmf/src/theme/selectorComponent.js
@@ -4,6 +4,7 @@ goog.require('gmf'); // nowebpack
 goog.require('gmf.theme.Manager');
 goog.require('gmf.theme.Themes');
 goog.require('ol.events');
+// webpack: import 'bootstrap/js/dropdown.js';
 
 
 /**


### PR DESCRIPTION
Not sure if it is added to the right file, but it is missing when building the app with webpack (consequence is EPFL theme selector is not visible when clicking the theme button).