### PR TITLE
Add missing import for jquery-ui touch support

### DIFF
--- a/src/misc/sortableComponent.js
+++ b/src/misc/sortableComponent.js
@@ -2,6 +2,7 @@
  * @module ngeo.misc.sortableComponent
  */
 import 'jquery-ui/ui/widgets/sortable.js';
+import 'jquery-ui-touch-punch';
 import googAsserts from 'goog/asserts.js';
 
 /**


### PR DESCRIPTION
With this fix the sort features is working again.

I feel it is hard (and has been hard on <=2.2) to use on touch devices because the draggable area  is very small. It may be a good idea to make it larger.