### PR TITLE
Be able to disable oeedit

### DIFF
--- a/contribs/gmf/apps/oeedit/index.html
+++ b/contribs/gmf/apps/oeedit/index.html
@@ -76,7 +76,7 @@
               </div>
               <gmf-objectediting
                 ng-if="mainCtrl.oeFeature && mainCtrl.oeLayerNodeId"
-                gmf-objectediting-active="mainCtrl.oeActive"
+                gmf-objectediting-active="mainCtrl.oeEditActive"
                 gmf-objectediting-feature="mainCtrl.oeFeature"
                 gmf-objectediting-geomtype="::mainCtrl.oeGeomType"
                 gmf-objectediting-layernodeid="::mainCtrl.oeLayerNodeId"

--- a/contribs/gmf/src/directives/objectediting.js
+++ b/contribs/gmf/src/directives/objectediting.js
@@ -393,6 +393,15 @@ gmf.ObjecteditingController.prototype.$onInit = function() {
     this.handleGetQueryableLayersInfo_.bind(this)
   );
 
+  this.scope_.$watch(
+    () => this.active,
+    (newVal, oldVal) => {
+      if (newVal != oldVal) {
+        this.toggle_(newVal);
+      }
+    }
+  );
+
   this.scope_.$watchCollection(
     () => {
       if (this.gmfTreeManager_.rootCtrl) {
@@ -448,7 +457,6 @@ gmf.ObjecteditingController.prototype.$onInit = function() {
 
   // Toggle on
   this.initializeInteractions_();
-  this.registerInteractions_();
   this.toggle_(true);
   this.resetGeometryChanges_();
 
@@ -545,7 +553,6 @@ gmf.ObjecteditingController.prototype.undo = function() {
 
 
 /**
- * Undo the latest modifications.
  * @return {boolean} Whether the state is INSERT or not.
  * @export
  */
@@ -693,9 +700,11 @@ gmf.ObjecteditingController.prototype.toggle_ = function(active) {
     toolMgr.registerTool(uid, this.modifyToolActivate_, true);
     toolMgr.registerTool(uid, this.toolsToolActivate_, false);
 
+    this.registerInteractions_();
+
   } else {
 
-    this.undoAllChanges_();
+    this.unregisterInteractions_();
 
     keys.forEach((key) => {
       ol.events.unlistenByKey(key);
@@ -706,6 +715,7 @@ gmf.ObjecteditingController.prototype.toggle_ = function(active) {
 
   }
 
+  this.toolsActive = active;
   this.modify_.setActive(active);
 };
 
@@ -1069,7 +1079,7 @@ gmf.ObjecteditingController.prototype.handleGetQueryableLayersInfo_ = function(
 gmf.ObjecteditingController.prototype.handleDestroy_ = function() {
   this.features_.clear();
   this.toggle_(false);
-  this.unregisterInteractions_();
+  this.undoAllChanges_();
 };
 
 

--- a/contribs/gmf/src/directives/objecteditingtools.js
+++ b/contribs/gmf/src/directives/objecteditingtools.js
@@ -252,6 +252,24 @@ gmf.ObjecteditingtoolsController = function($injector, $scope,
   $scope.$on('$destroy', this.handleDestroy_.bind(this));
 };
 
+/**
+ * Init the controller
+ */
+gmf.ObjecteditingtoolsController.prototype.$onInit = function() {
+  this.scope_.$watch(
+    () => this.active,
+    (newVal, oldVal) => {
+      // if it's not active, deactive tools
+      if (!this.active) {
+        this.requiresLayer = false;
+        for (let i = 0, ii = this.toolActiveNames_.length; i < ii; i++) {
+          this[this.toolActiveNames_[i]] = false;
+        }
+      }
+    }
+  );
+};
+
 
 /**
  * Register a tool using its `active` property name and what behavior it should
@@ -310,19 +328,15 @@ gmf.ObjecteditingtoolsController.prototype.handleToolActiveChange_ = function(
     this.requiresLayer = requiresLayer;
   }
 
-  // Update active property
+  // If one tool is active, update active property to true.
   let active = false;
   for (let i = 0, ii = this.toolActiveNames_.length; i < ii; i++) {
-    active = active || this[this.toolActiveNames_[i]];
+    active = this[this.toolActiveNames_[i]];
     if (active) {
       break;
     }
   }
   this.active = active;
-
-  if (!this.active) {
-    this.requiresLayer = false;
-  }
 };
 
 


### PR DESCRIPTION
FIX https://jira.camptocamp.com/browse/GEO-1652

Now if  the objectediting tool is deactivated, it's not possible anymore to edit the feature.

(Easier to understand commit per commit).

(currently corners are style displayed, even if we can't move them anymore. It's not very nice, but it causes no problem)