### PR TITLE
Add example usage of routing configuration [2.3]

### DIFF
--- a/contribs/gmf/apps/desktop_alt/Controller.js
+++ b/contribs/gmf/apps/desktop_alt/Controller.js
@@ -170,6 +170,24 @@ exports.module = angular.module('Appdesktop_alt', [
   ngeoStatemanagerWfsPermalink.module.name,
 ]);
 
+exports.module.constant('ngeoRoutingOptions', {
+  'backendUrl': 'http://routing.osm.ch/',
+  'profiles': [
+    {
+      label: 'Car',
+      profile: 'routed-car'
+    },
+    {
+      label: 'Bike (City)',
+      profile: 'routed-bike'
+    }
+  ]
+});
+
+exports.module.constant('ngeoNominatimSearchDefaultParams', {
+  'countrycodes': 'CH'
+});
+
 exports.module.controller('AlternativeDesktopController', exports);
 
 export default exports;


### PR DESCRIPTION
I added the example configuration for the routing in the desktop_alt app, which is described here:
http://camptocamp.github.io/c2cgeoportal/2.3/integrator/routing.html#configuration