### PR TITLE
Override contextual data in gmf apps

### DIFF
--- a/contribs/gmf/apps/desktop/Controller.js
+++ b/contribs/gmf/apps/desktop/Controller.js
@@ -106,6 +106,11 @@ exports.module = angular.module('Appdesktop', [
   gmfControllersAbstractDesktopController.module.name,
 ]);
 
+exports.module.value('gmfContextualdatacontentTemplateUrl', 'gmf/contextualdata');
+exports.module.run(/* @ngInject */ ($templateCache) => {
+  $templateCache.put('gmf/contextualdata', require('./contextualdata.html'));
+});
+
 exports.module.controller('DesktopController', exports);
 
 export default exports;

--- a/contribs/gmf/apps/oeedit/Controller.js
+++ b/contribs/gmf/apps/oeedit/Controller.js
@@ -216,6 +216,11 @@ exports.module = angular.module('Appoeedit', [
   gmfObjecteditingModule.name,
 ]);
 
+exports.module.value('gmfContextualdatacontentTemplateUrl', 'gmf/contextualdata');
+exports.module.run(/* @ngInject */ ($templateCache) => {
+  $templateCache.put('gmf/contextualdata', require('./contextualdata.html'));
+});
+
 exports.module.controller('OEEditController', exports);
 
 export default exports;

--- a/contribs/gmf/apps/oeview/Controller.js
+++ b/contribs/gmf/apps/oeview/Controller.js
@@ -106,6 +106,11 @@ exports.module = angular.module('Appoeview', [
   gmfControllersAbstractDesktopController.module.name,
 ]);
 
+exports.module.value('gmfContextualdatacontentTemplateUrl', 'gmf/contextualdata');
+exports.module.run(/* @ngInject */ ($templateCache) => {
+  $templateCache.put('gmf/contextualdata', require('./contextualdata.html'));
+});
+
 exports.module.controller('DesktopController', exports);
 
 export default exports;


### PR DESCRIPTION
I could not test: there were 500 errors with dynamic.js.
Same as what we did in EPFL project.