### PR TITLE
WIP 685 - Fix GMF examples

### DIFF
--- a/contribs/gmf/examples/authentication.js
+++ b/contribs/gmf/examples/authentication.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './authentication.css';
 import gmfAuthenticationModule from 'gmf/authentication/module.js';
 
@@ -16,7 +17,7 @@ exports.module = angular.module('gmfapp', [
 
 exports.module.value(
   'authenticationBaseUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/wsgi');
+  appURL.GMF_DEMO);
 
 exports.module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
 

--- a/contribs/gmf/examples/backgroundlayerselector.js
+++ b/contribs/gmf/examples/backgroundlayerselector.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './backgroundlayerselector.css';
 import gmfBackgroundlayerselectorModule from 'gmf/backgroundlayerselector/module.js';
 
@@ -24,10 +25,7 @@ exports.module = angular.module('gmfapp', [
 ]);
 
 
-exports.module.value(
-  'gmfTreeUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/themes?' +
-        'version=2&background=background');
+exports.module.value('gmfTreeUrl', appURL.GMF_THEMES);
 
 exports.module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
 

--- a/contribs/gmf/examples/common_dependencies.js
+++ b/contribs/gmf/examples/common_dependencies.js
@@ -2,6 +2,7 @@ import 'gmf/sass/vars.scss'
 import 'jquery';
 import 'angular';
 import 'angular-gettext';
+import 'bootstrap';
 
 import 'ol/ol.css';
 import 'bootstrap/dist/css/bootstrap.css';

--- a/contribs/gmf/examples/contextualdata.js
+++ b/contribs/gmf/examples/contextualdata.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './contextualdata.css';
 /** @suppress {extraRequire} */
 import gmfContextualdataModule from 'gmf/contextualdata/module.js';
@@ -25,9 +26,7 @@ exports.module = angular.module('gmfapp', [
 ]);
 
 
-exports.module.value(
-  'gmfRasterUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/raster');
+exports.module.value('gmfRasterUrl', appURL.RASTER);
 
 exports.module.value(
   'gmfContextualdatacontentTemplateUrl',

--- a/contribs/gmf/examples/displayquerygrid.html
+++ b/contribs/gmf/examples/displayquerygrid.html
@@ -6,6 +6,7 @@
     <meta name="viewport"
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <link href="./hidelayertree.inc.css" rel="stylesheet" />
   </head>
   <body ng-controller="MainController as ctrl">
 
@@ -22,6 +23,7 @@
       <div>
         <span>Theme:
         <select
+            class="form-control"
             ng-model="ctrl.treeSource"
             ng-options="theme.name for theme in ctrl.themes">
         </select>

--- a/contribs/gmf/examples/displayquerygrid.js
+++ b/contribs/gmf/examples/displayquerygrid.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './displayquerygrid.css';
 import gmfDatasourceManager from 'gmf/datasource/Manager.js';
 
@@ -53,10 +54,7 @@ exports.module.constant('ngeoQueryOptions', {
 });
 
 
-exports.module.constant(
-  'gmfTreeUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/themes?' +
-        'version=2&background=background');
+exports.module.constant('gmfTreeUrl', appURL.GMF_THEMES);
 
 exports.module.constant('defaultTheme', 'Demo');
 exports.module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');

--- a/contribs/gmf/examples/displayquerywindow.html
+++ b/contribs/gmf/examples/displayquerywindow.html
@@ -6,6 +6,7 @@
     <meta name="viewport"
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <link href="./hidelayertree.inc.css" rel="stylesheet" />
   </head>
   <body ng-controller="MainController as ctrl">
 
@@ -22,6 +23,7 @@
       <div>
         <span>Theme:
         <select
+            class="form-control"
             ng-model="ctrl.treeSource"
             ng-options="theme.name for theme in ctrl.themes">
         </select>
@@ -53,6 +55,7 @@
        ng-model="ctrl.queryActive" /> Query-Tool active
 
     <gmf-displayquerywindow
+      gmf-displayquerywindow-desktop="::ctrl.desktop"
       gmf-displayquerywindow-featuresstyle="ctrl.featureStyle">
     </gmf-displayquerywindow>
   </body>

--- a/contribs/gmf/examples/displayquerywindow.js
+++ b/contribs/gmf/examples/displayquerywindow.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './displayquerywindow.css';
 import gmfDatasourceManager from 'gmf/datasource/Manager.js';
 
@@ -50,10 +51,7 @@ exports.module.value('ngeoQueryOptions', {
 });
 
 
-exports.module.value(
-  'gmfTreeUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/themes?' +
-        'version=2&background=background');
+exports.module.value('gmfTreeUrl', appURL.GMF_THEMES);
 
 exports.module.constant('defaultTheme', 'Demo');
 exports.module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
@@ -106,6 +104,12 @@ exports.MainController = function(gmfThemes, gmfDataSourcesManager,
   ngeoFeatureOverlayMgr) {
 
   gmfThemes.loadThemes();
+
+  /**
+   * @type {boolean}
+   * @export
+   */
+  this.desktop = true;
 
   const fill = new olStyleFill({color: [255, 170, 0, 0.6]});
   const stroke = new olStyleStroke({color: [255, 170, 0, 1], width: 2});

--- a/contribs/gmf/examples/editfeature.js
+++ b/contribs/gmf/examples/editfeature.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './editfeature.css';
 import 'jquery-ui/ui/widgets/tooltip.js';
 import EPSG21781 from 'ngeo/proj/EPSG21781.js';
@@ -33,13 +34,8 @@ exports.module = angular.module('gmfapp', [
 ]);
 
 
-exports.module.value(
-  'authenticationBaseUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/wsgi');
-
-
-exports.module.value('gmfLayersUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/layers/');
+exports.module.value('authenticationBaseUrl', appURL.GMF_DEMO);
+exports.module.value('gmfLayersUrl', appURL.GMF_LAYERS);
 
 exports.module.constant('defaultTheme', 'Demo');
 exports.module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
@@ -77,7 +73,7 @@ exports.MainController = function($scope, gmfEditFeature, gmfUser) {
    * @private
    */
   this.wmsSource_ = new olSourceImageWMS({
-    url: 'https://geomapfish-demo-dc.camptocamp.com/2.4/mapserv_proxy',
+    url: appURL.MAPSERVER_PROXY,
     params: {'LAYERS': 'point'}
   });
 

--- a/contribs/gmf/examples/editfeatureselector.html
+++ b/contribs/gmf/examples/editfeatureselector.html
@@ -6,6 +6,7 @@
     <meta name="viewport"
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="mobile-web-app-capable" content="yes">
+    <link href="./hidelayertree.inc.css" rel="stylesheet" />
   </head>
   <body ng-controller="MainController as ctrl">
     <gmf-map gmf-map-map="ctrl.map"></gmf-map>

--- a/contribs/gmf/examples/editfeatureselector.js
+++ b/contribs/gmf/examples/editfeatureselector.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './editfeatureselector.css';
 import 'jquery-ui/ui/widgets/tooltip.js';
 import gmfAuthenticationModule from 'gmf/authentication/module.js';
@@ -44,21 +45,9 @@ exports.module = angular.module('gmfapp', [
 ]);
 
 
-exports.module.value('gmfTreeUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/themes?version=2&background=background');
-
-
-exports.module.value(
-  'authenticationBaseUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/wsgi');
-
-
-exports.module.value('gmfTreeUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/themes?version=2&background=background');
-
-
-exports.module.value('gmfLayersUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/layers/');
+exports.module.value('gmfTreeUrl', appURL.GMF_THEMES);
+exports.module.value('authenticationBaseUrl', appURL.GMF_DEMO);
+exports.module.value('gmfLayersUrl', appURL.GMF_LAYERS);
 
 exports.module.constant('defaultTheme', 'Edit');
 exports.module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');

--- a/contribs/gmf/examples/elevation.html
+++ b/contribs/gmf/examples/elevation.html
@@ -15,6 +15,7 @@
           gmf-elevation-elevation="elevationValue"
           gmf-elevation-loading="elevationLoading"
           gmf-elevation-layer="ctrl.selectedElevationLayer"
+          gmf-elevation-layersconfig="::ctrl.elevationLayers"
           gmf-elevation-map="::ctrl.map">
     </span>
 

--- a/contribs/gmf/examples/elevation.js
+++ b/contribs/gmf/examples/elevation.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './elevation.css';
 /** @suppress {extraRequire} */
 import gmfMapComponent from 'gmf/map/component.js';
@@ -23,9 +24,7 @@ exports.module = angular.module('gmfapp', [
 ]);
 
 
-exports.module.value(
-  'gmfRasterUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/raster');
+exports.module.value('gmfRasterUrl', appURL.RASTER);
 
 exports.module.constant('defaultTheme', 'Demo');
 exports.module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');

--- a/contribs/gmf/examples/featurestyle.js
+++ b/contribs/gmf/examples/featurestyle.js
@@ -18,7 +18,10 @@ import olView from 'ol/View.js';
 import olGeomCircle from 'ol/geom/Circle.js';
 import olGeomLineString from 'ol/geom/LineString.js';
 import olGeomPoint from 'ol/geom/Point.js';
-import olGeomPolygon from 'ol/geom/Polygon.js';
+import olGeomPolygon, {
+  fromCircle as olGeomPolygonFromCircle,
+  fromExtent as olGeomPolygonFromExtent
+} from 'ol/geom/Polygon.js';
 import olLayerTile from 'ol/layer/Tile.js';
 import olLayerVector from 'ol/layer/Vector.js';
 import olSourceOSM from 'ol/source/OSM.js';
@@ -131,7 +134,7 @@ exports.MainController = function($scope, ngeoFeatureHelper) {
   features.push(new olFeature(poly2Properties));
 
   const rectProperties = {
-    geometry: olGeomPolygon.fromExtent([-7874848, 6496535, -7730535, 6384020])
+    geometry: olGeomPolygonFromExtent([-7874848, 6496535, -7730535, 6384020])
   };
   rectProperties[ngeoFormatFeatureProperties.COLOR] = '#000000';
   rectProperties[ngeoFormatFeatureProperties.IS_RECTANGLE] = true;
@@ -141,7 +144,7 @@ exports.MainController = function($scope, ngeoFeatureHelper) {
   features.push(new olFeature(rectProperties));
 
   const circleProperties = {
-    geometry: olGeomPolygon.fromCircle(
+    geometry: olGeomPolygonFromCircle(
       new olGeomCircle([-7691093, 6166327], 35000), 64)
   };
   circleProperties[ngeoFormatFeatureProperties.COLOR] = '#000000';
@@ -188,7 +191,7 @@ exports.MainController = function($scope, ngeoFeatureHelper) {
    */
   this.selectedFeature = null;
 
-  this.map.on('singleclick', this.handleMapSingleClick_, this);
+  this.map.on('singleclick', this.handleMapSingleClick_.bind(this), this);
 };
 
 

--- a/contribs/gmf/examples/filterselector.js
+++ b/contribs/gmf/examples/filterselector.js
@@ -4,6 +4,7 @@
 const exports = {};
 // Todo - use the 'Filter' theme instead if the 'Edit' theme
 
+import appURL from './url.js';
 import './filterselector.css';
 import 'jquery-ui/ui/widgets/tooltip.js';
 import gmfAuthenticationModule from 'gmf/authentication/module.js';
@@ -48,21 +49,9 @@ exports.module = angular.module('gmfapp', [
 ]);
 
 
-exports.module.value('gmfTreeUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/themes?version=2&background=background');
-
-
-exports.module.value(
-  'authenticationBaseUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/wsgi');
-
-
-exports.module.value('gmfTreeUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/themes?version=2&background=background');
-
-
-exports.module.value('gmfLayersUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/layers/');
+exports.module.value('gmfTreeUrl', appURL.GMF_THEMES);
+exports.module.value('authenticationBaseUrl', appURL.GMF_DEMO);
+exports.module.value('gmfLayersUrl', appURL.GMF_LAYERS);
 
 exports.module.constant('defaultTheme', 'Filters');
 exports.module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
@@ -122,9 +111,9 @@ exports.MainController = class {
 
     gmfThemes.getThemesObject().then((themes) => {
       if (themes) {
-        // Set 'Filters' theme, i.e. the one with id 175
+        // Set 'Filters' theme, i.e. the one with id 176
         for (let i = 0, ii = themes.length; i < ii; i++) {
-          if (themes[i].id === 175) {
+          if (themes[i].id === 176) {
             this.gmfTreeManager.setFirstLevelGroups(themes[i].children);
             break;
           }

--- a/contribs/gmf/examples/importdatasource.js
+++ b/contribs/gmf/examples/importdatasource.js
@@ -4,6 +4,7 @@
 const exports = {};
 // Todo - use the 'Filter' theme instead if the 'Edit' theme
 
+import appURL from './url.js';
 import './importdatasource.css';
 import 'jquery-ui/ui/widgets/tooltip.js';
 /** @suppress {extraRequire} */
@@ -45,15 +46,9 @@ exports.module = angular.module('gmfapp', [
 ]);
 
 
-exports.module.value('gmfTreeUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/themes?version=2&background=background');
+exports.module.value('gmfTreeUrl', appURL.GMF_THEMES);
+exports.module.value('gmfLayersUrl', appURL.GMF_LAYERS);
 
-exports.module.value('gmfTreeUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/themes?version=2&background=background');
-
-
-exports.module.value('gmfLayersUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/layers/');
 
 exports.module.value('gmfExternalOGCServers', [{
   'name': 'Swiss Topo WMS',

--- a/contribs/gmf/examples/layertree.js
+++ b/contribs/gmf/examples/layertree.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './layertree.css';
 import gmfDisclaimerModule from 'gmf/disclaimer/module.js';
 
@@ -37,8 +38,7 @@ exports.module = angular.module('gmfapp', [
 ]);
 
 
-exports.module.value('gmfTreeUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/themes?version=2&background=background&interface=desktop');
+exports.module.value('gmfTreeUrl', appURL.GMF_THEMES);
 
 exports.module.constant('defaultTheme', 'Demo');
 exports.module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');

--- a/contribs/gmf/examples/layertreeadd.js
+++ b/contribs/gmf/examples/layertreeadd.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './layertreeadd.css';
 import gmfDisclaimerModule from 'gmf/disclaimer/module.js';
 
@@ -36,8 +37,7 @@ exports.module = angular.module('gmfapp', [
 ]);
 
 
-exports.module.value('gmfTreeUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/themes?version=2&background=background&interface=desktop');
+exports.module.value('gmfTreeUrl', appURL.GMF_THEMES);
 
 exports.module.constant('defaultTheme', 'Demo');
 exports.module.constant('gmfTreeManagerModeFlush', false);

--- a/contribs/gmf/examples/mobilemeasure.js
+++ b/contribs/gmf/examples/mobilemeasure.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './mobilemeasure.css';
 /** @suppress {extraRequire} */
 import gmfMapComponent from 'gmf/map/component.js';
@@ -32,9 +33,7 @@ exports.module = angular.module('gmfapp', [
 ]);
 
 
-exports.module.value(
-  'gmfRasterUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/raster');
+exports.module.value('gmfRasterUrl', appURL.RASTER);
 
 exports.module.constant('defaultTheme', 'Demo');
 exports.module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');

--- a/contribs/gmf/examples/objectediting.js
+++ b/contribs/gmf/examples/objectediting.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './objectediting.css';
 import gmfLayertreeComponent from 'gmf/layertree/component.js';
 
@@ -42,8 +43,8 @@ exports.module = angular.module('gmfapp', [
 ]);
 
 exports.module.constant('defaultTheme', 'ObjectEditing');
-exports.module.constant('gmfLayersUrl', 'https://geomapfish-demo-dc.camptocamp.com/2.4/layers/');
-exports.module.constant('gmfTreeUrl', 'https://geomapfish-demo-dc.camptocamp.com/2.4/themes?version=2&background=background');
+exports.module.constant('gmfLayersUrl', appURL.GMF_LAYERS);
+exports.module.constant('gmfTreeUrl', appURL.GMF_THEMES);
 exports.module.constant('gmfObjectEditingToolsOptions', {
   regularPolygonRadius: 150
 });

--- a/contribs/gmf/examples/objecteditinghub.js
+++ b/contribs/gmf/examples/objecteditinghub.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './objecteditinghub.css';
 import googAsserts from 'goog/asserts.js';
 
@@ -22,12 +23,8 @@ exports.module = angular.module('gmfapp', [
 ]);
 
 
-exports.module.value('gmfTreeUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/themes?version=2&background=background');
-
-
-exports.module.value('gmfLayersUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/layers/');
+exports.module.value('gmfTreeUrl', appURL.GMF_THEMES);
+exports.module.value('gmfLayersUrl', appURL.GMF_LAYERS);
 
 exports.module.constant('defaultTheme', 'Demo');
 exports.module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');

--- a/contribs/gmf/examples/print.html
+++ b/contribs/gmf/examples/print.html
@@ -6,6 +6,7 @@
     <meta name="viewport"
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <link href="./hidelayertree.inc.css" rel="stylesheet" />
   </head>
   <body ng-controller="MainController as ctrl">
 

--- a/contribs/gmf/examples/print.js
+++ b/contribs/gmf/examples/print.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './print.css';
 import gmfLayertreeComponent from 'gmf/layertree/component.js';
 
@@ -32,24 +33,10 @@ exports.module = angular.module('gmfapp', [
 ]);
 
 
-exports.module.value(
-  'gmfTreeUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/themes?' +
-        'version=2&background=background');
-
-
-exports.module.value('gmfPrintUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/printproxy');
-
-
-exports.module.value(
-  'authenticationBaseUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/wsgi'
-);
-
-
-exports.module.value('gmfLayersUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/layers/');
+exports.module.value('gmfTreeUrl', appURL.GMF_THEMES);
+exports.module.value('gmfPrintUrl', appURL.PRINT_PROXY);
+exports.module.value('authenticationBaseUrl', appURL.GMF_DEMO);
+exports.module.value('gmfLayersUrl', appURL.GMF_LAYERS);
 
 exports.module.constant('defaultTheme', 'Demo');
 exports.module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');

--- a/contribs/gmf/examples/profile.js
+++ b/contribs/gmf/examples/profile.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './profile.css';
 /** @suppress {extraRequire} */
 import gmfPermalinkPermalink from 'gmf/permalink/Permalink.js';
@@ -33,9 +34,7 @@ exports.module = angular.module('gmfapp', [
 ]);
 
 
-exports.module.value(
-  'gmfProfileJsonUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/profile.json');
+exports.module.value('gmfProfileJsonUrl', appURL.PROFILE);
 
 exports.module.constant('defaultTheme', 'Demo');
 exports.module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');

--- a/contribs/gmf/examples/search.js
+++ b/contribs/gmf/examples/search.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './search.css';
 /** @suppress {extraRequire} */
 import gmfMapComponent from 'gmf/map/component.js';
@@ -33,14 +34,9 @@ exports.module = angular.module('gmfapp', [
   ngeoMessageNotification.module.name,
 ]);
 
-exports.module.value('gmfTreeUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/themes?version=2&background=background');
-
-exports.module.value('fulltextsearchUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/fulltextsearch?limit=30&partitionlimit=5&interface=desktop');
-
-exports.module.value('gmfLayersUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/layers/');
+exports.module.value('gmfTreeUrl', appURL.GMF_THEMES);
+exports.module.value('fulltextsearchUrl', `${appURL.SEARCH}?limit=30&partitionlimit=5&interface=desktop`);
+exports.module.value('gmfLayersUrl', appURL.GMF_LAYERS);
 
 exports.module.constant('defaultTheme', 'Demo');
 exports.module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
@@ -73,7 +69,7 @@ exports.MainController = function(gmfThemes, ngeoFeatureOverlayMgr, ngeoNotifica
         rateLimitWait: 250
       }
     },
-    url: 'https://geomapfish-demo-dc.camptocamp.com/2.4/fulltextsearch'
+    url: appURL.SEARCH
   }];
 
   const fill = new olStyleFill({color: [255, 255, 255, 0.6]});

--- a/contribs/gmf/examples/share.js
+++ b/contribs/gmf/examples/share.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './share.css';
 /** @suppress {extraRequire} */
 import gmfPermalinkShareComponent from 'gmf/permalink/shareComponent.js';
@@ -19,7 +20,7 @@ exports.module = angular.module('gmfapp', [
 ]);
 
 exports.module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
-exports.module.constant('gmfShortenerCreateUrl', 'https://geomapfish-demo-dc.camptocamp.com/2.4/short/create');
+exports.module.constant('gmfShortenerCreateUrl', appURL.SHORT_CREATE);
 
 
 /**

--- a/contribs/gmf/examples/themeselector.js
+++ b/contribs/gmf/examples/themeselector.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './themeselector.css';
 /** @suppress {extraRequire} */
 import gmfThemeModule from 'gmf/theme/module.js';
@@ -16,8 +17,7 @@ exports.module = angular.module('gmfapp', [
   gmfThemeModule.name,
 ]);
 
-exports.module.value('gmfTreeUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/themes?version=2&background=background');
+exports.module.value('gmfTreeUrl', appURL.GMF_THEMES);
 
 exports.module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
 

--- a/contribs/gmf/examples/url.js
+++ b/contribs/gmf/examples/url.js
@@ -1,0 +1,66 @@
+/**
+ * @module app.url
+ */
+const exports = {};
+
+/**
+ * Base url for the GeoMapFish demo server.
+ * @type {string}
+ */
+exports.GMF_DEMO = 'https://geomapfish-demo-dc.camptocamp.com/2.4/';
+
+/**
+ * Base url for the GeoMapFish demo server.
+ * @type {string}
+ */
+exports.GMF_LAYERS = `${exports.GMF_DEMO}layers`;
+
+/**
+ * Base url for the GeoMapFish demo server.
+ * @type {string}
+ */
+exports.GMF_THEMES = `${exports.GMF_DEMO}themes?version=2&background=background`;
+
+/**
+ * WFS feature namespace for MapServer
+ * @type {string}
+ */
+exports.MAPSERVER_WFS_FEATURE_NS = 'http://mapserver.gis.umn.edu/mapserver';
+
+/**
+ * MapServer proxy
+ * @type {string}
+ */
+exports.MAPSERVER_PROXY = `${exports.GMF_DEMO}mapserv_proxy`;
+
+/**
+ * MapServer proxy
+ * @type {string}
+ */
+exports.PRINT_PROXY = `${exports.GMF_DEMO}printproxy`;
+
+/**
+ * Search service
+ * @type {string}
+ */
+exports.PROFILE = `${exports.GMF_DEMO}profile.json`;
+
+/**
+ * Search service
+ * @type {string}
+ */
+exports.RASTER = `${exports.GMF_DEMO}raster`;
+
+/**
+ * Search service
+ * @type {string}
+ */
+exports.SEARCH = `${exports.GMF_DEMO}fulltextsearch`;
+
+/**
+ * Search service
+ * @type {string}
+ */
+exports.SHORT_CREATE = `${exports.GMF_DEMO}short/create`;
+
+export default exports;

--- a/contribs/gmf/examples/wfspermalink.js
+++ b/contribs/gmf/examples/wfspermalink.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './wfspermalink.css';
 /** @suppress {extraRequire} */
 import gmfMapModule from 'gmf/map/module.js';
@@ -32,12 +33,12 @@ exports.module = angular.module('gmfapp', [
 
 exports.module.value('ngeoWfsPermalinkOptions',
   /** @type {ngeox.WfsPermalinkOptions} */ ({
-    url: 'https://geomapfish-demo-dc.camptocamp.com/2.4/mapserv_proxy',
+    url: appURL.MAPSERVER_PROXY,
     wfsTypes: [
       {featureType: 'fuel', label: 'display_name'},
       {featureType: 'osm_scale', label: 'display_name'}
     ],
-    defaultFeatureNS: 'http://mapserver.gis.umn.edu/mapserver',
+    defaultFeatureNS: appURL.MAPSERVER_WFS_FEATURE_NS,
     defaultFeaturePrefix: 'feature'
   }));
 

--- a/contribs/gmf/examples/xsdattributes.js
+++ b/contribs/gmf/examples/xsdattributes.js
@@ -3,6 +3,7 @@
  */
 const exports = {};
 
+import appURL from './url.js';
 import './xsdattributes.css';
 import gmfThemeThemes from 'gmf/theme/Themes.js';
 
@@ -22,11 +23,8 @@ exports.module = angular.module('gmfapp', [
 ]);
 
 
-exports.module.value('gmfTreeUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/themes?version=2&background=background');
-
-exports.module.value('gmfLayersUrl',
-  'https://geomapfish-demo-dc.camptocamp.com/2.4/layers/');
+exports.module.value('gmfTreeUrl', appURL.GMF_THEMES);
+exports.module.value('gmfLayersUrl', appURL.GMF_LAYERS);
 
 exports.module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
 

--- a/contribs/gmf/src/objectediting/toolsComponent.html
+++ b/contribs/gmf/src/objectediting/toolsComponent.html
@@ -13,7 +13,7 @@
     ng-model="oetCtrl.drawActive"
     title="{{'Add a point to the geometry' | translate}}">
     <span
-      class="fa fa-plus-square-o gmf-icon-oe-draw">
+      class="fa fa-plus-square gmf-icon-oe-draw">
     </span>
   </a>
   <a
@@ -30,7 +30,7 @@
     ng-model="oetCtrl.drawActive"
     title="{{'Add a linestring to the geometry' | translate}}">
     <span
-      class="fa fa-plus-square-o gmf-icon-oe-draw">
+      class="fa fa-plus-square gmf-icon-oe-draw">
     </span>
   </a>
   <a
@@ -47,7 +47,7 @@
     ng-model="oetCtrl.drawActive"
     title="{{'Add a polygon to the geometry' | translate}}">
     <span
-      class="fa fa-plus-square-o gmf-icon-oe-draw">
+      class="fa fa-plus-square gmf-icon-oe-draw">
     </span>
   </a>
 
@@ -64,7 +64,7 @@
     ng-model="oetCtrl.eraseActive"
     title="{{'Erase geometry' | translate}}">
     <span
-      class="fa fa-minus-square-o gmf-icon-oe-erase">
+      class="fa fa-minus-square gmf-icon-oe-erase">
     </span>
   </a>
 
@@ -117,7 +117,7 @@
     ng-model="oetCtrl.deleteFromActive"
     title="{{'Cut from external WMS feature' | translate}}">
     <span
-      class="fa fa-scissors gmf-icon-oe-deletefrom">
+      class="fa fa-cut gmf-icon-oe-deletefrom">
     </span>
   </a>
 

--- a/contribs/gmf/src/permalink/Permalink.js
+++ b/contribs/gmf/src/permalink/Permalink.js
@@ -3,6 +3,8 @@
  */
 import gmfBase from 'gmf/index.js';
 
+import gmfAuthenticationService from 'gmf/authentication/Service.js';
+
 /** @suppress {extraRequire} */
 import gmfThemeManager from 'gmf/theme/Manager.js';
 
@@ -1547,6 +1549,7 @@ exports.prototype.cleanParams = function(groups) {
 
 
 exports.module = angular.module('gmfPermalink', [
+  gmfAuthenticationService.module.name,
   gmfThemeManager.module.name,
   gmfThemeThemes.module.name,
   ngeoDrawFeatures.name,


### PR DESCRIPTION
Work in progress...

This patch fixes the GMF examples to make them work again.  It also includes a `url.js` file for all GMF examples to use.

The examples include bootstrap to make some of them work properly.

There's one fix in particular that's outside the scope of the examples, but all of them were failing otherwise due to a missing dependency: the fix to Permalink.js (was missing authentication service to have access to `gmfUser`).

## Still to do

 * ~~print is not working (error is thrown) - we might want to exclude this one from this PR and create a task out of it in JIRA.~~ We'll create an other issue for this.

There are still minor details to fix, but the theme service on demo stopped from responding and prevents me from going on.  I'll check again tomorrow.