### PR TITLE
[2.2] Update current theme after loadThemes call is done

### DIFF
--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -152,15 +152,10 @@ gmf.AbstractController = function(config, $scope, $injector) {
     this.gmfThemes_.loadThemes(roleId);
 
     if (evt.type !== gmf.AuthenticationEventType.READY) {
-      let listenerKey;
-      const themesLoaded = () => {
-        ol.events.unlistenByKey(listenerKey);
+      this.gmfThemes_.getThemesObject().then(() => {
         this.updateCurrentTheme_(previousThemeName);
-      };
-      listenerKey = ol.events.listen(this.gmfThemes_,
-        gmf.ThemesEventType.CHANGE, themesLoaded, this);
+      });
     }
-
     this.setDefaultBackground_(null);
     this.updateHasEditableLayers_();
   };

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -152,9 +152,7 @@ gmf.AbstractController = function(config, $scope, $injector) {
     this.gmfThemes_.loadThemes(roleId);
 
     if (evt.type !== gmf.AuthenticationEventType.READY) {
-      this.gmfThemes_.getThemesObject().then(() => {
-        this.updateCurrentTheme_(previousThemeName);
-      });
+      this.updateCurrentTheme_(previousThemeName);
     }
     this.setDefaultBackground_(null);
     this.updateHasEditableLayers_();

--- a/contribs/gmf/src/controllers/abstract.js
+++ b/contribs/gmf/src/controllers/abstract.js
@@ -147,11 +147,20 @@ gmf.AbstractController = function(config, $scope, $injector) {
     // Reload theme when login status changes.
     const previousThemeName = this.gmfThemeManager.getThemeName();
     this.gmfThemeManager.setThemeName('', true);
-    if (evt.type !== gmf.AuthenticationEventType.READY) {
-      this.updateCurrentTheme_(previousThemeName);
-    }
+
     // Reload themes and background layer when login status changes.
     this.gmfThemes_.loadThemes(roleId);
+
+    if (evt.type !== gmf.AuthenticationEventType.READY) {
+      let listenerKey;
+      const themesLoaded = () => {
+        ol.events.unlistenByKey(listenerKey);
+        this.updateCurrentTheme_(previousThemeName);
+      };
+      listenerKey = ol.events.listen(this.gmfThemes_,
+        gmf.ThemesEventType.CHANGE, themesLoaded, this);
+    }
+
     this.setDefaultBackground_(null);
     this.updateHasEditableLayers_();
   };


### PR DESCRIPTION
Currently, the updateCurrentTheme_ call happens before the  loadThemes call. This is problematic if you log in as an user who has a default theme that is non-public. At the time updateCurrentTheme_ gets called, this non-public theme is not available. It will be, after the loadThemes call has finished. That's why updateCurrentTheme_ should happen after loadThemes.