### PR TITLE
Fix text-decoration style in layertree

### DIFF
--- a/contribs/gmf/src/layertree/common.less
+++ b/contribs/gmf/src/layertree/common.less
@@ -31,7 +31,9 @@
     display: inline;
     line-height: inherit;
     padding-left: 0;
-    text-decoration: none;
+    &:hover, &:focus {
+      text-decoration: none;
+    }
 
     &.gmf-layertree-expand-node.fa {
       color : @color-light;


### PR DESCRIPTION
To have the same behavior as version 2.2