### PR TITLE
Fix 610 - Render drawn features from draw tool in mobile apps

### DIFF
--- a/contribs/gmf/src/controllers/AbstractAppController.js
+++ b/contribs/gmf/src/controllers/AbstractAppController.js
@@ -64,6 +64,20 @@ const exports = function(config, $scope, $injector) {
   googAsserts.assertInstanceof(this.map, olMap);
 
   /**
+   * Collection of features for the draw interaction
+   * @type {ol.Collection.<ol.Feature>}
+   */
+  const ngeoFeatures = $injector.get('ngeoFeatures');
+
+  /**
+   * @type {ngeo.map.FeatureOverlay}
+   * @export
+   */
+  this.drawFeatureLayer = $injector.get('ngeoFeatureOverlayMgr')
+    .getFeatureOverlay();
+  this.drawFeatureLayer.setFeatures(ngeoFeatures);
+
+  /**
    * Ngeo FeatureHelper service
    * @type {ngeo.misc.FeatureHelper}
    */

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -155,20 +155,6 @@ const exports = function(config, $scope, $injector) {
     body.off('touchstart.detectTouch');
   });
 
-  /**
-   * Collection of features for the draw interaction
-   * @type {ol.Collection.<ol.Feature>}
-   */
-  const ngeoFeatures = $injector.get('ngeoFeatures');
-
-  /**
-   * @type {ngeo.map.FeatureOverlay}
-   * @export
-   */
-  this.drawFeatureLayer = $injector.get('ngeoFeatureOverlayMgr')
-    .getFeatureOverlay();
-  this.drawFeatureLayer.setFeatures(ngeoFeatures);
-
   const ngeoFeatureHelper = $injector.get('ngeoFeatureHelper');
 
   /**


### PR DESCRIPTION
Fixes GSGMF-610.

This fix makes it possible to draw features using the draw tool (a.k.a. red lining) from a desktop application, then copy the `rl_features=zzz` parameter from the url and then open a mobile application, paste the `rl_features` param in it and be able to see the features that were drawn, without the possibility to edit them.

It turned out to be a very simple fix.  Here's a complete explanation why.

## How it works

Ngeo provides a `ngeoFeatures` angular value, which is an `ol.Collection`.  That value is injected in the GMF draw feature and it is where features are pushed when drawn.

GMF has a permalink module, which is responsible of reading params from the url.  It also injects `ngeoFeatures`, and any features present in the url are automatically pushed in the collection.

Finally, the rendering of the features in a vector layer are not the responsability of the GMF draw tool.  The abstract desktop controller was responsible of injecting `ngeoFeatures` and create a "FeatureOverlay" out of it.  Moving this code to the abstract app controller was enough to make it work.  No changes required in the draw tool at all.