### PR TITLE
793 - Fix GMF edit feature stop editing while dirty

### DIFF
--- a/contribs/gmf/src/editing/editFeatureComponent.js
+++ b/contribs/gmf/src/editing/editFeatureComponent.js
@@ -603,13 +603,27 @@ Controller.prototype.$onInit = function() {
     (newValue, oldValue) => {
       const state = EditingState;
       if (newValue === state.STOP_EDITING_PENDING) {
-        this.confirmCancel().then(() => {
+        if (this.feature && this.dirty) {
+          this.confirmCancel().then(() => {
+            this.timeout_(() => {
+              this.state = state.STOP_EDITING_EXECUTE;
+              this.scope_.$apply();
+            }, 500);
+          });
+        } else {
           this.state = state.STOP_EDITING_EXECUTE;
-        });
+        }
       } else if (newValue === state.DEACTIVATE_PENDING) {
-        this.confirmCancel().then(() => {
+        if (this.feature && this.dirty) {
+          this.confirmCancel().then(() => {
+            this.timeout_(() => {
+              this.state = state.DEACTIVATE_EXECUTE;
+              this.scope_.$apply();
+            }, 500);
+          });
+        } else {
           this.state = state.DEACTIVATE_EXECUTE;
-        });
+        }
       }
     }
   );


### PR DESCRIPTION
In the GMF feature editing tool, while trying to stop editing when there a feature is selected and dirty, a modal opens asking for confirmation.  In the process of applying the cancel, the modal gets hidden with an animation for a short period of time.  If we cancel right away, the modal gets destroyed while animating and the result is we have the modal backdrop still there.

This patch lets the modal do its animation then apply the cancel.