### PR TITLE
Fix 652 - Bootstrap 4 dropdown-menu use 'show' instead of 'open'

### DIFF
--- a/src/filter/rulecomponent.html
+++ b/src/filter/rulecomponent.html
@@ -1,6 +1,4 @@
-<div
-    class="dropdown"
-    ng-class="{open: $ctrl.rule.active}">
+<div class="dropdown">
   <button
       class="btn btn-default btn-sm btn-block dropdown-toggle"
       type="button"
@@ -8,7 +6,9 @@
       ng-click="$ctrl.toggle()">
     <span>{{ ::$ctrl.clone.name | translate }}</span>
   </button>
-  <div class="dropdown-menu form-group">
+  <div
+    class="dropdown-menu form-group"
+    ng-class="{show: $ctrl.rule.active}">
 
     <select
         class="form-control ngeo-rule-operators-list"


### PR DESCRIPTION
Fixes the issue that occurs in the filter "rule component", i.e. when selecting an attribute in the filter tool, the dropdown menu was not opened.  Clicking on the drop-down list did show the menu, but in the background we had a broken state.

Cause: in Bootstrap 4, the class `show` has to be used on the element with the css class `dropdown-menu`, see (inspect the drop down menu when opened, you'll see the "show" css class name":

https://www.w3schools.com/bootstrap4/tryit.asp?filename=trybs_dropdown-menu&stacked=h

In Bootstrap 3, this was different.  The css class `open` had to be set on the element with the `dropdown` css class.