### PR TITLE
Stop using 'assign' function from ol

### DIFF
--- a/contribs/gmf/src/contextualdata/component.js
+++ b/contribs/gmf/src/contextualdata/component.js
@@ -6,7 +6,6 @@ import googAsserts from 'goog/asserts.js';
 import olOverlay from 'ol/Overlay.js';
 import * as olProj from 'ol/proj.js';
 import * as olEvents from 'ol/events.js';
-import * as olObj from 'ol/obj.js';
 
 /**
  * @type {angular.IModule}
@@ -188,9 +187,9 @@ exports.Controller_.prototype.setContent_ = function(coordinate) {
   });
 
   const getRasterSuccess = function(resp) {
-    olObj.assign(scope, resp);
+    Object.assign(scope, resp);
     if (this.callback) {
-      olObj.assign(scope, this.callback.call(this, coordinate, resp));
+      Object.assign(scope, this.callback.call(this, coordinate, resp));
     }
   }.bind(this);
   const getRasterError = function(resp) {

--- a/contribs/gmf/src/controllers/AbstractAPIController.js
+++ b/contribs/gmf/src/controllers/AbstractAPIController.js
@@ -6,7 +6,6 @@ import ngeoQueryBboxQueryComponent from 'ngeo/query/bboxQueryComponent.js';
 import ngeoMapResizemap from 'ngeo/map/resizemap.js';
 import {inherits as olUtilInherits} from 'ol/util.js';
 import * as olProj from 'ol/proj.js';
-import * as olObj from 'ol/obj.js';
 import olMap from 'ol/Map.js';
 import olView from 'ol/View.js';
 import olControlScaleLine from 'ol/control/ScaleLine.js';
@@ -34,7 +33,7 @@ const exports = function(config, $scope, $injector) {
   const viewConfig = {
     projection: olProj.get(`EPSG:${config.srid || 21781}`)
   };
-  olObj.assign(viewConfig, config.mapViewConfig || {});
+  Object.assign(viewConfig, config.mapViewConfig || {});
 
   const arrow = gmfControllersAbstractAppController.prototype.getLocationIcon();
 

--- a/contribs/gmf/src/controllers/AbstractMobileController.js
+++ b/contribs/gmf/src/controllers/AbstractMobileController.js
@@ -7,7 +7,6 @@ import gmfMobileNavigationModule from 'gmf/mobile/navigation/module.js';
 import gmfQueryWindowComponent from 'gmf/query/windowComponent.js';
 import ngeoGeolocationMobile from 'ngeo/geolocation/mobile.js';
 import {inherits as olUtilInherits} from 'ol/util.js';
-import * as olObj from 'ol/obj.js';
 import * as olProj from 'ol/proj.js';
 import olMap from 'ol/Map.js';
 import olView from 'ol/View.js';
@@ -95,7 +94,7 @@ const exports = function(config, $scope, $injector) {
   const viewConfig = {
     projection: olProj.get(`EPSG:${config.srid || 21781}`)
   };
-  olObj.assign(viewConfig, config.mapViewConfig || {});
+  Object.assign(viewConfig, config.mapViewConfig || {});
 
   const arrow = gmfControllersAbstractAppController.prototype.getLocationIcon();
 

--- a/contribs/gmf/src/datasource/Helper.js
+++ b/contribs/gmf/src/datasource/Helper.js
@@ -4,7 +4,6 @@
 import gmfEditingEnumerateAttribute from 'gmf/editing/EnumerateAttribute.js';
 import ngeoDatasourceHelper from 'ngeo/datasource/Helper.js';
 import ngeoFormatAttributeType from 'ngeo/format/AttributeType.js';
-import * as olArray from 'ol/array.js';
 
 const exports = class {
 
@@ -104,7 +103,7 @@ const exports = class {
       if (enumAttributes && enumAttributes.length) {
         const promises = [];
         for (const attribute of attributes) {
-          if (olArray.includes(enumAttributes, attribute.name) &&
+          if (enumAttributes.includes(attribute.name) &&
              attribute.type !== ngeoFormatAttributeType.SELECT &&
              (!attribute.choices || !attribute.choices.length)) {
             promises.push(

--- a/contribs/gmf/src/drawing/drawFeatureComponent.js
+++ b/contribs/gmf/src/drawing/drawFeatureComponent.js
@@ -27,7 +27,6 @@ import ngeoMiscFeatureHelper from 'ngeo/misc/FeatureHelper.js';
 import ngeoMiscToolActivate from 'ngeo/misc/ToolActivate.js';
 import ngeoMiscToolActivateMgr from 'ngeo/misc/ToolActivateMgr.js';
 import {getUid as olUtilGetUid} from 'ol/util.js';
-import * as olArray from 'ol/array.js';
 import * as olEvents from 'ol/events.js';
 import olCollection from 'ol/Collection.js';
 import olStyleFill from 'ol/style/Fill.js';
@@ -590,7 +589,7 @@ exports.Controller_.prototype.handleMapClick_ = function(evt) {
     pixel,
     (feature) => {
       let ret = false;
-      if (olArray.includes(this.features.getArray(), feature)) {
+      if (this.features.getArray().includes(feature)) {
         ret = feature;
       }
       return ret;
@@ -646,7 +645,7 @@ exports.Controller_.prototype.handleMapContextMenu_ = function(evt) {
     pixel,
     (feature) => {
       let ret = false;
-      if (olArray.includes(this.features.getArray(), feature)) {
+      if (this.features.getArray().includes(feature)) {
         ret = feature;
       }
       return ret;

--- a/contribs/gmf/src/editing/editFeatureComponent.js
+++ b/contribs/gmf/src/editing/editFeatureComponent.js
@@ -43,7 +43,6 @@ import ngeoMiscToolActivate from 'ngeo/misc/ToolActivate.js';
 import ngeoMiscToolActivateMgr from 'ngeo/misc/ToolActivateMgr.js';
 
 import {getUid as olUtilGetUid} from 'ol/util.js';
-import * as olArray from 'ol/array.js';
 import olCollection from 'ol/Collection.js';
 import * as olEvents from 'ol/events.js';
 import * as olExtent from 'ol/extent.js';
@@ -1006,7 +1005,7 @@ exports.Controller_.prototype.handleMapClick_ = function(evt) {
     pixel,
     (feature) => {
       let ret = false;
-      if (olArray.includes(this.features.getArray(), feature)) {
+      if (this.features.getArray().includes(feature)) {
         ret = feature;
       }
       return ret;
@@ -1060,7 +1059,7 @@ exports.Controller_.prototype.handleMapContextMenu_ = function(evt) {
     pixel,
     (feature) => {
       let ret = false;
-      if (olArray.includes(this.features.getArray(), feature)) {
+      if (this.features.getArray().includes(feature)) {
         ret = feature;
       }
       return ret;

--- a/contribs/gmf/src/filters/filterselectorComponent.js
+++ b/contribs/gmf/src/filters/filterselectorComponent.js
@@ -500,7 +500,7 @@ exports.Controller_ = class {
     const msgs = [];
 
     // (1) The name of the DS must be in list of filtrable layer node names
-    if (olArray.includes(names, dataSource.name)) {
+    if (names.includes(dataSource.name)) {
 
       // (2) The DS must support WFS
       if (!dataSource.supportsWFS) {
@@ -594,7 +594,7 @@ exports.Controller_ = class {
               dataSource.gmfLayer.metadata.directedFilterAttributes;
           const attributes = googAsserts.assert(dataSource.attributes);
           for (const attribute of attributes) {
-            if (olArray.includes(directedAttributes, attribute.name)) {
+            if (directedAttributes.includes(attribute.name)) {
               item.directedRules.push(
                 this.ngeoRuleHelper_.createRuleFromAttribute(attribute)
               );

--- a/contribs/gmf/src/layertree/TreeManager.js
+++ b/contribs/gmf/src/layertree/TreeManager.js
@@ -8,7 +8,6 @@ import ngeoLayertreeController from 'ngeo/layertree/Controller.js';
 import ngeoMessageMessage from 'ngeo/message/Message.js';
 import ngeoMessageNotification from 'ngeo/message/Notification.js';
 import ngeoStatemanagerService from 'ngeo/statemanager/Service.js';
-import * as olArray from 'ol/array.js';
 import * as olEvents from 'ol/events.js';
 
 /**
@@ -425,7 +424,7 @@ exports.prototype.toggleNodeCheck_ = function(node, names) {
     if (childNode.children) {
       this.toggleNodeCheck_(childNode, names);
     } else if (childNode.metadata) {
-      childNode.metadata.isChecked = olArray.includes(names, childNode.name);
+      childNode.metadata.isChecked = names.includes(childNode.name);
     }
   });
 };

--- a/contribs/gmf/src/layertree/TreeManager.js
+++ b/contribs/gmf/src/layertree/TreeManager.js
@@ -10,7 +10,6 @@ import ngeoMessageNotification from 'ngeo/message/Notification.js';
 import ngeoStatemanagerService from 'ngeo/statemanager/Service.js';
 import * as olArray from 'ol/array.js';
 import * as olEvents from 'ol/events.js';
-import * as olObj from 'ol/obj.js';
 
 /**
  * Manage a tree with children. This service can be used in mode 'flush'
@@ -404,7 +403,7 @@ exports.prototype.removeAll = function() {
  * @private
  */
 exports.prototype.cloneGroupNode_ = function(group, names) {
-  const clone = /** @type {gmfThemes.GmfGroup} */ (olObj.assign({}, group));
+  const clone = /** @type {gmfThemes.GmfGroup} */ (Object.assign({}, group));
   this.toggleNodeCheck_(clone, names);
   return clone;
 };

--- a/contribs/gmf/src/permalink/Permalink.js
+++ b/contribs/gmf/src/permalink/Permalink.js
@@ -29,7 +29,6 @@ import ngeoStatemanagerService from 'ngeo/statemanager/Service.js';
 import ngeoLayertreeController from 'ngeo/layertree/Controller.js';
 import googAsserts from 'goog/asserts.js';
 import {getUid as olUtilGetUid} from 'ol/util.js';
-import * as olArray from 'ol/array.js';
 import * as olEvents from 'ol/events.js';
 import olFeature from 'ol/Feature.js';
 import olGeomMultiPoint from 'ol/geom/MultiPoint.js';
@@ -1016,7 +1015,7 @@ exports.prototype.initLayers_ = function() {
             const groupLayersArray = groupLayers == '' ? [] : groupLayers.split(',');
             treeCtrl.traverseDepthFirst((treeCtrl) => {
               if (treeCtrl.node.children === undefined) {
-                const enable = olArray.includes(groupLayersArray, treeCtrl.node.name);
+                const enable = groupLayersArray.includes(treeCtrl.node.name);
                 if (enable) {
                   groupLayersArray.splice(groupLayersArray.indexOf(treeCtrl.node.name), 1);
                 }

--- a/contribs/gmf/src/print/component.js
+++ b/contribs/gmf/src/print/component.js
@@ -14,7 +14,6 @@ import ngeoMiscFeatureHelper from 'ngeo/misc/FeatureHelper.js';
 import ngeoPrintService from 'ngeo/print/Service.js';
 import ngeoPrintUtils from 'ngeo/print/Utils.js';
 import ngeoQueryMapQuerent from 'ngeo/query/MapQuerent.js';
-import * as olArray from 'ol/array.js';
 import * as olEvents from 'ol/events.js';
 import olLayerImage from 'ol/layer/Image.js';
 import olLayerTile from 'ol/layer/Tile.js';
@@ -580,7 +579,7 @@ exports.Controller_ = class {
     googAsserts.assert(this.layoutInfo.scales);
     googAsserts.assert(this.layoutInfo.scale !== undefined);
     if (!this.scaleManuallySelected_ &&
-        (this.layoutInfo.scale === -1 || olArray.includes(this.layoutInfo.scales, this.layoutInfo.scale))) {
+        (this.layoutInfo.scale === -1 || this.layoutInfo.scales.includes(this.layoutInfo.scale))) {
       const mapSize = frameState.size;
       const viewResolution = frameState.viewState.resolution;
       this.layoutInfo.scale = this.getOptimalScale_(mapSize, viewResolution);

--- a/contribs/gmf/src/profile/component.js
+++ b/contribs/gmf/src/profile/component.js
@@ -7,7 +7,6 @@ import olFeature from 'ol/Feature.js';
 import olOverlay from 'ol/Overlay.js';
 import olGeomLineString from 'ol/geom/LineString.js';
 import olGeomPoint from 'ol/geom/Point.js';
-import * as olObj from 'ol/obj.js';
 import olStyleCircle from 'ol/style/Circle.js';
 import olStyleFill from 'ol/style/Fill.js';
 import olStyleStyle from 'ol/style/Style.js';
@@ -367,7 +366,7 @@ exports.Controller_.prototype.$onInit = function() {
   if (optionsFn) {
     const options = optionsFn();
     googAsserts.assertObject(options);
-    olObj.assign(this.profileOptions, options);
+    Object.assign(this.profileOptions, options);
   }
 };
 

--- a/contribs/gmf/src/search/component.js
+++ b/contribs/gmf/src/search/component.js
@@ -19,7 +19,6 @@ import ngeoSearchModule from 'ngeo/search/module.js';
 import olFeature from 'ol/Feature.js';
 import * as olColor from 'ol/color.js';
 import olGeomPoint from 'ol/geom/Point.js';
-import * as olObj from 'ol/obj.js';
 import olFormatGeoJSON from 'ol/format/GeoJSON.js';
 import * as olProj from 'ol/proj.js';
 import olStyleCircle from 'ol/style/Circle.js';
@@ -458,7 +457,7 @@ exports.SearchController_ = class {
     this.featureOverlay_.setStyle(this.getSearchStyle_.bind(this));
 
     if (this.typeaheadOptions) {
-      olObj.assign(this.options, this.typeaheadOptions);
+      Object.assign(this.options, this.typeaheadOptions);
     }
 
     this.initDatasets_();
@@ -643,7 +642,7 @@ exports.SearchController_ = class {
       })
     });
     if (config.typeaheadDatasetOptions) {
-      olObj.assign(typeaheadDataset, config.typeaheadDatasetOptions);
+      Object.assign(typeaheadDataset, config.typeaheadDatasetOptions);
     }
     return typeaheadDataset;
   }
@@ -808,7 +807,7 @@ exports.SearchController_ = class {
       stroke: stroke
     });
     const customStyles = this.featuresStyles || {};
-    olObj.assign(this.styles_, customStyles);
+    Object.assign(this.styles_, customStyles);
   }
 
   /**

--- a/contribs/gmf/test/spec/services/permalinkservice.spec.js
+++ b/contribs/gmf/test/spec/services/permalinkservice.spec.js
@@ -5,7 +5,6 @@ import olMap from 'ol/Map.js';
 import olView from 'ol/View.js';
 import olCollection from 'ol/Collection.js';
 import * as olProj from 'ol/proj.js';
-import * as olObj from 'ol/obj.js';
 
 
 describe('Permalink service', () => {
@@ -21,7 +20,7 @@ describe('Permalink service', () => {
     PermalinkService.setMap(map);
     // need to work on a clone of themes, because the permalink service
     // seems to change the original object?!
-    const themesClone = olObj.assign({}, gmfTestDataThemes);
+    const themesClone = Object.assign({}, gmfTestDataThemes);
     PermalinkService.themes_ = themesClone['themes'];
 
 

--- a/src/filter/RuleHelper.js
+++ b/src/filter/RuleHelper.js
@@ -13,7 +13,6 @@ import ngeoRuleSelect from 'ngeo/rule/Select.js';
 import ngeoRuleText from 'ngeo/rule/Text.js';
 import {writeFilter} from 'ol/format/WFS.js';
 import * as olFormatFilter from 'ol/format/filter.js';
-import * as olArray from 'ol/array.js';
 
 import moment from 'moment';
 
@@ -581,7 +580,7 @@ const exports = class {
         }
         filter = olFormatFilter.or.apply(null, conditions);
       }
-    } else if (olArray.includes(spatialTypes, operator)) {
+    } else if (spatialTypes.includes(operator)) {
       const geometryName = dataSource.geometryName;
       googAsserts.assertInstanceof(rule, ngeoRuleGeometry);
       const geometry = googAsserts.assert(rule.geometry);
@@ -604,7 +603,7 @@ const exports = class {
           opt_srsName
         );
       }
-    } else if (olArray.includes(numericTypes, operator)) {
+    } else if (numericTypes.includes(operator)) {
       const numericExpression = googAsserts.assertNumber(expression);
       if (operator === rot.GREATER_THAN) {
         filter = olFormatFilter.greaterThan(

--- a/src/filter/ruleComponent.js
+++ b/src/filter/ruleComponent.js
@@ -29,7 +29,6 @@ import {getUid as olUtilGetUid} from 'ol/util.js';
 import olFeature from 'ol/Feature.js';
 import olCollection from 'ol/Collection.js';
 import * as olEvents from 'ol/events.js';
-import * as olArray from 'ol/array.js';
 import olStyleStyle from 'ol/style/Style.js';
 import olStyleText from 'ol/style/Text.js';
 import olStyleFill from 'ol/style/Fill.js';
@@ -462,7 +461,7 @@ exports.RuleController_ = class {
                 ngeoGeometryType.POLYGON,
                 ngeoGeometryType.RECTANGLE
               ];
-              if (!olArray.includes(supportedTypes, geomType)) {
+              if (!supportedTypes.includes(geomType)) {
                 this.clone.setExpression(null);
               }
             }
@@ -843,7 +842,7 @@ exports.RuleController_ = class {
       pixel,
       (feature) => {
         let ret = false;
-        if (olArray.includes(this.selectedFeatures.getArray(), feature)) {
+        if (this.selectedFeatures.getArray().includes(feature)) {
           ret = feature;
         }
         return ret;

--- a/src/format/FeatureHash.js
+++ b/src/format/FeatureHash.js
@@ -8,7 +8,6 @@ import ngeoUtils from 'ngeo/utils.js';
 import {inherits as olUtilInherits} from 'ol/util.js';
 import olFeature from 'ol/Feature.js';
 import * as olColor from 'ol/color.js';
-import * as olArray from 'ol/array.js';
 import * as olFormatFeature from 'ol/format/Feature.js';
 import olFormatTextFeature from 'ol/format/TextFeature.js';
 import olGeomGeometryLayout from 'ol/geom/GeometryLayout.js';
@@ -694,9 +693,9 @@ exports.castValue_ = function(key, value) {
     'showLabel'
   ];
 
-  if (olArray.includes(numProperties, key)) {
+  if (numProperties.includes(key)) {
     return +value;
-  } else if (olArray.includes(boolProperties, key)) {
+  } else if (boolProperties.includes(key)) {
     return (value === 'true') ? true : false;
   } else {
     return value;

--- a/src/interaction/MeasureLengthMobile.js
+++ b/src/interaction/MeasureLengthMobile.js
@@ -4,7 +4,6 @@
 import ngeoInteractionMeasureLength from 'ngeo/interaction/MeasureLength.js';
 import ngeoInteractionMobileDraw from 'ngeo/interaction/MobileDraw.js';
 import {inherits as olUtilInherits} from 'ol/util.js';
-import * as olObj from 'ol/obj.js';
 
 /**
  * @classdesc
@@ -21,7 +20,7 @@ const exports = function(format, gettextCatalog, opt_options) {
 
   const options = opt_options !== undefined ? opt_options : {};
 
-  olObj.assign(options, {displayHelpTooltip: false});
+  Object.assign(options, {displayHelpTooltip: false});
 
   ngeoInteractionMeasureLength.call(this, format, gettextCatalog, options);
 

--- a/src/interaction/MeasurePointMobile.js
+++ b/src/interaction/MeasurePointMobile.js
@@ -5,7 +5,7 @@ import googAsserts from 'goog/asserts.js';
 import ngeoInteractionMeasure from 'ngeo/interaction/Measure.js';
 import ngeoInteractionMobileDraw from 'ngeo/interaction/MobileDraw.js';
 import {inherits as olUtilInherits} from 'ol/util.js';
-import * as olObj from 'ol/obj.js';
+
 import olGeomPoint from 'ol/geom/Point.js';
 
 /**
@@ -21,7 +21,7 @@ import olGeomPoint from 'ol/geom/Point.js';
  */
 const exports = function(format, coordFormat, options = /** @type {ngeox.interaction.MeasureOptions} */ ({})) {
 
-  olObj.assign(options, {displayHelpTooltip: false});
+  Object.assign(options, {displayHelpTooltip: false});
 
   ngeoInteractionMeasure.call(this, /** @type {ngeo.interaction.MeasureBaseOptions} */(options));
 

--- a/src/misc/FeatureHelper.js
+++ b/src/misc/FeatureHelper.js
@@ -11,7 +11,6 @@ import ngeoFormatFeatureProperties from 'ngeo/format/FeatureProperties.js';
 import ngeoGeometryType from 'ngeo/GeometryType.js';
 import ngeoInteractionMeasure from 'ngeo/interaction/Measure.js';
 import ngeoInteractionMeasureAzimut from 'ngeo/interaction/MeasureAzimut.js';
-import * as olArray from 'ol/array.js';
 import * as olColor from 'ol/color.js';
 import * as olExtent from 'ol/extent.js';
 import olFeature from 'ol/Feature.js';
@@ -793,7 +792,7 @@ exports.prototype.supportsVertex_ = function(feature) {
     ngeoGeometryType.RECTANGLE
   ];
   const type = this.getType(feature);
-  return olArray.includes(supported, type);
+  return supported.includes(type);
 };
 
 
@@ -811,7 +810,7 @@ exports.prototype.supportsVertexRemoval_ = function(feature) {
     ngeoGeometryType.POLYGON
   ];
   const type = this.getType(feature);
-  return olArray.includes(supported, type);
+  return supported.includes(type);
 };
 
 

--- a/src/print/Service.js
+++ b/src/print/Service.js
@@ -5,7 +5,6 @@ import googAsserts from 'goog/asserts.js';
 import ngeoPrintVectorEncoder from 'ngeo/print/VectorEncoder.js';
 import ngeoMapLayerHelper from 'ngeo/map/LayerHelper.js';
 import * as olArray from 'ol/array.js';
-import * as olObj from 'ol/obj.js';
 import olLayerImage from 'ol/layer/Image.js';
 import olLayerTile from 'ol/layer/Tile.js';
 import olLayerVector from 'ol/layer/Vector.js';
@@ -139,7 +138,7 @@ exports.prototype.createSpec = function(
   const attributes = /** @type {!MapFishPrintAttributes} */ ({
     map: specMap
   });
-  olObj.assign(attributes, customAttributes);
+  Object.assign(attributes, customAttributes);
 
   const lang = this.gettextCatalog_.currentLanguage;
 
@@ -427,7 +426,7 @@ exports.prototype.createReport = function(printSpec, opt_httpConfig) {
       'Content-Type': 'application/json; charset=UTF-8'
     }
   });
-  olObj.assign(httpConfig,
+  Object.assign(httpConfig,
     opt_httpConfig !== undefined ? opt_httpConfig : {});
   return this.$http_.post(url, printSpec, httpConfig);
 };

--- a/src/profile/d3Elevation.js
+++ b/src/profile/d3Elevation.js
@@ -2,7 +2,6 @@
  * @module ngeo.profile.d3Elevation
  */
 import googAsserts from 'goog/asserts.js';
-import * as olObj from 'ol/obj.js';
 
 import 'd3-transition';
 import {bisector, extent} from 'd3-array';
@@ -194,7 +193,7 @@ const exports = function(options) {
   };
 
   if (options.formatter !== undefined) {
-    olObj.assign(formatter, options.formatter);
+    Object.assign(formatter, options.formatter);
   }
 
   /**

--- a/src/profile/elevationComponent.js
+++ b/src/profile/elevationComponent.js
@@ -3,7 +3,6 @@
  */
 import googAsserts from 'goog/asserts.js';
 import * as olEvents from 'ol/events.js';
-import * as olObj from 'ol/obj.js';
 import ngeoMiscDebounce from 'ngeo/misc/debounce.js';
 import ngeoProfileD3Elevation from 'ngeo/profile/d3Elevation.js';
 
@@ -68,7 +67,7 @@ exports.directive_ = function(ngeoDebounce) {
       scope.$watchCollection(optionsAttr, (newVal) => {
 
         const options = /** @type {ngeox.profile.ProfileOptions} */
-                (olObj.assign({}, newVal));
+                (Object.assign({}, newVal));
 
         if (options !== undefined) {
 

--- a/src/query/MapQuerent.js
+++ b/src/query/MapQuerent.js
@@ -5,7 +5,6 @@ import googAsserts from 'goog/asserts.js';
 import ngeoQueryQuerent from 'ngeo/query/Querent.js';
 import ngeoDatasourceDataSources from 'ngeo/datasource/DataSources.js';
 import ngeoDatasourceHelper from 'ngeo/datasource/Helper.js';
-import * as olObj from 'ol/obj.js';
 
 const exports = class {
 
@@ -111,7 +110,7 @@ const exports = class {
     // (3) Update query options, update the pending property and issue the
     //     request.
     const limit = options.limit !== undefined ? options.limit : this.limit_;
-    olObj.assign(options, {
+    Object.assign(options, {
       queryableDataSources: queryableDataSources,
       limit: limit,
       tolerancePx: this.tolerancePx_,

--- a/src/query/Querent.js
+++ b/src/query/Querent.js
@@ -9,7 +9,6 @@ import olFormatWFS from 'ol/format/WFS.js';
 import ngeoWFSDescribeFeatureType from 'ngeo/WFSDescribeFeatureType.js';
 import olFormatWMSCapabilities from 'ol/format/WMSCapabilities.js';
 import olFormatWMTSCapabilities from 'ol/format/WMTSCapabilities.js';
-import * as olObj from 'ol/obj.js';
 import * as olUri from 'ol/uri.js';
 import * as olExtent from 'ol/extent.js';
 import olSourceImageWMS from 'ol/source/ImageWMS.js';
@@ -541,7 +540,7 @@ const exports = class {
           url = dataSource.wfsUrl;
 
           // All data sources combined share the same active dimensions
-          olObj.assign(params, dataSource.activeDimensions);
+          Object.assign(params, dataSource.activeDimensions);
         }
 
         // (b) Add queryable layer names in featureTypes array
@@ -606,7 +605,7 @@ const exports = class {
       let countPromise;
       if (wfsCount) {
         const getCountOptions = /** @type {olx.format.WFSWriteGetFeatureOptions} */ (
-          olObj.assign(
+          Object.assign(
             {
               resultType: 'hits'
             },
@@ -642,7 +641,7 @@ const exports = class {
         if (numberOfFeatures === undefined || numberOfFeatures < maxFeatures) {
 
           const getFeatureOptions = /** @type {olx.format.WFSWriteGetFeatureOptions} */ (
-            olObj.assign(
+            Object.assign(
               {
                 maxFeatures
               },
@@ -735,7 +734,7 @@ const exports = class {
         //     been combined together, therefore they share the same active
         //     dimensions.
         if (!activeDimensionsSet) {
-          olObj.assign(params, dataSource.activeDimensions);
+          Object.assign(params, dataSource.activeDimensions);
           activeDimensionsSet = true;
         }
 

--- a/src/search/createGeoJSONBloodhound.js
+++ b/src/search/createGeoJSONBloodhound.js
@@ -2,7 +2,6 @@
  * @module ngeo.search.createGeoJSONBloodhound
  */
 import olFormatGeoJSON from 'ol/format/GeoJSON.js';
-import * as olObj from 'ol/obj.js';
 
 import 'corejs-typeahead';
 
@@ -53,17 +52,17 @@ const exports = function(url, opt_filter, opt_featureProjection,
   });
 
   // the options objects are cloned to avoid updating the passed object
-  const options = olObj.assign({}, opt_options || {});
-  const remoteOptions = olObj.assign({}, opt_remoteOptions || {});
+  const options = Object.assign({}, opt_options || {});
+  const remoteOptions = Object.assign({}, opt_remoteOptions || {});
 
   if (options.remote) {
     // move the remote options to opt_remoteOptions
-    olObj.assign(remoteOptions, options.remote);
+    Object.assign(remoteOptions, options.remote);
     delete options.remote;
   }
 
-  olObj.assign(bloodhoundOptions, options);
-  olObj.assign(bloodhoundOptions.remote, remoteOptions);
+  Object.assign(bloodhoundOptions, options);
+  Object.assign(bloodhoundOptions.remote, remoteOptions);
 
   return new Bloodhound(bloodhoundOptions);
 };

--- a/src/search/createLocationSearchBloodhound.js
+++ b/src/search/createLocationSearchBloodhound.js
@@ -1,7 +1,6 @@
 /**
  * @module ngeo.search.createLocationSearchBloodhound
  */
-import * as olObj from 'ol/obj.js';
 import * as olProj from 'ol/proj.js';
 
 /** @suppress {extraRequire} */
@@ -107,17 +106,17 @@ const exports = function(opt_options) {
   });
 
   // the options objects are cloned to avoid updating the passed object
-  const bhOptions = olObj.assign({}, options.options || {});
-  const remoteOptions = olObj.assign({}, options.remoteOptions || {});
+  const bhOptions = Object.assign({}, options.options || {});
+  const remoteOptions = Object.assign({}, options.remoteOptions || {});
 
   if (bhOptions.remote) {
     // move the remote options to opt_remoteOptions
-    olObj.assign(remoteOptions, bhOptions.remote);
+    Object.assign(remoteOptions, bhOptions.remote);
     delete bhOptions.remote;
   }
 
-  olObj.assign(bloodhoundOptions, bhOptions);
-  olObj.assign(bloodhoundOptions.remote, remoteOptions);
+  Object.assign(bloodhoundOptions, bhOptions);
+  Object.assign(bloodhoundOptions.remote, remoteOptions);
 
   return new Bloodhound(bloodhoundOptions);
 };


### PR DESCRIPTION
The `assign` function from ol is already a polyfill for `Object.assign` but we're
loading this polyfill from polyfill.io: https://polyfill.io/v2/docs/features/#default-sets