### PR TITLE
Add max-zoom setting for point geometries for oedit permalinks [2.3]

### DIFF
--- a/contribs/gmf/apps/oeedit/Controller.js
+++ b/contribs/gmf/apps/oeedit/Controller.js
@@ -231,6 +231,10 @@ exports.module.run(/* @ngInject */ ($templateCache) => {
   $templateCache.put('gmf/contextualdata', require('./contextualdata.html'));
 });
 
+exports.module.value('gmfPermalinkOptions', /** @type {gmfx.PermalinkOptions} */ ({
+  pointRecenterZoom: 10
+}));
+
 exports.module.controller('OEEditController', exports);
 
 export default exports;

--- a/contribs/gmf/options/gmfx.js
+++ b/contribs/gmf/options/gmfx.js
@@ -247,7 +247,8 @@ gmfx.PasswordValidator;
  *     crosshairStyle: (Array<(null|ol.style.Style)>|null|ol.FeatureStyleFunction|ol.style.Style|undefined),
  *     crosshairEnabledByDefault: (boolean|undefined),
  *     projectionCodes: (Array.<string>|undefined),
- *     useLocalStorage: (boolean|undefined)
+ *     useLocalStorage: (boolean|undefined),
+ *     pointRecenterZoom: (number|undefined)
  * }}
  */
 gmfx.PermalinkOptions;
@@ -281,6 +282,14 @@ gmfx.PermalinkOptions.prototype.projectionCodes;
  * @type {boolean|undefined}
  */
 gmfx.PermalinkOptions.prototype.useLocalStorage;
+
+
+/**
+ * Zoom level to use when result is a single point feature. If not set the map
+ * is not zoomed to a specific zoom level.
+ * @type {number|undefined}
+ */
+gmfx.PermalinkOptions.prototype.pointRecenterZoom
 
 
 /**


### PR DESCRIPTION
same as #4279 but for 2.3

Test:
1. Make sure you're logged in here: https://geomapfish-demo.camptocamp.com/2.3
2. `make serve-gmf-apps-oeedit`
3. Open: http://localhost:3000/contribs/gmf/apps/oeedit.html?objectediting_geomtype=MultiPoint&objectediting_id=default_name&objectediting_layer=113&objectediting_theme=ObjectEditing&objectediting_property=name

=> should load on zoom level 10

