### PR TITLE
Don't wrap text in dropdown

### DIFF
--- a/contribs/gmf/src/controllers/desktop.scss
+++ b/contribs/gmf/src/controllers/desktop.scss
@@ -91,6 +91,7 @@ main {
     color: $color;
     padding: $input-btn-padding-y $input-btn-padding-x;
     display: block;
+    white-space: nowrap;
     &:hover {
       text-decoration: none;
       background-color: $onhover-color;


### PR DESCRIPTION
Fixes:

![screenshot from 2019-02-21 13-52-36](https://user-images.githubusercontent.com/100959/53170280-0ab39b00-35e0-11e9-8cd7-69d47ed3b3e8.png)


https://camptocamp.github.io/ngeo/master/examples/contribs/gmf/apps/desktop_alt.html