### PR TITLE
Force GMF apps to be accessed through https

### DIFF
--- a/contribs/gmf/apps/desktop/index.html.ejs
+++ b/contribs/gmf/apps/desktop/index.html.ejs
@@ -5,6 +5,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
     <link rel="shortcut icon" href="<%=require("./image/favicon.ico")%>" />
+    <script>
+    if (window.location.protocol === 'http:' && window.location.hostname !== 'localhost') {
+      window.location = 'https:' + window.location.href.substr(5);
+    }
+    </script>
     <% for (var css in htmlWebpackPlugin.files.css) { %>
     <link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
     <% } %>

--- a/contribs/gmf/apps/desktop_alt/index.html.ejs
+++ b/contribs/gmf/apps/desktop_alt/index.html.ejs
@@ -5,6 +5,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
     <link rel="shortcut icon" href="<%=require("./image/favicon.ico")%>" />
+    <script>
+    if (window.location.protocol === 'http:' && window.location.hostname !== 'localhost') {
+      window.location = 'https:' + window.location.href.substr(5);
+    }
+    </script>
     <% for (var css in htmlWebpackPlugin.files.css) { %>
     <link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
     <% } %>

--- a/contribs/gmf/apps/mobile/index.html.ejs
+++ b/contribs/gmf/apps/mobile/index.html.ejs
@@ -7,6 +7,11 @@
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <link rel="shortcut icon" href="<%=require("./image/favicon.ico")%>" />
+    <script>
+    if (window.location.protocol === 'http:' && window.location.hostname !== 'localhost') {
+      window.location = 'https:' + window.location.href.substr(5);
+    }
+    </script>
     <% for (var css in htmlWebpackPlugin.files.css) { %>
     <link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
     <% } %>

--- a/contribs/gmf/apps/mobile_alt/index.html.ejs
+++ b/contribs/gmf/apps/mobile_alt/index.html.ejs
@@ -7,6 +7,11 @@
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <link rel="shortcut icon" href="<%=require("./image/favicon.ico")%>" />
+    <script>
+    if (window.location.protocol === 'http:' && window.location.hostname !== 'localhost') {
+      window.location = 'https:' + window.location.href.substr(5);
+    }
+    </script>
     <% for (var css in htmlWebpackPlugin.files.css) { %>
     <link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
     <% } %>

--- a/contribs/gmf/apps/oeedit/index.html.ejs
+++ b/contribs/gmf/apps/oeedit/index.html.ejs
@@ -4,6 +4,11 @@
     <title ng-bind-template="{{'ObjectEditing - Edit Application'|translate}}">GeoMapFish</title>
     <meta charset="utf-8">
     <link rel="shortcut icon" href="<%=require("./image/favicon.ico")%>" />
+    <script>
+    if (window.location.protocol === 'http:' && window.location.hostname !== 'localhost') {
+      window.location = 'https:' + window.location.href.substr(5);
+    }
+    </script>
     <% for (var css in htmlWebpackPlugin.files.css) { %>
     <link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
     <% } %>

--- a/contribs/gmf/apps/oeview/index.html.ejs
+++ b/contribs/gmf/apps/oeview/index.html.ejs
@@ -4,6 +4,11 @@
     <title ng-bind-template="{{'ObjectEditing - Viewer Application'|translate}}">GeoMapFish</title>
     <meta charset="utf-8">
     <link rel="shortcut icon" href="<%=require("./image/favicon.ico")%>" />
+    <script>
+    if (window.location.protocol === 'http:' && window.location.hostname !== 'localhost') {
+      window.location = 'https:' + window.location.href.substr(5);
+    }
+    </script>
     <% for (var css in htmlWebpackPlugin.files.css) { %>
     <link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
     <% } %>


### PR DESCRIPTION
See https://jira.camptocamp.com/browse/GSGMF-465.
Client applications can easily allow http access by removing the block from the html template.