### PR TITLE
612 - GMF draw - Zoom out when required

### DIFF
--- a/contribs/gmf/src/drawing/drawFeatureComponent.js
+++ b/contribs/gmf/src/drawing/drawFeatureComponent.js
@@ -323,7 +323,7 @@ exports.Controller_ = function($scope, $timeout, gettextCatalog,
         this.selectedFeatures.push(newFeature);
         this.registerInteractions_();
         if (this.listSelectionInProgress_) {
-          this.featureHelper_.panMapToFeature(newFeature, this.map);
+          this.featureHelper_.fitMapToFeature(newFeature, this.map);
           this.listSelectionInProgress_ = false;
         }
       } else {


### PR DESCRIPTION
This patch introduces the missing behaviour that was explained in 612 for the GMF drawing tool: if a feature is visible but would not fit the extent of the map if we panned, then zoom out.

The NGEO featureHelper `panMapToFeature` has been renamed to `fitMapToFeature` and the `opt_zoom` option was removed.  It was getting too complex to keep that option, and not really wanted anyway.  Therefore, the goal of the method was no longer only to "pan", but to "pan", "zoom" or "fit" depending on the scenario.