### PR TITLE
[WIP] Fix 609 - Make desktop apps left data panel resizable and collapsible

### DIFF
--- a/contribs/gmf/apps/desktop/index.html.ejs
+++ b/contribs/gmf/apps/desktop/index.html.ejs
@@ -17,7 +17,12 @@
       </div>
     </header>
     <main>
-      <div class="gmf-app-data-panel" ng-cloak>
+      <div class="gmf-app-data-panel"
+      <div class="gmf-app-data-panel"
+           ngeo-resizemap="mainCtrl.map"
+           ngeo-resizemap-state="mainCtrl.dataPanelActive"
+           ng-class="{'gmf-app-inactive': !mainCtrl.dataPanelActive}"
+           ng-cloak>
         <div class="gmf-app-header">
           <div class="dropdown">
             <a href class="btn btn-block prime dropdown-toggle"

--- a/contribs/gmf/apps/desktop_alt/index.html.ejs
+++ b/contribs/gmf/apps/desktop_alt/index.html.ejs
@@ -17,7 +17,10 @@
       </div>
     </header>
     <main>
-      <div class="gmf-app-data-panel">
+      <div class="gmf-app-data-panel"
+           ngeo-resizemap="mainCtrl.map"
+           ngeo-resizemap-state="mainCtrl.dataPanelActive"
+           ng-class="{'gmf-app-inactive': !mainCtrl.dataPanelActive}">
         <div class="gmf-app-header">
           <div class="dropdown" ng-cloak>
             <a href class="btn btn-block prime dropdown-toggle" data-toggle="dropdown">

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -251,14 +251,19 @@ const exports = function(config, $scope, $injector) {
       this.$scope.$apply();
     });
 
-  $('<div>', {
-    'class':
-      `${dataPanelCls}-collapsible-btn btn prime btn-sm fa fa-arrow-left`
+  const collapsibleBtn = $('<div>', {
+    'class': `${dataPanelCls}-collapsible-btn btn prime btn-sm`
   }).appendTo($resizableEastHandle);
-  $('<div>', {
-    'class':
-      `${dataPanelCls}-expand-btn btn prime btn-sm fa fa-arrow-right`
+  $('<span>', {
+    'class': 'fa fa-arrow-left'
+  }).appendTo(collapsibleBtn);
+
+  const expandBtn = $('<div>', {
+    'class': `${dataPanelCls}-expand-btn btn prime btn-sm`
   }).appendTo($resizableEastHandle);
+  $('<span>', {
+    'class': 'fa fa-arrow-right'
+  }).appendTo(expandBtn);
 
   // Listen to window resize to set the max resizable width
   // accordingly, and set it also right away.

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -251,19 +251,22 @@ const exports = function(config, $scope, $injector) {
       this.$scope.$apply();
     });
 
-  const collapsibleBtn = $('<div>', {
-    'class': `${dataPanelCls}-collapsible-btn btn prime btn-sm`
-  }).appendTo($resizableEastHandle);
-  $('<span>', {
-    'class': 'fa fa-arrow-left'
-  }).appendTo(collapsibleBtn);
-
-  const expandBtn = $('<div>', {
-    'class': `${dataPanelCls}-expand-btn btn prime btn-sm`
-  }).appendTo($resizableEastHandle);
-  $('<span>', {
-    'class': 'fa fa-arrow-right'
-  }).appendTo(expandBtn);
+  // Add an extra element to act as a button to be clicked on for
+  // collapse/expand
+  $('<div>', {
+    'class': `${dataPanelCls}-toggle-btn btn prime btn-sm`
+  })
+    .appendTo($resizableEastHandle)
+    .append(
+      $('<span>', {
+        'class': `fa fa-angle-double-left ${dataPanelCls}-collapse-btn`
+      })
+    )
+    .append(
+      $('<span>', {
+        'class': `fa fa-angle-double-right ${dataPanelCls}-expand-btn`
+      })
+    );
 
   // Listen to window resize to set the max resizable width
   // accordingly, and set it also right away.

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -226,10 +226,10 @@ const exports = function(config, $scope, $injector) {
     })
     // ... and collapsible when the handle is clicked.
     .find('.ui-resizable-handle')
-    .on('click', function(evt) {
+    .on('click', (evt) => {
       this.dataPanelActive = !this.dataPanelActive;
       this.$scope.$apply();
-    }.bind(this));
+    });
 };
 
 olBase.inherits(exports, gmfControllersAbstractAppController);

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -87,6 +87,12 @@ const exports = function(config, $scope, $injector) {
    * @type {boolean}
    * @export
    */
+  this.dataPanelActive = true;
+
+  /**
+   * @type {boolean}
+   * @export
+   */
   this.loginActive = false;
 
   /**
@@ -207,6 +213,23 @@ const exports = function(config, $scope, $injector) {
       this.loginActive = false;
     }
   });
+
+  // Make the data panel (on the left) resizable...
+  $('.gmf-app-data-panel')
+    .resizable({
+      'ghost': true,
+      'handles': 'e',
+      'minWidth': 320,
+      'stop': (event, ui) => {
+        this.map.updateSize();
+      }
+    })
+    // ... and collapsible when the handle is clicked.
+    .find('.ui-resizable-handle')
+    .on('click', function(evt) {
+      this.dataPanelActive = !this.dataPanelActive;
+      this.$scope.$apply();
+    }.bind(this));
 };
 
 olBase.inherits(exports, gmfControllersAbstractAppController);

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -226,7 +226,8 @@ const exports = function(config, $scope, $injector) {
   this.dataPanelMinResizableWidth_ = 320;
 
   // Make the data panel (on the left) resizable...
-  const $dataPanel = $('.gmf-app-data-panel')
+  const dataPanelCls = 'gmf-app-data-panel';
+  const $dataPanel = $(`.${dataPanelCls}`)
     .resizable({
       'ghost': true,
       'handles': 'e',
@@ -243,12 +244,21 @@ const exports = function(config, $scope, $injector) {
   this.$dataPanel_ = $dataPanel;
 
   // ... and collapsible when the handle is clicked.
-  $dataPanel
-    .find('.ui-resizable-handle')
+  const $resizableEastHandle = $dataPanel
+    .find('.ui-resizable-e')
     .on('click', (evt) => {
       this.dataPanelActive = !this.dataPanelActive;
       this.$scope.$apply();
     });
+
+  $('<div>', {
+    'class':
+      `${dataPanelCls}-collapsible-btn btn prime btn-sm fa fa-arrow-left`
+  }).appendTo($resizableEastHandle);
+  $('<div>', {
+    'class':
+      `${dataPanelCls}-expand-btn btn prime btn-sm fa fa-arrow-right`
+  }).appendTo($resizableEastHandle);
 
   // Listen to window resize to set the max resizable width
   // accordingly, and set it also right away.

--- a/contribs/gmf/src/controllers/desktop.scss
+++ b/contribs/gmf/src/controllers/desktop.scss
@@ -256,6 +256,14 @@ gmf-search {
   &.gmf-app-inactive {
     width: 0 !important;
   }
+
+  .ui-resizable-e {
+    background-color: darken($brand-secondary, $standard-variation);
+    border: {
+      left: 0.06rem solid $border-color;
+      right: 0.06rem solid $border-color;
+    }
+  }
 }
 
 gmf-themeselector {

--- a/contribs/gmf/src/controllers/desktop.scss
+++ b/contribs/gmf/src/controllers/desktop.scss
@@ -255,7 +255,7 @@ gmf-search {
 
   &.gmf-app-inactive {
     width: 0 !important;
-    .gmf-app-data-panel-collapsible-btn {
+    .gmf-app-data-panel-collapse-btn {
       display: none;
     }
     .gmf-app-data-panel-expand-btn {
@@ -263,17 +263,17 @@ gmf-search {
     }
   }
 
-  .gmf-app-data-panel-collapsible-btn {
+  .gmf-app-data-panel-collapse-btn {
     display: block;
   }
   .gmf-app-data-panel-expand-btn {
     display: none;
   }
 
-  .gmf-app-data-panel-collapsible-btn,
-  .gmf-app-data-panel-expand-btn, {
+  .gmf-app-data-panel-toggle-btn {
     height: 2.5rem;
     left: -1px;
+    padding: 0.8rem 0.25rem;
     position: relative;
     top: calc(50% - 1.25rem);
   }

--- a/contribs/gmf/src/controllers/desktop.scss
+++ b/contribs/gmf/src/controllers/desktop.scss
@@ -255,6 +255,27 @@ gmf-search {
 
   &.gmf-app-inactive {
     width: 0 !important;
+    .gmf-app-data-panel-collapsible-btn {
+      display: none;
+    }
+    .gmf-app-data-panel-expand-btn {
+      display: block;
+    }
+  }
+
+  .gmf-app-data-panel-collapsible-btn {
+    display: block;
+  }
+  .gmf-app-data-panel-expand-btn {
+    display: none;
+  }
+
+  .gmf-app-data-panel-collapsible-btn,
+  .gmf-app-data-panel-expand-btn, {
+    height: 2.5rem;
+    left: -1px;
+    position: relative;
+    top: calc(50% - 1.25rem);
   }
 
   .ui-resizable-e {

--- a/contribs/gmf/src/controllers/desktop.scss
+++ b/contribs/gmf/src/controllers/desktop.scss
@@ -253,6 +253,9 @@ gmf-search {
     margin-bottom: $app-margin;
   }
 
+  &.gmf-app-inactive {
+    width: 0 !important;
+  }
 }
 
 gmf-themeselector {


### PR DESCRIPTION
Work in progress

Fix 609 - https://jira.camptocamp.com/browse/GSGMF-609

This patch makes it possible to resize and collapse the left 'data-panel' that is in both GMF desktop apps.

We use the jQuery "resizable" widget to do so.

When the handle is clicked, the "collapse" takes effect, using the ngeo MapResize directive.

### Todo

 * [x] define a maximum resizable width
 * [x] adjust the CSS style of the resizable handle to make it visible
 * [x] add an arrow button for to have a UI for the collapsible component
 * ~change the style of the cursor while mouse hovering to have 2 arrows instead of one pointing right~ No need to do that.
 * [x] change the style of the cursor to "pointer" on the arrow button
 * [x] fix bug, missing icon