### PR TITLE
Prevent alert in ie11 if there is no changes

### DIFF
--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -956,7 +956,7 @@ gmf.ObjecteditingController.prototype.refreshWMSLayer_ = function() {
  * Called before the window unloads. Show a confirmation message if there are
  * unsaved modifications.
  * @param {Event} e Event.
- * @return {string} Message
+ * @return {string|undefined} Message
  * @private
  */
 gmf.ObjecteditingController.prototype.handleWindowBeforeUnload_ = function(e) {
@@ -966,7 +966,7 @@ gmf.ObjecteditingController.prototype.handleWindowBeforeUnload_ = function(e) {
     (e || window.event).returnValue = msg;
     return msg;
   }
-  return '';
+  return undefined;
 };
 
 


### PR DESCRIPTION
FIX GEO-1043

Now if you close the tab / the page and have no modification, you'll be able to do it without any warning message on IE11 (was already working like that on other browsers.)