### PR TITLE
Dismiss popover on click instead of mousedown

### DIFF
--- a/src/message/popoverComponent.js
+++ b/src/message/popoverComponent.js
@@ -119,7 +119,7 @@ function PopoverController($scope) {
    */
   this.bodyElm = undefined;
 
-  function onMouseDown(clickEvent) {
+  function onClick(clickEvent) {
     if (this.anchorElm[0] !== clickEvent.target &&
       this.bodyElm.parent()[0] !== clickEvent.target &&
       this.bodyElm.parent().find(clickEvent.target).length === 0 && this.shown) {
@@ -127,10 +127,12 @@ function PopoverController($scope) {
     }
   }
 
-  angular.element('body').on('mousedown', onMouseDown.bind(this));
+  const clickHandler = onClick.bind(this);
+
+  angular.element('body').on('click', clickHandler);
 
   $scope.$on('$destroy', () => {
-    angular.element('body').off('mousedown', onMouseDown);
+    angular.element('body').off('click', clickHandler);
   });
 }
 


### PR DESCRIPTION
This patch changes the popover component to make it dismiss on body click instead of body mousedown.

It also fixes the unlistening (`off`) which given the wrong method (`on` was using an anonymous method returned by bind, `off` was using the original one).  Now they both use the same.