### PR TITLE
Fix #4471 - Call the function in watcher

### DIFF
--- a/contribs/gmf/src/query/window.less
+++ b/contribs/gmf/src/query/window.less
@@ -74,6 +74,9 @@ div.ngeo-displaywindow {
       &.ng-enter, &.ng-leave {
         transition: 0.3s ease-in all;
       }
+      .content-template-container {
+        overflow: auto;
+      }
     }
   }
   .animation-container-detailed {

--- a/src/message/displaywindowComponent.js
+++ b/src/message/displaywindowComponent.js
@@ -210,7 +210,7 @@ exports.Controller_ = class {
 
     this.scope_.$watch(
       () => this.contentTemplate,
-      () => this.updateContentTemplate_
+      () => this.updateContentTemplate_()
     );
   }
 


### PR DESCRIPTION
#4471 is not working, because, IHMO, we need to call the function and not just define it in the watcher.

I tested that in my project and it seems to work.

Could somebody please review that and eventually merge it, because I really need it inside 2.3...

Thanks a lot.