### PR TITLE
Force theme reload

### DIFF
--- a/contribs/gmf/src/theme/Themes.js
+++ b/contribs/gmf/src/theme/Themes.js
@@ -173,7 +173,7 @@ export class ThemesService extends olEventsEventTarget {
         ).then(callback.bind(null, gmfLayer)).then(null, (response) => {
           let message = `Unable to build layer "${gmfLayerWMTS.layer}" `
             + `from WMTSCapabilities: ${gmfLayerWMTS.url}\n`;
-          message += `OpenLayers error is "${response['message']}`;
+          message += `OpenLayers error is "${response['message']}"`;
           console.error(message);
           // Continue even if some layers have failed loading.
           return $q.resolve(undefined);
@@ -388,13 +388,16 @@ export class ThemesService extends olEventsEventTarget {
       this.loaded = false;
     }
 
+    const params = {
+      'cache_version': this.cacheVersion_,
+      'foobar': new Date().getTime()
+    };
+    if (opt_roleId !== undefined) {
+      params['role'] = opt_roleId;
+    }
+
     this.$http_.get(this.treeUrl_, {
-      params: opt_roleId !== undefined ? {
-        'role': opt_roleId,
-        'cache_version': this.cacheVersion_
-      } : {
-        'cache_version': this.cacheVersion_
-      },
+      params: params,
       cache: false,
       withCredentials: true
     }).then((response) => {


### PR DESCRIPTION
This hack forces theme to be obtained upon reloading after a login/logout.

The solution was taken from Martin's answer in this question on Stack Overflow: https://stackoverflow.com/questions/16098430/angular-ie-caching-issue-for-http

I tried the first solution and it didn't fix the issue. Trying the second one did.

I don't understand what suddenly made the previous code stop working...