### PR TITLE
Add the loader (0=>100%) and the offline menu icon

### DIFF
--- a/examples/offline.less
+++ b/examples/offline.less
@@ -1,4 +1,5 @@
 @import "~bootstrap/dist/css/bootstrap.css";
+@import "~font-awesome/less/font-awesome.less";
 
 #map {
   width: 600px;
@@ -12,17 +13,25 @@ ngeo-offline {
   }
   .main-button {
     position: absolute;
-    right: 0.5rem;
+    right: 1rem;
     bottom: 5rem;
-    background-color: white;
-    height: 2rem;
-    width: 4rem;
     cursor: pointer;
-    .no-data:after {
-      content: '[save]';
+    .no-data {
+      color: black;
     }
-    .with-data:after {
-      content: '[menu]';
+    .with-data {
+      color: red;
+    }
+    .no-data, .with-data {
+      background-color: white;
+      text-align: center;
+      font-size: 2.5rem;
+      line-height: 2rem;
+      border-radius: 2rem;
+      font-family: FontAwesome;
+      &::after {
+        content: @fa-var-arrow-circle-o-down;
+      }
     }
   }
 
@@ -31,6 +40,17 @@ ngeo-offline {
     bottom: 0.5rem;
     width: 10rem;
     left: calc(~"50% - 5rem");
+  }
+
+  .in-progress {
+    position: absolute;
+    left: calc(~"50% - 3.3rem");
+    top: calc(~"50% - 3rem");
+    color: white;
+    font-weight: bold;
+    background-color: #337ab7;
+    padding: 2rem 2rem;
+    border-radius: 1rem;
   }
 
   .modal-content {

--- a/src/offline/component.html
+++ b/src/offline/component.html
@@ -9,7 +9,12 @@
 
 <div ng-if="$ctrl.selectingExtent" class="validate-extent btn btn-primary">
   <div ng-if="!$ctrl.downloading" ng-click="$ctrl.displayAlertLoadData = true" translate>Save map</div>
-  <div ng-if="$ctrl.downloading" ng-click="$ctrl.abortDownload()" translate>Abort</div>
+  <div ng-if="$ctrl.downloading" ng-click="$ctrl.askAbortDownload()" translate>Abort</div>
+</div>
+
+
+<div ng-if="$ctrl.downloading" class="in-progress">
+  <div>{{$ctrl.progressPercents}}%</div>
 </div>
 
 <ngeo-modal ng-model="$ctrl.menuDisplayed">
@@ -77,6 +82,25 @@
       </button>
       <button type="button" class="delete btn btn-default"
               data-dismiss="modal"
+              translate>Cancel
+      </button>
+  </div>
+</ngeo-modal>
+
+<ngeo-modal ng-model="$ctrl.displayAlertAbortDownload">
+  <div class="modal-header">
+    <h4 class="modal-title" translate>Warning</h4>
+  </div>
+  <div class="modal-body">
+      <p translate>Do you really want to remove your data ?</p>
+      <button type="button" class="validate btn btn-primary"
+              data-dismiss="modal"
+              ng-click="$ctrl.abortDownload()"
+              translate>Ok
+      </button>
+      <button type="button" class="delete btn btn-default"
+              data-dismiss="modal"
+              ng-click="$ctrl.followDownloadProgression_()"
               translate>Cancel
       </button>
   </div>


### PR DESCRIPTION
GSLUX-79 and finish GSLUX-65

Result (there is also a new "Are-you-sur-you-want-aboart-download" modal menu):

![screenshot_from_2018-05-23_10-26-19](https://user-images.githubusercontent.com/1792111/40412768-8659949c-5e74-11e8-9fc2-4715fc4bcacc.png)

Note:
- The symbol is not the same because in GA, the symbol is from  the pro version of FontAwesome.
- The loading screen is not the same because it have a very special look in GA. So I've just done somethings easier / more "passe partout".
