### PR TITLE
Fix local data import button

### DIFF
--- a/contribs/gmf/src/import/importdatasourceComponent.html
+++ b/contribs/gmf/src/import/importdatasourceComponent.html
@@ -13,7 +13,7 @@
     novalidate
     ng-show="$ctrl.mode === 'Local'">
     <div class="form-group">
-      <div class="input-group input-group-sm">
+      <div class="input-group">
         <input
           name="file"
           type="file"


### PR DESCRIPTION
Fix for GSGMF-559
![image](https://user-images.githubusercontent.com/25748389/42693287-f56c5632-86ae-11e8-98dd-6ae01a249664.png)


There is somewhere a conflict with the bootstrap class "input-group-sm". My opinion is to remove the class, then the field looks normal again and there is actually no need to minifying the looks/height of it for a 3 elements panel ... The interface is not cluttered by a bigger button here from the initial idea.
![image](https://user-images.githubusercontent.com/25748389/42693323-1cb06008-86af-11e8-8c3a-046dd41dcdcb.png)
