### PR TITLE
Fix GMF query grid to support adding result

### DIFF
--- a/contribs/gmf/src/query/gridComponent.js
+++ b/contribs/gmf/src/query/gridComponent.js
@@ -377,7 +377,13 @@ Controller.prototype.getGridSources = function() {
  */
 Controller.prototype.updateData_ = function() {
   // close if there are no results
-  if (this.ngeoQueryResult.total === 0 && !this.hasOneWithTooManyResults_()) {
+  if (
+    (
+      this.ngeoQueryResult.pending ||
+      this.ngeoQueryResult.total === 0
+    ) &&
+    !this.hasOneWithTooManyResults_()
+  ) {
     const oldActive = this.active;
     this.clear();
     if (oldActive) {


### PR DESCRIPTION
Fixes the GMF query grid to support addition of features.

Before, since it was not possible to add new features, checking the total number of features and look for `0` as a way to make the grid pending was a good way to hide it or make it work (pending).  Now, features can be kept in the results, and the total may be > 0, which broke the logic.

This fix proposes that while the results are pending, we treat the grid as if it had 0 result (i.e. pending).