### PR TITLE
Offline has data in a service

### DIFF
--- a/src/offline/Mode.js
+++ b/src/offline/Mode.js
@@ -5,11 +5,12 @@ const ngeoBase = goog.require('ngeo');
 exports = class {
 
   /**
+   * @param {ngeo.offline.Configuration} ngeoOfflineConfiguration ngeo offline configuration service.
    * @ngInject
    * @ngdoc service
    * @ngname ngeoOfflineState
    */
-  constructor() {
+  constructor(ngeoOfflineConfiguration) {
 
     /**
      * Offline mode is enabled or not.
@@ -24,6 +25,12 @@ exports = class {
      * @private
      */
     this.component_;
+
+    /**
+     * @private
+     * @type {ngeo.offline.Configuration}
+     */
+    this.ngeoOfflineConfiguration_ = ngeoOfflineConfiguration;
   }
 
   /**
@@ -58,6 +65,15 @@ exports = class {
   activateOfflineMode() {
     this.component_.activateOfflineMode();
   }
+
+  /**
+   * @return {boolean} True if data are accessible offline.
+   * @export
+   */
+  hasData() {
+    return this.ngeoOfflineConfiguration_.hasOfflineDataForWatcher();
+  }
+
 };
 
 /**


### PR DESCRIPTION
Offline `hasdata` info should be dispatched in the mode service, which contains all info about the offline mode.
It must be extracted from component.