### PR TITLE
Add max-zoom setting for point geometries for oedit permalinks

### DIFF
--- a/contribs/gmf/apps/oeedit/index.html
+++ b/contribs/gmf/apps/oeedit/index.html
@@ -231,6 +231,10 @@
                 {action: 'add_layer', title: 'Add a layer'}
         ]);
         module.constant('gmfContextualdatacontentTemplateUrl', window.location.pathname + 'contextualdata.html');
+        module.value('gmfPermalinkOptions',
+            /** @type {gmfx.PermalinkOptions} */ ({
+              pointRecenterZoom: 10
+            }));
         module.value('ngeoWfsPermalinkOptions',
             /** @type {ngeox.WfsPermalinkOptions} */ ({
               url: 'https://geomapfish-demo.camptocamp.net/2.2/wsgi/mapserv_proxy',

--- a/contribs/gmf/options/gmfx.js
+++ b/contribs/gmf/options/gmfx.js
@@ -172,7 +172,7 @@ gmfx.ObjectEditingToolsOptions.prototype.regularPolygonRadius;
  *     crosshairEnabledByDefault: (boolean|undefined),
  *     projectionCodes: (Array.<string>|undefined),
  *     useLocalStorage: (boolean|undefined),
- *     pointRecenterZoom: (number|undefined),
+ *     pointRecenterZoom: (number|undefined)
  * }}
  */
 gmfx.PermalinkOptions;

--- a/contribs/gmf/options/gmfx.js
+++ b/contribs/gmf/options/gmfx.js
@@ -171,7 +171,8 @@ gmfx.ObjectEditingToolsOptions.prototype.regularPolygonRadius;
  *     crosshairStyle: (Array<(null|ol.style.Style)>|null|ol.FeatureStyleFunction|ol.style.Style|undefined),
  *     crosshairEnabledByDefault: (boolean|undefined),
  *     projectionCodes: (Array.<string>|undefined),
- *     useLocalStorage: (boolean|undefined)
+ *     useLocalStorage: (boolean|undefined),
+ *     pointRecenterZoom: (number|undefined),
  * }}
  */
 gmfx.PermalinkOptions;
@@ -205,6 +206,14 @@ gmfx.PermalinkOptions.prototype.projectionCodes;
  * @type {boolean|undefined}
  */
 gmfx.PermalinkOptions.prototype.useLocalStorage;
+
+
+/**
+ * Zoom level to use when result is a single point feature. If not set the map
+ * is not zoomed to a specific zoom level.
+ * @type {number|undefined}
+ */
+gmfx.PermalinkOptions.prototype.pointRecenterZoom
 
 
 /**

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -705,9 +705,9 @@ gmf.Permalink.prototype.registerMap_ = function(map, oeFeature) {
   // (1) Initialize the map view with either:
   //     a) the given ObjectEditing feature
   //     b) the X, Y and Z available within the permalink service, if available
-  if (oeFeature && oeFeature.getGeometry()) {
+  const geom = typeof oeFeature !== 'undefined' && oeFeature !== null ? oeFeature.getGeometry() : undefined;
+  if (geom) {
     const size = map.getSize();
-    const geom = oeFeature.getGeometry();
     goog.asserts.assert(size);
     let maxZoom;
     if (geom instanceof ol.geom.Point || geom instanceof ol.geom.MultiPoint) {

--- a/contribs/gmf/src/services/permalink.js
+++ b/contribs/gmf/src/services/permalink.js
@@ -22,6 +22,7 @@ goog.require('ngeo.WfsPermalink');
 goog.require('goog.asserts');
 goog.require('ol.Feature');
 goog.require('ol.geom.Point');
+goog.require('ol.geom.MultiPoint');
 goog.require('ol.proj');
 goog.require('ol.style.Stroke');
 goog.require('ol.style.RegularShape');
@@ -186,6 +187,12 @@ gmf.Permalink = function($timeout, $rootScope, $injector, ngeoDebounce, gettextC
    * @private
    */
   this.crosshairEnabledByDefault_ = !!gmfPermalinkOptions.crosshairEnabledByDefault;
+
+  /**
+   * @type {number|undefined}
+   * @private
+   */
+  this.pointRecenterZoom_ = gmfPermalinkOptions.pointRecenterZoom;
 
   /**
    * @type {?gmf.Themes}
@@ -700,8 +707,16 @@ gmf.Permalink.prototype.registerMap_ = function(map, oeFeature) {
   //     b) the X, Y and Z available within the permalink service, if available
   if (oeFeature && oeFeature.getGeometry()) {
     const size = map.getSize();
+    const geom = oeFeature.getGeometry();
     goog.asserts.assert(size);
-    view.fit(oeFeature.getGeometry().getExtent(), size);
+    let maxZoom;
+    if (geom instanceof ol.geom.Point || geom instanceof ol.geom.MultiPoint) {
+      maxZoom = this.pointRecenterZoom_;
+    }
+    view.fit(geom.getExtent(), {
+      size,
+      maxZoom
+    });
   } else {
     center = this.getMapCenter();
     if (center) {


### PR DESCRIPTION
see GEO-1465


Test link: http://localhost:3000/contribs/gmf/apps/oeedit/?&objectediting_geomtype=MultiPoint&objectediting_id=Le%20Mol%C3%A9son&objectediting_layer=113&objectediting_theme=ObjectEditing&objectediting_property=name

(You need to be logged into the demo 2.2 backend)

You can create new links here:
http://localhost:3000/contribs/gmf/examples/objecteditinghub.html