### PR TITLE
Fix search tt-menu max height.

### DIFF
--- a/contribs/gmf/src/search/search.less
+++ b/contribs/gmf/src/search/search.less
@@ -2,7 +2,6 @@
 @import "~gmf/less/vars.less";
 @import "~gmf/less/typeahead.less";
 
-@search-results-max-height: calc(~"100vh -" 6 * @app-margin);
 
 gmf-search {
   top: @app-margin;
@@ -70,7 +69,7 @@ gmf-search {
 
   .twitter-typeahead {
     .tt-menu {
-      max-height: @search-results-max-height;
+      max-height: 75vh;
       .gmf-search-no-results {
         padding: @app-margin;
         cursor: default;


### PR DESCRIPTION
GSGMF-418

`calc(~"100vh -" 6 * @app-margin);` was too big.
And we can't know (via a variable) the header (logo) size in this file, so I prefers to keep this variable simple and use a simple `vh` unit