### PR TITLE
Offline - Hide extent after downloading

### DIFF
--- a/src/offline/component.js
+++ b/src/offline/component.js
@@ -345,9 +345,6 @@ exports.Controller = class {
    */
   finishDownload_() {
     this.downloading = false;
-    const extent = this.getDowloadExtent_();
-    this.dataPolygon_ = this.createPolygonFromExtent_(extent);
-    this.displayExtent_();
     this.toggleViewExtentSelection(true);
   }
 


### PR DESCRIPTION
GSLUX-119
Relatively easy ;-)

Out of scope, but in same file:
In this file, we have references to a "debug" attribute that we don't use anymore. Should I remove it ? 