### PR TITLE
Uniformize buttons in right panel

### DIFF
--- a/contribs/gmf/apps/desktop/index.html.ejs
+++ b/contribs/gmf/apps/desktop/index.html.ejs
@@ -159,7 +159,7 @@
               </div>
             </div>
           </div>
-          <div ng-show="mainCtrl.drawProfilePanelActive" class="row">
+          <div ng-show="mainCtrl.drawProfilePanelActive" class="row profile-panel">
             <div class="col-sm-12">
               <div class="gmf-app-tools-content-heading">
                 {{'Profile'|translate}}
@@ -170,7 +170,7 @@
                    gmf-drawprofileline-map="::mainCtrl.map"
                    gmf-drawprofileline-line="mainCtrl.profileLine">
                  <p>
-                  <button class="btn btn-default"
+                  <button class="btn prime"
                     ngeo-btn ng-model="ctrl.interaction.active"
                     translate> Draw profile line
                   </button>

--- a/contribs/gmf/apps/desktop_alt/index.html.ejs
+++ b/contribs/gmf/apps/desktop_alt/index.html.ejs
@@ -175,7 +175,7 @@
               </div>
             </div>
           </div>
-          <div ng-show="mainCtrl.drawProfilePanelActive" class="row">
+          <div ng-show="mainCtrl.drawProfilePanelActive" class="row profile-panel">
             <div class="col-sm-12">
               <div class="gmf-app-tools-content-heading">
                 {{'Profile'|translate}}
@@ -186,7 +186,7 @@
                    gmf-drawprofileline-map="::mainCtrl.map"
                    gmf-drawprofileline-line="mainCtrl.profileLine">
                  <p>
-                  <button class="btn btn-default"
+                  <button class="btn prime"
                     ngeo-btn ng-model="ctrl.interaction.active"
                     translate>
                     Draw profile line

--- a/contribs/gmf/src/controllers/desktop.scss
+++ b/contribs/gmf/src/controllers/desktop.scss
@@ -330,8 +330,23 @@ $theme-selector-columns: 2;
       border-bottom: 0.06rem solid $color-light;
     }
 
+    .profile-panel button {
+      width: 100%;
+    }
+
     &.gmf-app-googlestreetview-active {
       width: $streeview-width + $app-margin + $app-margin;
+    }
+
+    .ngeo-routing {
+      ngeo-nominatim-input {
+        width: calc(100% - 1em - (2 * #{$app-margin}));
+      }
+
+      .fill button {
+        width: 100%;
+        margin-bottom: $half-app-margin;
+      }
     }
   }
 

--- a/contribs/gmf/src/drawing/drawFeatureComponent.js
+++ b/contribs/gmf/src/drawing/drawFeatureComponent.js
@@ -664,7 +664,7 @@ exports.Controller_.prototype.handleMapContextMenu_ = function(evt) {
     }
 
     actions = actions.concat([{
-      cls: 'fa fa-trash-o',
+      cls: 'fa fa-trash',
       label: gettextCatalog.getString('Delete'),
       name: 'delete'
     }]);

--- a/contribs/gmf/src/import/importdatasourceComponent.html
+++ b/contribs/gmf/src/import/importdatasourceComponent.html
@@ -39,7 +39,7 @@
     </div>
     <div class="form-group">
       <button
-        class="btn btn-sm btn-default form-control"
+        class="btn prime form-control"
         ng-class="{'has-error': $ctrl.hasError}"
         title="{{'Load a file from local' | translate}}"
         type="submit"
@@ -70,7 +70,7 @@
     </div>
     <div class="form-group">
       <button
-        class="btn btn-sm btn-default form-control gmf-importdatasource-connect-btn"
+        class="btn prime form-control gmf-importdatasource-connect-btn"
         ng-class="{'has-error': $ctrl.hasError}"
         title="{{'Connect to online resource' | translate}}"
         type="submit"

--- a/src/routing/routing.html
+++ b/src/routing/routing.html
@@ -20,8 +20,8 @@
             ngeo-routing-feature-on-change="$ctrl.handleChange">
           </ngeo-routing-feature>
         </div>
-        <button type="button" class="btn prime delete-via" ng-click="$ctrl.deleteVia(index)">
-          <span class="fa fa-trash-o"></span>
+        <button type="button" class="btn btn-default delete-via" ng-click="$ctrl.deleteVia(index)">
+          <span class="fa fa-trash"></span>
         </button>
       </div>
     </div>
@@ -36,14 +36,14 @@
     </ngeo-routing-feature>
   </div>
 
-  <div class="form-group pull-right">
-    <button type="button" class="btn prime" ng-click="$ctrl.clearRoute()">
-      <span class="fa fa-trash-o"></span> <span translate>Clear</span>
+  <div class="form-group fill">
+    <button type="button" class="btn btn-default" ng-click="$ctrl.clearRoute()">
+      <span class="fa fa-trash"></span> <span translate>Clear</span>
     </button>
-    <button type="button" class="btn prime" ng-click="$ctrl.reverseRoute()">
-      <span class="fa fa-exchange"></span> <span translate>Reverse</span>
+    <button type="button" class="btn btn-default" ng-click="$ctrl.reverseRoute()">
+      <span class="fa fa-exchange-alt"></span> <span translate>Reverse</span>
     </button>
-    <button type="button" class="btn prime" ng-click="$ctrl.addVia()">
+    <button type="button" class="btn btn-default" ng-click="$ctrl.addVia()">
       <span class="fa fa-plus"></span> <span translate>Add via</span>
     </button>
   </div>

--- a/src/routing/routing.scss
+++ b/src/routing/routing.scss
@@ -17,10 +17,6 @@
   text-shadow: -1px 0 #000000, 0 1px #000000, 1px 0 #000000, 0 -1px #000000;
 }
 
-.ngeo-nominatim-input {
-  height: 30px;
-}
-
 /**
  * Typeahead
  */


### PR DESCRIPTION
GSGMF-418

@sbrunner all buttons take 100% of the width in the right panels now (except for the print). Because:
 - That was easier.
 - Stack of button in the right corner was strange for "login / change password / reset password" and for routing buttons