### PR TITLE
703 - Set print layer zIndex to -200

### DIFF
--- a/contribs/gmf/src/print/component.js
+++ b/contribs/gmf/src/print/component.js
@@ -924,6 +924,7 @@ exports.Controller_ = class {
               server.imageType,
               server.type
             );
+            layer.setZIndex(-200);
           } else {
             console.error('Missing ogcServer:', server_name);
           }


### PR DESCRIPTION
This patch sets the zIndex of the layers created by the GMF print component to -200, just like the the background layers.

The issue that was happening with Cartoriviera is that the "Plan Cadstral" BG layer has a child with "printLayers" defined.  From what I understand this child is used when printing instead of the original first child.  OpenLayers Layer object are created in the GMF print componnent, but were not given a zIndex, i.e. it stays as 0.  When issuing a print requests, layers are ordered by zIndex, then reversed.  That print layer was therefore put on top.

There's currently no way to test this using the demo server.  I also don't have a lot of knowledge of the print tool, so I don't know if this will have an impact somewhere else.