### PR TITLE
Fix app map messages on mobile

### DIFF
--- a/contribs/gmf/src/controllers/mobile.scss
+++ b/contribs/gmf/src/controllers/mobile.scss
@@ -176,7 +176,12 @@ button[ngeo-mobile-geolocation] {
 
 /** Disclaimer, and tablet redirect */
 main .gmf-app-map-messages {
+  bottom: 50px;
   text-align: left;
+
+  .alert.fade:not(.show) {
+    display: none;
+  }
 }
 
 /** ngeo-displayquery-window */


### PR DESCRIPTION
The container of the messages in the mobile apps were partially rendered on top of the measure tools, which resulted in some of the buttons not working.  To fix this, the container is moved up in this patch.

I've noticed an other issue while working on that.  There was an extra message being shown, a link saying that "you're in the mobile version, go in the desktop version" which was hidden using opacity to 0.  That means that you were able to click on the link even if you couldn't see it and end up in an other page.  I think this could be considered as a bug.  Also, it left a big empty gap as well.

Instead of the opacity, I made it invisible using display:none only if it should be hidden.