### PR TITLE
752 - Alternate way to deal with query ADD and REMOVE

### DIFF
--- a/src/query/Keyboard.js
+++ b/src/query/Keyboard.js
@@ -10,8 +10,9 @@ class Keyboard {
    * Listens to the keyboard `keydown` and `keyup` events to keep
    * track of the query action to do depending on the key being
    * pressed.
+   * @param {angular.IScope} $rootScope .
    */
-  constructor() {
+  constructor($rootScope) {
 
     // Constants
 
@@ -45,6 +46,12 @@ class Keyboard {
      */
     this.activeKey_ = null;
 
+    /**
+     * @type {angular.IScope}
+     * @private
+     */
+    this.rootScope_ = $rootScope;
+
     // Event listeners
     olEventsListen(document, 'keydown', this.handleKeyDown_, this);
     olEventsListen(document, 'keyup', this.handleKeyUp_, this);
@@ -68,6 +75,17 @@ class Keyboard {
     return action;
   }
 
+  // Setters
+
+  /**
+   * @param {?string} key Key as active.
+   * @private
+   */
+  set activeKey(key) {
+    this.activeKey_ = key;
+    this.rootScope_.$apply();
+  }
+
   // Handlers
 
   /**
@@ -76,7 +94,7 @@ class Keyboard {
    */
   handleKeyDown_(evt) {
     if (!this.activeKey_ && this.keys_.includes(evt.key)) {
-      this.activeKey_ = evt.key;
+      this.activeKey = evt.key;
     }
   }
 
@@ -86,9 +104,17 @@ class Keyboard {
    */
   handleKeyUp_(evt) {
     if (this.activeKey_ && this.activeKey_ === evt.key) {
-      this.activeKey_ = null;
+      this.activeKey = null;
     }
   }
 }
 
-export default new Keyboard();
+/**
+ * @type {!angular.IModule}
+ */
+const module = angular.module('ngeoQueryKeyboard', [
+]);
+module.service('ngeoQueryKeyboard', Keyboard);
+
+
+export default module;

--- a/src/query/mapQueryComponent.js
+++ b/src/query/mapQueryComponent.js
@@ -8,6 +8,7 @@ import {
 } from 'ol/events.js';
 
 const module = angular.module('ngeoMapQuery', [
+  ngeoQueryKeyboard.name,
   ngeoQueryMapQuerent.name,
 ]);
 
@@ -35,13 +36,14 @@ const module = angular.module('ngeoMapQuery', [
  * See our live example: [../examples/mapquery.html](../examples/mapquery.html)
  *
  * @param {import("ngeo/query/MapQuerent.js").MapQuerent} ngeoMapQuerent The ngeo map querent service.
+ * @param {import("ngeo/query/Keyboard.js").Keyboard} ngeoQueryKeyboard The ngeo query keyboard service.
  * @param {angular.auto.IInjectorService} $injector Main injector.
  * @return {angular.IDirective} The Directive Definition Object.
  * @ngInject
  * @ngdoc directive
  * @ngname ngeoMapQuery
  */
-function directive(ngeoMapQuerent, $injector) {
+function directive(ngeoMapQuerent, ngeoQueryKeyboard, $injector) {
   return {
     restrict: 'A',
     scope: false,


### PR DESCRIPTION
This patch introduces a new way to deal with addition / removal of query results.  With this patch, while the user presses the "A" or "X" key, the map can either be clicked or have a box being drawn to either add or remove features to/from the query results.

In order to do that, the Keyboard class has been changed to a angular service to make its `action` getter watchable.  Then, in the bboxQuery directive, an extra section has been added to automatically add an OpenLayers DragBox interaction on top of all others to make it the active interaction while the user presses the "A" or "X" key.  The same handler is used to issue a request to the map querent, so nothing new needs to be done other than that.