### PR TITLE
IE11 distored layer images - backport #4230

### DIFF
--- a/contribs/gmf/src/layertree/component.html
+++ b/contribs/gmf/src/layertree/component.html
@@ -33,10 +33,12 @@
     ng-if="::!layertreeCtrl.node.children" ng-class="::{'gmf-layertree-no-layer-icon' : !gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl)}"
     class="gmf-layertree-layer-icon">
 
-    <img
-      ng-if="::(legendIconUrl=gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl))"
-      ng-src="{{::legendIconUrl}}">
-    </img>
+    <div><!--This div is required for flex issues with IE11-->
+      <img
+        ng-if="::(legendIconUrl=gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl))"
+        ng-src="{{::legendIconUrl}}">
+      </img>
+    </div>
   </a>
 
   <a


### PR DESCRIPTION
#4230 was merged into master, but we need that in 2.3.

I tested that locally since I am now able to use a local NGEO distribution out of Docker (and this is a little revolution, thanks @sbrunner !!!)

See comments in https://jira.camptocamp.com/browse/GSGMF-625#add-comment for more info !

Please review