### PR TITLE
No data no save

### DIFF
--- a/src/offline/component.html
+++ b/src/offline/component.html
@@ -78,6 +78,19 @@
   </div>
 </ngeo-modal>
 
+<ngeo-modal ng-model="$ctrl.displayAlertNoLayer">
+  <div class="modal-header">
+    <h4 class="modal-title" translate>Warning</h4>
+  </div>
+  <div class="modal-body">
+      <p translate>No maps selected for saving.</p>
+      <button type="button" class="delete btn btn-default"
+              data-dismiss="modal"
+              translate>Ok
+      </button>
+  </div>
+</ngeo-modal>
+
 <ngeo-modal ng-model="$ctrl.displayAlertDestroyData">
   <div class="modal-header">
     <h4 class="modal-title" translate>Warning</h4>

--- a/src/offline/component.js
+++ b/src/offline/component.js
@@ -227,6 +227,13 @@ exports.Controller = class {
     this.displayAlertLoadData = false;
 
     /**
+     * Whether the "no layer" modal is displayed.
+     * @type {boolean}
+     * @export
+     */
+    this.displayAlertNoLayer = false;
+
+    /**
      * Offline mask minimum margin in pixels.
      * @type {number}
      * @export
@@ -307,7 +314,11 @@ exports.Controller = class {
    */
   computeSizeAndDisplayAlertLoadData() {
     this.estimatedLoadDataSize = this.ngeoOfflineConfiguration_.estimateLoadDataSize(this.map);
-    this.displayAlertLoadData = true;
+    if (this.estimatedLoadDataSize > 0) {
+      this.displayAlertLoadData = true;
+    } else {
+      this.displayAlertNoLayer = true;
+    }
   }
   /**
    * Toggle the selecting extent view.

--- a/src/offline/component.js
+++ b/src/offline/component.js
@@ -55,7 +55,6 @@ function ngeoOfflineTemplateUrl($element, $attrs, ngeoOfflineTemplateUrl) {
  *       ngeo-offline-mask-margin="::100"
  *       ngeo-offline-min_zoom="::11"
  *       ngeo-offline-max_zoom="::15"
- *       debug="::true"
  *     </ngeo-offline>
  *
  * See our live example: [../examples/offline.html](../examples/offline.html)
@@ -73,7 +72,6 @@ exports.component_ = {
     'maskMargin': '<?ngeoOfflineMaskMargin',
     'minZoom': '<?ngeoOfflineMinZoom',
     'maxZoom': '<?ngeoOfflineMaxZoom',
-    'debug': '<',
   },
   controller: 'ngeoOfflineController',
   templateUrl: ngeoOfflineTemplateUrl
@@ -101,12 +99,6 @@ exports.Controller = class {
    * @ngname ngeoOfflineController
    */
   constructor($timeout, ngeoFeatureOverlayMgr, ngeoOfflineServiceManager, ngeoOfflineConfiguration, ngeoOfflineMode, ngeoNetworkStatus) {
-
-    /**
-     * @export
-     * @type {boolean}
-     */
-    this.debug;
 
     /**
      * @type {angular.$timeout}
@@ -326,11 +318,6 @@ exports.Controller = class {
    * @export
    */
   toggleViewExtentSelection(finished) {
-    if (this.debug && !finished) { // FIXME, remove this when downloader is implemented
-      const extent = this.getDowloadExtent_();
-      this.ngeoOfflineServiceManager_.save(extent, this.map);
-      return;
-    }
     this.menuDisplayed = false;
     this.selectingExtent = !this.selectingExtent;
 
@@ -389,10 +376,6 @@ exports.Controller = class {
    * @export
    */
   showMenu() {
-    if (this.debug) {
-      this.validateExtent();
-      return;
-    }
     this.menuDisplayed = true;
   }
 


### PR DESCRIPTION
Second commit to remove a now useless attribute.

**First commit for GSLUX-116.**
The condition I've added is never true in ngeo, but we can upgrade the "estimateLoadDataSize" in lux to answer `0` if no background and no layer is on the map.
