### PR TITLE
[API] Fix view center after selectObject

### DIFF
--- a/api/src/Map.js
+++ b/api/src/Map.js
@@ -74,8 +74,7 @@ class Map {
      * @type {Overlay}
      */
     this.overlay_ = new Overlay({
-      element: this.createOverlayDomTree_(),
-      autoPan: true
+      element: this.createOverlayDomTree_()
     });
     this.map_.addOverlay(this.overlay_);
 
@@ -277,9 +276,9 @@ class Map {
       const content = this.overlay_.getElement().querySelector('.ol-popup-content');
       content.innerHTML += `<div><b>${properties.title}</b></div>`;
       content.innerHTML += `<p>${properties.description}</p>`;
+      this.overlay_.setPosition(coordinates);
 
       this.view_.setCenter(coordinates);
-      this.overlay_.setPosition(coordinates);
     }
   }
 


### PR DESCRIPTION
Fix https://jira.camptocamp.com/browse/GSGMF-726

As map is not rendered yet when overlay.setPosition is called, overlay is not really positionned.
See: https://github.com/openlayers/openlayers/blob/c6be2c7ff5f6d7b64ec0011e6fc43b6c8e6a1524/src/ol/Overlay.js#L502
So autoPan has bad side effect.

As far as I understand, as we manually set the view center, we do not want to use autoPan on popup when the position is set on overlay, but to see the marker in center of the view.
