### PR TITLE
Add NetworkStatus service for offline detection

### DIFF
--- a/examples/offline.html
+++ b/examples/offline.html
@@ -6,8 +6,17 @@
     <meta name="viewport"
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="mobile-web-app-capable" content="yes">
+    <style>
+      .offline-msg {
+        display: none;
+      }
+      .offline .offline-msg {
+        display: block;
+      }
+    </style>
   </head>
-  <body ng-controller="MainController as ctrl">
+  <body ng-controller="MainController as ctrl" ng-class="{offline: ctrl.ngeoNetworkStatus.offline}">
+  <div class="offline-msg alert-danger" translate>You are currently offline.</div>
     <div id="map" ngeo-map="ctrl.map">
       <ngeo-offline
         ngeo-offline-map="ctrl.map"

--- a/examples/offline.html
+++ b/examples/offline.html
@@ -6,14 +6,6 @@
     <meta name="viewport"
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="mobile-web-app-capable" content="yes">
-    <style>
-      .offline-msg {
-        display: none;
-      }
-      .offline .offline-msg {
-        display: block;
-      }
-    </style>
   </head>
   <body ng-controller="MainController as ctrl" ng-class="{offline: ctrl.ngeoNetworkStatus.offline}">
   <div class="offline-msg alert-danger" translate>You are currently offline.</div>

--- a/examples/offline.js
+++ b/examples/offline.js
@@ -25,13 +25,15 @@ app.offline.module = angular.module('app', [
   ngeo.offline.module.name
 ]);
 
+app.offline.module.value('ngeoOfflineTestUrl', '../../src/offline/component.html');
 
 /**
  * @param {ngeoFeatureOverlayMgr} ngeoFeatureOverlayMgr ngeo feature overlay manager service.
+ * @param {ngeoNetworkStatus} ngeoNetworkStatus ngeo network status service.
  * @constructor
  * @ngInject
  */
-app.offline.MainController = function(ngeoFeatureOverlayMgr) {
+exports.MainController = function(ngeoFeatureOverlayMgr, ngeoNetworkStatus) {
 
   /**
    * Save a square of 10 km sideways (Map's unit is the meter).
@@ -39,6 +41,12 @@ app.offline.MainController = function(ngeoFeatureOverlayMgr) {
    * @export
    */
   this.offlineExtentSize = 10000;
+
+  /**
+   * @type {ngeoNetworkStatus}
+   * @export
+   */
+  this.ngeoNetworkStatus = ngeoNetworkStatus;
 
   /**
    * @type {ol.Map}

--- a/examples/offline.less
+++ b/examples/offline.less
@@ -65,3 +65,10 @@ ngeo-offline {
     }
   }
 }
+
+.offline-msg {
+  display: none;
+}
+.offline .offline-msg {
+  display: block;
+}

--- a/examples/simple3d.js
+++ b/examples/simple3d.js
@@ -23,8 +23,7 @@ app.simple3d.module = angular.module('app', [
 ]);
 
 
-/**
- * @constructor
+/*** @constructor
  * @ngInject
  * @param {angular.Scope} $rootScope Root scope.
  * @param {ngeo.olcs.Service} ngeoOlcsService The service.

--- a/src/offline/NetworkStatus.js
+++ b/src/offline/NetworkStatus.js
@@ -1,0 +1,209 @@
+goog.module('ngeo.offline.NetworkStatus');
+
+goog.require('ngeo.misc.debounce');
+
+
+class HttpInterceptor {
+
+  /**
+   * @ngInject
+   * @param {angular.$q} $q The Angular $q service.
+   * @param {ngeox.miscDebounce} ngeoDebounce ngeo debounce service.
+   * @param {ngeo.offline.NetworkStatus} ngeoNetworkStatus ngeo network status service.
+   */
+  constructor($q, ngeoDebounce, ngeoNetworkStatus) {
+    /**
+     * @private
+     * @type {angular.$q}
+     */
+    this.$q = $q;
+
+    /**
+     * @private
+     * @type {ngeox.miscDebounce}
+     */
+    this.ngeoDebounce_ = ngeoDebounce;
+
+    /**
+     * @private
+     * @type {ngeo.offline.NetworkStatus}
+     */
+    this.ngeoNetworkStatus_ = ngeoNetworkStatus;
+  }
+
+  request(config) {
+    return config;
+  }
+  requestError(rejection) {
+    return this.$q.reject(rejection);
+  }
+  response(response) {
+    return response;
+  }
+  responseError(rejection) {
+    this.ngeoDebounce_(() => this.ngeoNetworkStatus_.check(undefined), 2000, false);
+    return this.$q.reject(rejection);
+  }
+}
+
+const Service = class {
+
+  /**
+   * This service watches the status of network connection.
+   *
+   * Currently it watches every $http and $.ajax requests errors, if an error
+   * occurs we wait 2 sec then we make an http request on the checker file.
+   * If the checker responds that means we are online, otherwise we make a
+   * 2nd request 2 sec later, if the 2nd requests failed that means we
+   * are offline.
+   *
+   * A timeout of 1 sec is set for the checker file, so if we have a bad
+   * connection, we consider we are offline.
+   *
+   * During offline mode we test every 2 sec if we are back online.
+   *
+   * @ngInject
+   * @param {!jQuery} $document Angular document service.
+   * @param {angular.$window} $window Angular window service.
+   * @param {!angular.$timeout} $timeout Angular timeout service.
+   * @param {angular.Scope} $rootScope The root scope.
+   * @param {string} ngeoOfflineTestUrl Url of the test page.
+   */
+  constructor($document, $window, $timeout, $rootScope, ngeoOfflineTestUrl) {
+
+    /**
+     * @private
+     * @type {!jQuery}
+     */
+    this.$document_ = $document;
+
+    /**
+     * @private
+     * @type {!Window}
+     */
+    this.$window_ = $window;
+
+    /**
+     * @private
+     * @type {!angular.$timeout}
+     */
+    this.$timeout_ = $timeout;
+
+    /**
+     * @private
+     * @type {angular.Scope}
+     */
+    this.$rootScope_ = $rootScope;
+
+    /**
+     * @private
+     * @type {string}
+     */
+    this.ngeoOfflineTestUrl_ = ngeoOfflineTestUrl;
+
+    /**
+     * @private
+     * @type {!number}
+     */
+    this.count_ = 0;
+
+    /**
+     * @type {!boolean|undefined}
+     */
+    this.offline;
+
+    /**
+     * @private
+     * @type {angular.$q.Promise|undefined}
+     */
+    this.promise_;
+
+    this.initialize_();
+
+  }
+
+  initialize_() {
+    this.offline = !this.$window_.navigator.onLine;
+
+    // airplane mode, works offline(firefox)
+    this.$window_.addEventListener('offline', () => {
+      this.triggerChangeStatusEvent_(true);
+    });
+
+    // online event doesn't means we have a internet connection, that means we
+    // have possiby one (connected to a router ...)
+    this.$window_.addEventListener('online', () => {
+      this.check(undefined);
+    });
+
+    // We catch every $.ajax request errors or (canceled request).
+    this.$document_.ajaxError((evt, jqxhr, settings, thrownError) => {
+      // Filter out canceled requests
+      if (!/^(canceled|abort)$/.test(thrownError)) {
+        this.check(2000);
+      }
+    });
+
+  }
+
+  /**
+   * Check fir network status
+   *
+   * @param {number|undefined} timeout Delay for timeout.
+   */
+  check(timeout) {
+    if (this.promise_) {
+      this.$timeout_.cancel(this.promise_);
+      this.promise_ = undefined;
+    }
+    if (timeout) {
+      this.count_++;
+      this.promise_ = this.$timeout_(this.check.bind(this), timeout);
+      return;
+    }
+    $.ajax({
+      method: 'GET',
+      url: this.ngeoOfflineTestUrl_,
+      timeout: 1000,
+      success: () => {
+        this.count_ = 0;
+        if (this.offline) {
+          this.triggerChangeStatusEvent_(false);
+        }
+      },
+      error: () => {
+        this.count_++;
+        // We consider we are offline after 3 requests failed
+        if (this.count_ > 2 && !this.offline) {
+          this.triggerChangeStatusEvent_(true);
+        }
+      }
+    });
+
+  }
+
+  /**
+   * @private
+   */
+  triggerChangeStatusEvent_(offline) {
+    this.offline = offline;
+    // this.$rootScope_.$broadcast('ngeoNetworkStatusChange', net.offline);
+    this.$rootScope_.$digest();
+  }
+
+};
+
+const name = 'ngeoNetworkStatus';
+
+Service.module = angular.module(name, [
+  ngeo.misc.debounce.name
+]);
+Service.module.factory('httpInterceptor', HttpInterceptor);
+Service.module.service(name, Service);
+Service.module.config(function($httpProvider) {
+  $httpProvider.interceptors.push('httpInterceptor');
+});
+
+Service.module.value('ngeoOfflineTestUrl', '');
+
+exports = Service;

--- a/src/offline/module.js
+++ b/src/offline/module.js
@@ -2,6 +2,7 @@ goog.provide('ngeo.offline.module');
 
 goog.require('ngeo');
 goog.require('ngeo.offline.component');
+goog.require('ngeo.offline.NetworkStatus');
 
 /**
  * @type {!angular.Module}
@@ -9,4 +10,5 @@ goog.require('ngeo.offline.component');
 ngeo.offline.module = angular.module('ngeoOfflineModule', [
   ngeo.module.name, // Change me when all dependencies are in a module.
   ngeo.offline.component.name,
+  'ngeoNetworkStatus',
 ]);


### PR DESCRIPTION
Add a service that keeps network status up to date.

See comment:
```
   * This service watches the status of network connection.
   *
   * Currently it watches every $http and $.ajax requests errors, if an error
   * occurs we wait 2 sec then we make an http request on the checker file.
   * If the checker responds that means we are online, otherwise we make a
   * 2nd request 2 sec later, if the 2nd requests failed that means we
   * are offline.
   *
   * A timeout of 1 sec is set for the checker file, so if we have a bad
   * connection, we consider we are offline.
   *
   * During offline mode we test every 2 sec if we are back online.

```
I wonder why that have chosen to use ` $.ajax` instead of `$http`.
Some code is useless if we have no action while request are currently loading and not yet responded (ga use it for their `gaWaitCursor`).

Please have a first check @ger-benjamin or @gberaudo thanks
