### PR TITLE
Fix unwanted title in ngeo displaywindow component

### DIFF
--- a/src/message/displaywindowComponent.html
+++ b/src/message/displaywindowComponent.html
@@ -2,6 +2,7 @@
   class="ngeo-displaywindow"
   ng-show="$ctrl.open"
   ng-style="$ctrl.style"
+  title=""
 >
 
   <div class="windowcontainer">


### PR DESCRIPTION
For version 2.3

An issue happened with ngeo displaywindow components in desktop apps.  A title was being shown with `mainCtrl.displaywindowTitle` as content when mouse hovering any of its content (close button, header, container, etc.)

```
gmfx.openIframePopup('page.html', 'My page', 500, 400);
```

This happens because the one of the component's options is `title`, which is a reserved attribute in HTML:

```
        <ngeo-displaywindow
          content="mainCtrl.displaywindowContent"
          desktop="true"
          draggable-containment="mainCtrl.displaywindowDraggableContainment"
          height="mainCtrl.displaywindowHeight"
          open="mainCtrl.displaywindowOpen"
          title="mainCtrl.displaywindowTitle" <------
          url="mainCtrl.displaywindowUrl"
          width="mainCtrl.displaywindowWidth"
        ></ngeo-displaywindow>
```

To bypass this issue, setting `title=""` in the template container div does the trick.

A better fix would be to change this option, but I think this should be addressed for v2.5 (as changing the name of an attribute would break the backward compatibility).