### PR TITLE
Bump

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -270,12 +270,15 @@ fdescribe('...', function() {
 ### Create a package on npm
 
 ```
-git checkout master
+git checkout <release-branch>
 git fetch origin
-git reset --hard origin/master
+git reset --hard origin/<release-branche>
 ```
 
-Create a tag named the same as the version.
+Where `<release-branch>` stand for `2.x`.
+
+Verify that the `<version>` (`2.x.x`) in package.json match with the tag you'll
+create. Then create a tag named the same as the version.
 ```
 git tag <version>
 git push <version>
@@ -283,17 +286,16 @@ git push <version>
 
 Travis will create a new package on npm.
 
-
 If you create a new release, bump version in the package.json file:
 ```
 git checkout -b bump
 vi package.json
 git add package.json
-git commit -m "Bump version to 2.2.x+1"
+git commit -m "Bump version to <version + 1>"
 git push origin bump
 ```
 
-Do the pull request
+Do the pull request on branch `<release-branche>`
 
 
 ### Create a new stabilisation branch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngeo",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "description": "AngularJS OpenLayers Library",
   "scripts": {
     "prepublish": "make -f npm.mk install"


### PR DESCRIPTION
For the 2.2.9 release.
I've moved the "create tag" section in the release doc **after** the change in package.json. That's more logical, no ?

That means, I've updated the package.json to 2.2.9 now, and once I'v merged this PR, I'll create the 2.2.9 tag.