### PR TITLE
Fix 612 - GMF Drawing, zoom out if feature doesn't fit map view extent

### DIFF
--- a/src/misc/FeatureHelper.js
+++ b/src/misc/FeatureHelper.js
@@ -1212,7 +1212,7 @@ exports.prototype.getType = function(feature) {
  * @param {!ol.Feature} feature Feature.
  * @param {!ol.Map} map Map.
  * @param {boolean=} opt_zoomOut Whether the map should also be zoomed
- *     out if the feature would not fit inside the current map view
+ *     out if the feature doesn't fit inside the current map view
  *     extent. Defaults to `true`.
  * @param {number=} opt_panDuration Pan animation duration. Defaults to `250`.
  * @export


### PR DESCRIPTION
Fixes https://jira.camptocamp.com/browse/GSGMF-612

In the GMF Drawing tool, when selecting a feature from the list, if the feature would be too big for the current map view extent, then fit the view to the feature instead of just panning to it.