### PR TITLE
Fix 615 - Support readonly attributes in editing

### DIFF
--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -78,8 +78,16 @@ ngeox.Attribute.prototype.alias;
 
 
 /**
- * Whether the attribute required to have a value set or not. Defaults to
- * `false`.
+ * Whether the attribute's value should be prevented from being edited
+ * or not. Defaults to `false`.
+ * @type {boolean|undefined}
+ */
+ngeox.Attribute.prototype.readonly;
+
+
+/**
+ * Whether the attribute is required to have a value set or
+ * not. Defaults to `false`.
  * @type {boolean|undefined}
  */
 ngeox.Attribute.prototype.required;

--- a/src/editing/attributescomponent.html
+++ b/src/editing/attributescomponent.html
@@ -7,7 +7,17 @@
           ng-if="::attribute.type !== 'boolean'"
           class="col-form-label">{{ ::attribute.name | translate }} <span class="text-muted">{{::attribute.required ? "*" : ""}}</span>
       </label>
-      <div ng-switch="::attribute.type">
+
+      <div
+          class="form-control"
+          ng-if="::attribute.readonly"
+          readonly>
+        {{::attrCtrl.properties[attribute.name]}}
+      </div>
+
+      <div
+          ng-if="::!attribute.readonly"
+          ng-switch="::attribute.type">
 
         <div
             ng-switch-when="boolean"

--- a/src/format/XSDAttribute.js
+++ b/src/format/XSDAttribute.js
@@ -94,9 +94,15 @@ exports.prototype.readFromElementNode_ = function(node) {
   const nillable = node.getAttribute('nillable');
   const required = !(nillable === true || nillable === 'true');
 
+  const readonlyEls = node.getElementsByTagName('readonly');
+  const readonly = readonlyEls[0] ?
+    readonlyEls[0].getAttribute('value') === 'true' :
+    false;
+
   const attribute = {
     name,
     alias,
+    readonly,
     required
   };
 


### PR DESCRIPTION
Fixes 615: https://jira.camptocamp.com/browse/GSGMF-615

This patch introduces the concept of read-only attributes in the GMF feature editing tool and the XSDAttributes.

Instead of binding a list of read-only attributes in the themes, i.e. using a metadata parameter containing the list of read-only attributes, we went for a definition in the XSD that describes the attributes instead since it was much closer to what the current implementation uses.

Here's an example of how the definition of a readonly attribute is made:

```
<xsd:element minOccurs="0" name="datetime" nillable="true" type="xsd:dateTime">
  <xsd:annotation>
    <xsd:appinfo>
      <readonly value="true"/>
    </xsd:appinfo>
  </xsd:annotation>
</xsd:element>
```

The XSDAttribute format parses that property and sets a new `readonly` property in the attribute object.

In the ngeo attribute component, we render such attributes as a plain div, but using the boostrap classes to make it render like a form control and in readonly.

On the GMF side, more specifically on the client-side, we do nothing for these properties in particular.  The editing service still sends these with the same value as what was returned by the feature.  Since the server must deal with these read-only attributes, it's not required to do so on the client side.