### PR TITLE
On kml import force the use of default style

### DIFF
--- a/contribs/gmf/src/datasource/ExternalDataSourcesManager.js
+++ b/contribs/gmf/src/datasource/ExternalDataSourcesManager.js
@@ -532,7 +532,7 @@ const exports = class {
         };
 
         if (ngeoFile.isKml(content)) {
-          features = new olFormatKML().readFeatures(content, readOptions);
+          features = new olFormatKML({extractStyles: false}).readFeatures(content, readOptions);
         } else if (ngeoFile.isGpx(content)) {
           features = new olFormatGPX().readFeatures(content, readOptions);
         }

--- a/examples/importfeatures.js
+++ b/examples/importfeatures.js
@@ -39,7 +39,9 @@ exports.MainController = function($scope) {
    * @private
    * @type {ol.format.KML}
    */
-  this.kmlFormat_ = new olFormatKML();
+  this.kmlFormat_ = new olFormatKML({
+    extractStyles: false
+  });
 
   /**
    * @private


### PR DESCRIPTION
https://jira.camptocamp.com/browse/GSGMF-628

ExtractStyles options is true by default, if style is defined in the kml openlayers will use
a white border and fill => https://openlayers.org/en/v4.6.5/apidoc/ol.format.KML.html

By setting ExtractStyles to false, the default ol.Style will be used !