### PR TITLE
Fix 613 - Delete feature vertex on right click with menu

### DIFF
--- a/src/misc/FeatureHelper.js
+++ b/src/misc/FeatureHelper.js
@@ -529,7 +529,6 @@ exports.prototype.createEditingStyles = function(feature) {
  * @param {!ol.Coordinate} coordinate Coordinate.
  * @param {number} resolution Current map view resolution.
  * @return {?Array.<number>} The indexes of the vertex (coordinate) that hits.
- * @export
  */
 exports.prototype.getVertexInfoAtCoordinate = function(
   feature, coordinate, resolution
@@ -720,7 +719,6 @@ exports.prototype.getVertexStyle = function(opt_incGeomFunc) {
  * @param {!ol.Feature} feature Feature.
  * @param {!Array.<number>} vertexInfo The indexes of the vertex
  *     (coordinate) to remove.
- * @export
  */
 exports.prototype.removeVertex = function(feature, vertexInfo) {
   let deleted = false;

--- a/src/misc/FeatureHelper.js
+++ b/src/misc/FeatureHelper.js
@@ -21,6 +21,7 @@ import olGeomMultiPoint from 'ol/geom/MultiPoint.js';
 import olGeomPoint from 'ol/geom/Point.js';
 import olGeomPolygon from 'ol/geom/Polygon.js';
 import olGeomMultiPolygon from 'ol/geom/MultiPolygon.js';
+import olGeomSimpleGeometry from 'ol/geom/SimpleGeometry.js';
 import olFormatGPX from 'ol/format/GPX.js';
 import olFormatKML from 'ol/format/KML.js';
 import olStyleCircle from 'ol/style/Circle.js';
@@ -509,6 +510,140 @@ exports.prototype.createEditingStyles = function(feature) {
 
 
 /**
+ * For a given feature, if its geometry supports vertice that can be
+ * removed on click, then check if there is a vertex a the given
+ * coordinate. The map current map view resolution is used to
+ * calculate a buffer of the size of the vertex (using its style).
+ *
+ * If a vertex hits, then return its information, i.e. its indexes
+ * among the coordinates of the geometry of the feature, as an
+ * array. For example, if the geometry is a LineString, then the
+ * coordinates are an array of ol.Coordinate, so a single index is
+ * required. For a polygon, coordinates are an array of array of
+ * coordinates, so 2 indexes are required.
+ *
+ * If removing a vertex would make the geometry invalid, then the
+ * vertex info is not returned.
+ *
+ * @param {!ol.Feature} feature Feature.
+ * @param {!ol.Coordinate} coordinate Coordinate.
+ * @param {number} resolution Current map view resolution.
+ * @return {?Array.<number>} The indexes of the vertex (coordinate) that hits.
+ * @export
+ */
+exports.prototype.getVertexInfoAtCoordinate = function(
+  feature, coordinate, resolution
+) {
+  let info = null;
+
+  if (this.supportsVertexRemoval_(feature)) {
+
+    const buffer = resolution * exports.VertexStyleRegularShapeRadius;
+    let coordinates = null;
+    let coordinatess = null;
+    let coordinatesss = null;
+    let minNumCoordinates;
+
+    const geometry = feature.getGeometry();
+    if (geometry instanceof olGeomLineString) {
+      coordinates = geometry.getCoordinates();
+      minNumCoordinates = 2;
+    } else if (geometry instanceof olGeomPolygon) {
+      coordinatess = geometry.getCoordinates();
+      minNumCoordinates = 4;
+    } else if (geometry instanceof olGeomMultiLineString) {
+      coordinatess = geometry.getCoordinates();
+      minNumCoordinates = 2;
+    } else if (geometry instanceof olGeomMultiPolygon) {
+      coordinatesss = geometry.getCoordinates();
+      minNumCoordinates = 4;
+    }
+
+    if (coordinates) {
+      // Array of ol.Coordinate - 1 index
+      const index = this.getCoordinateIndexThatHitsAt_(
+        coordinates, coordinate, minNumCoordinates, buffer);
+      if (index !== -1) {
+        info = [index];
+      }
+    } else if (coordinatess) {
+      // Array of Array of ol.Coordinate - 2 indexes
+      const ii = coordinatess.length;
+      for (let i = 0; i < ii; i++) {
+        const index = this.getCoordinateIndexThatHitsAt_(
+          coordinatess[i], coordinate, minNumCoordinates, buffer);
+        if (index !== -1) {
+          info = [i, index];
+          break;
+        }
+      }
+    } else if (coordinatesss) {
+      // Array of Array of Array of ol.Coordinate - 3 indexes
+      const ii = coordinatesss.length;
+      for (let i = 0; i < ii; i++) {
+        const coordinatess = coordinatesss[i];
+        const jj = coordinatess.length;
+        for (let j = 0; j < jj; j++) {
+          const index = this.getCoordinateIndexThatHitsAt_(
+            coordinatess[j], coordinate, minNumCoordinates, buffer);
+          if (index !== -1) {
+            info = [i, j, index];
+            break;
+          }
+        }
+        if (info) {
+          break;
+        }
+      }
+    }
+  }
+
+  return info;
+};
+
+
+/**
+ * Loop in the given coordinates and look one that hits an other given
+ * coordinate using a buffer. If one does, return its index.
+ *
+ * @param {!Array.<!ol.Coordinate>} coordinates Coordinates in which to
+ *     loop to find the one that hits the other given coordinate.
+ * @param {!ol.Coordinate} coordinate Coordinate that has to hit.
+ * @param {number} min Minimum number of coordinates required to look
+ *     for the one that hits.
+ * @param {number} buffer Buffer, in map view units, to extend the
+ *     extent with.
+ * @return {number} Index of the coordinate that hits. If none did, -1
+ *     is returned.
+ * @private
+ */
+exports.prototype.getCoordinateIndexThatHitsAt_ = function(
+  coordinates, coordinate, min, buffer
+) {
+  let index = -1;
+  const ii = coordinates.length;
+
+  if (ii > min) {
+    for (let i = 0; i < ii; i++) {
+      const hits = olExtent.containsCoordinate(
+        olExtent.buffer(
+          olExtent.createOrUpdateFromCoordinate(coordinates[i]),
+          buffer
+        ),
+        coordinate
+      );
+      if (hits) {
+        index = i;
+        break;
+      }
+    }
+  }
+
+  return index;
+};
+
+
+/**
  * Create and return a style object to be used for vertex.
  * @param {boolean=} opt_incGeomFunc Whether to include the geometry function
  *     or not. One wants to use the geometry function when you want to draw
@@ -524,7 +659,7 @@ exports.prototype.getVertexStyle = function(opt_incGeomFunc) {
 
   const options = {
     image: new olStyleRegularShape({
-      radius: 6,
+      radius: exports.VertexStyleRegularShapeRadius,
       points: 4,
       angle: Math.PI / 4,
       fill: new olStyleFill({
@@ -580,6 +715,73 @@ exports.prototype.getVertexStyle = function(opt_incGeomFunc) {
 
 
 /**
+ * Remove a vertex from a feature using the given information (indexes).
+ *
+ * @param {!ol.Feature} feature Feature.
+ * @param {!Array.<number>} vertexInfo The indexes of the vertex
+ *     (coordinate) to remove.
+ * @export
+ */
+exports.prototype.removeVertex = function(feature, vertexInfo) {
+  let deleted = false;
+
+  const geometry = feature.getGeometry();
+  googAsserts.assertInstanceof(geometry, olGeomSimpleGeometry);
+  const coordinates = geometry.getCoordinates();
+
+  if (geometry instanceof olGeomLineString) {
+    // LineString
+    const index = vertexInfo[0];
+    if (coordinates.length > 2) {
+      coordinates.splice(index, 1);
+      deleted = true;
+    }
+  } else if (geometry instanceof olGeomPolygon) {
+    // Polygon
+    const indexOne = vertexInfo[0];
+    const indexTwo = vertexInfo[1];
+    const component = coordinates[indexOne];
+    if (component.length > 4) {
+      component.splice(indexTwo, 1);
+      deleted = true;
+      // close the ring again
+      if (indexTwo === 0) {
+        component.pop();
+        component.push(component[0]);
+      }
+    }
+  } else if (geometry instanceof olGeomMultiLineString) {
+    // MultiLineString
+    const indexOne = vertexInfo[0];
+    const indexTwo = vertexInfo[1];
+    if (coordinates[indexOne].length > 2) {
+      coordinates[indexOne].splice(indexTwo, 1);
+      deleted = true;
+    }
+  } else if (geometry instanceof olGeomMultiPolygon) {
+    // MultiPolygon
+    const indexOne = vertexInfo[0];
+    const indexTwo = vertexInfo[1];
+    const indexThree = vertexInfo[2];
+    const component = coordinates[indexOne][indexTwo];
+    if (component.length > 4) {
+      component.splice(indexThree, 1);
+      deleted = true;
+      // close the ring again
+      if (indexThree === 0) {
+        component.pop();
+        component.push(component[0]);
+      }
+    }
+  }
+
+  if (deleted) {
+    geometry.setCoordinates(coordinates);
+  }
+};
+
+
+/**
  * @param {!ol.Feature} feature Feature.
  * @return {boolean} Whether the feature supports vertex or not.
  * @private
@@ -587,8 +789,28 @@ exports.prototype.getVertexStyle = function(opt_incGeomFunc) {
 exports.prototype.supportsVertex_ = function(feature) {
   const supported = [
     ngeoGeometryType.LINE_STRING,
+    ngeoGeometryType.MULTI_LINE_STRING,
+    ngeoGeometryType.MULTI_POLYGON,
     ngeoGeometryType.POLYGON,
     ngeoGeometryType.RECTANGLE
+  ];
+  const type = this.getType(feature);
+  return olArray.includes(supported, type);
+};
+
+
+/**
+ * @param {!ol.Feature} feature Feature.
+ * @return {boolean} Whether the feature supports having its vertex
+ *     removed or not. Does not validate the number of coordinates.
+ * @private
+ */
+exports.prototype.supportsVertexRemoval_ = function(feature) {
+  const supported = [
+    ngeoGeometryType.LINE_STRING,
+    ngeoGeometryType.MULTI_LINE_STRING,
+    ngeoGeometryType.MULTI_POLYGON,
+    ngeoGeometryType.POLYGON
   ];
   const type = this.getType(feature);
   return olArray.includes(supported, type);
@@ -1106,6 +1328,14 @@ exports.FormatType = {
    */
   KML: 'KML'
 };
+
+
+/**
+ * The radius, in pixels, of the regular shape rendered as style for
+ * the vertex of a feature while it's being edited.
+ * @private
+ */
+exports.VertexStyleRegularShapeRadius = 6;
 
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -114,7 +114,7 @@ exports.encodeQueryString = function(queryData) {
  * @return {boolean} The result.
  */
 exports.deleteCondition = function(event) {
-  return olEventsCondition.noModifierKeys(event) && olEventsCondition.singleClick(event);
+  return olEventsCondition.platformModifierKeyOnly(event) && olEventsCondition.singleClick(event);
 };
 
 


### PR DESCRIPTION
~~Requires #4244 to be merged first.~~

This patch changes the way vertice can be removed from a feature.

## Originally

The original behaviour was: on left click, delete the vertex immediately.  This is the default behaviour in OpenLayers.

## From now on

This behaviour has been changed to two ways:

 1. on left click + ctrl (cmd on Mac), delete the vertex immediately.
 1. on right click, show a menu with the `Delete vertex` item that, when clicked, deletes the vertex

**Approval required** The first behaviour was not originally specifically asked.  It is a suggestion on my end for avanced users that are used to clicking on the vertice directly to remove them.

## Affected tools

 * GMF drawing tool (a.k.a. redlining)
 * GMF editing tool

## Technicallities

The way the detection of a vertex work is this: upon hitting a feature with the `contextual` menu event, we ask the ngeo featureHelper module to detect if the event occured on top of a vertex.  The style of the vertex is used alongside the current resolution of the map view to return a buffered extent around each vertex of the feature.

If one of these extents contains the location where the event occured, that's a vertex hit.  When that happens, we keep the indexes of the coordinate that hit to be able to delete it later.

The FeatureHelper has 2 new methods to help us in this way:

 * `getVertexInfoAtCoordinate`
 * `removeVertex`