### PR TITLE
Fix remaining typechecks in gmf

### DIFF
--- a/contribs/gmf/src/authentication/Service.js
+++ b/contribs/gmf/src/authentication/Service.js
@@ -10,6 +10,7 @@ import olEventsEventTarget from 'ol/events/Target.js';
  * @property {Array.<string>} default_theme Theme to use by default.
  * @property {Array.<string>} [filtrable_layers] A list of layer names that can be filtered.
  * @property location: {Array.<string>} Availables locations.
+ * @property {Array.<!string>} [open_panel] When set, contains the name of the panel to open upon loading an application.
  */
 
 

--- a/contribs/gmf/src/controllers/AbstractAPIController.js
+++ b/contribs/gmf/src/controllers/AbstractAPIController.js
@@ -18,7 +18,7 @@ import * as olInteraction from 'ol/interaction.js';
  */
 export class AbstractAPIController extends AbstractAppController {
   /**
-   * @param {Config} config A part of the application config.
+   * @param {import('gmf/controllers/AbstractAppController.js').Config} config A part of the application
    * @param {angular.IScope} $scope Scope.
    * @param {angular.auto.IInjectorService} $injector Main injector.
    * @ngInject

--- a/contribs/gmf/src/controllers/AbstractAppController.js
+++ b/contribs/gmf/src/controllers/AbstractAppController.js
@@ -561,7 +561,7 @@ export function AbstractAppController(config, map, $scope, $injector) {
   /**
    * @export
    */
-  // @ts-ignore: todo
+  // @ts-ignore: We do want to define a new property on `window`.
   window.gmfx = gmfx;
 
   /**
@@ -614,7 +614,7 @@ export function AbstractAppController(config, map, $scope, $injector) {
   /**
    * @export
    */
-  // @ts-ignore: todo
+  // @ts-ignore: We do want to define a new property on `window`.
   window.cgxp = cgxp;
   /**
    * @export

--- a/contribs/gmf/src/controllers/AbstractAppController.js
+++ b/contribs/gmf/src/controllers/AbstractAppController.js
@@ -40,7 +40,7 @@ import {findThemeByName} from 'gmf/theme/Themes.js';
  * @property {import("ol/style/Style.js").default} [positionFeatureStyle]
  * @property {import("ol/style/Style.js").default} [accuracyFeatureStyle]
  * @property {number} [geolocationZoom]
- * @property {boolean|undefined} [autorotate]
+ * @property {boolean} [autorotate]
  * @property {olx.ViewOptions} [mapViewConfig]
  * @property {import("ol/Collection.js").default.<import('ol/control/Control.js').default>|Array.<import('ol/control/Control.js').default>} [mapControls]
  * @property {import("ol/Collection.js").default.<import('"ol/interaction/Interaction.js').default>|Array.<import('ol/interaction/Interaction.js').default>} [mapInteractions]

--- a/contribs/gmf/src/controllers/AbstractAppController.js
+++ b/contribs/gmf/src/controllers/AbstractAppController.js
@@ -30,7 +30,7 @@ import olStyleFill from 'ol/style/Fill.js';
 import olStyleStroke from 'ol/style/Stroke.js';
 import olStyleStyle from 'ol/style/Style.js';
 import {ThemeEventType} from 'gmf/theme/Manager.js';
-import gmfThemeThemes from 'gmf/theme/Themes.js';
+import {findThemeByName} from 'gmf/theme/Themes.js';
 
 
 /**
@@ -40,44 +40,12 @@ import gmfThemeThemes from 'gmf/theme/Themes.js';
  * @property {import("ol/style/Style.js").default} [positionFeatureStyle]
  * @property {import("ol/style/Style.js").default} [accuracyFeatureStyle]
  * @property {number} [geolocationZoom]
- * @property {string} [autorotate]
+ * @property {boolean|undefined} [autorotate]
  * @property {olx.ViewOptions} [mapViewConfig]
  * @property {import("ol/Collection.js").default.<import('ol/control/Control.js').default>|Array.<import('ol/control/Control.js').default>} [mapControls]
  * @property {import("ol/Collection.js").default.<import('"ol/interaction/Interaction.js').default>|Array.<import('ol/interaction/Interaction.js').default>} [mapInteractions]
  * @property {number} [mapPixelRatio]
  * }} Config
- */
-
-
-/**
- * Static function to create a popup with html content.
- * @typedef {Function} openTextPopup
- * @param {string} content (text or html).
- * @param {string} title (text).
- * @param {string=} opt_width CSS width.
- * @param {string=} opt_height CSS height.
- * @param {boolean=} opt_apply If true, trigger the Angular digest loop. Default to true.
- */
-
-
-/**
- * Static function to create a popup with an iframe.
- * @typedef {Function} openInfoWindow
- * @param {string} url an url.
- * @param {string} title (text).
- * @param {string=} opt_width CSS width.
- * @param {string=} opt_height CSS height.
- * @param {boolean=} opt_apply If true, trigger the Angular digest loop. Default to true.
- */
-
-
-/**
- * @typedef {Function} openPopup_
- * @param {import("ngeo/message/Popup.js").default!} popup a ngeoPopup.
- * @param {string} title (text).
- * @param {string=} opt_width CSS width.
- * @param {string=} opt_height CSS height.
- * @param {boolean=} opt_apply If true, trigger the Angular digest loop. Default to true.
  */
 
 
@@ -105,6 +73,7 @@ export function AbstractAppController(config, map, $scope, $injector) {
   this.ngeoLocation = $injector.get('ngeoLocation');
   if (this.ngeoLocation.hasParam('debug')) {
     // make the injector globally available
+    // @ts-ignore: available in debug mode only
     window.injector = $injector;
   }
 
@@ -223,11 +192,11 @@ export function AbstractAppController(config, map, $scope, $injector) {
   });
 
   /**
-   * @param {AuthenticationEvent} evt Event.
+   * @param {import('gmf/authentication/Service.js').AuthenticationEvent} evt Event.
    */
   const userChange = (evt) => {
     if (this.loginRedirectUrl) {
-      window.location = this.loginRedirectUrl;
+      window.location.href = this.loginRedirectUrl;
       return;
     }
     const user = evt.detail.user;
@@ -265,6 +234,7 @@ export function AbstractAppController(config, map, $scope, $injector) {
    * @export
    */
   this.searchDatasources = [{
+    datasetTitle: undefined,
     labelKey: 'label',
     groupValues: /** @type {Array.<string>} **/ ($injector.get('gmfSearchGroups')),
     groupActions: /** @type {Array.<string>} **/ ($injector.get('gmfSearchActions')),
@@ -432,7 +402,7 @@ export function AbstractAppController(config, map, $scope, $injector) {
   this.gmfUser = $injector.get('gmfUser');
 
   /**
-   * @type {miscGetBrowserLanguage}
+   * @type {import('ngeo/misc/getBrowserLanguage.js').miscGetBrowserLanguage}
    */
   this.getBrowserLanguage = $injector.get('ngeoGetBrowserLanguage');
 
@@ -442,7 +412,7 @@ export function AbstractAppController(config, map, $scope, $injector) {
   this.stateManager = $injector.get('ngeoStateManager');
 
   /**
-   * @type {tmhDynamicLocale}
+   * @type {angular.dynamicLocale.tmhDynamicLocaleService}
    */
   this.tmhDynamicLocale = $injector.get('tmhDynamicLocale');
 
@@ -591,6 +561,7 @@ export function AbstractAppController(config, map, $scope, $injector) {
   /**
    * @export
    */
+  // @ts-ignore: todo
   window.gmfx = gmfx;
 
   /**
@@ -643,6 +614,7 @@ export function AbstractAppController(config, map, $scope, $injector) {
   /**
    * @export
    */
+  // @ts-ignore: todo
   window.cgxp = cgxp;
   /**
    * @export
@@ -810,7 +782,7 @@ AbstractAppController.prototype.updateCurrentTheme_ = function(fallbackThemeName
   this.gmfThemes_.getThemesObject().then((themes) => {
     const themeName = this.permalink_.defaultThemeNameFromFunctionalities();
     if (themeName) {
-      const theme = gmfThemeThemes.findThemeByName(themes, /** @type {string} */ (themeName));
+      const theme = findThemeByName(themes, /** @type {string} */ (themeName));
       if (theme) {
         this.gmfThemeManager.addTheme(theme, true);
       }
@@ -822,7 +794,7 @@ AbstractAppController.prototype.updateCurrentTheme_ = function(fallbackThemeName
 
 /**
  * @protected
- * @return {Element} Span element with font-awesome inside of it
+ * @return {HTMLSpanElement} Span element with font-awesome inside of it
  */
 export function getLocationIcon() {
   const arrow = document.createElement('span');
@@ -868,7 +840,8 @@ module.value('ngeoExportFeatureFormats', [
 
 module.config(['tmhDynamicLocaleProvider', 'angularLocaleScript',
   /**
-   * @param {tmhDynamicLocaleProvider} tmhDynamicLocaleProvider angular-dynamic-locale provider.
+   * @param {angular.dynamicLocale.tmhDynamicLocaleProvider} tmhDynamicLocaleProvider
+   *     angular-dynamic-locale provider.
    * @param {string} angularLocaleScript the script.
    */
   function(tmhDynamicLocaleProvider, angularLocaleScript) {

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -26,7 +26,8 @@ import olStyleText from 'ol/style/Text.js';
  */
 export class AbstractDesktopController extends AbstractAPIController {
   /**
-   * @param {Config} config A part of the application config.
+   * @param {import('gmf/controllers/AbstractAppController.js').Config} config A part of the application
+   *     config.
    * @param {angular.IScope} $scope Scope.
    * @param {angular.auto.IInjectorService} $injector Main injector.
    * @ngInject

--- a/contribs/gmf/src/controllers/AbstractMobileController.js
+++ b/contribs/gmf/src/controllers/AbstractMobileController.js
@@ -24,7 +24,8 @@ import olStyleStyle from 'ol/style/Style.js';
  */
 export class AbstractMobileController extends AbstractAppController {
   /**
-   * @param {Config} config A part of the application config.
+   * @param {import('gmf/controllers/AbstractAppController.js').Config} config A part of the application
+   *     config.
    * @param {angular.IScope} $scope Scope.
    * @param {angular.auto.IInjectorService} $injector Main injector.
    * @ngInject
@@ -166,7 +167,7 @@ export class AbstractMobileController extends AbstractAppController {
   openNavMenu(target) {
     const navElements = document.getElementsByClassName('gmf-mobile-nav-button');
     for (let i = 0; i < navElements.length; i++) {
-      const element = navElements[i];
+      const element = /** @type HTMLElement */ (navElements[i]);
       if (element.dataset && element.dataset.target === target) {
         element.click();
       }

--- a/contribs/gmf/src/controllers/bootstrap.js
+++ b/contribs/gmf/src/controllers/bootstrap.js
@@ -1,12 +1,13 @@
+// FIXME DocumentTouch is deprecated, see:
+// https://developer.mozilla.org/en-US/docs/Web/API/DocumentTouch
 /* global DocumentTouch */
 
 import $ from 'jquery';
 import angular from 'angular';
 
-
 function bootstrap(module) {
-  const interface_ = $('meta[name=interface]')[0].attributes.content.value;
-  const dynamicUrl_ = $('meta[name=dynamicUrl]')[0].attributes.content.value;
+  const interface_ = $('meta[name=interface]')[0].getAttribute('content');
+  const dynamicUrl_ = $('meta[name=dynamicUrl]')[0].getAttribute('content');
   const dynamicUrl = `${dynamicUrl_}?interface=${interface_}&query=${encodeURIComponent(document.location.search)}`;
   const request = $.ajax(dynamicUrl, {
     'dataType': 'json',

--- a/contribs/gmf/src/datasource/ExternalDataSourcesManager.js
+++ b/contribs/gmf/src/datasource/ExternalDataSourcesManager.js
@@ -679,11 +679,11 @@ export class ExternalDatSourcesManager {
  * using the `ol.getUid` method, plus a million.
  *
  * @param {!Object} layer WMS/WMTS Capability Layer object.
- * @return {string} Data source id.
+ * @return {number} Data source id.
  * @export
  */
 function getId(layer) {
-  return `${olUtilGetUid(layer)}+1000000`;
+  return Number(olUtilGetUid(layer)) + 1000000;
 }
 
 

--- a/contribs/gmf/src/datasource/Helper.js
+++ b/contribs/gmf/src/datasource/Helper.js
@@ -95,8 +95,8 @@ export class DatasourceHelper {
       // (2) The attribute names that are in the `enumeratedAttributes`
       //     metadata are the ones that need to have their values fetched.
       //     Do that once then set the type to SELECT and the choices.
-      const meta = dataSource.gmfLayer.metadata || {};
-      const enumAttributes = meta.enumeratedAttributes;
+      const enumAttributes = dataSource.gmfLayer.metadata ?
+        dataSource.gmfLayer.metadata.enumeratedAttributes : undefined;
       if (enumAttributes && enumAttributes.length) {
         const promises = [];
         for (const attribute of attributes) {
@@ -114,9 +114,9 @@ export class DatasourceHelper {
             );
           }
         }
-        return this.q_.all(promises).then(
-          prepareFiltrableDataSourceDefer.resolve(dataSource)
-        );
+        return this.q_.all(promises).then(() => {
+          prepareFiltrableDataSourceDefer.resolve(dataSource);
+        });
       } else {
         prepareFiltrableDataSourceDefer.resolve(dataSource);
       }

--- a/contribs/gmf/src/datasource/OGC.js
+++ b/contribs/gmf/src/datasource/OGC.js
@@ -6,6 +6,65 @@ import ngeoDatasourceOGC from 'ngeo/datasource/OGC.js';
  * @typedef {Object} OGCOptions
  * @property {import('gmf/themes.js').GmfLayer} gmfLayer A reference to the GMF layer node that was used to create the
  * data source. It may contains additional information, such as metadata, about the data source.
+ *
+ * ===
+ *
+ * TODO - inherit typedef properly once TypeScript supports it
+ * Extends (ngeo/datasource/OGC.js).OGCOptions
+ * @property {import('ngeo/datasource/OGC.js').Dimensions} [activeDimensions] The dimensions that are currently active on the data source.
+ * @property {boolean} [copyable] Whether the geometry from this data source can be copied to other data
+ * sources or not. Defaults to `false`.
+ * @property {import('ngeo/datasource/OGC.js').Dimensions} [dimensions] A reference to the dimensions.
+ * @property {import('ngeo/datasource/OGC.js').Dimensions} [dimensionsConfig] The dimensions configuration, which determines those supported by this data
+ * source and whether they should use a static value or the one defined in the
+ * dimensions.
+ * @property {string} [filterCondition] The filter condition to apply to the filter rules (if any). Defaults to
+ * `ngeo.filter.Condition.AND`.
+ * @property {!Array.<!import('ngeo/rule/Rule.js').default>} [filterRules] A list of filter rules to apply to this data source using the filter condition.
+ * @property {boolean} [filtrable] Whether the data source is filtrable or not.
+ * @property {string} [geometryName] The name of the geometry attribute.
+ * @property {string} [ogcImageType] The type of images to fetch by queries by the (WMS) or (WMTS).
+ * @property {Array.<!import('ngeo/datasource/OGC').OGCLayer>} [ogcLayers] A list of layer definitions that are used by (WMS) and (WFS) queries.
+ * These are **not** used by the (WMTS) queries (the wmtsLayers is used by WMTS queries).
+ * @property {string} [ogcServerType] The type of OGC server.
+ * @property {string} [ogcType] The type data source. Can be: 'WMS' or 'WMTS'.
+ * @property {boolean} [snappable] Whether the geometry from this data source can be used to snap the geometry
+ * of features from other data sources that are being edited. Defaults to `false`.
+ * @property {boolean} [snappingToEdges] Determines whether external features can be snapped to the edges of
+ * features from this data source or not. Defaults to `true`. Requires `snappable` to be set.
+ * @property {boolean} [snappingToVertice] Determines whether external features can be snapped to the vertice of
+ * features from this data source or not. Defaults to `true`. Requires `snappable` to be set.
+ * @property {number} [snappingTolerance=10] The tolerance in pixels the snapping should occur.
+ * @property {string} [timeAttributeName]  The name of the time attribute.
+ * @property {number} [timeLowerValue] The time lower value, which can be combined with the time upper value
+ * to determine a range.
+ * @property {import('ngeo/datasource/OGC').TimeProperty} [timeProperty] The time property for the data source. Used to apply time filters.
+ * @property {number} [timeUpperValue] The time upper value, which can be combined with the time lower value
+ * to determine a range.
+ * @property {string} [wfsFeatureNS] The feature namespace to use with WFS requests.
+ * @property {string} [wfsFeaturePrefix] The feature prefix to use with WFS requests.
+ * @property {string} [wfsOutputFormat] The OutputFormat to use with WFS requests.
+ * @property {string} [wfsUrl] The URL to use for (WFS) requests.
+ * @property {string} [wmsInfoFormat] The InfoFormat to use with WMS requests.
+ * @property {boolean} [wmsIsSingleTile] Whether the (WMS) images returned by this data source should be single tiles
+ * or not. Defaults to `false`
+ * @property {string} [wmsUrl] The URL to use for (WMS) requests.
+ * @property {string} [wmtsLayer] The layer name to use for the (WMTS) requests.
+ * @property {string} [wmtsUrl] The URL to use for (WMTS) requests.
+ *
+ * ===
+ *
+ * TODO - inherit typedef properly once TypeScript supports it
+ * Extends (ngeo/datasource/OGC.js).DataSourceOptions
+ * @property {Array.<import('ngeo/format/Attribute.js').Attribute>} [attributes] (DataSourceOptions)
+ * @property {import('ngeo/datasource/OGC.js').DimensionsFiltersConfig} [dimensionsFiltersConfig] (DataSourceOptions)
+ * @property {number} id (DataSourceOptions)
+ * @property {string} [identifierAttribute] (DataSourceOptions)
+ * @property {boolean} [inRange] (DataSourceOptions)
+ * @property {number} [minResolution] (DataSourceOptions)
+ * @property {number} [maxResolution] (DataSourceOptions)
+ * @property {string} name (DataSourceOptions)
+ * @property {boolean} [visible=false] (DataSourceOptions)
  */
 
 

--- a/contribs/gmf/src/drawing/drawFeatureComponent.js
+++ b/contribs/gmf/src/drawing/drawFeatureComponent.js
@@ -576,19 +576,20 @@ Controller.prototype.handleMapClick_ = function(evt) {
 
   const pixel = evt.pixel;
 
-  let feature = this.map.forEachFeatureAtPixel(
+  let feature = /** @type {import('ol/Feature.js').default|undefined} */ (this.map.forEachFeatureAtPixel(
     pixel,
     (feature) => {
-      let ret = false;
-      if (this.features.getArray().includes(feature)) {
+      let ret = null;
+      if (this.features.getArray().includes(/** @type import('ol/Feature.js').default */ (feature))) {
         ret = feature;
       }
       return ret;
     },
     {
-      hitTolerance: 5
+      hitTolerance: 5,
+      layerFilter: undefined
     }
-  );
+  ));
 
   feature = feature ? feature : null;
 
@@ -608,7 +609,7 @@ Controller.prototype.handleMapClick_ = function(evt) {
  * @private
  */
 Controller.prototype.handleMapTouchStart_ = function(evt) {
-  this.longPressTimeout_ = setTimeout(() => {
+  this.longPressTimeout_ = window.setTimeout(() => {
     this.handleMapContextMenu_(evt);
   }, 500);
 };
@@ -632,19 +633,20 @@ Controller.prototype.handleMapContextMenu_ = function(evt) {
   const pixel = this.map.getEventPixel(evt);
   const coordinate = this.map.getCoordinateFromPixel(pixel);
 
-  let feature = this.map.forEachFeatureAtPixel(
+  let feature = /** @type {import('ol/Feature.js').default|undefined} */ (this.map.forEachFeatureAtPixel(
     pixel,
     (feature) => {
-      let ret = false;
-      if (this.features.getArray().includes(feature)) {
+      let ret = null;
+      if (this.features.getArray().includes(/** @type import('ol/Feature.js').default */ (feature))) {
         ret = feature;
       }
       return ret;
     },
     {
-      hitTolerance: 7
+      hitTolerance: 7,
+      layerFilter: undefined
     }
-  );
+  ));
 
   feature = feature ? feature : null;
 
@@ -703,7 +705,7 @@ Controller.prototype.handleMapContextMenu_ = function(evt) {
 
   this.modify_.setActive(true);
 
-  this.selectedFeature = feature;
+  this.selectedFeature = /** @type import('ol/Feature.js').default */ (feature);
 
   this.scope_.$apply();
 };
@@ -746,7 +748,7 @@ Controller.prototype.handleMenuActionClick_ = function(vertexInfo, evt) {
 
 
 /**
- * @param {!import("ol/interaction/Translate/Event.js").default} evt Event.
+ * @param {!import("ol/interaction/Translate.js").TranslateEvent} evt Event.
  * @private
  */
 Controller.prototype.handleTranslateEnd_ = function(evt) {

--- a/contribs/gmf/src/drawing/featureStyleComponent.js
+++ b/contribs/gmf/src/drawing/featureStyleComponent.js
@@ -64,7 +64,7 @@ module.directive('gmfFeaturestyle', directive);
 function Controller($scope, ngeoFeatureHelper) {
 
   /**
-   * @type {number}
+   * @type {string}
    * @export
    */
   this.uid = olUtilGetUid(this);
@@ -209,7 +209,7 @@ Controller.prototype.handleColorSet_ = function(newColor) {
  * @export
  */
 Controller.prototype.getSetAngle = function(value) {
-  return this.getSetProperty_(ngeoFormatFeatureProperties.ANGLE, value);
+  return /** @type number */ (this.getSetProperty_(ngeoFormatFeatureProperties.ANGLE, value));
 };
 
 
@@ -219,7 +219,7 @@ Controller.prototype.getSetAngle = function(value) {
  * @export
  */
 Controller.prototype.getSetName = function(value) {
-  return this.getSetProperty_(ngeoFormatFeatureProperties.NAME, value);
+  return /** @type string */ (this.getSetProperty_(ngeoFormatFeatureProperties.NAME, value));
 };
 
 /**
@@ -229,7 +229,7 @@ Controller.prototype.getSetName = function(value) {
  * @export
  */
 Controller.prototype.getSetShowLabel = function(value) {
-  return typeof this.getSetProperty_(ngeoFormatFeatureProperties.SHOW_LABEL, value);
+  return /** @type boolean */ (this.getSetProperty_(ngeoFormatFeatureProperties.SHOW_LABEL, value));
 };
 
 /**
@@ -238,7 +238,7 @@ Controller.prototype.getSetShowLabel = function(value) {
  * @export
  */
 Controller.prototype.getSetOpacity = function(value) {
-  return typeof this.getSetProperty_(ngeoFormatFeatureProperties.OPACITY, value);
+  return /** @type number */ (this.getSetProperty_(ngeoFormatFeatureProperties.OPACITY, value));
 };
 
 
@@ -249,7 +249,7 @@ Controller.prototype.getSetOpacity = function(value) {
  * @export
  */
 Controller.prototype.getSetShowMeasure = function(value) {
-  return this.getSetProperty_(ngeoFormatFeatureProperties.SHOW_MEASURE, value);
+  return /** @type boolean */ (this.getSetProperty_(ngeoFormatFeatureProperties.SHOW_MEASURE, value));
 };
 
 
@@ -259,7 +259,7 @@ Controller.prototype.getSetShowMeasure = function(value) {
  * @export
  */
 Controller.prototype.getSetSize = function(value) {
-  return this.getSetProperty_(ngeoFormatFeatureProperties.SIZE, value);
+  return /** @type number */ (this.getSetProperty_(ngeoFormatFeatureProperties.SIZE, value));
 };
 
 
@@ -269,7 +269,7 @@ Controller.prototype.getSetSize = function(value) {
  * @export
  */
 Controller.prototype.getSetStroke = function(value) {
-  return this.getSetProperty_(ngeoFormatFeatureProperties.STROKE, value);
+  return /** @type number */ (this.getSetProperty_(ngeoFormatFeatureProperties.STROKE, value));
 };
 
 

--- a/contribs/gmf/src/search/component.js
+++ b/contribs/gmf/src/search/component.js
@@ -40,7 +40,7 @@ import {appendParams as olUriAppendParams} from 'ol/uri.js';
  * this dataset. See: https://github.com/twitter/typeahead.js/blob/master/
  * @property {string} url URL of the search service. Must contain a '%QUERY' term that will be
  * replaced by the input string.
- * @property {string} datasetTitle
+ * @property {string|undefined} datasetTitle
  * }}
  */
 

--- a/contribs/gmf/src/search/component.js
+++ b/contribs/gmf/src/search/component.js
@@ -40,7 +40,7 @@ import {appendParams as olUriAppendParams} from 'ol/uri.js';
  * this dataset. See: https://github.com/twitter/typeahead.js/blob/master/
  * @property {string} url URL of the search service. Must contain a '%QUERY' term that will be
  * replaced by the input string.
- * @property {string|undefined} datasetTitle
+ * @property {string} [datasetTitle]
  * }}
  */
 

--- a/contribs/gmf/src/themes.js
+++ b/contribs/gmf/src/themes.js
@@ -148,11 +148,11 @@
  * @property {string|undefined} geometryName Geometry name.
  * @property {string} imageType 'image/png' or 'image/jpeg'.
  * @property {boolean} isSingleTile
- * @property {string|undefined} namespace Namespace
+ * @property {string} [namespace] Namespace
  * @property {string} type 'mapserver', 'qgisserver', 'geoserver' or 'other'.
  * @property {string} url
  * @property {string} urlWfs The WFS URL.
- * @property {string|undefined} wfsFeatureNS WFS feature namespace
+ * @property {string} [wfsFeatureNS] WFS feature namespace
  * @property {boolean} wfsSupport
  */
 

--- a/contribs/gmf/src/themes.js
+++ b/contribs/gmf/src/themes.js
@@ -148,6 +148,7 @@
  * @property {string|undefined} geometryName Geometry name.
  * @property {string} imageType 'image/png' or 'image/jpeg'.
  * @property {boolean} isSingleTile
+ * @property {string|undefined} namespace Namespace
  * @property {string} type 'mapserver', 'qgisserver', 'geoserver' or 'other'.
  * @property {string} url
  * @property {string} urlWfs The WFS URL.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@openlayers/eslint-plugin": "4.0.0-beta.2",
     "@types/angular": "1.6.54",
     "@types/angular-animate": "1.5.10",
+    "@types/angular-dynamic-locale": "0.1.34",
     "@types/angular-gettext": "2.1.34",
     "@types/angular-mocks": "1.7.0",
     "@types/bootstrap": "4.2.1",

--- a/src/filter/RuleHelper.js
+++ b/src/filter/RuleHelper.js
@@ -37,7 +37,7 @@ import moment from 'moment';
  * @property {!Array.<import('ngeo/rule/Rule.js').default>} [filterRules] An alternative list of filter rules to use instead of those that are defined
  * within the data source. Useful when one wants to get the data of a given
  * filter without applying it to the data source.
- * @property {string|undefined} [projCode] Projection code.
+ * @property {string} [projCode] Projection code.
  * @property {string} [srsName] The SRS name used with the spatial filters created by the method.
  */
 

--- a/src/filter/RuleHelper.js
+++ b/src/filter/RuleHelper.js
@@ -37,6 +37,7 @@ import moment from 'moment';
  * @property {!Array.<import('ngeo/rule/Rule.js').default>} [filterRules] An alternative list of filter rules to use instead of those that are defined
  * within the data source. Useful when one wants to get the data of a given
  * filter without applying it to the data source.
+ * @property {string|undefined} [projCode] Projection code.
  * @property {string} [srsName] The SRS name used with the spatial filters created by the method.
  */
 


### PR DESCRIPTION
This patch fixes the remaining type issues in GMF.

Following @fredj recommendation, I copied the properties from ("ngeo/datasource/OGC.js").OGCOptions to ("gmf/datasource/OGC.js").OGCOptions, because typescript doesn't currently support inheritence of objects for typing purpose.

There are also 2 remaining errors that I don't know what to do about.  They are about the use of DocumentTouch property, which seems to be deprecated.  I suspect this is something that needs to be addressed (and not just ignored using ts-ignore). Here they are:

```
contribs/gmf/src/controllers/bootstrap.js:24:65 - error TS2339: Property 'DocumentTouch' does not exist on type 'never'.

24       if (small_screen && (('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch)) {
                                                                   ~~~~~~~~~~~~~

contribs/gmf/src/controllers/bootstrap.js:24:102 - error TS2304: Cannot find name 'DocumentTouch'.

24       if (small_screen && (('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch)) {
         
```