### PR TITLE
Set higher z-index for map messages

### DIFF
--- a/contribs/gmf/src/less/map.less
+++ b/contribs/gmf/src/less/map.less
@@ -137,7 +137,7 @@ button[ngeo-mobile-geolocation] {
   bottom: @app-margin;
   left: @app-margin;
   width: 30rem;
-  z-index: @above-content-index;
+  z-index: @above-search-index;
 
   .alert {
     padding: @half-app-margin @app-margin;


### PR DESCRIPTION
In some case, the close button for disclaimer is hidden behind button.

Before
![image](https://user-images.githubusercontent.com/4549666/63267605-bb9aaa00-c292-11e9-8089-2c175bba7ca4.png)

After
![image](https://user-images.githubusercontent.com/4549666/63267613-bfc6c780-c292-11e9-9797-714a97c25b58.png)
