### PR TITLE
Use application/geo+json instead of application/json

### DIFF
--- a/contribs/gmf/src/editing/EditFeature.js
+++ b/contribs/gmf/src/editing/EditFeature.js
@@ -110,7 +110,7 @@ EditingEditFeature.prototype.insertFeatures = function(layerId, features) {
   const url = `${this.baseUrl_}/${layerId}`;
   const geoJSON = new olFormatGeoJSON().writeFeatures(features);
   return this.http_.post(url, geoJSON, {
-    headers: {'Content-Type': 'application/json'},
+    headers: {'Content-Type': 'application/geo+json'},
     withCredentials: true
   });
 };
@@ -125,7 +125,7 @@ EditingEditFeature.prototype.updateFeature = function(layerId, feature) {
   const url = `${this.baseUrl_}/${layerId.toString()}/${feature.getId()}`;
   const geoJSON = new olFormatGeoJSON().writeFeature(feature);
   return this.http_.put(url, geoJSON, {
-    headers: {'Content-Type': 'application/json'},
+    headers: {'Content-Type': 'application/geo+json'},
     withCredentials: true
   });
 };
@@ -139,7 +139,6 @@ EditingEditFeature.prototype.updateFeature = function(layerId, feature) {
 EditingEditFeature.prototype.deleteFeature = function(layerId, feature) {
   const url = `${this.baseUrl_}/${layerId.toString()}/${feature.getId()}`;
   return this.http_.delete(url, {
-    headers: {'Content-Type': 'application/json'},
     withCredentials: true
   });
 };

--- a/contribs/gmf/src/editing/editFeatureComponent.js
+++ b/contribs/gmf/src/editing/editFeatureComponent.js
@@ -681,20 +681,20 @@ Controller.prototype.save = function() {
       this.editableNode_.id,
       [feature]
     );
-  promise.then(
-    (response) => {
+  promise
+    .then((response) => {
       this.dirty = false;
-      this.pending = false;
       this.handleEditFeature_(response);
       this.gmfSnapping_.refresh();
-    },
-    (response) => {
+    })
+    .catch((response) => {
       this.showServerError = true;
-      this.pending = false;
       this.serverErrorType = `error type : ${response.data['error_type']}`;
       this.serverErrorMessage = `error message : ${response.data['message']}`;
-    }
-  );
+    })
+    .finally(() => {
+      this.pending = false;
+    });
 };
 
 


### PR DESCRIPTION
`application/geo+json` is the type returned by the service:
https://geomapfish-demo-dc.camptocamp.com/2.4/layers/112

No need to send the `Content-Type` for the `delete`.