### PR TITLE
Support columnsOrder in grid and window components

### DIFF
--- a/contribs/gmf/externs/gmf-themes.js
+++ b/contribs/gmf/externs/gmf-themes.js
@@ -399,6 +399,11 @@ gmfThemes.GmfFunctionalities.prototype.preset_layer_filter;
  */
 gmfThemes.GmfMetaData = function() {};
 
+/**
+ * Ordered list of attribute names.
+ * @type {Array.<string>|undefined}
+ */
+gmfThemes.GmfMetaData.prototype.attributesOrder
 
 /**
  * Names of layers on which the geometry can be copied to (in the edition mode).

--- a/contribs/gmf/options/gmfx.js
+++ b/contribs/gmf/options/gmfx.js
@@ -752,6 +752,12 @@ gmfx.datasource.OGCOptions;
 
 
 /**
+ * Ordered list of attribute names.
+ * @type {Array.<string>|undefined}
+ */
+gmfx.datasource.OGCOptions.prototype.attributesOrder;
+
+/**
  * A reference to the GMF layer node that was used to create the data source.
  * It may contains additional information, such as metadata, about the data
  * source.

--- a/contribs/gmf/src/datasource/Manager.js
+++ b/contribs/gmf/src/datasource/Manager.js
@@ -488,11 +488,11 @@ const exports = class {
     const name = gmfLayer.name;
     const timeAttributeName = meta.timeAttribute;
     const visible = meta.isChecked === true;
-    const columnsOrder = meta.columnsOrder;
+    const attributesOrder = meta.attributesOrder;
 
     // Create the data source and add it to the cache
     this.dataSourcesCache_[id] = new gmfDatasourceOGC({
-      columnsOrder,
+      attributesOrder,
       copyable,
       dimensions,
       dimensionsConfig,

--- a/contribs/gmf/src/datasource/Manager.js
+++ b/contribs/gmf/src/datasource/Manager.js
@@ -488,9 +488,11 @@ const exports = class {
     const name = gmfLayer.name;
     const timeAttributeName = meta.timeAttribute;
     const visible = meta.isChecked === true;
+    const columnsOrder = meta.columnsOrder;
 
     // Create the data source and add it to the cache
     this.dataSourcesCache_[id] = new gmfDatasourceOGC({
+      columnsOrder,
       copyable,
       dimensions,
       dimensionsConfig,

--- a/contribs/gmf/src/datasource/OGC.js
+++ b/contribs/gmf/src/datasource/OGC.js
@@ -24,6 +24,11 @@ const exports = class extends ngeoDatasourceOGC {
      */
     this.gmfLayer_ = options.gmfLayer;
 
+    /**
+     * @type {?Array.<string>}
+     * @export
+     */
+    this.columnsOrder_ = options.columnsOrder;
   }
 
   // === Static property getters/setters ===
@@ -34,6 +39,14 @@ const exports = class extends ngeoDatasourceOGC {
    */
   get gmfLayer() {
     return this.gmfLayer_;
+  }
+
+  /**
+   * @return {?Array.<string>} Ordered list of column names
+   * @export
+   */
+  get columnsOrder() {
+    return this.columnsOrder_;
   }
 
 };

--- a/contribs/gmf/src/datasource/OGC.js
+++ b/contribs/gmf/src/datasource/OGC.js
@@ -25,10 +25,10 @@ const exports = class extends ngeoDatasourceOGC {
     this.gmfLayer_ = options.gmfLayer;
 
     /**
-     * @type {?Array.<string>}
+     * @type {Array.<string>|undefined}
      * @export
      */
-    this.columnsOrder_ = options.columnsOrder;
+    this.attributesOrder_ = options.attributesOrder;
   }
 
   // === Static property getters/setters ===
@@ -42,11 +42,11 @@ const exports = class extends ngeoDatasourceOGC {
   }
 
   /**
-   * @return {?Array.<string>} Ordered list of column names
+   * @return {?Array.<string>|undefined} Ordered list of attribute names.
    * @export
    */
-  get columnsOrder() {
-    return this.columnsOrder_;
+  get attributesOrder() {
+    return this.attributesOrder_;
   }
 
 };

--- a/contribs/gmf/src/query/gridComponent.js
+++ b/contribs/gmf/src/query/gridComponent.js
@@ -3,8 +3,6 @@
  */
 import googAsserts from 'goog/asserts.js';
 
-import ngeoDatasourceDataSources from 'ngeo/datasource/DataSources.js';
-
 /** @suppress {extraRequire} */
 import ngeoDownloadCsv from 'ngeo/download/Csv.js';
 
@@ -35,7 +33,6 @@ import 'bootstrap/js/src/dropdown.js';
  * @type {!angular.Module}
  */
 const exports = angular.module('gmfQueryGridComponent', [
-  ngeoDatasourceDataSources.module.name,
   ngeoDownloadCsv.module.name,
   ngeoDownloadService.name,
   ngeoGridComponent.name,
@@ -144,7 +141,6 @@ exports.component('gmfDisplayquerygrid', exports.component_);
  *     overlay manager service.
  * @param {!angular.$timeout} $timeout Angular timeout service.
  * @param {!ngeo.download.Csv} ngeoCsvDownload CSV download service.
- * @param {ngeo.datasource.DataSources} ngeoDataSources Ngeo data sources service.
  *     data sources service.
  * @param {!angular.JQLite} $element Element.
  * @constructor
@@ -154,7 +150,7 @@ exports.component('gmfDisplayquerygrid', exports.component_);
  * @ngname GmfDisplayquerygridController
  */
 exports.Controller_ = function($injector, $scope, ngeoQueryResult, ngeoMapQuerent,
-  ngeoFeatureOverlayMgr, $timeout, ngeoCsvDownload, ngeoDataSources, $element) {
+  ngeoFeatureOverlayMgr, $timeout, ngeoCsvDownload, $element) {
 
   const queryOptions = /** @type {ngeox.QueryOptions} */ (
     $injector.has('ngeoQueryOptions') ?
@@ -189,12 +185,6 @@ exports.Controller_ = function($injector, $scope, ngeoQueryResult, ngeoMapQueren
    * @private
    */
   this.ngeoCsvDownload_ = ngeoCsvDownload;
-
-  /**
-   * @type {ngeo.datasource.DataSources}
-   * @private
-   */
-  this.ngeoDataSources_ = ngeoDataSources;
 
   /**
    * @type {!angular.JQLite}
@@ -692,12 +682,13 @@ exports.Controller_.prototype.getGridConfiguration_ = function(data) {
   Object.assign(clone, data[0]);
   delete clone.ol_uid;
 
-  const dataSource = this.ngeoDataSources_.collection.getArray().find(
-    ds => ds.id == clone.ngeo_datasource_id);
-  delete clone.ngeo_datasource_id;
-
-  const columns = dataSource && dataSource.columnsOrder.filter(key => key in clone)
-    || Object.keys(clone);
+  let columns;
+  const dataSource = clone.ngeo_datasource_;
+  if (dataSource && dataSource.attributesOrder) {
+    columns = dataSource.attributesOrder.filter(key => key in clone);
+  } else {
+    columns = Object.keys(clone);
+  }
 
   /** @type {Array.<ngeox.GridColumnDef>} */
   const columnDefs = [];

--- a/contribs/gmf/src/query/gridComponent.js
+++ b/contribs/gmf/src/query/gridComponent.js
@@ -3,6 +3,8 @@
  */
 import googAsserts from 'goog/asserts.js';
 
+import ngeoDatasourceDataSources from 'ngeo/datasource/DataSources.js';
+
 /** @suppress {extraRequire} */
 import ngeoDownloadCsv from 'ngeo/download/Csv.js';
 
@@ -33,6 +35,7 @@ import 'bootstrap/js/src/dropdown.js';
  * @type {!angular.Module}
  */
 const exports = angular.module('gmfQueryGridComponent', [
+  ngeoDatasourceDataSources.module.name,
   ngeoDownloadCsv.module.name,
   ngeoDownloadService.name,
   ngeoGridComponent.name,
@@ -141,6 +144,8 @@ exports.component('gmfDisplayquerygrid', exports.component_);
  *     overlay manager service.
  * @param {!angular.$timeout} $timeout Angular timeout service.
  * @param {!ngeo.download.Csv} ngeoCsvDownload CSV download service.
+ * @param {ngeo.datasource.DataSources} ngeoDataSources Ngeo data sources service.
+ *     data sources service.
  * @param {!angular.JQLite} $element Element.
  * @constructor
  * @private
@@ -149,7 +154,7 @@ exports.component('gmfDisplayquerygrid', exports.component_);
  * @ngname GmfDisplayquerygridController
  */
 exports.Controller_ = function($injector, $scope, ngeoQueryResult, ngeoMapQuerent,
-  ngeoFeatureOverlayMgr, $timeout, ngeoCsvDownload, $element) {
+  ngeoFeatureOverlayMgr, $timeout, ngeoCsvDownload, ngeoDataSources, $element) {
 
   const queryOptions = /** @type {ngeox.QueryOptions} */ (
     $injector.has('ngeoQueryOptions') ?
@@ -184,6 +189,12 @@ exports.Controller_ = function($injector, $scope, ngeoQueryResult, ngeoMapQueren
    * @private
    */
   this.ngeoCsvDownload_ = ngeoCsvDownload;
+
+  /**
+   * @type {ngeo.datasource.DataSources}
+   * @private
+   */
+  this.ngeoDataSources_ = ngeoDataSources;
 
   /**
    * @type {!angular.JQLite}
@@ -675,13 +686,18 @@ exports.Controller_.prototype.makeGrid_ = function(data, source) {
  * @return {?ngeo.grid.Config} Grid config.
  * @private
  */
-exports.Controller_.prototype.getGridConfiguration_ = function(
-  data) {
+exports.Controller_.prototype.getGridConfiguration_ = function(data) {
   googAsserts.assert(data.length > 0);
   const clone = {};
   Object.assign(clone, data[0]);
   delete clone.ol_uid;
-  const columns = Object.keys(clone);
+
+  const dataSource = this.ngeoDataSources_.collection.getArray().find(
+    ds => ds.id == clone.ngeo_datasource_id);
+  delete clone.ngeo_datasource_id;
+
+  const columns = dataSource && dataSource.columnsOrder.filter(key => key in clone)
+    || Object.keys(clone);
 
   /** @type {Array.<ngeox.GridColumnDef>} */
   const columnDefs = [];

--- a/contribs/gmf/src/query/windowComponent.html
+++ b/contribs/gmf/src/query/windowComponent.html
@@ -45,15 +45,15 @@
         <div class="details">
           <table>
             <tr
-              ng-repeat="(key, value) in ctrl.getFeatureValues()"
-              ng-if="value !== undefined">
+              ng-repeat="key in ctrl.getOrderedColumns()"
+              ng-if="ctrl.feature.get(key) !== undefined">
               <td
                 class="details-key"
                 ng-bind-html="key | translate | ngeoTrustHtml"
                 ></td>
               <td
                 class="details-value"
-                ng-bind-html="value | ngeoTrustHtmlAuto"
+                ng-bind-html="ctrl.feature.get(key) | ngeoTrustHtmlAuto"
                 ></td>
             </tr>
           </table>

--- a/contribs/gmf/src/query/windowComponent.js
+++ b/contribs/gmf/src/query/windowComponent.js
@@ -2,6 +2,7 @@
  * @module gmf.query.windowComponent
  */
 import googAsserts from 'goog/asserts.js';
+import ngeoDatasourceDataSources from 'ngeo/datasource/DataSources.js';
 import ngeoMapFeatureOverlayMgr from 'ngeo/map/FeatureOverlayMgr.js';
 import ngeoMiscFeatureHelper from 'ngeo/misc/FeatureHelper.js';
 
@@ -29,6 +30,7 @@ import 'bootstrap/js/src/dropdown.js';
  * @type {!angular.Module}
  */
 const exports = angular.module('gmfQueryWindowComponent', [
+  ngeoDatasourceDataSources.module.name,
   ngeoMapFeatureOverlayMgr.module.name,
   ngeoMiscFeatureHelper.module.name,
   ngeoMiscSwipe.name,
@@ -134,6 +136,8 @@ exports.component('gmfDisplayquerywindow', exports.component_);
  * @param {!ngeo.query.MapQuerent} ngeoMapQuerent ngeo map querent service.
  * @param {!ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *     overlay manager service.
+ * @param {ngeo.datasource.DataSources} ngeoDataSources Ngeo data sources service.
+ *     data sources service.
  * @constructor
  * @private
  * @ngInject
@@ -141,7 +145,7 @@ exports.component('gmfDisplayquerywindow', exports.component_);
  * @ngname GmfDisplayquerywindowController
  */
 exports.Controller_ = function($element, $scope, ngeoQueryResult, ngeoMapQuerent,
-  ngeoFeatureOverlayMgr) {
+  ngeoFeatureOverlayMgr, ngeoDataSources) {
 
   /**
    * @type {Element|string}
@@ -209,6 +213,12 @@ exports.Controller_ = function($element, $scope, ngeoQueryResult, ngeoMapQuerent
    * @private
    */
   this.ngeoFeatureOverlayMgr_ = ngeoFeatureOverlayMgr;
+
+  /**
+   * @type {ngeo.datasource.DataSources}
+   * @private
+   */
+  this.ngeoDataSources_ = ngeoDataSources;
 
   /**
    * @type {!ol.Collection}
@@ -477,16 +487,19 @@ exports.Controller_.prototype.isLast = function() {
 
 
 /**
- * Delete the unwanted ol3 properties from the current feature then return the
- * properties.
+ * Return property names from dataSource.columnsOrder if defined,
+ * else return filtered property names from ol3 feature object.
  * @return {Object?} Filtered properties of the current feature or null.
  * @export
  */
-exports.Controller_.prototype.getFeatureValues = function() {
+exports.Controller_.prototype.getOrderedColumns = function() {
   if (!this.feature) {
     return null;
   }
-  return ngeoMiscFeatureHelper.getFilteredFeatureValues(this.feature);
+  const dataSource = this.ngeoDataSources_.collection.getArray().find(
+    ds => ds.id == this.feature.get('ngeo_datasource_id'));
+  return dataSource && dataSource.columnsOrder ||
+    Object.keys(ngeoMiscFeatureHelper.getFilteredFeatureValues(this.feature));
 };
 
 

--- a/contribs/gmf/src/query/windowComponent.js
+++ b/contribs/gmf/src/query/windowComponent.js
@@ -2,7 +2,6 @@
  * @module gmf.query.windowComponent
  */
 import googAsserts from 'goog/asserts.js';
-import ngeoDatasourceDataSources from 'ngeo/datasource/DataSources.js';
 import ngeoMapFeatureOverlayMgr from 'ngeo/map/FeatureOverlayMgr.js';
 import ngeoMiscFeatureHelper from 'ngeo/misc/FeatureHelper.js';
 
@@ -30,7 +29,6 @@ import 'bootstrap/js/src/dropdown.js';
  * @type {!angular.Module}
  */
 const exports = angular.module('gmfQueryWindowComponent', [
-  ngeoDatasourceDataSources.module.name,
   ngeoMapFeatureOverlayMgr.module.name,
   ngeoMiscFeatureHelper.module.name,
   ngeoMiscSwipe.name,
@@ -136,8 +134,6 @@ exports.component('gmfDisplayquerywindow', exports.component_);
  * @param {!ngeo.query.MapQuerent} ngeoMapQuerent ngeo map querent service.
  * @param {!ngeo.map.FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *     overlay manager service.
- * @param {ngeo.datasource.DataSources} ngeoDataSources Ngeo data sources service.
- *     data sources service.
  * @constructor
  * @private
  * @ngInject
@@ -145,7 +141,7 @@ exports.component('gmfDisplayquerywindow', exports.component_);
  * @ngname GmfDisplayquerywindowController
  */
 exports.Controller_ = function($element, $scope, ngeoQueryResult, ngeoMapQuerent,
-  ngeoFeatureOverlayMgr, ngeoDataSources) {
+  ngeoFeatureOverlayMgr) {
 
   /**
    * @type {Element|string}
@@ -213,12 +209,6 @@ exports.Controller_ = function($element, $scope, ngeoQueryResult, ngeoMapQuerent
    * @private
    */
   this.ngeoFeatureOverlayMgr_ = ngeoFeatureOverlayMgr;
-
-  /**
-   * @type {ngeo.datasource.DataSources}
-   * @private
-   */
-  this.ngeoDataSources_ = ngeoDataSources;
 
   /**
    * @type {!ol.Collection}
@@ -487,7 +477,7 @@ exports.Controller_.prototype.isLast = function() {
 
 
 /**
- * Return property names from dataSource.columnsOrder if defined,
+ * Return property names from dataSource.attributesOrder if defined,
  * else return filtered property names from ol3 feature object.
  * @return {Object?} Filtered properties of the current feature or null.
  * @export
@@ -496,9 +486,8 @@ exports.Controller_.prototype.getOrderedColumns = function() {
   if (!this.feature) {
     return null;
   }
-  const dataSource = this.ngeoDataSources_.collection.getArray().find(
-    ds => ds.id == this.feature.get('ngeo_datasource_id'));
-  return dataSource && dataSource.columnsOrder ||
+  const dataSource = this.feature.get('ngeo_datasource_');
+  return dataSource && dataSource.attributesOrder ||
     Object.keys(ngeoMiscFeatureHelper.getFilteredFeatureValues(this.feature));
 };
 

--- a/src/misc/FeatureHelper.js
+++ b/src/misc/FeatureHelper.js
@@ -884,6 +884,7 @@ exports.getFilteredFeatureValues = function(feature) {
   delete properties['boundedBy'];
   delete properties[feature.getGeometryName()];
   delete properties['ngeo_feature_type_'];
+  delete properties['ngeo_datasource_id'];
   return properties;
 };
 

--- a/src/query/Querent.js
+++ b/src/query/Querent.js
@@ -430,6 +430,7 @@ const exports = class {
       if (readFeatures.length > 0) {
         readFeatures.forEach((feature) => {
           feature.set('ngeo_feature_type_', type);
+          feature.set('ngeo_datasource_id', dataSource.id);
           features.push(feature);
         });
       }

--- a/src/query/Querent.js
+++ b/src/query/Querent.js
@@ -430,7 +430,7 @@ const exports = class {
       if (readFeatures.length > 0) {
         readFeatures.forEach((feature) => {
           feature.set('ngeo_feature_type_', type);
-          feature.set('ngeo_datasource_id', dataSource.id);
+          feature.set('ngeo_datasource_', dataSource);
           features.push(feature);
         });
       }


### PR DESCRIPTION
Add attribute columnsOrder to gmfDatasourceOGC base on columnsOrder metadata.
Add property ngeo_datasource_id to features in Querent.
Use columns order from datasource in grid and window components.

Client part of https://jira.camptocamp.com/browse/GSGMF-616