### PR TITLE
636 - Take url out of ngeoWfsPermalinkOptions

### DIFF
--- a/contribs/gmf/examples/wfspermalink.js
+++ b/contribs/gmf/examples/wfspermalink.js
@@ -33,7 +33,6 @@ exports.module = angular.module('gmfapp', [
 
 exports.module.value('ngeoWfsPermalinkOptions',
   /** @type {ngeox.WfsPermalinkOptions} */ ({
-    url: appURL.MAPSERVER_PROXY,
     wfsTypes: [
       {featureType: 'fuel', label: 'display_name'},
       {featureType: 'osm_scale', label: 'display_name'}
@@ -42,6 +41,7 @@ exports.module.value('ngeoWfsPermalinkOptions',
     defaultFeaturePrefix: 'feature'
   }));
 
+exports.module.constant('ngeoPermalinkOgcserverUrl', appURL.MAPSERVER_PROXY);
 exports.module.constant('defaultTheme', 'Demo');
 exports.module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
 

--- a/options/ngeox.js
+++ b/options/ngeox.js
@@ -884,7 +884,6 @@ ngeox.WfsType.prototype.featurePrefix;
 /**
  * The options for the WFS query service (permalink).
  * @typedef {{
- *     url: (string),
  *     wfsTypes: (!Array.<ngeox.WfsType>),
  *     pointRecenterZoom: (number|undefined),
  *     defaultFeatureNS: (string),
@@ -893,13 +892,6 @@ ngeox.WfsType.prototype.featurePrefix;
  * }}
  */
 ngeox.WfsPermalinkOptions;
-
-
-/**
- * URL to the WFS server.
- * @type {string}
- */
-ngeox.WfsPermalinkOptions.prototype.url;
 
 
 /**

--- a/src/statemanager/WfsPermalink.js
+++ b/src/statemanager/WfsPermalink.js
@@ -42,6 +42,7 @@ import olFormatWFS from 'ol/format/WFS.js';
  * @constructor
  * @struct
  * @param {angular.$http} $http Angular $http service.
+ * @param {string} ngeoPermalinkOgcserverUrl Url to the WFS server
  * @param {ngeox.QueryResult} ngeoQueryResult The ngeo query result service.
  * @param {ngeox.WfsPermalinkOptions} ngeoWfsPermalinkOptions The options to
  *     configure the ngeo wfs permalink service with.
@@ -49,7 +50,9 @@ import olFormatWFS from 'ol/format/WFS.js';
  * @ngname ngeoWfsPermalink
  * @ngInject
  */
-const WfsPermalinkService = function($http, ngeoQueryResult, ngeoWfsPermalinkOptions) {
+const WfsPermalinkService = function(
+  $http, ngeoPermalinkOgcserverUrl, ngeoQueryResult, ngeoWfsPermalinkOptions
+) {
 
   const options = ngeoWfsPermalinkOptions;
 
@@ -57,7 +60,7 @@ const WfsPermalinkService = function($http, ngeoQueryResult, ngeoWfsPermalinkOpt
    * @type {string}
    * @private
    */
-  this.url_ = options.url;
+  this.url_ = ngeoPermalinkOgcserverUrl;
 
   /**
    * @type {number}

--- a/src/statemanager/WfsPermalink.js
+++ b/src/statemanager/WfsPermalink.js
@@ -308,6 +308,12 @@ WfsPermalinkService.module = angular.module('ngeoWfsPermalink', [
 
 
 /**
+ * Set this value to enable WFS permalink.
+ */
+WfsPermalinkService.module.value('ngeoPermalinkOgcserverUrl', '');
+
+
+/**
  * Value that is supposed to be set in applications to enable the WFS
  * permalink functionality.
  */

--- a/test/spec/services/wfspermalink.spec.js
+++ b/test/spec/services/wfspermalink.spec.js
@@ -14,8 +14,11 @@ describe('ngeo.statemanager.WfsPermalink', () => {
 
   beforeEach(() => {
     angular.mock.module('ngeo', ($provide) => {
+      $provide.value(
+        'ngeoPermalinkOgcserverUrl',
+        'https://geomapfish-demo-dc.camptocamp.com/2.4/mapserv_proxy'
+      );
       $provide.value('ngeoWfsPermalinkOptions', {
-        url: 'https://geomapfish-demo-dc.camptocamp.com/2.4/mapserv_proxy',
         wfsTypes: [{featureType: 'fuel'}, {featureType: 'highway'}],
         defaultFeatureNS: 'http://mapserver.gis.umn.edu/mapserver',
         defaultFeaturePrefix: 'ms'


### PR DESCRIPTION
Take the `url` option out of ngeoWfsPermalinkOptions and define as ngeoPermalinkOgcserverUrl instead.