### PR TITLE
Fix root examples

### DIFF
--- a/examples/backgroundlayer.css
+++ b/examples/backgroundlayer.css
@@ -2,3 +2,6 @@
 #map {
   height: 400px;
 }
+.backgroundlayer-selector {
+  width: 200px;
+}

--- a/examples/backgroundlayer.js
+++ b/examples/backgroundlayer.js
@@ -22,6 +22,11 @@ exports.module = angular.module('app', [
 ]);
 
 
+exports.module.run(/* @ngInject */ ($templateCache) => {
+  $templateCache.put('partials/backgroundlayer', require('./partials/backgroundlayer.html'));
+});
+
+
 /**
  * The application-specific background layer component.
  *
@@ -39,7 +44,7 @@ exports.backgroundlayerComponent = {
   bindings: {
     'map': '=appBackgroundlayerMap'
   },
-  template: require('./partials/backgroundlayer.html'),
+  templateUrl: 'partials/backgroundlayer',
   controller: 'AppBackgroundlayerController'
 };
 

--- a/examples/backgroundlayerdropdown.js
+++ b/examples/backgroundlayerdropdown.js
@@ -22,6 +22,11 @@ exports.module = angular.module('app', [
 ]);
 
 
+exports.module.run(/* @ngInject */ ($templateCache) => {
+  $templateCache.put('partials/backgroundlayerdropdown', require('./partials/backgroundlayerdropdown.html'));
+});
+
+
 /**
  * The application-specific background layer component.
  *
@@ -34,7 +39,7 @@ exports.backgroundlayerComponent = {
   bindings: {
     'map': '=appBackgroundlayerMap'
   },
-  template: require('./partials/backgroundlayerdropdown.html'),
+  templateUrl: 'partials/backgroundlayerdropdown',
   controller: 'AppBackgroundlayerController'
 };
 

--- a/examples/bboxquery.js
+++ b/examples/bboxquery.js
@@ -32,6 +32,11 @@ exports.module = angular.module('app', [
 ]);
 
 
+exports.module.run(/* @ngInject */ ($templateCache) => {
+  $templateCache.put('partials/queryresult', require('./partials/queryresult.html'));
+});
+
+
 exports.module.value('ngeoQueryOptions', {
   'limit': 20
 });
@@ -44,7 +49,7 @@ exports.module.value('ngeoQueryOptions', {
  */
 exports.queryresultComponent = {
   controller: 'AppQueryresultController',
-  template: require('./partials/queryresult.html')
+  templateUrl: 'partials/queryresult'
 };
 
 exports.module.component('appQueryresult', exports.queryresultComponent);

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -37,6 +37,11 @@ exports.module = angular.module('app', [
 ]);
 
 
+exports.module.run(/* @ngInject */ ($templateCache) => {
+  $templateCache.put('partials/measuretools', require('./partials/measuretools.html'));
+});
+
+
 /**
  * App-specific component wrapping the measure tools. The component's
  * controller has a property "map" including a reference to the OpenLayers
@@ -50,7 +55,7 @@ exports.measuretoolsComponent = {
     'lang': '=appMeasuretoolsLang'
   },
   controller: 'AppMeasuretoolsController',
-  template: require('./partials/measuretools.html')
+  templateUrl: 'partials/measuretools'
 };
 
 exports.module.component('appMeasuretools', exports.measuretoolsComponent);

--- a/examples/partials/backgroundlayer.html
+++ b/examples/partials/backgroundlayer.html
@@ -1,4 +1,4 @@
-<select class="form-control"
+<select class="form-control backgroundlayer-selector"
   ng-options="layer.name for layer in ::$ctrl.bgLayers"
   ng-model="$ctrl.bgLayer" ng-change="$ctrl.change()">
 </select>

--- a/examples/partials/backgroundlayerdropdown.html
+++ b/examples/partials/backgroundlayerdropdown.html
@@ -3,7 +3,7 @@
     {{$ctrl.currentBgLayer.name}}
   </button>
   <ul class="dropdown-menu" role="menu">
-    <li ng-repeat="layer in ::$ctrl.bgLayers">
+    <li class="dropdown-item" ng-repeat="layer in ::$ctrl.bgLayers">
       <a href ng-click="$ctrl.setLayer(layer)">{{::layer.name}}</a>
     </li>
   </ul>


### PR DESCRIPTION
I saw that this was the preferred solution since you migrated to webpack.

Alternatively, you could use `html-loader` and do something like:

```js
import templateString from './template.html';

exports.myComponent = {
  template: templateString
};
```