### PR TITLE
Permalink authentication required fixes

### DIFF
--- a/contribs/gmf/src/permalink/Permalink.js
+++ b/contribs/gmf/src/permalink/Permalink.js
@@ -1011,7 +1011,7 @@ exports.prototype.initLayers_ = function() {
             exports.ParamPrefix.TREE_GROUP_LAYERS + treeCtrl.node.name
           );
           if (groupLayers !== undefined) {
-            const groupLayersArray = groupLayers.split(',');
+            const groupLayersArray = groupLayers == '' ? [] : groupLayers.split(',');
             treeCtrl.traverseDepthFirst((treeCtrl) => {
               if (treeCtrl.node.children === undefined) {
                 const enable = olArray.includes(groupLayersArray, treeCtrl.node.name);

--- a/contribs/gmf/src/permalink/Permalink.js
+++ b/contribs/gmf/src/permalink/Permalink.js
@@ -978,6 +978,9 @@ exports.prototype.initLayers_ = function() {
     this.$timeout_(() => {
       if (!this.gmfTreeManager_ || !this.gmfTreeManager_.rootCtrl) {
         // we don't have any layertree
+        if (authenticationRequired && this.user_.role_id === null) {
+          this.rootScope_.$broadcast('authenticationrequired', {url: initialUri});
+        }
         return;
       }
       // Enable the layers and set the opacity


### PR DESCRIPTION
Fix GSGMF-688: Emit the authenticationrequired event even when the function return prematurely in case layertree is empty.

Fix GSGMF-695: Avoid emitting authenticationrequired event for groups whith no check layers (avoid empty string in groupLayersArray).
