### PR TITLE
Fix offline detection

### DIFF
--- a/src/offline/NetworkStatus.js
+++ b/src/offline/NetworkStatus.js
@@ -92,6 +92,7 @@ const Service = class {
 
     /**
      * @type {!boolean|undefined}
+     * @export
      */
     this.offline;
 


### PR DESCRIPTION
Part of GSLUX-89

I'm not sure how it's compiled now, but it looks like that the "offline" property doesn't exist for the html. So perhaps this fix the problem.

(there is no problem on the demo with `?debug` params)