### PR TITLE
GMF Print - support sending printed file to email

### DIFF
--- a/contribs/gmf/src/authentication/Service.js
+++ b/contribs/gmf/src/authentication/Service.js
@@ -16,6 +16,7 @@ import olEventsEventTarget from 'ol/events/Target.js';
 
 /**
  * @typedef {Object} User
+ * @property {string|null} email User's email address
  * @property {AuthenticationFunctionalities|null} functionalities Configured functionalities of the user
  * @property {boolean|null} is_password_changed True if the password of the user has been changed. False otherwise.
  * @property {number|null} role_id the role id of the user.
@@ -207,6 +208,13 @@ export class AuthenticationService extends olEventsEventTarget {
     return this.$http_.post(url, $.param({'login': login}), {
       headers: {'Content-Type': 'application/x-www-form-urlencoded'}
     }).then(successFn);
+  }
+
+  /**
+   * @return {string|null} User's email
+   */
+  getEmail() {
+    return this.user_.email || null;
   }
 
   /**

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -3,7 +3,7 @@ import gmfControllersAbstractAPIController, {AbstractAPIController} from 'gmf/co
 import gmfContextualdataModule from 'gmf/contextualdata/module.js';
 import gmfEditingModule from 'gmf/editing/module.js';
 import gmfPermalinkShareComponent from 'gmf/permalink/shareComponent.js';
-import gmfPrintComponent from 'gmf/print/component.js';
+import gmfPrintModule from 'gmf/print/module.js';
 import gmfProfileModule from 'gmf/profile/module.js';
 import gmfRasterComponent from 'gmf/raster/component.js';
 import ngeoDrawFeatures from 'ngeo/draw/features.js';
@@ -258,7 +258,7 @@ const module = angular.module('GmfAbstractDesktopControllerModule', [
   gmfContextualdataModule.name,
   gmfEditingModule.name,
   gmfPermalinkShareComponent.name,
-  gmfPrintComponent.name,
+  gmfPrintModule.name,
   gmfProfileModule.name,
   gmfRasterComponent.name,
   ngeoDrawFeatures.name,

--- a/contribs/gmf/src/print/component.html
+++ b/contribs/gmf/src/print/component.html
@@ -174,6 +174,17 @@
 
     </div>
 
+    <div
+      ng-show="$ctrl.smtpSupported && $ctrl.smtpEmail"
+      class="gmf-print-smtp checkbox">
+      <label>
+        <input
+          ng-model="$ctrl.smtpEnabled"
+          type="checkbox">
+        <span translate>Send file by email</span>
+      </label>
+    </div>
+
     <div class="gmf-print-actions form-group pull-right">
       <span ng-show="$ctrl.isState('PRINTING')">
         <i class="fa fa-refresh fa-spinner fa-spin"></i>

--- a/contribs/gmf/src/print/component.html
+++ b/contribs/gmf/src/print/component.html
@@ -179,6 +179,7 @@
       class="gmf-print-smtp checkbox">
       <label>
         <input
+          ng-disabled="$ctrl.isState('PRINTING')"
           ng-model="$ctrl.smtpEnabled"
           type="checkbox">
         <span translate>Send file by email</span>

--- a/contribs/gmf/src/print/component.html
+++ b/contribs/gmf/src/print/component.html
@@ -229,4 +229,13 @@
     class="gmf-print-error-capabilities form-group pull-left text-danger">
     <p>{{'The print server is unavailable. Please, try later.' | translate}}</p>
   </div>
+
+  <div
+    ng-show="$ctrl.smtpMessage"
+    class="gmf-print-smtp-message form-group pull-left">
+    <button
+      class="btn prime"
+      ng-click="$ctrl.closeSmtpMessage()" translate>Close</button>
+    <p>{{'The file will be sent to your email when ready.' | translate}}</p>
+  </div>
 </div>

--- a/contribs/gmf/src/print/component.js
+++ b/contribs/gmf/src/print/component.js
@@ -503,6 +503,21 @@ class Controller {
     this.rotation = 0;
 
     /**
+     * @type {?string}
+     */
+    this.smtpEmail = null;
+
+    /**
+     * @type {boolean}
+     */
+    this.smtpEnabled = false;
+
+    /**
+     * @type {boolean}
+     */
+    this.smtpSupported = false;
+
+    /**
      * @type {Array.<string>}
      */
     this.hiddenAttributeNames;
@@ -565,6 +580,11 @@ class Controller {
     this.$scope_.$watch(() => this.gmfAuthenticationService_.getRoleId(), () => {
       this.gmfPrintState_.state = PrintStateEnum.CAPABILITIES_NOT_LOADED;
       this.capabilities_ = null;
+    });
+
+    // Store user email
+    this.$scope_.$watch(() => this.gmfAuthenticationService_.getEmail(), (newValue) => {
+      this.smtpEmail = newValue;
     });
 
     this.$scope_.$watch(() => this.active, (active) => {
@@ -700,6 +720,8 @@ class Controller {
     this.layouts_.forEach((layout) => {
       this.layoutInfo.layouts.push(layout.name);
     });
+
+    this.smtpSupported = data['smtp'] && data['smtp']['enabled'];
 
     this.updateFields_();
   }
@@ -981,8 +1003,10 @@ class Controller {
     group.set('printNativeAngle', print_native_angle);
     map.setLayerGroup(group);
 
+    const email = this.smtpSupported && this.smtpEmail && this.smtpEnabled ? this.smtpEmail : undefined;
+
     const spec = this.ngeoPrint_.createSpec(map, scale, this.layoutInfo.dpi,
-      this.layoutInfo.layout, format, customAttributes);
+      this.layoutInfo.layout, format, customAttributes, email);
 
     // Add feature overlay layer to print spec.
     const layers = [];

--- a/contribs/gmf/src/print/component.js
+++ b/contribs/gmf/src/print/component.js
@@ -503,16 +503,28 @@ class Controller {
     this.rotation = 0;
 
     /**
+     * The email of the user to which send the file. Obtained from the
+     * authentication service.
      * @type {?string}
      */
     this.smtpEmail = null;
 
     /**
+     * Whether to send the printed file by email or not.
      * @type {boolean}
      */
     this.smtpEnabled = false;
 
     /**
+     * Flag that determines whether to show a message notifying the
+     * user about his upcomping file or not.
+     * @type {boolean}
+     */
+    this.smtpMessage = false;
+
+    /**
+     * Whether sending file by email is supported or not. Obtained
+     * from the print capabilities.
      * @type {boolean}
      */
     this.smtpSupported = false;
@@ -1161,6 +1173,10 @@ class Controller {
         // The report is ready. Open it by changing the window location.
         window.location.href = this.ngeoPrint_.getReportUrl(ref);
         this.resetPrintStates_();
+        // If the file was sent by email, show message
+        if (this.smtpSupported && this.smtpEmail && this.smtpEnabled) {
+          this.smtpMessage = true;
+        }
       } else {
         console.error(mfResp.error);
         this.handleCreateReportError_();
@@ -1331,6 +1347,13 @@ class Controller {
    */
   isState(stateEnumKey) {
     return this.gmfPrintState_.state === PrintStateEnum[stateEnumKey];
+  }
+
+  /**
+   * Close the SMTP message
+   */
+  closeSmtpMessage() {
+    this.smtpMessage = false;
   }
 }
 

--- a/contribs/gmf/src/print/print.scss
+++ b/contribs/gmf/src/print/print.scss
@@ -4,3 +4,17 @@
     width: 5rem;
   }
 }
+
+.gmf-print-smtp-message {
+  background-color: white;
+  clear: both;
+  padding: 10px;
+
+  button {
+    float: right;
+  }
+
+  p {
+    margin: 0;
+  }
+}

--- a/src/print/Service.js
+++ b/src/print/Service.js
@@ -124,10 +124,11 @@ PrintService.prototype.cancel = function(ref, opt_httpConfig) {
  * @param {string} layout Layout.
  * @param {string} format Formats.
  * @param {Object.<string, *>} customAttributes Custom attributes.
+ * @param {string=} email Email to send the file to.
  * @return {import('ngeo/print/mapfish-print-v3.js').MapFishPrintSpec} The print spec.
  */
 PrintService.prototype.createSpec = function(
-  map, scale, dpi, layout, format, customAttributes) {
+  map, scale, dpi, layout, format, customAttributes, email) {
 
   const specMap = /** @type {import('ngeo/print/mapfish-print-v3.js').MapFishPrintMap} */ ({
     dpi: dpi,
@@ -151,6 +152,10 @@ PrintService.prototype.createSpec = function(
     lang,
     layout
   };
+
+  if (email) {
+    spec.smtp = {to: email};
+  }
 
   return spec;
 };

--- a/src/print/mapfish-print-v3.js
+++ b/src/print/mapfish-print-v3.js
@@ -4,6 +4,7 @@
  * @property {string} layout
  * @property {string} format
  * @property {string} lang
+ * @property {MapFishPrintSMTP} [smtp] STMP object definition
  */
 
 
@@ -183,6 +184,13 @@
  * @property {number} haloRadius
  * @property {string} fontColor
  */
+
+
+/**
+ * @typedef {Object} MapFishPrintSMTP
+ * @property {string} to Email address
+ */
+
 
 /**
  * @hidden


### PR DESCRIPTION
This patch introduces sending a printed file using the GMF Print tool to an email.  The specs are described in this task: https://jira.camptocamp.com/browse/GSGMF-738

It is not yet completed, as there are things remaining to do:

 * [x] show a message about the file that is going to be sent by email
 * [ ] the request, when using the email, currently doesn't work. More details to come in a comment.