### PR TITLE
Fix font name used in OpenLayers text style

### DIFF
--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -81,7 +81,7 @@ export class AbstractDesktopController extends AbstractAPIController {
     this.googleStreetViewStyle = new olStyleStyle({
       text: new olStyleText({
         fill: new olStyleFill({color: '#279B61'}),
-        font: 'normal 30px FontAwesome',
+        font: '900 30px "Font Awesome 5 Free"',
         offsetY: -15,
         stroke: new olStyleStroke({color: '#ffffff', width: 3}),
         text: '\uf041'

--- a/contribs/gmf/src/drawing/drawFeatureComponent.js
+++ b/contribs/gmf/src/drawing/drawFeatureComponent.js
@@ -223,7 +223,7 @@ function Controller($scope, $timeout, gettextCatalog, ngeoFeatureHelper, ngeoFea
     style: new olStyleStyle({
       text: new olStyleText({
         text: '\uf047',
-        font: 'normal 18px FontAwesome',
+        font: '900 18px "Font Awesome 5 Free"',
         fill: new olStyleFill({
           color: '#7a7a7a'
         })
@@ -241,7 +241,7 @@ function Controller($scope, $timeout, gettextCatalog, ngeoFeatureHelper, ngeoFea
     style: new olStyleStyle({
       text: new olStyleText({
         text: '\uf01e',
-        font: 'normal 18px FontAwesome',
+        font: '900 18px "Font Awesome 5 Free"',
         fill: new olStyleFill({
           color: '#7a7a7a'
         })

--- a/contribs/gmf/src/editing/editFeatureComponent.js
+++ b/contribs/gmf/src/editing/editFeatureComponent.js
@@ -536,7 +536,7 @@ Controller.prototype.$onInit = function() {
     style: new olStyleStyle({
       text: new olStyleText({
         text: '\uf01e',
-        font: 'normal 18px FontAwesome',
+        font: '900 18px "Font Awesome 5 Free"',
         fill: new olStyleFill({
           color: '#7a7a7a'
         })
@@ -550,7 +550,7 @@ Controller.prototype.$onInit = function() {
     style: new olStyleStyle({
       text: new olStyleText({
         text: '\uf047',
-        font: 'normal 18px FontAwesome',
+        font: '900 18px "Font Awesome 5 Free"',
         fill: new olStyleFill({
           color: '#7a7a7a'
         })

--- a/examples/googlestreetview.js
+++ b/examples/googlestreetview.js
@@ -48,7 +48,7 @@ function MainController(ngeoFeatureOverlayMgr, ngeoToolActivateMgr) {
   this.style = new olStyleStyle({
     text: new olStyleText({
       fill: new olStyleFill({color: '#279B61'}),
-      font: 'normal 30px FontAwesome',
+      font: '900 30px "Font Awesome 5 Free"',
       offsetY: -15,
       stroke: new olStyleStroke({color: '#ffffff', width: 3}),
       text: '\uf041'

--- a/examples/rotate.js
+++ b/examples/rotate.js
@@ -103,7 +103,7 @@ function MainController() {
       image: new olStyleCircle(),
       text: new olStyleText({
         text: '\uf01e',
-        font: 'normal 18px FontAwesome',
+        font: '900 18px "Font Awesome 5 Free"',
         fill: new olStyleFill({
           color: '#ffffff'
         })

--- a/src/filter/ruleComponent.js
+++ b/src/filter/ruleComponent.js
@@ -317,7 +317,7 @@ class RuleController {
       style: new olStyleStyle({
         text: new olStyleText({
           text: '\uf01e',
-          font: 'normal 18px FontAwesome',
+          font: '900 18px "Font Awesome 5 Free"',
           fill: new olStyleFill({
             color: '#7a7a7a'
           })
@@ -335,7 +335,7 @@ class RuleController {
       style: new olStyleStyle({
         text: new olStyleText({
           text: '\uf047',
-          font: 'normal 18px FontAwesome',
+          font: '900 18px "Font Awesome 5 Free"',
           fill: new olStyleFill({
             color: '#7a7a7a'
           })

--- a/src/routing/RoutingFeatureComponent.js
+++ b/src/routing/RoutingFeatureComponent.js
@@ -152,7 +152,7 @@ function Controller($scope, $timeout, $q, ngeoNominatimService) {
           fill: new olStyleFill({
             color: this.fillColor || '#000000'
           }),
-          font: 'normal 30px FontAwesome',
+          font: '900 30px "Font Awesome 5 Free"',
           offsetY: -15,
           stroke: new olStyleStroke({
             width: 3,

--- a/test/spec/services/print.spec.js
+++ b/test/spec/services/print.spec.js
@@ -361,7 +361,7 @@ describe('ngeo.print.Service', () => {
 
         style3 = new olStyleStyle({
           text: new olStyleText({
-            font: 'normal 16px "sans serif"',
+            font: '900 16px "sans serif"',
             text: 'Ngeo',
             textAlign: 'left',
             offsetX: 42,
@@ -375,7 +375,7 @@ describe('ngeo.print.Service', () => {
         // Here to check that textAlign default value is set.
         style4 = new olStyleStyle({
           text: new olStyleText({
-            font: 'normal 16px "sans serif"',
+            font: '900 16px "sans serif"',
             text: 'Ngeo',
             offsetX: 42,
             offsetY: -42,
@@ -479,7 +479,7 @@ describe('ngeo.print.Service', () => {
           symbolizers: [{
             type: 'Text',
             fontColor: '#030303',
-            fontWeight: 'normal',
+            fontWeight: '900',
             fontSize: '16px',
             fontFamily: '"sans serif"',
             label: 'Ngeo',
@@ -492,7 +492,7 @@ describe('ngeo.print.Service', () => {
           symbolizers: [{
             type: 'Text',
             fontColor: '#030303',
-            fontWeight: 'normal',
+            fontWeight: '900',
             fontSize: '16px',
             fontFamily: '"sans serif"',
             label: 'Ngeo',


### PR DESCRIPTION
Use `Font Awesome 5 Free` instead of `FontAwesome` and weight `900` instead of `normal` (alias to `400`)