### PR TITLE
Fix print layer order

### DIFF
--- a/src/print/Service.js
+++ b/src/print/Service.js
@@ -189,7 +189,7 @@ PrintService.prototype.encodeMap_ = function(map, scale, object) {
   let layers = this.ngeoLayerHelper_.getFlatLayers(mapLayerGroup);
 
   // Sort the layer by ZIndex
-  olArray.stableSort(layers, (layer_a, layer_b) => layer_a.getZIndex() - layer_b.getZIndex());
+  olArray.stableSort(layers, (layer_a, layer_b) => (layer_a.getZIndex() || 0) - (layer_b.getZIndex() || 0));
   layers = layers.slice().reverse();
 
   layers.forEach((layer) => {


### PR DESCRIPTION
The ngeo print service is responsible of creating the specs for the print request, which includes the layers to print in a specific order: by zIndex.  The issue was that the layers were not ordered properly.

After investigating, it turns out that the method responsible for ordering by zIndex was not working properly due to undefined values returned some of the layers z indexes.  Marking those as `0` made the method worked properly and the order correctly set from there on.