### PR TITLE
Fix offline default img to make it transparent

### DIFF
--- a/src/offline/DefaultConfiguration.js
+++ b/src/offline/DefaultConfiguration.js
@@ -242,8 +242,8 @@ exports = class extends ol.Observable {
       // FIXME: ideally we should not load all the storage in memory
       let content = offlineLayer.tiles[utils.normalizeURL(src)];
       if (!content) {
-        // use a white 1x1 image to make the map consistent
-        content = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII=';
+        // use a transparent 1x1 image to make the map consistent
+        content = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
       }
       imageTile.getImage().src = content;
     };


### PR DESCRIPTION
The default offline image was a blank image, it overlap other images so it must be transparent.
1x1 px transparent.