### PR TITLE
Restrict dragging to header handle of displaywindow component (+ imports)

### DIFF
--- a/examples/displaywindow.css
+++ b/examples/displaywindow.css
@@ -24,7 +24,7 @@
   font-weight: bold;
 }
 
-.ui-draggable {
+.ui-draggable .ui-draggable-handle {
   cursor: pointer;
 }
 

--- a/src/message/displaywindowComponent.html
+++ b/src/message/displaywindowComponent.html
@@ -15,7 +15,7 @@
     <div class="animation-container">
       <div class="slide-animation ">
         <div
-          class="header"
+          class="header ui-draggable-handle"
           ng-if="$ctrl.title !== null">
           <p class="title">{{ $ctrl.title }}</p>
         </div>

--- a/src/message/displaywindowComponent.js
+++ b/src/message/displaywindowComponent.js
@@ -2,6 +2,7 @@ goog.provide('ngeo.message.displaywindowComponent');
 
 goog.require('ngeo'); // nowebpack
 // webpack: import 'jquery-ui/ui/widgets/resizable.js';
+// webpack: import 'jquery-ui/ui/widgets/draggable.js';
 // webpack: import 'angular-sanitize';
 
 

--- a/src/message/displaywindowComponent.js
+++ b/src/message/displaywindowComponent.js
@@ -161,7 +161,8 @@ ngeo.message.displaywindowComponent.Controller_ = class {
     // Draggable
     if (this.draggable) {
       this.element_.find('.ngeo-displaywindow .windowcontainer').draggable({
-        'containment': this.draggableContainment
+        'containment': this.draggableContainment,
+        'handle': 'div.header'
       });
     }
 


### PR DESCRIPTION
- [minor change] Add draggable to webpack imports (like resizable)

- **Restrict dragging to header handle.**
If the whole window is the handle, the user cannot interact with certain elements of the window. For example, it is not possible to select text there. ~~A potential issue introduced with this change is, that there is no visual indicator, that the header is the dragging-handle. I'm open for suggestions.~~
Edit: The only visual indicator currently is the cursor, which changes if the window is draggable and the user is hovering over the header. This should be enough for the example, right?