### PR TITLE
Fix search to remove 'No result' on change and empty query

### DIFF
--- a/contribs/gmf/src/search/component.js
+++ b/contribs/gmf/src/search/component.js
@@ -489,6 +489,7 @@ class SearchController {
       this.additionalListeners,
       /** @type {import('ngeo/search/searchDirective.js').SearchDirectiveListeners} */ ({
         select: this.select_.bind(this),
+        change: this.handleChange_.bind(this),
         close: this.close_.bind(this),
         datasetsempty: this.datasetsempty_.bind(this)
       })
@@ -533,6 +534,7 @@ class SearchController {
           listeners.close();
           additionalListeners.close();
         },
+      change: additionalListeners.change,
       cursorchange: additionalListeners.cursorchange,
       datasetsempty: additionalListeners.datasetsempty,
       select: additionalListeners.select === undefined ?
@@ -1091,6 +1093,21 @@ class SearchController {
           this.inputValue = /** @type {string} */ (feature.get('label'));
         }
       });
+  }
+
+  /**
+   * @param {JQueryEventObject} event Event.
+   * @param {string} query Query.
+   * @private
+   */
+  handleChange_(event, query) {
+    // On change, if there's a query then no need to do anything
+    if (query) {
+      return;
+    }
+
+    // There's no query, hide the no result message
+    this.datasetsempty_(event, query, false);
   }
 }
 

--- a/src/search/searchDirective.js
+++ b/src/search/searchDirective.js
@@ -9,6 +9,7 @@ import angular from 'angular';
  * @property {function(JQueryEventObject, Object, Twitter.Typeahead.Dataset): void} [select]
  * @property {function(JQueryEventObject, Object, Twitter.Typeahead.Dataset): void} [autocomplete]
  * @property {function(JQueryEventObject, string, boolean): void} [datasetsempty]
+ * @property {function(JQueryEventObject, string): void} [change]
  */
 
 
@@ -124,6 +125,17 @@ function searchComponent() {
           });
         });
 
+      element.on('typeahead:change',
+        /**
+         * @param {JQueryEventObject} event Event.
+         */
+        (event) => {
+          scope.$apply(() => {
+            const query = element.data('tt-typeahead')['input']['query'];
+            typeaheadListeners.change(event, query);
+          });
+        });
+
     }
   };
 }
@@ -147,7 +159,8 @@ function adaptListeners_(object) {
       cursorchange() {},
       datasetsempty() {},
       select() {},
-      autocomplete() {}
+      autocomplete() {},
+      change() {}
     };
   } else {
     typeaheadListeners = {
@@ -162,7 +175,9 @@ function adaptListeners_(object) {
       select: object.select !== undefined ?
         object.select : () => {},
       autocomplete: object.autocomplete !== undefined ?
-        object.autocomplete : () => {}
+        object.autocomplete : () => {},
+      change: object.change !== undefined ?
+        object.change : () => {}
     };
   }
   return typeaheadListeners;


### PR DESCRIPTION
In the GMF search component, when there are no results found after a query, an item "No result found" is added.  When clearing the query to an empty text, then clickout the search tool and then go back in, the message is still there.

This patch fixes this issue by listening the the typeahead `change` event and do an extra check there in case the query string is empty.