### PR TITLE
Speedup build

### DIFF
--- a/buildtools/webpack.prod.js
+++ b/buildtools/webpack.prod.js
@@ -44,6 +44,9 @@ module.exports = {
         cache: true,
         parallel: true,
         sourceMap: true,
+        uglifyOptions: {
+          compress: false
+        }
       })
     ]
   },


### PR DESCRIPTION
Currently on my host:
Desktop size: 1954962
Mobile size: 1694458
Real time: 5.08 [min]
CPU time (user + sys): 10.93 [min]

With this pull request:
Desktop size: 1982910 (+6.7%)
Mobile size: 1715072 (+6.8%)
Real time: 3.7 [min] (-27%)
CPU time (user + sys): 5.9 [min] (-46%)

Just by no suppress unused code:
Desktop size: 1982910 (+1.4%)
Mobile size: 1715072 (+1.2%)
Real time: 4.5 [min] (-12%)
CPU time (user + sys): 8.8 [min] (-20%)

No mangle and no suppress unused code::
Desktop size: 3184860 (+63%)
Mobile size: 2805945 (+66%)
Real time: 3.9 [min] (-23%)
CPU time (user + sys): 8.3 [min] (-24%)

Details: [ngeo-build-time.zip](https://github.com/camptocamp/ngeo/files/2505623/ngeo-build-time.zip)