### PR TITLE
In flush mode load current theme private groups on login

### DIFF
--- a/contribs/gmf/src/controllers/AbstractAppController.js
+++ b/contribs/gmf/src/controllers/AbstractAppController.js
@@ -33,7 +33,6 @@ import olStyleFill from 'ol/style/Fill.js';
 import olStyleStroke from 'ol/style/Stroke.js';
 import olStyleStyle from 'ol/style/Style.js';
 import gmfThemeManager from 'gmf/theme/Manager.js';
-import gmfThemeThemes from 'gmf/theme/Themes.js';
 
 /**
  * Application abstract controller.
@@ -191,7 +190,8 @@ const exports = function(config, $scope, $injector) {
     this.gmfThemes_.loadThemes(roleId);
 
     if (evt.type !== 'ready') {
-      this.updateCurrentTheme_(previousThemeName);
+      const themeName = this.permalink_.defaultThemeNameFromFunctionalities();
+      this.gmfThemeManager.updateCurrentTheme(themeName, previousThemeName);
     }
     this.setDefaultBackground_(null);
     this.updateHasEditableLayers_();
@@ -737,23 +737,6 @@ exports.prototype.setDefaultBackground_ = function(theme) {
   });
 };
 
-/**
- * @param {string} fallbackThemeName fallback theme name.
- * @private
- */
-exports.prototype.updateCurrentTheme_ = function(fallbackThemeName) {
-  this.gmfThemes_.getThemesObject().then((themes) => {
-    const themeName = this.permalink_.defaultThemeNameFromFunctionalities();
-    if (themeName) {
-      const theme = gmfThemeThemes.findThemeByName(themes, /** @type {string} */ (themeName));
-      if (theme) {
-        this.gmfThemeManager.addTheme(theme, true);
-      }
-    } else {
-      this.gmfThemeManager.setThemeName(fallbackThemeName);
-    }
-  });
-};
 
 /**
  * @protected

--- a/contribs/gmf/src/theme/Manager.js
+++ b/contribs/gmf/src/theme/Manager.js
@@ -107,6 +107,33 @@ exports.prototype.isLoading = function() {
   return !this.gmfThemes_.loaded;
 };
 
+
+/**
+ * @param {string} themeName wanted theme name.
+ * @param {string} fallbackThemeName fallback theme name.
+ * @export
+ */
+exports.prototype.updateCurrentTheme = function(themeName, fallbackThemeName) {
+  this.gmfThemes_.getThemesObject().then((themes) => {
+    if (!themeName && this.modeFlush) {
+      // In flush mode load current theme private groups
+      const fallbackTheme = gmfThemeThemes.findThemeByName(themes, /** @type {string} */ (fallbackThemeName));
+      if (fallbackTheme) {
+        this.gmfTreeManager_.addFirstLevelGroups(fallbackTheme.children, false, false);
+      }
+    }
+    if (themeName) {
+      const theme = gmfThemeThemes.findThemeByName(themes, /** @type {string} */ (themeName));
+      if (theme) {
+        this.addTheme(theme, true);
+      }
+    } else {
+      this.setThemeName(fallbackThemeName);
+    }
+  });
+};
+
+
 /**
  * @param {string} name The new theme name.
  * @param {boolean=} opt_silent Don't emit a theme change event, default is false.


### PR DESCRIPTION
To keep things simple, I simply reload current theme when in flush mode and no default_theme for the user.
This have no impact on "not flush" mode.