### PR TITLE
More polyfills for IE11 (and print)

### DIFF
--- a/contribs/gmf/apps/desktop/index.html.ejs
+++ b/contribs/gmf/apps/desktop/index.html.ejs
@@ -318,7 +318,7 @@
         ngeo-resizemap-state="profileChartActive">
       </gmf-profile>
     </footer>
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,default-3.6"></script>
     <script src="https://maps.googleapis.com/maps/api/js?v=3&key=AIzaSyCYnqxEQA5sz13sWSgMr97ejzvUeGP8gz4"></script>
     <% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
     <script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>

--- a/contribs/gmf/apps/desktop_alt/index.html.ejs
+++ b/contribs/gmf/apps/desktop_alt/index.html.ejs
@@ -350,7 +350,7 @@
         ngeo-resizemap-state="queryGridActive">
       </gmf-displayquerygrid>
     </footer>
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,default-3.6"></script>
     <script src="https://maps.googleapis.com/maps/api/js?v=3&key=AIzaSyCYnqxEQA5sz13sWSgMr97ejzvUeGP8gz4"></script>
     <% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
     <script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>

--- a/contribs/gmf/apps/mobile/index.html.ejs
+++ b/contribs/gmf/apps/mobile/index.html.ejs
@@ -169,7 +169,7 @@
         </gmf-authentication>
       </div>
     </ngeo-modal>
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,default-3.6"></script>
     <% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
     <script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
     <% } %>

--- a/contribs/gmf/apps/mobile_alt/index.html.ejs
+++ b/contribs/gmf/apps/mobile_alt/index.html.ejs
@@ -163,7 +163,7 @@
         gmf-mobile-nav-back="authCtrl.gmfUser.username !== null">
       </gmf-authentication>
     </nav>
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,default-3.6"></script>
     <% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
     <script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
     <% } %>


### PR DESCRIPTION
Fix https://jira.camptocamp.com/browse/GSGMF-621

IE11 need URL polyfill and this is not included in the default es6 parameter. This add the last polyfill from the polyfill.io library.