### PR TITLE
Fix total in MapQuerent.clear when keep is true

### DIFF
--- a/src/query/MapQuerent.js
+++ b/src/query/MapQuerent.js
@@ -156,6 +156,8 @@ const exports = class {
       if (!keep) {
         source.features.length = 0;
         source.totalFeatureCount = undefined;
+      } else {
+        this.result_.total += source.features.length;
       }
       source.pending = false;
       source.queried = false;


### PR DESCRIPTION
Fix total when keep is true.
Without this, when removing from selection, after handleResult_, total is < 0 so selection is not shown.