### PR TITLE
685 - Fix remaining issues with GMF examples

### DIFF
--- a/contribs/gmf/examples/displayquerygrid.html
+++ b/contribs/gmf/examples/displayquerygrid.html
@@ -6,7 +6,7 @@
     <meta name="viewport"
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <link href="./hidelayertree.inc.css" rel="stylesheet" />
+    <link href="./gmf-hidden.inc.css" rel="stylesheet" />
   </head>
   <body ng-controller="MainController as ctrl">
 
@@ -29,10 +29,12 @@
         </select>
         </span>
       </div>
-      <gmf-layertree
-          gmf-layertree-map="::ctrl.map"
-          gmf-layertree-openlinksinnewwindow="::true">
-      </gmf-layertree>
+      <div class="gmf-hidden">
+        <gmf-layertree
+            gmf-layertree-map="::ctrl.map"
+            gmf-layertree-openlinksinnewwindow="::true">
+        </gmf-layertree>
+      </div>
     </div>
 
     <div class="clear-left"></div>

--- a/contribs/gmf/examples/displayquerywindow.html
+++ b/contribs/gmf/examples/displayquerywindow.html
@@ -6,7 +6,7 @@
     <meta name="viewport"
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <link href="./hidelayertree.inc.css" rel="stylesheet" />
+    <link href="./gmf-hidden.inc.css" rel="stylesheet" />
   </head>
   <body ng-controller="MainController as ctrl">
 
@@ -29,10 +29,12 @@
         </select>
         </span>
       </div>
-      <gmf-layertree
-          gmf-layertree-map="::ctrl.map"
-          gmf-layertree-openlinksinnewwindow="::true">
-      </gmf-layertree>
+      <div class="gmf-hidden">
+        <gmf-layertree
+            gmf-layertree-map="::ctrl.map"
+            gmf-layertree-openlinksinnewwindow="::true">
+        </gmf-layertree>
+      </div>
     </div>
 
     <div class="clear-left"></div>

--- a/contribs/gmf/examples/editfeatureselector.html
+++ b/contribs/gmf/examples/editfeatureselector.html
@@ -6,7 +6,7 @@
     <meta name="viewport"
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="mobile-web-app-capable" content="yes">
-    <link href="./hidelayertree.inc.css" rel="stylesheet" />
+    <link href="./gmf-hidden.inc.css" rel="stylesheet" />
   </head>
   <body ng-controller="MainController as ctrl">
     <gmf-map gmf-map-map="ctrl.map"></gmf-map>
@@ -22,10 +22,12 @@
 
     <p><strong>Note:</strong> After logging it, you need to refresh the page</p>
 
-    <gmf-layertree
-        class="panel panel-default panel-body"
-        gmf-layertree-map="::ctrl.map">
-    </gmf-layertree>
+    <div class="gmf-hidden">
+      <gmf-layertree
+          class="panel panel-default panel-body"
+          gmf-layertree-map="::ctrl.map">
+      </gmf-layertree>
+    </div>
 
     <gmf-authentication
         class="panel panel-default panel-body">

--- a/contribs/gmf/examples/gmf-hidden.inc.css
+++ b/contribs/gmf/examples/gmf-hidden.inc.css
@@ -1,0 +1,3 @@
+.gmf-hidden {
+  display: none;
+}

--- a/contribs/gmf/examples/hidelayertree.inc.css
+++ b/contribs/gmf/examples/hidelayertree.inc.css
@@ -1,3 +1,0 @@
-gmf-layertree {
-  display: none !important;
-}

--- a/contribs/gmf/examples/hidelayertree.inc.css
+++ b/contribs/gmf/examples/hidelayertree.inc.css
@@ -1,0 +1,3 @@
+gmf-layertree {
+  display: none !important;
+}

--- a/contribs/gmf/examples/print.html
+++ b/contribs/gmf/examples/print.html
@@ -6,7 +6,7 @@
     <meta name="viewport"
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <link href="./hidelayertree.inc.css" rel="stylesheet" />
+    <link href="./gmf-hidden.inc.css" rel="stylesheet" />
   </head>
   <body ng-controller="MainController as ctrl">
 
@@ -21,10 +21,12 @@
         </select>
         </span>
       </div>
-      <gmf-layertree
-          gmf-layertree-map="::ctrl.map"
-          gmf-layertree-openlinksinnewwindow="::true">
-      </gmf-layertree>
+      <div class="gmf-hidden">
+        <gmf-layertree
+            gmf-layertree-map="::ctrl.map"
+            gmf-layertree-openlinksinnewwindow="::true">
+        </gmf-layertree>
+      </div>
     </div>
 
     <div class="clear-left"></div>

--- a/contribs/gmf/examples/search.css
+++ b/contribs/gmf/examples/search.css
@@ -57,6 +57,9 @@ span.twitter-typeahead {
 .gmf-search > * {
   float: left;
 }
+gmf-search .gmf-search {
+  width: auto !important;
+}
 .gmf-search > .gmf-clear-button{
   margin-left: -15px;
   padding: 3px 0 2px;

--- a/contribs/gmf/examples/search.css
+++ b/contribs/gmf/examples/search.css
@@ -57,8 +57,15 @@ span.twitter-typeahead {
 .gmf-search > * {
   float: left;
 }
-gmf-search .gmf-search {
-  width: auto !important;
+@media (max-width: 576px) {
+  .container-fluid gmf-search .gmf-search {
+    width: auto;
+  }
+}
+@media (min-width: 576px) {
+  .container-fluid gmf-search .gmf-search {
+    width: auto;
+  }
 }
 .gmf-search > .gmf-clear-button{
   margin-left: -15px;

--- a/contribs/gmf/examples/share.html
+++ b/contribs/gmf/examples/share.html
@@ -31,7 +31,7 @@
       <gmf-share ng-if="ctrl.modalShareShown" gmf-share-email="false"/>
     </ngeo-modal>
     <ngeo-modal ng-model="ctrl.modalShareWithEmailShown">
-      <gmf-share ng-if="ctrl.modalShareShown" gmf-share-email="true"/>
+      <gmf-share ng-if="ctrl.modalShareWithEmailShown" gmf-share-email="true"/>
     </ngeo-modal>
   </body>
 </html>

--- a/contribs/gmf/examples/wfspermalink.css
+++ b/contribs/gmf/examples/wfspermalink.css
@@ -143,3 +143,11 @@ gmf-map > div {
     bottom: 0;
   }
 }
+
+.gmf-displayquerywindow button::before,
+.gmf-displayquerywindow button::after,
+.ngeo-displaywindow button::before,
+.ngeo-displaywindow button::after {
+  font-family: 'Font Awesome 5 Free';
+  font-weight: 900;
+}

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -60,7 +60,7 @@ exports.prototype.setMap = function(map) {
 
   const currentMap = this.getMap();
   if (currentMap) {
-    $(element).popover('destroy');
+    $(element).popover('dispose');
   }
 
   olOverlay.prototype.setMap.call(this, map);
@@ -77,8 +77,8 @@ exports.prototype.setMap = function(map) {
           'template': [
             '<div class="popover ngeo-popover" role="tooltip">',
             '  <div class="arrow"></div>',
-            '  <h3 class="popover-title"></h3>',
-            '  <div class="popover-content"></div>',
+            '  <h3 class="popover-header"></h3>',
+            '  <div class="popover-body"></div>',
             '</div>'
           ].join('')
         })


### PR DESCRIPTION
This patch includes fixes for the remaining issues with GMF examples (excluding the print one).

 * permalink (well, not entirely the permalink, but more a fix to the popover which wasn't working anymore since the upgrade to Bootstrap 4)
 * search (color chooser)
 * share (emailing popup)
 * wfspermalink (was missing FontAwesome css definition)
 * missing css file to exclude the layer tree from some of the examples