### PR TITLE
Extract @search-size to allow overriding in apps

### DIFF
--- a/contribs/gmf/src/less/vars.less
+++ b/contribs/gmf/src/less/vars.less
@@ -1,5 +1,7 @@
 @import "~bootstrap/less/variables.less";
 
+@search-width: 6 * @map-tools-size;
+
 @app-margin: 1rem;
 @half-app-margin: 0.5rem;
 @micro-app-margin: 0.2rem;

--- a/contribs/gmf/src/search/search.less
+++ b/contribs/gmf/src/search/search.less
@@ -108,8 +108,6 @@ gmf-search {
   }
 }
 
-@search-width: 6 * @map-tools-size;
-
 // Overrides for tablet devices and up
 @media (min-width: @screen-sm-min) {
   gmf-search {


### PR DESCRIPTION
In some cases, overriding won't work if the variable is defined in the very file it is used.

By moving the variable to the vars.less file, it is trivial for the app to control the order of the overrides.