### PR TITLE
Remove HardSourceWebpackPlugin

### DIFF
--- a/buildtools/webpack.commons.js
+++ b/buildtools/webpack.commons.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const webpack = require('webpack');
 const SassPlugin = require('./webpack.plugin.js');
-const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
 const devMode = process.env.NODE_ENV !== 'production';
 
@@ -158,7 +157,6 @@ const config = function(hardSourceConfig, babelLoaderCacheDirectory) {
         }
       }),
       new webpack.IgnorePlugin(/^\.\/locale$/, /node_modules\/moment\/src\/lib\/locale$/),
-      new HardSourceWebpackPlugin(hardSourceConfig || {}),
     ],
     resolve: {
       modules: [

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "file-saver": "2.0.0",
     "floatthead": "2.1.2",
     "fs-extra": "7.0.1",
-    "hard-source-webpack-plugin": "0.6.12",
     "html-webpack-include-assets-plugin": "1.0.6",
     "html-webpack-plugin": "3.2.0",
     "istanbul-instrumenter-loader": "3.0.1",


### PR DESCRIPTION
Unmaintained ans have some incompatibility issues with Dll plugin.

I get error like:
```
ERROR in chunk oeedit [entry]
oeedit.085aa7.js
/usr/lib/node_modules/babel-loader/lib/index.js??ref--13!/src/geoportal/demo_geoportal/static-ngeo/js/apps/Controlleroeedit.js
e4de6c920a5f4bbd861837c15c7a4eec
Unexpected token (1:95)
| /* harmony default export */ var __WEBPACK_MODULE_DEFAULT_EXPORT__ =
(undefinedfunction (o, i) {
    |   return o.interfaces_ && o.interfaces_.indexOf(i) > -1;
    | });
```

See also:
https://github.com/mzgoddard/hard-source-webpack-plugin/issues/443