### PR TITLE
Fix error message modal dialog in editFeatureComponent

### DIFF
--- a/contribs/gmf/src/editing/editFeatureComponent.html
+++ b/contribs/gmf/src/editing/editFeatureComponent.html
@@ -127,7 +127,7 @@
   </ngeo-modal>
   <ngeo-modal ng-model="efCtrl.showServerError">
     <div class="modal-header">{{'Server error.' | translate}}</div>
-    <div class="modal-body">{{$parent.efCtrl.serverErrorType}}<br>
-    {{$parent.efCtrl.serverErrorMessage || ('Unexpected server error.' | translate)}}</div>
+    <div class="modal-body">{{efCtrl.serverErrorType}}<br>
+    {{efCtrl.serverErrorMessage || ('Unexpected server error.' | translate)}}</div>
   </ngeo-modal>
 </div>


### PR DESCRIPTION
I don't know why `$parent` was there, it probably works some time.
But it does not works anymore and `efCtrl` is used directly everywhere in this file since 2 years.