### PR TITLE
Fix apply filter

### DIFF
--- a/contribs/gmf/src/datasource/Manager.js
+++ b/contribs/gmf/src/datasource/Manager.js
@@ -801,7 +801,7 @@ export class DatasourceManager {
         const gmfOGCDataSource = /** @type import('gmf/datasource/OGC.js').default */ (dataSource);
         const gmfLayerWMS = /** @type import('gmf/themes.js').GmfLayerWMS */ (gmfOGCDataSource.gmfLayer);
         if (olUtilGetUid(dsLayer) == olUtilGetUid(layer) &&
-            layer.get('querySourceIds').indexOf(dataSource.id) >= 0 &&
+            layer.get('querySourceIds').indexOf(String(dataSource.id)) >= 0 &&
             gmfLayerWMS.layers.split(',').indexOf(wmsLayerName) >= 0) {
 
           const id = olUtilGetUid(gmfOGCDataSource.gmfLayer);


### PR DESCRIPTION
This patch fixes the filters component, more specifically when applying a filter.

The bug why it wasn't working anymore is simply because the OpenLayers getUid utils method used to return numbers.  Now, it returns strings.  There were a lot of places in ngeo/gmf that this value was used as number and was automatically changed as string, but that caused errors.  Some of them were reverted like what they were before: numbers.

However, this caused a simple logic issue with the filter while checking onto what data source to apply it.  Casting it to string then does the trick.