### PR TITLE
716 - Remove full OL import

### DIFF
--- a/contribs/gmf/apps/desktop/Controller.js
+++ b/contribs/gmf/apps/desktop/Controller.js
@@ -13,7 +13,7 @@ import gmfControllersAbstractDesktopController from 'gmf/controllers/AbstractDes
 import appBase from '../appmodule.js';
 import EPSG2056 from '@geoblocks/proj/src/EPSG_2056.js';
 import EPSG21781 from '@geoblocks/proj/src/EPSG_21781.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import Raven from 'raven-js/src/raven.js';
 import RavenPluginsAngular from 'raven-js/plugins/angular.js';
 
@@ -115,7 +115,7 @@ const exports = function($scope, $injector) {
   }
 };
 
-olBase.inherits(exports, gmfControllersAbstractDesktopController);
+olUtilInherits(exports, gmfControllersAbstractDesktopController);
 
 exports.module = angular.module('Appdesktop', [
   appBase.module.name,

--- a/contribs/gmf/apps/desktop_alt/Controller.js
+++ b/contribs/gmf/apps/desktop_alt/Controller.js
@@ -17,7 +17,7 @@ import ngeoRoutingModule from 'ngeo/routing/module.js';
 import EPSG2056 from '@geoblocks/proj/src/EPSG_2056.js';
 import EPSG21781 from '@geoblocks/proj/src/EPSG_21781.js';
 import ngeoStatemanagerWfsPermalink from 'ngeo/statemanager/WfsPermalink.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import Raven from 'raven-js/src/raven.js';
 import RavenPluginsAngular from 'raven-js/plugins/angular.js';
 
@@ -146,7 +146,7 @@ const exports = function($scope, $injector, ngeoFile, gettext, $q) {
   }
 };
 
-olBase.inherits(exports, gmfControllersAbstractDesktopController);
+olUtilInherits(exports, gmfControllersAbstractDesktopController);
 
 
 /**

--- a/contribs/gmf/apps/iframe_api/Controller.js
+++ b/contribs/gmf/apps/iframe_api/Controller.js
@@ -13,7 +13,7 @@ import gmfControllersAbstractAPIController from 'gmf/controllers/AbstractAPICont
 import appBase from '../appmodule.js';
 import EPSG2056 from '@geoblocks/proj/src/EPSG_2056.js';
 import EPSG21781 from '@geoblocks/proj/src/EPSG_21781.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import Raven from 'raven-js/src/raven.js';
 import RavenPluginsAngular from 'raven-js/plugins/angular.js';
 
@@ -54,7 +54,7 @@ const exports = function($scope, $injector) {
   }
 };
 
-olBase.inherits(exports, gmfControllersAbstractAPIController);
+olUtilInherits(exports, gmfControllersAbstractAPIController);
 
 exports.module = angular.module('Appiframe_api', [
   appBase.module.name,

--- a/contribs/gmf/apps/mobile/Controller.js
+++ b/contribs/gmf/apps/mobile/Controller.js
@@ -13,7 +13,7 @@ import 'gmf/controllers/mobile.scss';
 import appBase from '../appmodule.js';
 import EPSG2056 from '@geoblocks/proj/src/EPSG_2056.js';
 import EPSG21781 from '@geoblocks/proj/src/EPSG_21781.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import Raven from 'raven-js/src/raven.js';
 import RavenPluginsAngular from 'raven-js/plugins/angular.js';
 
@@ -67,7 +67,7 @@ const exports = function($scope, $injector) {
   }
 };
 
-olBase.inherits(exports, gmfControllersAbstractMobileController);
+olUtilInherits(exports, gmfControllersAbstractMobileController);
 
 exports.module = angular.module('Appmobile', [
   appBase.module.name,

--- a/contribs/gmf/apps/mobile_alt/Controller.js
+++ b/contribs/gmf/apps/mobile_alt/Controller.js
@@ -13,7 +13,7 @@ import './sass/mobile_alt.scss';
 import appBase from '../appmodule.js';
 import EPSG2056 from '@geoblocks/proj/src/EPSG_2056.js';
 import EPSG21781 from '@geoblocks/proj/src/EPSG_21781.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import olStyleFill from 'ol/style/Fill.js';
 import olStyleRegularShape from 'ol/style/RegularShape.js';
 import olStyleStroke from 'ol/style/Stroke.js';
@@ -104,7 +104,7 @@ const exports = function($scope, $injector) {
   }
 };
 
-olBase.inherits(exports, gmfControllersAbstractMobileController);
+olUtilInherits(exports, gmfControllersAbstractMobileController);
 
 
 exports.module = angular.module('Appmobile_alt', [

--- a/contribs/gmf/apps/oeedit/Controller.js
+++ b/contribs/gmf/apps/oeedit/Controller.js
@@ -15,7 +15,7 @@ import gmfObjecteditingModule from 'gmf/objectediting/module.js';
 import ngeoMiscToolActivate from 'ngeo/misc/ToolActivate.js';
 import EPSG2056 from '@geoblocks/proj/src/EPSG_2056.js';
 import EPSG21781 from '@geoblocks/proj/src/EPSG_21781.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import olCollection from 'ol/Collection.js';
 import olLayerVector from 'ol/layer/Vector.js';
 import olSourceVector from 'ol/source/Vector.js';
@@ -218,7 +218,7 @@ const exports = function($scope, $injector, $timeout) {
   }
 };
 
-olBase.inherits(exports, gmfControllersAbstractDesktopController);
+olUtilInherits(exports, gmfControllersAbstractDesktopController);
 
 exports.module = angular.module('Appoeedit', [
   appBase.module.name,

--- a/contribs/gmf/apps/oeview/Controller.js
+++ b/contribs/gmf/apps/oeview/Controller.js
@@ -13,7 +13,7 @@ import './sass/oeview.scss';
 import appBase from '../appmodule.js';
 import EPSG2056 from '@geoblocks/proj/src/EPSG_2056.js';
 import EPSG21781 from '@geoblocks/proj/src/EPSG_21781.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import Raven from 'raven-js/src/raven.js';
 import RavenPluginsAngular from 'raven-js/plugins/angular.js';
 
@@ -109,7 +109,7 @@ const exports = function($scope, $injector) {
   }
 };
 
-olBase.inherits(exports, gmfControllersAbstractDesktopController);
+olUtilInherits(exports, gmfControllersAbstractDesktopController);
 
 exports.module = angular.module('Appoeview', [
   appBase.module.name,

--- a/contribs/gmf/src/controllers/AbstractAPIController.js
+++ b/contribs/gmf/src/controllers/AbstractAPIController.js
@@ -4,7 +4,7 @@
 import gmfControllersAbstractAppController from 'gmf/controllers/AbstractAppController.js';
 import ngeoQueryBboxQueryComponent from 'ngeo/query/bboxQueryComponent.js';
 import ngeoMapResizemap from 'ngeo/map/resizemap.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import * as olProj from 'ol/proj.js';
 import * as olObj from 'ol/obj.js';
 import olMap from 'ol/Map.js';
@@ -70,7 +70,7 @@ const exports = function(config, $scope, $injector) {
   gmfControllersAbstractAppController.call(this, config, $scope, $injector);
 };
 
-olBase.inherits(exports, gmfControllersAbstractAppController);
+olUtilInherits(exports, gmfControllersAbstractAppController);
 
 
 exports.module = angular.module('GmfAbstractAPIControllerModule', [

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -11,7 +11,7 @@ import gmfRasterComponent from 'gmf/raster/component.js';
 import ngeoDrawFeatures from 'ngeo/draw/features.js';
 import ngeoMiscToolActivate from 'ngeo/misc/ToolActivate.js';
 import gmfImportModule from 'gmf/import/module.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import olCollection from 'ol/Collection.js';
 import * as olEvents from 'ol/events.js';
 import olLayerVector from 'ol/layer/Vector.js';
@@ -233,7 +233,7 @@ const exports = function(config, $scope, $injector) {
   this.setDataPanelMaxResizableWidth_();
 };
 
-olBase.inherits(exports, gmfControllersAbstractAPIController);
+olUtilInherits(exports, gmfControllersAbstractAPIController);
 
 /**
  * Set the data panel (on the left) maximum resizable width depending

--- a/contribs/gmf/src/controllers/AbstractMobileController.js
+++ b/contribs/gmf/src/controllers/AbstractMobileController.js
@@ -6,7 +6,7 @@ import gmfMobileMeasureModule from 'gmf/mobile/measure/module.js';
 import gmfMobileNavigationModule from 'gmf/mobile/navigation/module.js';
 import gmfQueryWindowComponent from 'gmf/query/windowComponent.js';
 import ngeoGeolocationMobile from 'ngeo/geolocation/mobile.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import * as olObj from 'ol/obj.js';
 import * as olProj from 'ol/proj.js';
 import olMap from 'ol/Map.js';
@@ -142,7 +142,7 @@ const exports = function(config, $scope, $injector) {
   this.redirectUrl = $injector.get('redirectUrl');
 };
 
-olBase.inherits(exports, gmfControllersAbstractAppController);
+olUtilInherits(exports, gmfControllersAbstractAppController);
 
 
 /**

--- a/contribs/gmf/src/datasource/ExternalDataSourcesManager.js
+++ b/contribs/gmf/src/datasource/ExternalDataSourcesManager.js
@@ -14,7 +14,7 @@ import ngeoDatasourceFileGroup from 'ngeo/datasource/FileGroup.js';
 import ngeoDatasourceOGC from 'ngeo/datasource/OGC.js';
 import ngeoDatasourceOGCGroup from 'ngeo/datasource/OGCGroup.js';
 import ngeoDatasourceWMSGroup from 'ngeo/datasource/WMSGroup.js';
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 import {isEmpty} from 'ol/extent.js';
 import * as olEvents from 'ol/events.js';
 import olCollection from 'ol/Collection.js';
@@ -678,7 +678,7 @@ const exports = class {
  * @export
  */
 exports.getId = function(layer) {
-  return olBase.getUid(layer) + 1000000;
+  return olUtilGetUid(layer) + 1000000;
 };
 
 

--- a/contribs/gmf/src/datasource/Manager.js
+++ b/contribs/gmf/src/datasource/Manager.js
@@ -19,7 +19,7 @@ import ngeoFilterRuleHelper from 'ngeo/filter/RuleHelper.js';
 import ngeoMapBackgroundLayerMgr from 'ngeo/map/BackgroundLayerMgr.js';
 import ngeoMapLayerHelper from 'ngeo/map/LayerHelper.js';
 import ngeoMiscWMSTime from 'ngeo/misc/WMSTime.js';
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 import * as olEvents from 'ol/events.js';
 import olLayerTile from 'ol/layer/Tile.js';
 import * as olObj from 'ol/obj.js';
@@ -240,7 +240,7 @@ const exports = class {
             if (layer == undefined) {
               return;
             }
-            const id = olBase.getUid(layer);
+            const id = olUtilGetUid(layer);
             if (layerIds.indexOf(id) == -1) {
               layers.push(layer);
               layerIds.push(id);
@@ -416,7 +416,7 @@ const exports = class {
     const gmfLayer = /** @type gmfThemes.GmfLayer */ (node);
 
     // (2) Skip layer node if a data source with the same id exists
-    const id = olBase.getUid(gmfLayer);
+    const id = olUtilGetUid(gmfLayer);
     if (this.dataSourcesCache_[id]) {
       return;
     }
@@ -583,7 +583,7 @@ const exports = class {
    */
   addTreeCtrlToCache_(treeCtrl) {
 
-    const id = olBase.getUid(treeCtrl.node);
+    const id = olUtilGetUid(treeCtrl.node);
     const dataSource = this.dataSourcesCache_[id];
     googAsserts.assert(dataSource, 'DataSource should be set');
     treeCtrl.setDataSource(dataSource);
@@ -666,7 +666,7 @@ const exports = class {
     if (item.timeUpperValueWatcherUnregister) {
       item.timeUpperValueWatcherUnregister();
     }
-    delete this.treeCtrlCache_[olBase.getUid(item.treeCtrl.node)];
+    delete this.treeCtrlCache_[olUtilGetUid(item.treeCtrl.node)];
   }
 
   /**
@@ -718,7 +718,7 @@ const exports = class {
    * @private
    */
   getTreeCtrlCacheItem_(treeCtrl) {
-    return this.treeCtrlCache_[olBase.getUid(treeCtrl.node)] || null;
+    return this.treeCtrlCache_[olUtilGetUid(treeCtrl.node)] || null;
   }
 
   /**
@@ -729,7 +729,7 @@ const exports = class {
    */
   getDataSourceLayer_(dataSource) {
     dataSource = /** @type {!gmf.DataSource} */ (dataSource);
-    const id = olBase.getUid(dataSource.gmfLayer);
+    const id = olUtilGetUid(dataSource.gmfLayer);
     const item = this.treeCtrlCache_[id];
     if (item == undefined) {
       return;
@@ -773,10 +773,10 @@ const exports = class {
         if (dsLayer == undefined) {
           continue;
         }
-        if (olBase.getUid(dsLayer) == olBase.getUid(layer) &&
+        if (olUtilGetUid(dsLayer) == olUtilGetUid(layer) &&
             dataSourceName === dataSource.name) {
 
-          const id = olBase.getUid(dataSource.gmfLayer);
+          const id = olUtilGetUid(dataSource.gmfLayer);
           const item = this.treeCtrlCache_[id];
           googAsserts.assert(item);
           const treeCtrl = item.treeCtrl;
@@ -845,7 +845,7 @@ const exports = class {
    */
   handleDataSourceTimeValueChange_(dataSource) {
 
-    const id = olBase.getUid(dataSource.gmfLayer);
+    const id = olUtilGetUid(dataSource.gmfLayer);
     const item = this.treeCtrlCache_[id];
     googAsserts.assert(item);
     const wmsLayer = googAsserts.assert(item.wmsLayer);

--- a/contribs/gmf/src/disclaimer/component.js
+++ b/contribs/gmf/src/disclaimer/component.js
@@ -1,7 +1,7 @@
 /**
  * @module gmf.disclaimer.component
  */
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 import * as olEvents from 'ol/events.js';
 import olLayerBase from 'ol/layer/Base.js';
 import olLayerGroup from 'ol/layer/Group.js';
@@ -178,7 +178,7 @@ exports.Controller_.prototype.handleLayersRemove_ = function(evt) {
  */
 exports.Controller_.prototype.registerLayer_ = function(layer) {
 
-  const layerUid = olBase.getUid(layer);
+  const layerUid = olUtilGetUid(layer);
 
   if (layer instanceof olLayerGroup) {
 
@@ -226,7 +226,7 @@ exports.Controller_.prototype.registerLayer_ = function(layer) {
  */
 exports.Controller_.prototype.unregisterLayer_ = function(layer) {
 
-  const layerUid = olBase.getUid(layer);
+  const layerUid = olUtilGetUid(layer);
 
   if (layer instanceof olLayerGroup) {
 

--- a/contribs/gmf/src/drawing/drawFeatureComponent.js
+++ b/contribs/gmf/src/drawing/drawFeatureComponent.js
@@ -26,7 +26,7 @@ import ngeoMiscDecorate from 'ngeo/misc/decorate.js';
 import ngeoMiscFeatureHelper from 'ngeo/misc/FeatureHelper.js';
 import ngeoMiscToolActivate from 'ngeo/misc/ToolActivate.js';
 import ngeoMiscToolActivateMgr from 'ngeo/misc/ToolActivateMgr.js';
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 import * as olArray from 'ol/array.js';
 import * as olEvents from 'ol/events.js';
 import olCollection from 'ol/Collection.js';
@@ -406,8 +406,8 @@ exports.Controller_.prototype.unregisterInteractions_ = function() {
 exports.Controller_.prototype.handleActiveChange_ = function(active) {
 
   const keys = this.listenerKeys_;
-  const drawUid = ['draw-', olBase.getUid(this)].join('-');
-  const otherUid = ['other-', olBase.getUid(this)].join('-');
+  const drawUid = ['draw-', olUtilGetUid(this)].join('-');
+  const otherUid = ['other-', olUtilGetUid(this)].join('-');
   const toolMgr = this.ngeoToolActivateMgr_;
 
   if (active) {

--- a/contribs/gmf/src/drawing/featureStyleComponent.js
+++ b/contribs/gmf/src/drawing/featureStyleComponent.js
@@ -2,7 +2,7 @@
  * @module gmf.drawing.featureStyleComponent
  */
 import googAsserts from 'goog/asserts.js';
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 import * as olEvents from 'ol/events.js';
 import ngeoFormatFeatureProperties from 'ngeo/format/FeatureProperties.js';
 
@@ -71,7 +71,7 @@ exports.Controller_ = function($scope, ngeoFeatureHelper) {
    * @type {number}
    * @export
    */
-  this.uid = olBase.getUid(this);
+  this.uid = olUtilGetUid(this);
 
   /**
    * @type {?ol.Feature}

--- a/contribs/gmf/src/editing/Snapping.js
+++ b/contribs/gmf/src/editing/Snapping.js
@@ -5,7 +5,7 @@ import gmfLayertreeTreeManager from 'gmf/layertree/TreeManager.js';
 import gmfThemeThemes from 'gmf/theme/Themes.js';
 import googAsserts from 'goog/asserts.js';
 import ngeoLayertreeController from 'ngeo/layertree/Controller.js';
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 import * as olEvents from 'ol/events.js';
 import olCollection from 'ol/Collection.js';
 import olFormatWFS from 'ol/format/WFS.js';
@@ -219,7 +219,7 @@ exports.prototype.registerTreeCtrl_ = function(treeCtrl) {
   if (snappingConfig) {
     const wfsConfig = this.getWFSConfig_(treeCtrl);
     if (wfsConfig) {
-      const uid = olBase.getUid(treeCtrl);
+      const uid = olUtilGetUid(treeCtrl);
 
       const stateWatcherUnregister = this.rootScope_.$watch(
         () => treeCtrl.getState(),
@@ -366,7 +366,7 @@ exports.prototype.getWFSConfig_ = function(treeCtrl) {
  */
 exports.prototype.handleTreeCtrlStateChange_ = function(treeCtrl, newVal) {
 
-  const uid = olBase.getUid(treeCtrl);
+  const uid = olUtilGetUid(treeCtrl);
   const item = this.cache_[uid];
 
   // Note: a snappable treeCtrl can only be a leaf, therefore the only possible

--- a/contribs/gmf/src/editing/editFeatureComponent.js
+++ b/contribs/gmf/src/editing/editFeatureComponent.js
@@ -42,7 +42,7 @@ import ngeoMiscToolActivate from 'ngeo/misc/ToolActivate.js';
 /** @suppress {extraRequire} */
 import ngeoMiscToolActivateMgr from 'ngeo/misc/ToolActivateMgr.js';
 
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 import * as olArray from 'ol/array.js';
 import olCollection from 'ol/Collection.js';
 import * as olEvents from 'ol/events.js';
@@ -567,7 +567,7 @@ exports.Controller_.prototype.$onInit = function() {
 
   this.scope_.$on('$destroy', this.handleDestroy_.bind(this));
 
-  const uid = olBase.getUid(this);
+  const uid = olUtilGetUid(this);
   this.ngeoEventHelper_.addListenerKey(
     uid,
     olEvents.listen(
@@ -896,8 +896,8 @@ exports.Controller_.prototype.handleFeatureAdd_ = function(evt) {
 exports.Controller_.prototype.toggle_ = function(active) {
 
   const keys = this.listenerKeys_;
-  const createUid = ['create-', olBase.getUid(this)].join('-');
-  const otherUid = ['other-', olBase.getUid(this)].join('-');
+  const createUid = ['create-', olUtilGetUid(this)].join('-');
+  const otherUid = ['other-', olUtilGetUid(this)].join('-');
   const toolMgr = this.ngeoToolActivateMgr_;
 
   if (active) {
@@ -1294,7 +1294,7 @@ exports.Controller_.prototype.handleDestroy_ = function() {
   this.features.clear();
   this.handleFeatureChange_(null, this.feature);
   this.feature = null;
-  const uid = olBase.getUid(this);
+  const uid = olUtilGetUid(this);
   this.ngeoEventHelper_.clearListenerKey(uid);
   this.toggle_(false);
   this.handleMapSelectActiveChange_(false);

--- a/contribs/gmf/src/import/wmsCapabilityLayertreeComponent.js
+++ b/contribs/gmf/src/import/wmsCapabilityLayertreeComponent.js
@@ -8,7 +8,7 @@ import gmfDatasourceExternalDataSourcesManager from 'gmf/datasource/ExternalData
 /** @suppress {extraRequire} */
 import ngeoMessagePopup from 'ngeo/message/Popup.js';
 
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 
 import 'bootstrap/js/src/collapse.js';
 
@@ -116,7 +116,7 @@ exports.Controller_ = class {
    * @export
    */
   getUid(layer) {
-    return olBase.getUid(layer);
+    return olUtilGetUid(layer);
   }
 };
 

--- a/contribs/gmf/src/import/wmtsCapabilityLayertreeComponent.js
+++ b/contribs/gmf/src/import/wmtsCapabilityLayertreeComponent.js
@@ -8,7 +8,7 @@ import gmfDatasourceExternalDataSourcesManager from 'gmf/datasource/ExternalData
 /** @suppress {extraRequire} */
 import ngeoMessagePopup from 'ngeo/message/Popup.js';
 
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 
 const exports = angular.module('gmfWmtscapabilitylayertree', [
   gmfDatasourceExternalDataSourcesManager.module.name,
@@ -114,7 +114,7 @@ exports.Controller_ = class {
    * @export
    */
   getUid(layer) {
-    return olBase.getUid(layer);
+    return olUtilGetUid(layer);
   }
 };
 

--- a/contribs/gmf/src/layertree/SyncLayertreeMap.js
+++ b/contribs/gmf/src/layertree/SyncLayertreeMap.js
@@ -5,7 +5,7 @@ import gmfThemeThemes from 'gmf/theme/Themes.js';
 import googAsserts from 'goog/asserts.js';
 import ngeoLayertreeController from 'ngeo/layertree/Controller.js';
 import ngeoMiscWMSTime from 'ngeo/misc/WMSTime.js';
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 import olLayerImage from 'ol/layer/Image.js';
 import olLayerTile from 'ol/layer/Tile.js';
 
@@ -347,7 +347,7 @@ exports.prototype.createWMTSLayer_ = function(gmfLayerWMTS) {
  * @private
  */
 exports.prototype.updateLayerReferences_ = function(leafNode, layer) {
-  const id = olBase.getUid(leafNode);
+  const id = olUtilGetUid(leafNode);
   const querySourceIds = layer.get('querySourceIds') || [];
   querySourceIds.push(id);
   layer.set('querySourceIds', querySourceIds);

--- a/contribs/gmf/src/layertree/datasourceGroupTreeComponent.js
+++ b/contribs/gmf/src/layertree/datasourceGroupTreeComponent.js
@@ -2,7 +2,7 @@
  * @module gmf.layertree.datasourceGroupTreeComponent
  */
 import ngeoDatasourceDataSources from 'ngeo/datasource/DataSources.js';
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 
 /**
  * @type {!angular.IModule}
@@ -85,7 +85,7 @@ exports.Controller_ = class {
    * @export
    */
   getGroupUid() {
-    return `datasourcegrouptree-${olBase.getUid(this.group)}`;
+    return `datasourcegrouptree-${olUtilGetUid(this.group)}`;
   }
 
   /**

--- a/contribs/gmf/src/objectediting/component.js
+++ b/contribs/gmf/src/objectediting/component.js
@@ -22,7 +22,7 @@ import ngeoMiscToolActivate from 'ngeo/misc/ToolActivate.js';
 import ngeoMiscToolActivateMgr from 'ngeo/misc/ToolActivateMgr.js';
 
 import ngeoUtils from 'ngeo/utils.js';
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 import olCollection from 'ol/Collection.js';
 import * as olEvents from 'ol/events.js';
 import olFormatGeoJSON from 'ol/format/GeoJSON.js';
@@ -668,7 +668,7 @@ exports.Controller.prototype.unregisterInteractions_ = function() {
 exports.Controller.prototype.toggle_ = function(active) {
 
   const keys = this.listenerKeys_;
-  const uid = `${exports.Controller.NAMESPACE_}-${olBase.getUid(this)}`;
+  const uid = `${exports.Controller.NAMESPACE_}-${olUtilGetUid(this)}`;
   const toolMgr = this.ngeoToolActivateMgr_;
 
   if (active) {

--- a/contribs/gmf/src/objectediting/toolsComponent.js
+++ b/contribs/gmf/src/objectediting/toolsComponent.js
@@ -18,7 +18,7 @@ import ngeoMiscBtnComponent from 'ngeo/misc/btnComponent.js';
 
 import ngeoMiscToolActivate from 'ngeo/misc/ToolActivate.js';
 import ngeoMiscToolActivateMgr from 'ngeo/misc/ToolActivateMgr.js';
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 
 /**
  * @type {!angular.IModule}
@@ -299,7 +299,7 @@ exports.Controller_.prototype.registerTool_ = function(
     this.handleToolActiveChange_.bind(this, process, requiresLayer)
   );
 
-  const group = `${exports.Controller_.NAMESPACE_}-${olBase.getUid(this)}`;
+  const group = `${exports.Controller_.NAMESPACE_}-${olUtilGetUid(this)}`;
   const toolActivate = new ngeoMiscToolActivate(this, toolActiveName);
   this.ngeoToolActivateMgr_.registerTool(group, toolActivate, false);
 

--- a/contribs/gmf/src/permalink/Permalink.js
+++ b/contribs/gmf/src/permalink/Permalink.js
@@ -28,7 +28,7 @@ import ngeoStatemanagerModule from 'ngeo/statemanager/module.js';
 import ngeoStatemanagerService from 'ngeo/statemanager/Service.js';
 import ngeoLayertreeController from 'ngeo/layertree/Controller.js';
 import googAsserts from 'goog/asserts.js';
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 import * as olArray from 'ol/array.js';
 import * as olEvents from 'ol/events.js';
 import olFeature from 'ol/Feature.js';
@@ -1079,7 +1079,7 @@ exports.prototype.handleNgeoFeaturesRemove_ = function(event) {
  * @private
  */
 exports.prototype.addNgeoFeature_ = function(feature) {
-  const uid = olBase.getUid(feature);
+  const uid = olUtilGetUid(feature);
   this.ngeoEventHelper_.addListenerKey(
     uid,
     olEvents.listen(feature, 'change',
@@ -1094,7 +1094,7 @@ exports.prototype.addNgeoFeature_ = function(feature) {
  * @private
  */
 exports.prototype.removeNgeoFeature_ = function(feature) {
-  const uid = olBase.getUid(feature);
+  const uid = olUtilGetUid(feature);
   this.ngeoEventHelper_.clearListenerKey(uid);
   this.handleNgeoFeaturesChange_();
 };

--- a/contribs/gmf/src/permalink/shareComponent.js
+++ b/contribs/gmf/src/permalink/shareComponent.js
@@ -3,7 +3,7 @@
  */
 import gmfPermalinkShareService from 'gmf/permalink/ShareService.js';
 import ngeoStatemanagerLocation from 'ngeo/statemanager/Location.js';
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 
 const exports = angular.module('gmfPermalinkShareComponent', [
   gmfPermalinkShareService.module.name,
@@ -79,7 +79,7 @@ class ShareComponentController {
      * @type {number}
      * @export
      */
-    this.uid = olBase.getUid(this);
+    this.uid = olUtilGetUid(this);
 
     /**
      * @type {angular.IScope}

--- a/contribs/gmf/src/theme/Themes.js
+++ b/contribs/gmf/src/theme/Themes.js
@@ -3,7 +3,10 @@
  */
 import googAsserts from 'goog/asserts.js';
 import ngeoMapLayerHelper from 'ngeo/map/LayerHelper.js';
-import * as olBase from 'ol/index.js';
+import {
+  getUid as olUtilGetUid,
+  inherits as olUtilInherits
+} from 'ol/util.js';
 import * as olArray from 'ol/array.js';
 import olCollection from 'ol/Collection.js';
 import olEventsEventTarget from 'ol/events/Target.js';
@@ -111,7 +114,7 @@ const exports = function($http, $injector, $q, ngeoLayerHelper, gettextCatalog, 
   this.bgLayerPromise_ = null;
 };
 
-olBase.inherits(exports, olEventsEventTarget);
+olUtilInherits(exports, olEventsEventTarget);
 
 
 /**
@@ -233,7 +236,7 @@ exports.prototype.getBgLayers = function() {
    * @param {Array.<number>} array Array of ids;
    */
   const getIds = function(item, array) {
-    array.push(olBase.getUid(item));
+    array.push(olUtilGetUid(item));
     const children = item.children || [];
     children.forEach((child) => {
       getIds(child, array);

--- a/src/CustomEvent.js
+++ b/src/CustomEvent.js
@@ -1,7 +1,7 @@
 /**
  * @module ngeo.CustomEvent
  */
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import olEventsEvent from 'ol/events/Event.js';
 
 /**
@@ -22,7 +22,7 @@ const exports = function(type, detail = {}) {
 
 };
 
-olBase.inherits(exports, olEventsEvent);
+olUtilInherits(exports, olEventsEvent);
 
 
 export default exports;

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -3,7 +3,7 @@
  */
 import googAsserts from 'goog/asserts.js';
 import ngeoCustomEvent from 'ngeo/CustomEvent.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import * as olEvents from 'ol/events.js';
 import olOverlay from 'ol/Overlay.js';
 import olOverlayPositioning from 'ol/OverlayPositioning.js';
@@ -93,7 +93,7 @@ const exports = function(menuOptions, opt_overlayOptions) {
 
 };
 
-olBase.inherits(exports, olOverlay);
+olUtilInherits(exports, olOverlay);
 
 
 /**

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -1,7 +1,7 @@
 /**
  * @module ngeo.Popover
  */
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import olOverlay from 'ol/Overlay.js';
 
 /**
@@ -48,7 +48,7 @@ const exports = function(opt_options) {
 
 };
 
-olBase.inherits(exports, olOverlay);
+olUtilInherits(exports, olOverlay);
 
 
 /**

--- a/src/WFSDescribeFeatureType.js
+++ b/src/WFSDescribeFeatureType.js
@@ -2,7 +2,7 @@
  * @module ngeo.WFSDescribeFeatureType
  */
 import googAsserts from 'goog/asserts.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import olFormatXML from 'ol/format/XML.js';
 import * as olXml from 'ol/xml.js';
 
@@ -20,7 +20,7 @@ const exports = function() {
 
 };
 
-olBase.inherits(exports, olFormatXML);
+olUtilInherits(exports, olFormatXML);
 
 
 /**

--- a/src/editing/attributesComponent.js
+++ b/src/editing/attributesComponent.js
@@ -1,7 +1,7 @@
 /**
  * @module ngeo.editing.attributesComponent
  */
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 import * as olEvents from 'ol/events.js';
 import ngeoMiscEventHelper from 'ngeo/misc/EventHelper.js';
 import ngeoMiscDatetimepickerComponent from 'ngeo/misc/datetimepickerComponent.js';
@@ -148,7 +148,7 @@ exports.Controller_.prototype.$onInit = function() {
   this.properties = this.feature.getProperties();
 
   // Listen to the feature inner properties change and apply them to the form
-  const uid = olBase.getUid(this);
+  const uid = olUtilGetUid(this);
   this.ngeoEventHelper_.addListenerKey(
     uid,
     olEvents.listen(this.feature, 'propertychange', this.handleFeaturePropertyChange_, this)
@@ -173,7 +173,7 @@ exports.Controller_.prototype.handleInputChange = function(name) {
  * Cleanup event listeners.
  */
 exports.Controller_.prototype.$onDestroy = function() {
-  const uid = olBase.getUid(this);
+  const uid = olUtilGetUid(this);
   this.ngeoEventHelper_.clearListenerKey(uid);
 };
 

--- a/src/editing/createfeatureComponent.js
+++ b/src/editing/createfeatureComponent.js
@@ -8,7 +8,7 @@ import ngeoInteractionMeasureArea from 'ngeo/interaction/MeasureArea.js';
 import ngeoInteractionMeasureLength from 'ngeo/interaction/MeasureLength.js';
 import ngeoMiscEventHelper from 'ngeo/misc/EventHelper.js';
 import ngeoUtils from 'ngeo/utils.js';
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 import olCollection from 'ol/Collection.js';
 import * as olEvents from 'ol/events.js';
 import olFeature from 'ol/Feature.js';
@@ -230,7 +230,7 @@ exports.Controller_.prototype.$onInit = function() {
   this.interaction_ = interaction;
   this.map.addInteraction(interaction);
 
-  const uid = olBase.getUid(this);
+  const uid = olUtilGetUid(this);
   if (interaction instanceof olInteractionDraw) {
     this.ngeoEventHelper_.addListenerKey(
       uid,
@@ -293,7 +293,7 @@ exports.Controller_.prototype.handleDrawEnd_ = function(event) {
  */
 exports.Controller_.prototype.$onDestroy = function() {
   this.timeout_(() => {
-    const uid = olBase.getUid(this);
+    const uid = olUtilGetUid(this);
     this.ngeoEventHelper_.clearListenerKey(uid);
     this.interaction_.setActive(false);
     this.map.removeInteraction(this.interaction_);

--- a/src/editing/exportfeaturesComponent.js
+++ b/src/editing/exportfeaturesComponent.js
@@ -2,7 +2,7 @@
  * @module ngeo.editing.exportfeaturesComponent
  */
 import ngeoMiscFeatureHelper from 'ngeo/misc/FeatureHelper.js';
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 import olGeomPoint from 'ol/geom/Point.js';
 import olGeomLineString from 'ol/geom/LineString.js';
 
@@ -75,7 +75,7 @@ exports.Controller_ = function($element, $injector, $scope,
    */
   this.element_ = $element;
 
-  const uid = olBase.getUid(this);
+  const uid = olUtilGetUid(this);
   const id = ['ngeo-exportfeature', uid].join('-');
 
   /**

--- a/src/filter/component.js
+++ b/src/filter/component.js
@@ -14,7 +14,7 @@ import ngeoFilterRuleHelper from 'ngeo/filter/RuleHelper.js';
 import ngeoFormatAttributeType from 'ngeo/format/AttributeType.js';
 import ngeoRuleGeometry from 'ngeo/rule/Geometry.js';
 import ngeoMapFeatureOverlay from 'ngeo/map/FeatureOverlay.js';
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 import * as olArray from 'ol/array.js';
 import 'ngeo/sass/font.scss';
 
@@ -390,7 +390,7 @@ exports.FilterController_ = class {
    * @export
    */
   registerRule_(rule) {
-    const uid = olBase.getUid(rule);
+    const uid = olUtilGetUid(rule);
     this.ruleUnlisteners_[uid] = this.scope_.$watch(
       () => rule.active,
       this.handleRuleActiveChange_.bind(this)
@@ -406,7 +406,7 @@ exports.FilterController_ = class {
    * @export
    */
   unregisterRule_(rule) {
-    const uid = olBase.getUid(rule);
+    const uid = olUtilGetUid(rule);
     const unlistener = this.ruleUnlisteners_[uid];
     googAsserts.assert(unlistener);
     unlistener();

--- a/src/filter/ruleComponent.js
+++ b/src/filter/ruleComponent.js
@@ -25,7 +25,7 @@ import ngeoMiscToolActivateMgr from 'ngeo/misc/ToolActivateMgr.js';
 import ngeoRuleRule from 'ngeo/rule/Rule.js';
 import ngeoRuleGeometry from 'ngeo/rule/Geometry.js';
 import ngeoRuleSelect from 'ngeo/rule/Select.js';
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 import olFeature from 'ol/Feature.js';
 import olCollection from 'ol/Collection.js';
 import * as olEvents from 'ol/events.js';
@@ -661,7 +661,7 @@ exports.RuleController_ = class {
     }
 
     const keys = this.listenerKeys_;
-    const uid = ['ngeo-rule-', olBase.getUid(this)].join('-');
+    const uid = ['ngeo-rule-', olUtilGetUid(this)].join('-');
     const toolMgr = this.ngeoToolActivateMgr_;
 
     const ruleFeature = this.rule.feature;

--- a/src/format/FeatureHash.js
+++ b/src/format/FeatureHash.js
@@ -5,7 +5,7 @@ import googAsserts from 'goog/asserts.js';
 import ngeoFormatFeatureProperties from 'ngeo/format/FeatureProperties.js';
 import ngeoFormatFeatureHashStyleType from 'ngeo/format/FeatureHashStyleType.js';
 import ngeoUtils from 'ngeo/utils.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import olFeature from 'ol/Feature.js';
 import * as olColor from 'ol/color.js';
 import * as olArray from 'ol/array.js';
@@ -107,7 +107,7 @@ const exports = function(opt_options) {
 
 };
 
-olBase.inherits(exports, olFormatTextFeature);
+olUtilInherits(exports, olFormatTextFeature);
 
 
 /**

--- a/src/format/XSDAttribute.js
+++ b/src/format/XSDAttribute.js
@@ -4,7 +4,7 @@
 import googAsserts from 'goog/asserts.js';
 import ngeoFormatAttribute from 'ngeo/format/Attribute.js';
 import ngeoFormatAttributeType from 'ngeo/format/AttributeType.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import olFormatXML from 'ol/format/XML.js';
 
 /**
@@ -19,7 +19,7 @@ const exports = function() {
   olFormatXML.call(this);
 };
 
-olBase.inherits(exports, olFormatXML);
+olUtilInherits(exports, olFormatXML);
 
 
 /**

--- a/src/grid/Config.js
+++ b/src/grid/Config.js
@@ -1,7 +1,7 @@
 /**
  * @module ngeo.grid.Config
  */
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 
 /**
  * @param {Array.<Object>|undefined} data Entries/objects to be shown in a grid.
@@ -38,7 +38,7 @@ const exports = function(data, columnDefs) {
  * @export
  */
 exports.getRowUid = function(attributes) {
-  return `${olBase.getUid(attributes)}`;
+  return `${olUtilGetUid(attributes)}`;
 };
 
 

--- a/src/interaction/DrawAzimut.js
+++ b/src/interaction/DrawAzimut.js
@@ -4,7 +4,7 @@
 import googAsserts from 'goog/asserts.js';
 import ngeoInteractionCommon from 'ngeo/interaction/common.js';
 import ngeoCustomEvent from 'ngeo/CustomEvent.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import olFeature from 'ol/Feature.js';
 import * as olEvents from 'ol/events.js';
 import * as olFunctions from 'ol/functions.js';
@@ -94,7 +94,7 @@ const exports = function(options) {
   olEvents.listen(this, 'change:active', this.updateState_, this);
 };
 
-olBase.inherits(exports, olInteractionPointer);
+olUtilInherits(exports, olInteractionPointer);
 
 
 /**

--- a/src/interaction/DrawRegularPolygonFromClick.js
+++ b/src/interaction/DrawRegularPolygonFromClick.js
@@ -3,7 +3,7 @@
  */
 import googAsserts from 'goog/asserts.js';
 import ngeoCustomEvent from 'ngeo/CustomEvent.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import * as olEvents from 'ol/events.js';
 import olFeature from 'ol/Feature.js';
 import * as olFunctions from 'ol/functions.js';
@@ -54,7 +54,7 @@ const exports = function(options) {
 
 };
 
-olBase.inherits(
+olUtilInherits(
   exports, olInteractionInteraction);
 
 

--- a/src/interaction/Measure.js
+++ b/src/interaction/Measure.js
@@ -3,7 +3,7 @@
  */
 import googAsserts from 'goog/asserts.js';
 import ngeoCustomEvent from 'ngeo/CustomEvent.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import * as olDom from 'ol/dom.js';
 import * as olProj from 'ol/proj.js';
 import olOverlay from 'ol/Overlay.js';
@@ -184,7 +184,7 @@ const exports = function(options = /** @type {ngeo.interaction.MeasureBaseOption
   olEvents.listen(this, 'change:active', this.updateState_, this);
 };
 
-olBase.inherits(exports, olInteractionInteraction);
+olUtilInherits(exports, olInteractionInteraction);
 
 
 /**

--- a/src/interaction/MeasureArea.js
+++ b/src/interaction/MeasureArea.js
@@ -3,7 +3,7 @@
  */
 import googAsserts from 'goog/asserts.js';
 import ngeoInteractionMeasure from 'ngeo/interaction/Measure.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import olGeomPolygon from 'ol/geom/Polygon.js';
 import olInteractionDraw from 'ol/interaction/Draw.js';
 
@@ -48,7 +48,7 @@ const exports = function(format, gettextCatalog, options = {}) {
 
 };
 
-olBase.inherits(exports, ngeoInteractionMeasure);
+olUtilInherits(exports, ngeoInteractionMeasure);
 
 
 /**

--- a/src/interaction/MeasureAzimut.js
+++ b/src/interaction/MeasureAzimut.js
@@ -4,7 +4,7 @@
 import googAsserts from 'goog/asserts.js';
 import ngeoInteractionDrawAzimut from 'ngeo/interaction/DrawAzimut.js';
 import ngeoInteractionMeasure from 'ngeo/interaction/Measure.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import olGeomGeometryCollection from 'ol/geom/GeometryCollection.js';
 import olGeomLineString from 'ol/geom/LineString.js';
 import olProjProjection from 'ol/proj/Projection.js';
@@ -54,7 +54,7 @@ const exports = function(unitPrefixFormat, numberFormat, options = /** @type {ng
 
 };
 
-olBase.inherits(exports, ngeoInteractionMeasure);
+olUtilInherits(exports, ngeoInteractionMeasure);
 
 
 /**

--- a/src/interaction/MeasureLength.js
+++ b/src/interaction/MeasureLength.js
@@ -3,7 +3,7 @@
  */
 import googAsserts from 'goog/asserts.js';
 import ngeoInteractionMeasure from 'ngeo/interaction/Measure.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import olGeomLineString from 'ol/geom/LineString.js';
 import olInteractionDraw from 'ol/interaction/Draw.js';
 
@@ -43,7 +43,7 @@ const exports = function(format, gettextCatalog, options = /** @type {ngeox.inte
 
 };
 
-olBase.inherits(exports, ngeoInteractionMeasure);
+olUtilInherits(exports, ngeoInteractionMeasure);
 
 
 /**

--- a/src/interaction/MeasureLengthMobile.js
+++ b/src/interaction/MeasureLengthMobile.js
@@ -3,7 +3,7 @@
  */
 import ngeoInteractionMeasureLength from 'ngeo/interaction/MeasureLength.js';
 import ngeoInteractionMobileDraw from 'ngeo/interaction/MobileDraw.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import * as olObj from 'ol/obj.js';
 
 /**
@@ -27,7 +27,7 @@ const exports = function(format, gettextCatalog, opt_options) {
 
 };
 
-olBase.inherits(
+olUtilInherits(
   exports, ngeoInteractionMeasureLength);
 
 

--- a/src/interaction/MeasurePointMobile.js
+++ b/src/interaction/MeasurePointMobile.js
@@ -4,7 +4,7 @@
 import googAsserts from 'goog/asserts.js';
 import ngeoInteractionMeasure from 'ngeo/interaction/Measure.js';
 import ngeoInteractionMobileDraw from 'ngeo/interaction/MobileDraw.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import * as olObj from 'ol/obj.js';
 import olGeomPoint from 'ol/geom/Point.js';
 
@@ -38,7 +38,7 @@ const exports = function(format, coordFormat, options = /** @type {ngeox.interac
   this.coordFormat_ = coordFormat;
 };
 
-olBase.inherits(exports, ngeoInteractionMeasure);
+olUtilInherits(exports, ngeoInteractionMeasure);
 
 
 /**

--- a/src/interaction/MobileDraw.js
+++ b/src/interaction/MobileDraw.js
@@ -4,7 +4,7 @@
 import googAsserts from 'goog/asserts.js';
 import ngeoInteractionCommon from 'ngeo/interaction/common.js';
 import ngeoCustomEvent from 'ngeo/CustomEvent.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import * as olEvents from 'ol/events.js';
 import olFeature from 'ol/Feature.js';
 import * as olFunctions from 'ol/functions.js';
@@ -105,7 +105,7 @@ const exports = function(options) {
 
 };
 
-olBase.inherits(exports, olInteractionInteraction);
+olUtilInherits(exports, olInteractionInteraction);
 
 
 /**

--- a/src/interaction/Modify.js
+++ b/src/interaction/Modify.js
@@ -6,7 +6,7 @@ import ngeoUtils from 'ngeo/utils.js';
 import ngeoFormatFeatureProperties from 'ngeo/format/FeatureProperties.js';
 import ngeoInteractionModifyCircle from 'ngeo/interaction/ModifyCircle.js';
 import ngeoInteractionModifyRectangle from 'ngeo/interaction/ModifyRectangle.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import * as olEvents from 'ol/events.js';
 import * as olFunctions from 'ol/functions.js';
 import olInteractionInteraction from 'ol/interaction/Interaction.js';
@@ -104,7 +104,7 @@ const exports = function(options) {
 
 };
 
-olBase.inherits(exports, olInteractionInteraction);
+olUtilInherits(exports, olInteractionInteraction);
 
 
 /**

--- a/src/interaction/ModifyCircle.js
+++ b/src/interaction/ModifyCircle.js
@@ -6,7 +6,10 @@ import ngeoCustomEvent from 'ngeo/CustomEvent.js';
 import ngeoFormatFeatureProperties from 'ngeo/format/FeatureProperties.js';
 import ngeoInteractionCommon from 'ngeo/interaction/common.js';
 import ngeoInteractionMeasureAzimut from 'ngeo/interaction/MeasureAzimut.js';
-import * as olBase from 'ol/index.js';
+import {
+  getUid as olUtilGetUid,
+  inherits as olUtilInherits
+} from 'ol/util.js';
 import olFeature from 'ol/Feature.js';
 import olMapBrowserPointerEvent from 'ol/MapBrowserPointerEvent.js';
 import * as olCoordinate from 'ol/coordinate.js';
@@ -123,7 +126,7 @@ const exports = function(options) {
 
 };
 
-olBase.inherits(exports, olInteractionPointer);
+olUtilInherits(exports, olInteractionPointer);
 
 
 /**
@@ -302,7 +305,7 @@ exports.handleDownEvent_ = function(evt) {
     for (let i = 0, ii = segmentDataMatches.length; i < ii; ++i) {
       const segmentDataMatch = segmentDataMatches[i];
       const segment = segmentDataMatch.segment;
-      let uid = olBase.getUid(segmentDataMatch.feature);
+      let uid = olUtilGetUid(segmentDataMatch.feature);
       const depth = segmentDataMatch.depth;
       if (depth) {
         uid += `-${depth.join('-')}`; // separate feature components
@@ -448,7 +451,7 @@ exports.prototype.handlePointerAtPixel_ = function(pixel, map) {
           closestSegment[1] : closestSegment[0];
         this.createOrUpdateVertexFeature_(vertex);
         const vertexSegments = {};
-        vertexSegments[olBase.getUid(closestSegment)] = true;
+        vertexSegments[olUtilGetUid(closestSegment)] = true;
         let segment;
         for (let i = 1, ii = nodes.length; i < ii; ++i) {
           segment = nodes[i].segment;
@@ -456,7 +459,7 @@ exports.prototype.handlePointerAtPixel_ = function(pixel, map) {
               olCoordinate.equals(closestSegment[1], segment[1]) ||
               (olCoordinate.equals(closestSegment[0], segment[1]) &&
               olCoordinate.equals(closestSegment[1], segment[0])))) {
-            vertexSegments[olBase.getUid(segment)] = true;
+            vertexSegments[olUtilGetUid(segment)] = true;
           } else {
             break;
           }

--- a/src/interaction/ModifyRectangle.js
+++ b/src/interaction/ModifyRectangle.js
@@ -4,7 +4,10 @@
 import googAsserts from 'goog/asserts.js';
 import ngeoInteractionCommon from 'ngeo/interaction/common.js';
 import ngeoCustomEvent from 'ngeo/CustomEvent.js';
-import * as olBase from 'ol/index.js';
+import {
+  getUid as olUtilGetUid,
+  inherits as olUtilInherits
+} from 'ol/util.js';
 import olFeature from 'ol/Feature.js';
 import * as olEvents from 'ol/events.js';
 import olGeomPoint from 'ol/geom/Point.js';
@@ -88,7 +91,7 @@ const exports = function(options) {
 
 };
 
-olBase.inherits(exports, olInteractionPointer);
+olUtilInherits(exports, olInteractionPointer);
 
 
 /**
@@ -111,7 +114,7 @@ exports.prototype.addFeature_ = function(feature) {
   if (featureGeom instanceof olGeomPolygon) {
 
     // If the feature's corners are already set, no need to set them again
-    const uid = olBase.getUid(feature);
+    const uid = olUtilGetUid(feature);
     let item = this.cache_[uid];
     if (item) {
       return;
@@ -268,7 +271,7 @@ exports.prototype.initializeParams_ = function() {
  * @private
  */
 exports.prototype.removeFeature_ = function(feature) {
-  const uid = olBase.getUid(feature);
+  const uid = olUtilGetUid(feature);
   const item = this.cache_[uid];
   const corners = item.corners;
   for (let i = 0; i < corners.length; i++) {

--- a/src/interaction/Rotate.js
+++ b/src/interaction/Rotate.js
@@ -4,7 +4,10 @@
 import googAsserts from 'goog/asserts.js';
 import ngeoInteractionCommon from 'ngeo/interaction/common.js';
 import ngeoCustomEvent from 'ngeo/CustomEvent.js';
-import * as olBase from 'ol/index.js';
+import {
+  getUid as olUtilGetUid,
+  inherits as olUtilInherits
+} from 'ol/util.js';
 import * as olExtent from 'ol/extent.js';
 import olFeature from 'ol/Feature.js';
 import * as olEvents from 'ol/events.js';
@@ -118,7 +121,7 @@ const exports = function(options) {
 
 };
 
-olBase.inherits(exports, olInteractionPointer);
+olUtilInherits(exports, olInteractionPointer);
 
 
 /**
@@ -167,7 +170,7 @@ exports.prototype.addFeature_ = function(feature) {
   feature.set('angle', 0);
 
   // Add the center icon to the overlay
-  const uid = olBase.getUid(feature);
+  const uid = olUtilGetUid(feature);
   const point = new olGeomPoint(this.getCenterCoordinate_(geometry));
   const centerFeature = new olFeature(point);
   this.centerFeatures_[uid] = centerFeature;
@@ -199,7 +202,7 @@ exports.prototype.removeFeature_ = function(feature) {
   //this.overlay_.getSource().removeFeature(feature);
 
   if (feature) {
-    const uid = olBase.getUid(feature);
+    const uid = olUtilGetUid(feature);
 
     if (this.centerFeatures_[uid]) {
       this.overlay_.getSource().removeFeature(this.centerFeatures_[uid]);
@@ -254,7 +257,7 @@ exports.prototype.handleDown_ = function(evt) {
   if (feature) {
     let found = false;
     this.features_.forEach((f) => {
-      if (olBase.getUid(f) == olBase.getUid(feature)) {
+      if (olUtilGetUid(f) == olUtilGetUid(feature)) {
         found = true;
       }
     });

--- a/src/interaction/Translate.js
+++ b/src/interaction/Translate.js
@@ -2,7 +2,10 @@
  * @module ngeo.interaction.Translate
  */
 import googAsserts from 'goog/asserts.js';
-import * as olBase from 'ol/index.js';
+import {
+  getUid as olUtilGetUid,
+  inherits as olUtilInherits
+} from 'ol/util.js';
 import * as olExtent from 'ol/extent.js';
 import olFeature from 'ol/Feature.js';
 import * as olEvents from 'ol/events.js';
@@ -82,7 +85,7 @@ const exports = function(options) {
     this, /** @type {olx.interaction.TranslateOptions} */ (options));
 };
 
-olBase.inherits(exports, olInteractionTranslate);
+olUtilInherits(exports, olInteractionTranslate);
 
 
 /**
@@ -192,7 +195,7 @@ exports.prototype.handleFeaturesRemove_ = function(evt) {
  * @private
  */
 exports.prototype.addFeature_ = function(feature) {
-  const uid = olBase.getUid(feature);
+  const uid = olUtilGetUid(feature);
   const geometry = feature.getGeometry();
   googAsserts.assertInstanceof(geometry, olGeomGeometry);
 
@@ -215,7 +218,7 @@ exports.prototype.addFeature_ = function(feature) {
  * @private
  */
 exports.prototype.removeFeature_ = function(feature) {
-  const uid = olBase.getUid(feature);
+  const uid = olUtilGetUid(feature);
   if (this.featureListenerKeys_[uid]) {
     olEvents.unlistenByKey(this.featureListenerKeys_[uid]);
     delete this.featureListenerKeys_[uid];
@@ -237,7 +240,7 @@ exports.prototype.handleGeometryChange_ = function(feature,
   googAsserts.assertInstanceof(geometry, olGeomGeometry);
 
   const point = this.getGeometryCenterPoint_(geometry);
-  const uid = olBase.getUid(feature);
+  const uid = olUtilGetUid(feature);
   this.centerFeatures_[uid].setGeometry(point);
 };
 

--- a/src/layertree/Controller.js
+++ b/src/layertree/Controller.js
@@ -3,7 +3,7 @@
  */
 import googAsserts from 'goog/asserts.js';
 import ngeoMiscDecorate from 'ngeo/misc/decorate.js';
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 import * as olEvents from 'ol/events.js';
 import olLayerGroup from 'ol/layer/Group.js';
 import olLayerLayer from 'ol/layer/Layer.js';
@@ -97,7 +97,7 @@ const exports = function($scope, $rootScope, $attrs) {
    * @type {number}
    * @export
    */
-  this.uid = olBase.getUid(this);
+  this.uid = olUtilGetUid(this);
 
   /**
    * @type {number}

--- a/src/map/BackgroundLayerMgr.js
+++ b/src/map/BackgroundLayerMgr.js
@@ -3,7 +3,10 @@
  */
 import googAsserts from 'goog/asserts.js';
 import ngeoCustomEvent from 'ngeo/CustomEvent.js';
-import * as olBase from 'ol/index.js';
+import {
+  getUid as olUtilGetUid,
+  inherits as olUtilInherits
+} from 'ol/util.js';
 import olObservable from 'ol/Observable.js';
 import olLayerGroup from 'ol/layer/Group.js';
 import olLayerLayer from 'ol/layer/Layer.js';
@@ -77,7 +80,7 @@ const exports = function(ngeoLayerHelper) {
 
 };
 
-olBase.inherits(exports, olObservable);
+olUtilInherits(exports, olObservable);
 
 
 /**
@@ -88,7 +91,7 @@ olBase.inherits(exports, olObservable);
  * @export
  */
 exports.prototype.get = function(map) {
-  const mapUid = olBase.getUid(map).toString();
+  const mapUid = olUtilGetUid(map).toString();
   return mapUid in this.mapUids_ ? this.ngeoLayerHelper_.getGroupFromMap(map,
     exports.BACKGROUNDLAYERGROUP_NAME).getLayers().item(0) : null;
 };
@@ -104,7 +107,7 @@ exports.prototype.get = function(map) {
  */
 exports.prototype.set = function(map, layer) {
   const ZIndex = -200;
-  const mapUid = olBase.getUid(map).toString();
+  const mapUid = olUtilGetUid(map).toString();
   const previous = this.get(map);
   if (layer !== null) {
     layer.setZIndex(ZIndex);
@@ -143,7 +146,7 @@ exports.prototype.set = function(map, layer) {
  * @export
  */
 exports.prototype.getOpacityBgLayer = function(map) {
-  const mapUid = olBase.getUid(map).toString();
+  const mapUid = olUtilGetUid(map).toString();
   return mapUid in this.mapUids_ ? this.ngeoLayerHelper_.getGroupFromMap(map,
     exports.BACKGROUNDLAYERGROUP_NAME).getLayers().item(1) : null;
 };

--- a/src/map/FeatureOverlayMgr.js
+++ b/src/map/FeatureOverlayMgr.js
@@ -3,7 +3,7 @@
  */
 import googAsserts from 'goog/asserts.js';
 import ngeoMapFeatureOverlay from 'ngeo/map/FeatureOverlay.js';
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 import olLayerVector from 'ol/layer/Vector.js';
 import * as olObj from 'ol/obj.js';
 import olSourceVector from 'ol/source/Vector.js';
@@ -77,7 +77,7 @@ const exports = function() {
 exports.prototype.addFeature = function(feature, groupIndex) {
   googAsserts.assert(groupIndex >= 0);
   googAsserts.assert(groupIndex < this.groups_.length);
-  const featureUid = olBase.getUid(feature).toString();
+  const featureUid = olUtilGetUid(feature).toString();
   this.featureUidToGroupIndex_[featureUid] = groupIndex;
   this.groups_[groupIndex].features[featureUid] = feature;
   this.source_.addFeature(feature);
@@ -92,7 +92,7 @@ exports.prototype.addFeature = function(feature, groupIndex) {
 exports.prototype.removeFeature = function(feature, groupIndex) {
   googAsserts.assert(groupIndex >= 0);
   googAsserts.assert(groupIndex < this.groups_.length);
-  const featureUid = olBase.getUid(feature).toString();
+  const featureUid = olUtilGetUid(feature).toString();
   delete this.featureUidToGroupIndex_[featureUid];
   delete this.groups_[groupIndex].features[featureUid];
   this.source_.removeFeature(feature);
@@ -167,7 +167,7 @@ exports.prototype.setStyle = function(style, groupIndex) {
  * @private
  */
 exports.prototype.styleFunction_ = function(feature, resolution) {
-  const featureUid = olBase.getUid(feature).toString();
+  const featureUid = olUtilGetUid(feature).toString();
   googAsserts.assert(featureUid in this.featureUidToGroupIndex_);
   const groupIndex = this.featureUidToGroupIndex_[featureUid];
   const group = this.groups_[groupIndex];

--- a/src/message/Disclaimer.js
+++ b/src/message/Disclaimer.js
@@ -6,7 +6,7 @@ import googAsserts from 'goog/asserts.js';
 
 import ngeoMessagePopup from 'ngeo/message/Popup.js';
 import ngeoMessageMessage from 'ngeo/message/Message.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 import 'ngeo/sass/font.scss';
 
 /**
@@ -64,7 +64,7 @@ const exports = function($sce, gettextCatalog, ngeoCreatePopup) {
 
 };
 
-olBase.inherits(exports, ngeoMessageMessage);
+olUtilInherits(exports, ngeoMessageMessage);
 
 
 /**

--- a/src/message/Notification.js
+++ b/src/message/Notification.js
@@ -5,7 +5,10 @@ import 'bootstrap/js/src/alert.js';
 import googAsserts from 'goog/asserts.js';
 
 import ngeoMessageMessage from 'ngeo/message/Message.js';
-import * as olBase from 'ol/index.js';
+import {
+  getUid as olUtilGetUid,
+  inherits as olUtilInherits
+} from 'ol/util.js';
 
 /**
  * Provides methods to display any sort of messages, notifications, errors,
@@ -48,7 +51,7 @@ const exports = function($timeout) {
 
 };
 
-olBase.inherits(exports, ngeoMessageMessage);
+olUtilInherits(exports, ngeoMessageMessage);
 
 
 /**
@@ -131,7 +134,7 @@ exports.prototype.showMessage = function(message) {
 
   // Keep a reference to the promise, in case we want to manually cancel it
   // before the delay
-  const uid = olBase.getUid(el);
+  const uid = olUtilGetUid(el);
   item.promise = this.timeout_(() => {
     el.alert('close');
     delete this.cache_[uid];
@@ -149,7 +152,7 @@ exports.prototype.showMessage = function(message) {
 exports.prototype.clearMessageByCacheItem_ = function(item) {
   const el = item.el;
   const promise = item.promise;
-  const uid = olBase.getUid(el);
+  const uid = olUtilGetUid(el);
 
   // Close the message
   el.alert('close');

--- a/src/misc/WMSTime.js
+++ b/src/misc/WMSTime.js
@@ -3,7 +3,7 @@
  */
 import googAsserts from 'goog/asserts.js';
 import ngeoMiscTime from 'ngeo/misc/Time.js';
-import * as olBase from 'ol/index.js';
+import {inherits as olUtilInherits} from 'ol/util.js';
 
 /**
  * ngeo - WMS time service
@@ -33,7 +33,7 @@ const exports = function($filter, gettextCatalog) {
   ngeoMiscTime.call(this);
 };
 
-olBase.inherits(exports, ngeoMiscTime);
+olUtilInherits(exports, ngeoMiscTime);
 
 
 /**

--- a/src/print/VectorEncoder.js
+++ b/src/print/VectorEncoder.js
@@ -3,7 +3,7 @@
  */
 import googAsserts from 'goog/asserts.js';
 import ngeoUtils from 'ngeo/utils.js';
-import * as olBase from 'ol/index.js';
+import {getUid as olUtilGetUid} from 'ol/util.js';
 import olFormatGeoJSON from 'ol/format/GeoJSON.js';
 import olSourceVector from 'ol/source/Vector.js';
 import olStyleRegularShape from 'ol/style/RegularShape.js';
@@ -110,7 +110,7 @@ exports.prototype.encodeVectorLayer = function(arr, layer, resolution) {
         }
 
         const featureStyleProp = `_ngeo_style_${j}`;
-        const styleId = `${olBase.getUid(style).toString()}-${geometryType}`;
+        const styleId = `${olUtilGetUid(style).toString()}-${geometryType}`;
         this.encodeVectorStyle(mapfishStyleObject, geometryType, style, styleId, featureStyleProp);
         geojsonFeature.properties[featureStyleProp] = styleId;
       }


### PR DESCRIPTION
Fixes 716, see: https://jira.camptocamp.com/browse/GSGMF-716

This patch removes all imports that ended up importing the whole OpenLayers library and replace them by individual method imports instead:

`import * as olBase from 'ol/index.js';`

Aliases are used for naming consistency.