### PR TITLE
Even more typecheck fixes for gmf

### DIFF
--- a/contribs/gmf/src/datasource/Helper.js
+++ b/contribs/gmf/src/datasource/Helper.js
@@ -3,7 +3,7 @@ import gmfEditingEnumerateAttribute from 'gmf/editing/EnumerateAttribute.js';
 import ngeoDatasourceHelper from 'ngeo/datasource/Helper.js';
 import ngeoFormatAttributeType from 'ngeo/format/AttributeType.js';
 
-class Helper {
+export class Helper {
 
   /**
    * A service that provides utility methods to manipulate or get GMF data

--- a/contribs/gmf/src/datasource/Helper.js
+++ b/contribs/gmf/src/datasource/Helper.js
@@ -12,7 +12,7 @@ export class Helper {
    * @param {angular.IQService} $q The Angular $q service.
    * @param {import("gmf/editing/EnumerateAttribute.js").EditingEnumerateAttributeService} gmfEnumerateAttribute The Gmf enumerate
    *     attribute service.
-   * @param {import("ngeo/datasource/Helper.js").Helper} ngeoDataSourcesHelper Ngeo data
+   * @param {import("ngeo/datasource/Helper.js").DatasourceHelper} ngeoDataSourcesHelper Ngeo data
    *     source helper service.
    * @ngdoc service
    * @ngname gmfDataSourcesHelper
@@ -35,7 +35,7 @@ export class Helper {
     this.gmfEnumerateAttribute_ = gmfEnumerateAttribute;
 
     /**
-     * @type {import("ngeo/datasource/Helper.js").Helper}
+     * @type {import("ngeo/datasource/Helper.js").DatasourceHelper}
      * @private
      */
     this.ngeoDataSourcesHelper_ = ngeoDataSourcesHelper;

--- a/contribs/gmf/src/datasource/Helper.js
+++ b/contribs/gmf/src/datasource/Helper.js
@@ -3,7 +3,7 @@ import gmfEditingEnumerateAttribute from 'gmf/editing/EnumerateAttribute.js';
 import ngeoDatasourceHelper from 'ngeo/datasource/Helper.js';
 import ngeoFormatAttributeType from 'ngeo/format/AttributeType.js';
 
-export class Helper {
+export class DatasourceHelper {
 
   /**
    * A service that provides utility methods to manipulate or get GMF data
@@ -135,7 +135,7 @@ const module = angular.module('gmfDataSourcesHelper', [
   ngeoDatasourceHelper.name,
   gmfEditingEnumerateAttribute.name,
 ]);
-module.service('gmfDataSourcesHelper', Helper);
+module.service('gmfDataSourcesHelper', DatasourceHelper);
 
 
 export default module;

--- a/contribs/gmf/src/datasource/OGC.js
+++ b/contribs/gmf/src/datasource/OGC.js
@@ -9,7 +9,7 @@ import ngeoDatasourceOGC from 'ngeo/datasource/OGC.js';
  */
 
 
-export default class extends ngeoDatasourceOGC {
+class gmfDatasourceOGC extends ngeoDatasourceOGC {
 
   /**
    * A `gmf.datasource.OGC` extends a `ngeo.datasource.OGC` and
@@ -42,3 +42,5 @@ export default class extends ngeoDatasourceOGC {
   }
 
 }
+
+export default gmfDatasourceOGC;

--- a/contribs/gmf/src/datasource/WFSAliases.js
+++ b/contribs/gmf/src/datasource/WFSAliases.js
@@ -8,7 +8,7 @@ export class DatasourceWFSAlias {
    * Service that provides methods to get additional information and actions
    * when performing WFS requests.
    *
-   * @param {import("ngeo/datasource/Helper.js").Helper} ngeoDataSourcesHelper Ngeo data
+   * @param {import("ngeo/datasource/Helper.js").DatasourceHelper} ngeoDataSourcesHelper Ngeo data
    *     source helper service.
    * @ngdoc service
    * @ngname gmfWFSAliases
@@ -19,7 +19,7 @@ export class DatasourceWFSAlias {
     // === Injected properties ===
 
     /**
-     * @type {import("ngeo/datasource/Helper.js").Helper}
+     * @type {import("ngeo/datasource/Helper.js").DatasourceHelper}
      * @private
      */
     this.ngeoDataSourcesHelper_ = ngeoDataSourcesHelper;

--- a/contribs/gmf/src/editing/Snapping.js
+++ b/contribs/gmf/src/editing/Snapping.js
@@ -205,7 +205,8 @@ EditingSnappingService.prototype.registerTreeCtrl_ = function(treeCtrl) {
 
   // Skip any Layertree controller that has a node that is not a leaf
   let node = /** @type {import('gmf/themes.js').GmfGroup|import('gmf/themes.js').GmfLayer} */ (treeCtrl.node);
-  if (node.children) {
+  const groupNode = /** @type import('gmf/themes.js').GmfGroup */ (node);
+  if (groupNode.children) {
     return;
   }
 
@@ -268,7 +269,7 @@ EditingSnappingService.prototype.unregisterAllTreeCtrl_ = function() {
  * Get the OGC server.
  *
  * @param {import("ngeo/layertree/Controller.js").LayertreeController} treeCtrl The layer tree controller
- * @return {?import('gmf/themes.js').GmfOgcServers} The OGC server.
+ * @return {?import('gmf/themes.js').GmfOgcServer} The OGC server.
  * @private
  */
 EditingSnappingService.prototype.getOGCServer_ = function(treeCtrl) {

--- a/contribs/gmf/src/filters/SavedFilters.js
+++ b/contribs/gmf/src/filters/SavedFilters.js
@@ -234,7 +234,7 @@ SavedFilterItem.prototype.condition;
 
 /**
  * The list of custom rules of the saved filter item.
- * @type {!Array.<!AnyOptions>}
+ * @type {!Array.<!import("ngeo/filter/RuleHelper.js").AnyOptions>}
  * @export
  */
 SavedFilterItem.prototype.customRules;
@@ -250,7 +250,7 @@ SavedFilterItem.prototype.dataSourceId;
 
 /**
  * The list of directed rules of the saved filter item.
- * @type {!Array.<!AnyOptions>}
+ * @type {!Array.<!import("ngeo/filter/RuleHelper.js").AnyOptions>}
  * @export
  */
 SavedFilterItem.prototype.directedRules;

--- a/contribs/gmf/src/filters/filterselectorComponent.js
+++ b/contribs/gmf/src/filters/filterselectorComponent.js
@@ -76,7 +76,7 @@ class Controller {
    * @param {import('gmf/datasource/DataSourceBeingFiltered.js').DataSourceBeingFiltered} gmfDataSourceBeingFiltered
    *     The Gmf value service that determines the data source currently being
    *     filtered.
-   * @param {import("gmf/datasource/Helper.js").Helper} gmfDataSourcesHelper Gmf data
+   * @param {import("gmf/datasource/Helper.js").DatasourceHelper} gmfDataSourcesHelper Gmf data
    *     sources helper service.
    * @param {import("gmf/filters/SavedFilters.js").SavedFilter} gmfSavedFilters Gmf saved filters service.
    * @param {import('gmf/authentication/Service.js').User} gmfUser User.
@@ -149,7 +149,7 @@ class Controller {
     );
 
     /**
-     * @type {import("gmf/datasource/Helper.js").Helper}
+     * @type {import("gmf/datasource/Helper.js").DatasourceHelper}
      * @private
      */
     this.gmfDataSourcesHelper_ = gmfDataSourcesHelper;

--- a/contribs/gmf/src/import/importdatasourceComponent.js
+++ b/contribs/gmf/src/import/importdatasourceComponent.js
@@ -248,15 +248,15 @@ class Controller {
           return datumTokenizers;
         },
         queryTokenizer: Bloodhound.tokenizers.whitespace,
-        identify: false,
         local: serverUrls
       });
     }
 
     // Register input[type=file] onchange event, use HTML5 File api
     this.fileInput_.on('change', () => {
-      this.file = this.fileInput_[0].files && this.fileInput_[0].files[0] ?
-        this.fileInput_[0].files[0] : undefined;
+      const fileInput = /** @type HTMLInputElement */ (this.fileInput_[0]);
+      const files = fileInput.files;
+      this.file = files && files[0] ? files[0] : undefined;
       this.scope_.$apply();
     });
   }

--- a/contribs/gmf/src/import/wmsCapabilityLayertreeComponent.js
+++ b/contribs/gmf/src/import/wmsCapabilityLayertreeComponent.js
@@ -108,7 +108,7 @@ class Controller {
 
   /**
    * @param {!Object} layer WMS Capability Layer object
-   * @return {number} Unique id for the Capability Layer.
+   * @return {string} Unique id for the Capability Layer.
    * @export
    */
   getUid(layer) {

--- a/contribs/gmf/src/import/wmtsCapabilityLayertreeComponent.js
+++ b/contribs/gmf/src/import/wmtsCapabilityLayertreeComponent.js
@@ -106,7 +106,7 @@ class Controller {
 
   /**
    * @param {!Object} layer WMTS Capability Layer object
-   * @return {number} Unique id for the Capability Layer.
+   * @return {string} Unique id for the Capability Layer.
    * @export
    */
   getUid(layer) {

--- a/contribs/gmf/src/layertree/SyncLayertreeMap.js
+++ b/contribs/gmf/src/layertree/SyncLayertreeMap.js
@@ -46,7 +46,7 @@ export function SyncLayertreeMap($rootScope, ngeoLayerHelper, ngeoWMSTime, gmfTh
   });
 
   $rootScope.$on('ngeo-layertree-state', (map, treeCtrl, firstParent) => {
-    this.sync_(/** @type import("ol/Map.js").default */ (map), firstParent);
+    this.sync_(firstParent);
   });
 }
 
@@ -94,14 +94,14 @@ SyncLayertreeMap.prototype.createLayer = function(treeCtrl, map, dataLayerGroup,
 /**
  * Synchronise the state of each layers corresponding to the given tree and
  * all its children.
- * @param {import("ol/Map.js").default} map A map that contains the layers.
  * @param {import("ngeo/layertree/Controller.js").LayertreeController} treeCtrl ngeo layertree controller.
  * @private
  */
-SyncLayertreeMap.prototype.sync_ = function(map, treeCtrl) {
+SyncLayertreeMap.prototype.sync_ = function(treeCtrl) {
   treeCtrl.traverseDepthFirst((treeCtrl) => {
     if (treeCtrl.layer && !treeCtrl.node.mixed) {
       this.updateLayerState_(/** @type import("ol/layer/Image.js").default|import("ol/layer/Tile.js").default */ (treeCtrl.layer), treeCtrl);
+      return LayertreeVisitorDecision.DESCEND;
     }
   });
 };
@@ -127,6 +127,7 @@ SyncLayertreeMap.prototype.updateLayerState_ = function(layer, treeCtrl) {
         names.push(treeCtrl.node.layers);
         const style = (treeCtrl.node.style !== undefined) ? treeCtrl.node.style : '';
         styles.push(style);
+        return LayertreeVisitorDecision.DESCEND;
       }
     });
     if (names.length === 0) {
@@ -231,6 +232,7 @@ SyncLayertreeMap.prototype.createLayerFromGroup_ = function(treeCtrl,
         ctrl.setState('on', false);
         this.updateLayerState_(/** @type {import("ol/layer/Image.js").default} */ (layer), ctrl);
         hasActiveChildren = true;
+        return LayertreeVisitorDecision.DESCEND;
       }
     });
     layer.setVisible(hasActiveChildren);

--- a/contribs/gmf/src/layertree/TreeManager.js
+++ b/contribs/gmf/src/layertree/TreeManager.js
@@ -202,7 +202,7 @@ LayertreeTreeManager.prototype.addFirstLevelGroups = function(firstLevelGroups,
  * @private
  */
 LayertreeTreeManager.prototype.updateTreeGroupsState_ = function(groups) {
-  const treeGroupsParam = {};
+  const treeGroupsParam = /** @type Object.<string, string> */ ({});
   treeGroupsParam[PermalinkParam.TREE_GROUPS] = groups.map(node => node.name).join(',');
   this.ngeoStateManager_.updateState(treeGroupsParam);
   if (this.$injector_.has('gmfPermalink')) {
@@ -286,11 +286,13 @@ LayertreeTreeManager.prototype.addFirstLevelGroup_ = function(group) {
  * @private
  */
 LayertreeTreeManager.prototype.manageExclusiveGroupSingleChecked_ = function(node, found) {
-  const children = node.children;
+  const groupNode = /** @type import('gmf/themes.js').GmfGroup */ (node);
+  const children = groupNode.children;
   if (children) {
     for (const child of children) {
-      if (child.children) {
-        found = this.manageExclusiveGroupSingleChecked_(child, found);
+      const childGroup = /** @type import('gmf/themes.js').GmfGroup */ (child);
+      if (childGroup.children) {
+        found = this.manageExclusiveGroupSingleChecked_(childGroup, found);
       } else {
         if (child.metadata.isChecked) {
           if (found) {
@@ -342,7 +344,7 @@ LayertreeTreeManager.prototype.addGroupByLayerName = function(layerName, opt_add
           console.warn('Tree controller not found, unable to add the group');
           return;
         }
-        let treeCtrlToActive;
+        let treeCtrlToActive = /** @type import("ngeo/layertree/Controller.js").LayertreeController */ (null);
         treeCtrl.traverseDepthFirst((treeCtrl) => {
           if (treeCtrl.node.name === layerName) {
             treeCtrlToActive = treeCtrl;
@@ -423,12 +425,15 @@ LayertreeTreeManager.prototype.cloneGroupNode_ = function(group, names) {
  * @private
  */
 LayertreeTreeManager.prototype.toggleNodeCheck_ = function(node, names) {
-  if (!node.children) {
+  const groupNode = /** @type import('gmf/themes.js').GmfGroup */ (node);
+  if (!groupNode.children) {
     return;
   }
-  node.children.forEach((childNode) => {
-    if (childNode.children) {
-      this.toggleNodeCheck_(childNode, names);
+  groupNode.children.forEach((childNode) => {
+    const childGroupNode = /** @type import('gmf/themes.js').GmfGroup */ (
+      childNode);
+    if (childGroupNode.children) {
+      this.toggleNodeCheck_(childGroupNode, names);
     } else if (childNode.metadata) {
       childNode.metadata.isChecked = names.includes(childNode.name);
     }
@@ -557,7 +562,7 @@ LayertreeTreeManager.prototype.refreshFirstLevelGroups_ = function(themes) {
  * @private
  */
 LayertreeTreeManager.prototype.getFirstLevelGroupFullState_ = function(treeCtrl) {
-  const children = {};
+  const children = /** @type Object.<string, TreeManagerFullState>} */ ({});
   // Get the state of the treeCtrl children recursively.
   treeCtrl.children.map((child) => {
     children[child.node.name] = this.getFirstLevelGroupFullState_(child);
@@ -610,8 +615,9 @@ LayertreeTreeManager.prototype.setNodeMetadataFromFullState_ = function(node, fu
   }
 
   // Set the metadata of the node children recursively.
-  if (node.children) {
-    node.children.map((child) => {
+  const groupNode = /** @type import('gmf/themes.js').GmfGroup */ (node);
+  if (groupNode.children) {
+    groupNode.children.map((child) => {
       this.setNodeMetadataFromFullState_(child, fullState.children[child.name]);
     });
   }

--- a/contribs/gmf/src/themes.js
+++ b/contribs/gmf/src/themes.js
@@ -145,11 +145,13 @@
 /**
  * @typedef {Object} GmfOgcServer
  * @property {boolean} credential
+ * @property {string|undefined} geometryName Geometry name.
  * @property {string} imageType 'image/png' or 'image/jpeg'.
  * @property {boolean} isSingleTile
  * @property {string} type 'mapserver', 'qgisserver', 'geoserver' or 'other'.
  * @property {string} url
  * @property {string} urlWfs The WFS URL.
+ * @property {string|undefined} wfsFeatureNS WFS feature namespace
  * @property {boolean} wfsSupport
  */
 

--- a/contribs/gmf/test/spec/services/syncLayertreeMap.spec.js
+++ b/contribs/gmf/test/spec/services/syncLayertreeMap.spec.js
@@ -151,12 +151,12 @@ describe('gmf.layertree.SyncLayertreeMap', () => {
     const treeLeaf = treeGroup.children[0]; // osm scale;
 
     roottreeCtrl.setState('off');
-    gmfSyncLayertreeMap_.sync_(map, treeGroup);
+    gmfSyncLayertreeMap_.sync_(treeGroup);
     expect(treeLeaf.layer.getVisible()).toBe(false);
 
-    gmfSyncLayertreeMap_.sync_(map, treeGroup);
+    gmfSyncLayertreeMap_.sync_(treeGroup);
     treeLeaf.setState('on');
-    gmfSyncLayertreeMap_.sync_(map, treeLeaf);
+    gmfSyncLayertreeMap_.sync_(treeLeaf);
     const wmsParamLayers = treeLeaf.layer.getSource().getParams()['LAYERS'];
     expect(wmsParamLayers).toBe('osm_scale');
   });
@@ -176,17 +176,17 @@ describe('gmf.layertree.SyncLayertreeMap', () => {
     const treeLeaf = treeGroup.children[0]; // Leaf 'cinema'
 
     roottreeCtrl.setState('off');
-    gmfSyncLayertreeMap_.sync_(map, treeGroup);
+    gmfSyncLayertreeMap_.sync_(treeGroup);
     expect(treeGroup.layer.getVisible()).toBe(false);
 
     treeLeaf.setState('on');
-    gmfSyncLayertreeMap_.sync_(map, treeLeaf);
+    gmfSyncLayertreeMap_.sync_(treeLeaf);
     let wmsParamLayers = treeGroup.layer.getSource().getParams()['LAYERS'];
     expect(wmsParamLayers).toBe('cinema');
 
     // Group is on, original order must be kept.
     treeGroup.setState('on');
-    gmfSyncLayertreeMap_.sync_(map, treeGroup);
+    gmfSyncLayertreeMap_.sync_(treeGroup);
     wmsParamLayers = treeGroup.layer.getSource().getParams()['LAYERS'];
     expect(wmsParamLayers).toEqual('hospitals,sustenance,entertainment,' +
             'osm_time,post_office,police,cinema');
@@ -209,11 +209,11 @@ describe('gmf.layertree.SyncLayertreeMap', () => {
     const treeLeaf = treeGroup.children[4]; // Leaf 'ch.are.alpenkonvention'
 
     treeGroup.setState('off');
-    gmfSyncLayertreeMap_.sync_(map, treeGroup);
+    gmfSyncLayertreeMap_.sync_(treeGroup);
     expect(treeLeaf.layer.getVisible()).toBe(false);
 
     treeLeaf.setState('on');
-    gmfSyncLayertreeMap_.sync_(map, treeLeaf);
+    gmfSyncLayertreeMap_.sync_(treeLeaf);
     expect(treeLeaf.layer.getVisible()).toBe(true);
   });
 });

--- a/src/datasource/Helper.js
+++ b/src/datasource/Helper.js
@@ -5,7 +5,7 @@ import ngeoFormatWFSAttribute from 'ngeo/format/WFSAttribute.js';
 import ngeoQueryQuerent from 'ngeo/query/Querent.js';
 import * as olEvents from 'ol/events.js';
 
-export class Helper {
+export class DatasourceHelper {
   /**
    * A service that provides utility methods to manipulate or get data sources.
    *
@@ -153,7 +153,7 @@ const module = angular.module('ngeoDataSourcesHelper', [
   ngeoDatasourceDataSources.name,
   ngeoQueryQuerent.name,
 ]);
-module.service('ngeoDataSourcesHelper', Helper);
+module.service('ngeoDataSourcesHelper', DatasourceHelper);
 
 
 export default module;

--- a/src/datasource/OGC.js
+++ b/src/datasource/OGC.js
@@ -216,7 +216,7 @@ class OGC extends ngeoDatasourceDataSource {
      * The filter condition to apply to the filter rules (if any).
      * @type {string}
      */
-    this.filterCondition = options.filterCondition || ngeoFilterCondition.AND;
+    this.filterCondition_ = options.filterCondition || ngeoFilterCondition.AND;
 
     /**
      * A list of filter rules to apply to this data source using the filter
@@ -474,6 +474,22 @@ class OGC extends ngeoDatasourceDataSource {
    */
   get dimensions() {
     return this.dimensions_;
+  }
+
+  /**
+   * @return {string} Filter condition
+   * @export
+   */
+  get filterCondition() {
+    return this.filterCondition_;
+  }
+
+  /**
+   * @param {string} filterCondition Filter condition
+   * @export
+   */
+  set filterCondition(filterCondition) {
+    this.filterCondition_ = filterCondition;
   }
 
   /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,8 +26,8 @@
       "src/**/*.js",
       "api/src/**/*.js",
       "contribs/gmf/src/**/*.js",
-      "test/spec/**/*.js",
-      "contribs/gmf/test/spec/**/*.js",
+      //"test/spec/**/*.js",
+      //"contribs/gmf/test/spec/**/*.js",
       "examples/*.js",
       "contribs/gmf/examples/*.js",
     ]


### PR DESCRIPTION
As title says.

I noticed that the getter/setters `filterCondition` for ngeo/datasource/OGC have been removed.  Why?