### PR TITLE
Remove url-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "uglify-js": "3.3.27",
     "uglifyjs-webpack-plugin": "1.2.5",
     "url-loader": "1.0.1",
-    "url-polyfill": "1.0.13",
     "webpack": "4.8.2",
     "webpack-cli": "2.1.2",
     "webpack-dev-server": "3.1.4",


### PR DESCRIPTION
Url-polyfill is (maybe) useless since: https://github.com/camptocamp/ngeo/pull/4086/commits/80ad2964db4d31383a4988fa3054c219743f4896

Can supersede #4112 If this PR works (I0ll test with gh-pages).
