### PR TITLE
Call dispose on tooltips and popovers

### DIFF
--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -111,7 +111,7 @@ export class AbstractDesktopController extends AbstractAPIController {
 
     // deactivate tooltips on touch device
     body.on('touchstart.detectTouch', () => {
-      body.tooltip('destroy');
+      body.tooltip('dispose');
       body.off('touchstart.detectTouch');
     });
 

--- a/src/message/popoverComponent.js
+++ b/src/message/popoverComponent.js
@@ -53,7 +53,7 @@ function component() {
       }
 
       scope.$on('$destroy', () => {
-        ngeoPopoverCtrl.anchorElm.popover('destroy');
+        ngeoPopoverCtrl.anchorElm.popover('dispose');
         ngeoPopoverCtrl.anchorElm.unbind('inserted.bs.popover');
         ngeoPopoverCtrl.anchorElm.unbind('hidden.bs.popover');
       });


### PR DESCRIPTION
The name was changed between version 3 and 4:
https://getbootstrap.com/docs/4.0/components/tooltips/#methods
https://getbootstrap.com/docs/4.0/components/popovers/#methods