### PR TITLE
Don't overwrite possibly pending ngeoMapQuerent state [2.3]

### DIFF
--- a/contribs/gmf/src/query/windowComponent.js
+++ b/contribs/gmf/src/query/windowComponent.js
@@ -551,7 +551,6 @@ function(opt_lastFeature) {
 exports.Controller_.prototype.close = function() {
   this.open = false;
   this.clear();
-  this.ngeoMapQuerent_.clear();
 };
 
 


### PR DESCRIPTION
Bugfix from #4852

> I wanted to show a different cursor if there is a pending map query. But query/windowComponent (formerly displayquerywindow) keeps clearing ngeoQueryResult right after MapQuerent.issue() gets called. This clearing is not distinguishable from a unsuccessful query.
