### PR TITLE
Offline - Manage extent

### DIFF
--- a/examples/offline.html
+++ b/examples/offline.html
@@ -10,7 +10,8 @@
   <body ng-controller="MainController as ctrl">
     <div id="map" ngeo-map="ctrl.map">
       <ngeo-offline
-        ngeo-offline-map="ctrl.map">
+        ngeo-offline-map="ctrl.map"
+        ngeo-offline-extentsize="ctrl.offlineExtentSize">
       </ngeo-offline>
     </div>
     <p id="desc">This example shows how to use the <code><a href="../apidoc/ngeo.offline.component.html" title="Read our documentation">ngeo-offline</a></code> component.</p>

--- a/examples/offline.js
+++ b/examples/offline.js
@@ -27,10 +27,18 @@ app.offline.module = angular.module('app', [
 
 
 /**
+ * @param {ngeoFeatureOverlayMgr} ngeoFeatureOverlayMgr ngeo feature overlay manager service.
  * @constructor
  * @ngInject
  */
-app.offline.MainController = function() {
+app.offline.MainController = function(ngeoFeatureOverlayMgr) {
+
+  /**
+   * Save a square of 10 km sideways (Map's unit is the meter).
+   * @type {number}
+   * @export
+   */
+  this.offlineExtentSize = 10000;
 
   /**
    * @type {ol.Map}
@@ -47,6 +55,8 @@ app.offline.MainController = function() {
       zoom: 4
     })
   });
+
+  ngeoFeatureOverlayMgr.init(this.map);
 };
 
 

--- a/src/offline/component.html
+++ b/src/offline/component.html
@@ -1,8 +1,8 @@
 <div class="main-button">
-  <span ng-if="!$ctrl.hasData">
-    <div class="no-data" ng-click="$ctrl.toggleDisplayExtentSelection()"></div>
+  <span ng-if="!$ctrl.hasData()">
+    <div class="no-data" ng-click="$ctrl.toggleViewExtentSelection()"></div>
   </span>
-  <span ng-if="$ctrl.hasData">
+  <span ng-if="$ctrl.hasData()">
     <div class="with-data" ng-click="$ctrl.showMenu()"></div>
   </span>
 </div>
@@ -22,24 +22,24 @@
     <h4 class="modal-title" translate>Offline map</h4>
   </div>
   <div class="modal-body">
-    <div ng-if="$ctrl.hasData">
+    <div ng-if="$ctrl.hasData()">
       <button type="button" class="extent-zoom btn btn-default"
               ng-click="$ctrl.zoomToExtent()"
               translate>Zoom to extent
       </button>
       <button type="button" class="extent-show btn btn-default"
-              ng-click="$ctrl.toggleExtent()">
-        <span ng-if="$ctrl.visibleExtent" translate>Hide extent</span>
-        <span ng-if="!$ctrl.visibleExtent" translate >Show extent</span>
+              ng-click="$ctrl.toggleExtentVisibility()">
+        <span ng-if="$ctrl.isExtentVisible()" translate>Hide extent</span>
+        <span ng-if="!$ctrl.isExtentVisible()" translate >Show extent</span>
       </button>
       <button type="button" class="delete btn btn-default"
               ng-click="$ctrl.displayAlertDestroyData = true"
               translate>Delete data
       </button>
     </div>
-    <div ng-if="!$ctrl.hasData">
+    <div ng-if="!$ctrl.hasData()">
       <button type="button" class="new-data btn btn-default"
-              ng-click="$ctrl.toggleDisplayExtentSelection()"
+              ng-click="$ctrl.toggleViewExtentSelection()"
               translate>Save new map
       </button>
     </div>


### PR DESCRIPTION
GSLUX-78

 - Manage mask
 - Manage extent (polygon on overlay, and recenter on)

![out](https://user-images.githubusercontent.com/1792111/40174906-c62ade34-59d6-11e8-9ade-1ce4de47aa24.gif)

(color and quality are bad only in the gif)


Works well with map in meters. I'm not sure if all are well with another unit.