### PR TITLE
Fix 752 - Alternate key to query while adding

### DIFF
--- a/src/query/Keyboard.js
+++ b/src/query/Keyboard.js
@@ -20,7 +20,7 @@ class Keyboard {
      * @type {string}
      * @private
      */
-    this.keyAdd_ = 'a';
+    this.keyAdd_ = 'q';
 
     /**
      * The key to press for "REMOVE" action


### PR DESCRIPTION
Ctrl + A selects all the text of the browser.  This is a default behaviour.  Therefore, using Ctrl + A as a way to add more features in a map query is not wanted.  We need an other key.

Let's use CTRL + Q instead.  On a qwerty keyboard, Q is right next to A and there's nothing assigned to Ctrl + Q.