### PR TITLE
[2.2] Fix theme selector layout when label is too long

### DIFF
--- a/contribs/gmf/less/map.less
+++ b/contribs/gmf/less/map.less
@@ -114,6 +114,7 @@ button[ngeo-mobile-geolocation] {
     text-overflow: ellipsis;
     white-space: nowrap;
     flex: 1 1 auto;
+    width: inherit;
   }
 
   .gmf-thumb {


### PR DESCRIPTION
When a theme label (in the theme selector popup) is too long it is cropped with a "..." but without the width attribute the text move pushes the icon inside the container. This fixes the icon alignment inside the container while keeping current flex rules for the container styling.

This issue was visible on long labels, mainly long german labels.