### PR TITLE
Fix group translation in notifications

### DIFF
--- a/contribs/gmf/src/services/treemanager.js
+++ b/contribs/gmf/src/services/treemanager.js
@@ -407,7 +407,7 @@ gmf.TreeManager.prototype.notifyCantAddGroups_ = function(groups) {
   const names = [];
   const gettextCatalog = this.gettextCatalog_;
   groups.forEach((group) => {
-    names.push(group.name);
+    names.push(gettextCatalog.getString(group.name));
   });
   const msg = (names.length < 2) ?
     gettextCatalog.getString('group is already loaded.') :


### PR DESCRIPTION
This fixes the group name that are not translated when we add a theme twice and receive the notification that it cannot be added again. (desktop alt interface in the demo)