### PR TITLE
GMF - Load drawing module in all apps, not only in desktop

### DIFF
--- a/contribs/gmf/src/controllers/AbstractAppController.js
+++ b/contribs/gmf/src/controllers/AbstractAppController.js
@@ -10,6 +10,7 @@ import gmfAuthenticationModule from 'gmf/authentication/module.js';
 import gmfBackgroundlayerselectorComponent from 'gmf/backgroundlayerselector/component.js';
 import gmfDatasourceModule from 'gmf/datasource/module.js';
 import gmfDisclaimerComponent from 'gmf/disclaimer/component.js';
+import gmfDrawingModule from 'gmf/drawing/module.js';
 import gmfFiltersModule from 'gmf/filters/module.js';
 import gmfLayertreeModule from 'gmf/layertree/module.js';
 import gmfMapModule from 'gmf/map/module.js';
@@ -737,6 +738,7 @@ exports.module = angular.module('GmfAbstractAppControllerModule', [
   gmfBackgroundlayerselectorComponent.name,
   gmfDatasourceModule.name,
   gmfDisclaimerComponent.name,
+  gmfDrawingModule.name,
   gmfFiltersModule.name,
   gmfLayertreeModule.name,
   gmfMapModule.name,

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -3,7 +3,6 @@
  */
 import gmfControllersAbstractAppController from 'gmf/controllers/AbstractAppController.js';
 import gmfContextualdataModule from 'gmf/contextualdata/module.js';
-import gmfDrawingModule from 'gmf/drawing/module.js';
 import gmfEditingModule from 'gmf/editing/module.js';
 import gmfPermalinkShareComponent from 'gmf/permalink/shareComponent.js';
 import gmfPrintComponent from 'gmf/print/component.js';
@@ -215,7 +214,6 @@ olBase.inherits(exports, gmfControllersAbstractAppController);
 exports.module = angular.module('GmfAbstractDesktopControllerModule', [
   gmfControllersAbstractAppController.module.name,
   gmfContextualdataModule.name,
-  gmfDrawingModule.name,
   gmfEditingModule.name,
   gmfPermalinkShareComponent.name,
   gmfPrintComponent.name,


### PR DESCRIPTION
This patch makes sure that the GMF drawing module is loaded in all apps, not only in the desktop ones.

Follow-up of #4243.