### PR TITLE
Don't use 'in' operator with Map

### DIFF
--- a/api/src/Themes.js
+++ b/api/src/Themes.js
@@ -236,7 +236,7 @@ const capabilities = new Map();
  * @return {Object} Any
  */
 function getWMTSCapability(url) {
-  if (!(url in capabilities)) {
+  if (!capabilities.has(url)) {
     const request = fetch(url)
       .then(response => response.text())
       .then((capability) => {


### PR DESCRIPTION
```js
const map = new Map();
console.log('item' in map);
map.set('item', 'yes !')
console.log('item' in map);
```
prints:
```js
false
false
```

:cry: 