### PR TITLE
Reorder private groups

### DIFF
--- a/contribs/gmf/src/layertree/TreeManager.js
+++ b/contribs/gmf/src/layertree/TreeManager.js
@@ -129,6 +129,12 @@ export function LayertreeTreeManager($timeout, $injector, gettextCatalog, ngeoLa
   this.ngeoStateManager_ = ngeoStateManager;
 
   /**
+   * @type {Array.<import('gmf/themes.js').GmfGroup>|undefined}
+   * @private
+   */
+  this.initialLevelFirstGroups_ = undefined;
+
+  /**
    * A reference to the OGC servers loaded by the theme service.
    * @type {import('gmf/themes.js').GmfOgcServers|null}
    * @private
@@ -196,6 +202,22 @@ LayertreeTreeManager.prototype.addFirstLevelGroups = function(firstLevelGroups,
   return groupNotAdded.length === 0;
 };
 
+/**
+ * @param {Array.<import('gmf/themes.js').GmfGroup>} firstGroups The groups we add to the layertree
+ */
+LayertreeTreeManager.prototype.setItintialFirstLevelGroups = function(firstGroups) {
+  this.initialLevelFirstGroups_ = firstGroups;
+};
+
+/**
+ * @param {array} array An array of groups.
+ * @param {number} old_index The old index before reorder (the current one).
+ * @param {number} new_index The new index after reorder.
+ * @private
+ */
+LayertreeTreeManager.prototype.reorderChild_ = function(array, old_index, new_index) {
+  array.splice(new_index, 0, array.splice(old_index, 1)[0]);
+};
 
 /**
  * Update the application state with the list of first level groups in the tree
@@ -257,7 +279,20 @@ LayertreeTreeManager.prototype.addFirstLevelGroup_ = function(group) {
     // Add each first-level-groups.
     this.groupsToAddInThisDigestLoop_.forEach((grp) => {
       this.root.children.unshift(grp);
+
+      // We reorder the groups now as it has to be done before the permalink to be updated
+      // initialFirstGroups_ is only defined for user change theme loading
+      if (this.initialLevelFirstGroups_ !== undefined) {
+        this.root.children.forEach((group, old_index) => {
+          const new_index = this.initialLevelFirstGroups_.findIndex(
+            firstLevelGroup => firstLevelGroup.id === group.id);
+          if (new_index !== -1 && new_index !== old_index) {
+            this.reorderChild_(this.root.children, old_index, new_index);
+          }
+        });
+      }
     });
+    this.initialLevelFirstGroups_ = undefined;
     //Update the permalink
     this.updateTreeGroupsState_(this.root.children);
     // Reset the groups and the promise state. Don't reset the

--- a/contribs/gmf/src/layertree/datasourceGroupTreeComponent.html
+++ b/contribs/gmf/src/layertree/datasourceGroupTreeComponent.html
@@ -61,7 +61,7 @@
           ng-click="$ctrl.removeDataSource(dataSource)">
           <span class="fa fa-trash"></span>
         </a>
-  </span>
+      </span>
     </div>
   </li>
 </ul>

--- a/contribs/gmf/src/theme/Manager.js
+++ b/contribs/gmf/src/theme/Manager.js
@@ -128,6 +128,7 @@ ThemeManagerService.prototype.updateCurrentTheme = function(themeName, fallbackT
       // In flush mode load current theme private groups
       const fallbackTheme = findThemeByName(themes, fallbackThemeName);
       if (fallbackTheme) {
+        this.gmfTreeManager_.setItintialFirstLevelGroups(fallbackTheme.children);
         this.gmfTreeManager_.addFirstLevelGroups(fallbackTheme.children, false, opt_silent);
       }
     }


### PR DESCRIPTION
Not really happy with this fix.

Initially I wanted to just set a boolean but refreshFirstLevelGroups_ function is called after and modify the firstLevelGroups variable that is used in the function addFirstLevelGroups called in the process of user change. That means that I don't get the full array of current groups to reload but just a set after the modification, and I was forced to save it at user change in a separate variable to keep its current state (in this.initialLevelFirstGroups_).

Fix: GSGMF-1086