### PR TITLE
Waiting cursor for map query [2.3]

### DIFF
--- a/contribs/gmf/apps/desktop/Controller.js
+++ b/contribs/gmf/apps/desktop/Controller.js
@@ -27,12 +27,13 @@ if (!window.requestAnimationFrame) {
 /**
  * @param {angular.Scope} $scope Scope.
  * @param {angular.$injector} $injector Main injector.
+ * @param {!ngeox.QueryResult} ngeoQueryResult ngeo query result.
  * @constructor
  * @extends {gmf.controllers.AbstractDesktopController}
  * @ngInject
  * @export
  */
-const exports = function($scope, $injector) {
+const exports = function($scope, $injector, ngeoQueryResult) {
   gmfControllersAbstractDesktopController.call(this, {
     srid: 21781,
     mapViewConfig: {
@@ -114,6 +115,27 @@ const exports = function($scope, $injector) {
       .addPlugin(RavenPluginsAngular)
       .install();
   }
+
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.hasPendingQuery_ = false;
+
+  // Change to a waiting cursor if there is a pending map query
+  $scope.$watchCollection(
+    () => ngeoQueryResult,
+    (newQueryResult, oldQueryResult) => {
+      if (newQueryResult.pending !== this.hasPendingQuery_) {
+        this.hasPendingQuery_ = newQueryResult.pending;
+        if (this.hasPendingQuery_) {
+          document.body.classList.add('gmf-query-pending');
+        } else {
+          document.body.classList.remove('gmf-query-pending');
+        }
+      }
+    }
+  );
 };
 
 olBase.inherits(exports, gmfControllersAbstractDesktopController);

--- a/contribs/gmf/src/controllers/desktop.less
+++ b/contribs/gmf/src/controllers/desktop.less
@@ -23,6 +23,9 @@ html, body {
 
 body {
   padding-top: @topbar-height;
+  &.gmf-query-pending {
+    cursor: wait;
+  }
 }
 
 header {

--- a/contribs/gmf/src/query/windowComponent.js
+++ b/contribs/gmf/src/query/windowComponent.js
@@ -551,7 +551,6 @@ function(opt_lastFeature) {
 exports.Controller_.prototype.close = function() {
   this.open = false;
   this.clear();
-  this.ngeoMapQuerent_.clear();
 };
 
 


### PR DESCRIPTION
I wanted to show a different cursor if there is a pending map query. But query/windowComponent (formerly displayquerywindow) keeps clearing ngeoQueryResult right after MapQuerent.issue() gets called. This clearing is not distinguishable from a unsuccessful query.

For my feature, I need the first commit in ngeo (the one that removes the clear). GMF seems to work fine without it.

The second commit is the cursor feature, which does not need to be part of gmf.