### PR TITLE
Introduce a new query component and example

### DIFF
--- a/examples/query.css
+++ b/examples/query.css
@@ -1,0 +1,5 @@
+
+#map {
+  width: 600px;
+  height: 400px;
+}

--- a/examples/query.html
+++ b/examples/query.html
@@ -32,9 +32,13 @@
           href="../apidoc/ngeo.misc.ToolActivateMgr.html"
           title="Read our documentation">ngeo.misc.ToolActivate</a>
       </code>
-      can be used to make the directive inactive when an other tool
+      can be used to make the component inactive when an other tool
       becomes active.  The "Dummy" button here does nothing, but when
-      toggled the query directive becomes inactive.
+      toggled the query component becomes inactive. Click on the map to
+      issue a query. Hold down the "ctrl" key (meta on MAC) then click twice
+      in the map to draw a box instead. Hold the A key to add the results to
+      existing ones. Hold the X key to remove the results from the existing
+      ones.
     </p>
 
     <button

--- a/examples/query.html
+++ b/examples/query.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+  <head>
+    <title>Query example</title>
+    <meta charset="utf-8" />
+    <meta name="viewport"
+          content="initial-scale=1.0, user-scalable=no, width=device-width" />
+    <meta name="mobile-web-app-capable" content="yes" />
+  </head>
+  <body ng-controller="MainController as ctrl">
+    <div
+      id="map"
+      ngeo-map="ctrl.map">
+    </div>
+
+    <ngeo-query
+        active="ctrl.queryActive"
+        autoclear="ctrl.queryAutoClear"
+        map="::ctrl.map">
+    </ngeo-query>
+
+    <p id="desc">
+      This example shows how to use the
+      <code>
+        <a
+          href="../apidoc/ngeo.query.component.html"
+          title="Read our documentation">ngeo-query</a>
+      </code>
+      component. It also shows how the
+      <code>
+        <a
+          href="../apidoc/ngeo.misc.ToolActivateMgr.html"
+          title="Read our documentation">ngeo.misc.ToolActivate</a>
+      </code>
+      can be used to make the directive inactive when an other tool
+      becomes active.  The "Dummy" button here does nothing, but when
+      toggled the query directive becomes inactive.
+    </p>
+
+    <button
+      ngeo-btn=""
+      class="btn btn-info"
+      ng-model="ctrl.getSetDummyActive"
+      ng-model-options="{getterSetter: true}">Dummy</button>
+
+    <span>Mode: {{ ctrl.ngeoQueryModeSelector.mode }}</span>,
+    <span>Action: {{ ctrl.ngeoQueryModeSelector.action }}</span>
+    <br />
+
+    <app-queryresult></app-queryresult>
+
+    <script type="text/javascript" src="dist/vendor.js"></script>
+  </body>
+</html>

--- a/examples/query.js
+++ b/examples/query.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
 import {MAPSERVER_PROXY, MAPSERVER_WFS_FEATURE_NS} from './url.js';
-import './mapquery.css';
+import './query.css';
 import EPSG21781 from '@geoblocks/proj/src/EPSG_21781.js';
 
 import ngeoDatasourceDataSources from 'ngeo/datasource/DataSources.js';

--- a/examples/query.js
+++ b/examples/query.js
@@ -152,7 +152,7 @@ function MainController(
       projection: EPSG21781,
       resolutions: [200, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5],
       center: [537635, 152640],
-      zoom: 0
+      zoom: 4
     })
   });
 

--- a/examples/query.js
+++ b/examples/query.js
@@ -1,0 +1,220 @@
+import angular from 'angular';
+import {MAPSERVER_PROXY, MAPSERVER_WFS_FEATURE_NS} from './url.js';
+import './mapquery.css';
+import EPSG21781 from '@geoblocks/proj/src/EPSG_21781.js';
+
+import ngeoDatasourceDataSources from 'ngeo/datasource/DataSources.js';
+import ngeoDatasourceOGC from 'ngeo/datasource/OGC.js';
+import ngeoMapModule from 'ngeo/map/module.js';
+
+import ngeoMiscBtnComponent from 'ngeo/misc/btnComponent.js';
+
+import ngeoMiscToolActivate from 'ngeo/misc/ToolActivate.js';
+import ngeoMiscToolActivateMgr from 'ngeo/misc/ToolActivateMgr.js';
+import ngeoQueryComponent from 'ngeo/query/component.js';
+import ngeoQueryModule from 'ngeo/query/module.js';
+import ngeoQueryModeSelector from 'ngeo/query/ModeSelector.js';
+
+import olMap from 'ol/Map.js';
+import olView from 'ol/View.js';
+import olLayerImage from 'ol/layer/Image.js';
+import olLayerTile from 'ol/layer/Tile.js';
+import olSourceImageWMS from 'ol/source/ImageWMS.js';
+import olSourceOSM from 'ol/source/OSM.js';
+
+
+/** @type {angular.IModule} **/
+const module = angular.module('app', [
+  'gettext',
+  ngeoDatasourceDataSources.name,
+  ngeoMapModule.name,
+  ngeoMiscBtnComponent.name,
+  ngeoMiscToolActivateMgr.name,
+  ngeoQueryComponent.name,
+  ngeoQueryModule.name,
+]);
+
+
+module.run(
+  /**
+   * @ngInject
+   * @param {angular.ITemplateCacheService} $templateCache
+   */
+  ($templateCache) => {
+    // @ts-ignore: webpack
+    $templateCache.put('partials/queryresult', require('./partials/queryresult.html'));
+  });
+
+
+module.value('ngeoQueryOptions', {
+  'cursorHover': true,
+  'limit': 20
+});
+
+
+/**
+ * A sample component to display the result.
+ *
+ * @type {angular.IComponentOptions}
+ */
+const queryresultComponent = {
+  controller: 'AppQueryresultController',
+  templateUrl: 'partials/queryresult'
+};
+
+module.component('appQueryresult', queryresultComponent);
+
+
+/**
+ * @param {import('ngeo/query/MapQuerent.js').QueryResult} ngeoQueryResult The ngeo query service.
+ * @constructor
+ * @ngInject
+ */
+function QueryresultController(ngeoQueryResult) {
+
+  /**
+   * @type {import('ngeo/query/MapQuerent.js').QueryResult}
+   */
+  this.result = ngeoQueryResult;
+
+}
+
+
+module.controller('AppQueryresultController', QueryresultController);
+
+
+/**
+ * @param {angular.IScope} $scope Scope.
+ * @param {import("ngeo/datasource/DataSources.js").DataSource} ngeoDataSources Ngeo data sources service.
+ * @param {import("ngeo/misc/ToolActivateMgr.js").ToolActivateMgr} ngeoToolActivateMgr The ngeo ToolActivate
+ *     manager.
+ * @param {import("ngeo/query/ModeSelector.js").QueryModeSelector} ngeoQueryModeSelector The ngeo QueryModeSelector service
+
+ * @constructor
+ * @ngInject
+ */
+function MainController(
+  $scope, ngeoDataSources, ngeoToolActivateMgr, ngeoQueryModeSelector
+) {
+
+  /**
+   * @type {boolean}
+   */
+  this.dummyActive = false;
+
+  /**
+   * @type {boolean}
+   */
+  this.queryActive = true;
+
+  /**
+   * @type {boolean}
+   */
+  this.queryAutoClear = true;
+
+  /**
+   * @type {import("ngeo/query/ModeSelector.js").QueryModeSelector}
+   */
+  this.ngeoQueryModeSelector = ngeoQueryModeSelector;
+
+  const source1 = new olSourceImageWMS({
+    url: MAPSERVER_PROXY,
+    projection: undefined, // should be removed in next OL version
+    params: {'LAYERS': 'bus_stop'}
+  });
+  // @ts-ignore: OL issue
+  const busStopLayer = new olLayerImage({
+    source: source1
+  });
+
+  const source2 = new olSourceImageWMS({
+    url: MAPSERVER_PROXY,
+    projection: undefined, // should be removed in next OL version
+    params: {'LAYERS': 'information'}
+  });
+  // @ts-ignore: OL issue
+  const informationLayer = new olLayerImage({
+    source: source2
+  });
+
+  /**
+   * @type {import("ol/Map.js").default}
+   */
+  this.map = new olMap({
+    layers: [
+      new olLayerTile({
+        source: new olSourceOSM()
+      }),
+      informationLayer,
+      busStopLayer
+    ],
+    view: new olView({
+      projection: EPSG21781,
+      resolutions: [200, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5],
+      center: [537635, 152640],
+      zoom: 0
+    })
+  });
+
+  ngeoDataSources.map = this.map;
+
+  ngeoDataSources.collection.push(new ngeoDatasourceOGC({
+    id: 1,
+    name: 'bus_stop',
+    visible: true,
+    wmsUrl: MAPSERVER_PROXY,
+    wmsLayers: [{
+      name: 'bus_stop',
+      queryable: true
+    }],
+    wfsUrl: MAPSERVER_PROXY,
+    wfsFeatureNS: MAPSERVER_WFS_FEATURE_NS,
+    wfsLayers: [{
+      name: 'bus_stop',
+      queryable: true
+    }]
+  }));
+
+  ngeoDataSources.collection.push(new ngeoDatasourceOGC({
+    id: 2,
+    name: 'information',
+    visible: true,
+    wmsUrl: MAPSERVER_PROXY,
+    wmsLayers: [{
+      name: 'information',
+      queryable: true
+    }],
+    wfsFeatureNS: MAPSERVER_WFS_FEATURE_NS,
+    wfsUrl: MAPSERVER_PROXY,
+    wfsLayers: [{
+      name: 'information',
+      queryable: true
+    }]
+  }));
+
+  const queryToolActivate = new ngeoMiscToolActivate(this, 'queryActive');
+  ngeoToolActivateMgr.registerTool('mapTools', queryToolActivate, true);
+
+  const dummyToolActivate = new ngeoMiscToolActivate(this, 'dummyActive');
+  ngeoToolActivateMgr.registerTool('mapTools', dummyToolActivate);
+
+}
+
+
+/**
+ * @param {boolean|undefined} val Value.
+ * @return {boolean|undefined} Value.
+ */
+MainController.prototype.getSetDummyActive = function(val) {
+  if (val !== undefined) {
+    this.dummyActive = val;
+  } else {
+    return this.dummyActive;
+  }
+};
+
+
+module.controller('MainController', MainController);
+
+
+export default module;

--- a/src/datasource/Helper.js
+++ b/src/datasource/Helper.js
@@ -57,6 +57,9 @@ export class DatasourceHelper {
 
     olEvents.listen(this.collection_, 'add', this.handleDataSourcesAdd_, this);
     olEvents.listen(this.collection_, 'remove', this.handleDataSourcesRemove_, this);
+
+    // Register data sources that are already in the collection
+    this.collection_.forEach(this.registerDataSource_.bind(this));
   }
 
   /**
@@ -122,6 +125,24 @@ export class DatasourceHelper {
   }
 
   /**
+   * Register a data source, adding it to the cache.
+   * @param {ngeoDatasourceDataSource} dataSource An ngeo data source
+   * @private
+   */
+  registerDataSource_(dataSource) {
+    this.cache_[dataSource.id] = dataSource;
+  }
+
+  /**
+   * Unregister a data source, removing it to from cache.
+   * @param {ngeoDatasourceDataSource} dataSource An ngeo data source
+   * @private
+   */
+  unregisterDataSource_(dataSource) {
+    delete this.cache_[dataSource.id];
+  }
+
+  /**
    * Called when a new data source is added to the ngeo collection. Add it
    * to the cache.
    * @param {Event|import("ol/events/Event.js").default} evt Event
@@ -131,7 +152,7 @@ export class DatasourceHelper {
     if (evt instanceof CollectionEvent) {
       const dataSource = evt.element;
       console.assert(dataSource instanceof ngeoDatasourceDataSource);
-      this.cache_[dataSource.id] = dataSource;
+      this.registerDataSource_(dataSource);
     }
   }
 
@@ -144,7 +165,7 @@ export class DatasourceHelper {
   handleDataSourcesRemove_(evt) {
     if (evt instanceof CollectionEvent) {
       const dataSource = evt.element;
-      delete this.cache_[dataSource.id];
+      this.unregisterDataSource_(dataSource);
     }
   }
 

--- a/src/events.js
+++ b/src/events.js
@@ -1,0 +1,15 @@
+import {unlistenByKey} from 'ol/events.js';
+
+/**
+ * Unregisters event listeners on a list of event targets, then empty
+ * the list.
+ *
+ * @param {Array<import('ol/events.js').EventsKey>} keys List of keys
+ *     to unlisten.
+ */
+export function unlistenByKeys(keys) {
+  for (const key of keys) {
+    unlistenByKey(key);
+  }
+  keys.length = 0;
+}

--- a/src/query/MapQuerent.js
+++ b/src/query/MapQuerent.js
@@ -156,6 +156,7 @@ export class MapQuerent {
 
   /**
    * @param {import('ngeo/query/Querent.js').IssueGetFeaturesOptions} options Options.
+   * @return {angular.IPromise<QuerentResult>} Promise.
    */
   issue(options) {
     const action = options.action ? options.action : ngeoQueryAction.REPLACE;
@@ -185,7 +186,8 @@ export class MapQuerent {
       bboxAsGETParam: this.bboxAsGETParam_
     });
     this.result_.pending = true;
-    this.ngeoQuerent_.issue(options).then(this.handleResult_.bind(this, action));
+    return this.ngeoQuerent_.issue(options).then(
+      this.handleResult_.bind(this, action));
   }
 
   /**

--- a/src/query/MapQuerent.js
+++ b/src/query/MapQuerent.js
@@ -156,7 +156,7 @@ export class MapQuerent {
 
   /**
    * @param {import('ngeo/query/Querent.js').IssueGetFeaturesOptions} options Options.
-   * @return {angular.IPromise<QuerentResult>} Promise.
+   * @return {angular.IPromise<void|import('ngeo/query/Querent.js').QuerentResult>} Promise.
    */
   issue(options) {
     const action = options.action ? options.action : ngeoQueryAction.REPLACE;

--- a/src/query/Mode.js
+++ b/src/query/Mode.js
@@ -1,0 +1,5 @@
+export default {
+  CLICK: 'click',
+  DRAW_BOX: 'drawbox',
+  DRAW_POLYGON: 'drawpolygon',
+};

--- a/src/query/ModeSelector.js
+++ b/src/query/ModeSelector.js
@@ -113,7 +113,7 @@ export class QueryModeSelector {
   }
 
   /**
-   * @param {string} The query action to set as active
+   * @param {string} action The query action to set as active
    */
   set action(action) {
     this.action_ = action;
@@ -127,7 +127,7 @@ export class QueryModeSelector {
   }
 
   /**
-   * @param {string} The query mode to set as active
+   * @param {string} mode The query mode to set as active
    */
   set mode(mode) {
     this.mode_ = mode;

--- a/src/query/ModeSelector.js
+++ b/src/query/ModeSelector.js
@@ -105,13 +105,18 @@ export class QueryModeSelector {
     olEventsListen(document, 'keyup', this.handleKeyUp_, this);
   }
 
-  // Getters
-
   /**
    * @return {string} The query action currently active
    */
   get action() {
     return this.action_;
+  }
+
+  /**
+   * @param {string} The query action to set as active
+   */
+  set action(action) {
+    this.action_ = action;
   }
 
   /**
@@ -121,20 +126,11 @@ export class QueryModeSelector {
     return this.mode_;
   }
 
-  // Setters
-
-  /**
-   * @param {string} The query action to set as active
-   */
-  set action(action) {
-    this.action_ = action
-  }
-
   /**
    * @param {string} The query mode to set as active
    */
   set mode(mode) {
-    this.mode_ = mode
+    this.mode_ = mode;
   }
 
   // Handlers

--- a/src/query/ModeSelector.js
+++ b/src/query/ModeSelector.js
@@ -1,0 +1,226 @@
+import angular from 'angular';
+import ngeoQueryAction from 'ngeo/query/Action.js';
+import ngeoQueryMode from 'ngeo/query/Mode.js';
+
+import {listen as olEventsListen} from 'ol/events.js';
+import {MAC} from 'ol/has.js';
+
+
+/**
+ * @hidden
+ */
+export class QueryModeSelector {
+
+  /**
+   * Service that provides the query "mode", i.e. how queries on the
+   * map should be made by the user.
+   *
+   * It also provides the query "action", i.e. what to do with the
+   * query results.
+   *
+   * Both the "mode" and "action" can be temporarily set if a key is
+   * pressed on the keyboard by the user. Therefore, this service
+   * listens to the keyboard `keydown` and `keyup` events to
+   * temporarily set them accordingly depending on the key that was
+   * pressed.
+   *
+   * @param {angular.IScope} $rootScope .
+   */
+  constructor($rootScope) {
+
+    // Constants
+
+    /**
+     * The key to press to temporarily set the action to "ADD"
+     * @type {string}
+     * @private
+     */
+    this.keyActionAdd_ = 'a';
+
+    /**
+     * The key to press to temporarily set the action to "REMOVE"
+     * @type {string}
+     * @private
+     */
+    this.keyActionRemove_ = 'x';
+
+    /**
+     * @type {string[]}
+     * @private
+     */
+    this.keysAction_ = [this.keyActionAdd_, this.keyActionRemove_];
+
+    // Variables
+
+    /**
+     * The action currently active.
+     * @type {string}
+     * @private
+     */
+    this.action_ = ngeoQueryAction.REPLACE;
+
+    /**
+     * If a key is pressed, it can temporarily change the currently
+     * active action. When that happens, the currently active action
+     * is stored here to be restored later, after the key has been
+     * released.
+     * @type {?string}
+     * @private
+     */
+    this.previousAction_ = null;
+
+    /**
+     * The mode currently active.
+     * @type {string}
+     * @private
+     */
+    this.mode_ = ngeoQueryMode.CLICK;
+
+    /**
+     * If a key is pressed, it can temporarily change the currently
+     * active mode. When that happens, the currently active mode is
+     * stored here to be restored later, after the key has been
+     * released.
+     * @type {?string}
+     * @private
+     */
+    this.previousMode_ = null;
+
+    /**
+     * The action key currently being pressed. Only those registered
+     * in `this.keysAction_` can be active.
+     * @type {?string}
+     * @private
+     */
+    this.activeActionKey_ = null;
+
+    /**
+     * @type {angular.IScope}
+     * @private
+     */
+    this.rootScope_ = $rootScope;
+
+    // Event listeners
+    olEventsListen(document, 'keydown', this.handleKeyDown_, this);
+    olEventsListen(document, 'keyup', this.handleKeyUp_, this);
+  }
+
+  // Getters
+
+  /**
+   * @return {string} The query action currently active
+   */
+  get action() {
+    return this.action_;
+  }
+
+  /**
+   * @return {string} The query mode currently active
+   */
+  get mode() {
+    return this.mode_;
+  }
+
+  // Setters
+
+  /**
+   * @param {string} The query action to set as active
+   */
+  set action(action) {
+    this.action_ = action
+  }
+
+  /**
+   * @param {string} The query mode to set as active
+   */
+  set mode(mode) {
+    this.mode_ = mode
+  }
+
+  // Handlers
+
+  /**
+   * @param {Event|import("ol/events/Event.js").default} evt Event.
+   * @private
+   */
+  handleKeyDown_(evt) {
+    if (!(evt instanceof KeyboardEvent)) {
+      return;
+    }
+
+    const key = evt.key;
+    if (this.keysAction_.includes(key) && !this.previousAction_) {
+      // An 'action' key was pressed and none were already previously
+      // pressed. In other words, only the first 'action key' is handled.
+      this.previousAction_ = this.action;
+      let newAction;
+      switch (key) {
+        case this.keyActionAdd_:
+          newAction = ngeoQueryAction.ADD;
+          break;
+        case this.keyActionRemove_:
+          newAction = ngeoQueryAction.REMOVE;
+          break;
+        default:
+          break;
+      }
+      if (newAction) {
+        this.action = newAction;
+        this.activeActionKey_ = key;
+        this.rootScope_.$apply();
+      }
+
+    } else if ((MAC ? evt.metaKey : evt.ctrlKey) && !this.previousMode_) {
+      // The 'ctrl' (or 'meta' key) on mac was pressed
+      this.previousMode_ = this.mode;
+      this.mode = ngeoQueryMode.DRAW_BOX;
+      this.rootScope_.$apply();
+    }
+  }
+
+  /**
+   * @param {Event|import("ol/events/Event.js").default} evt Event.
+   * @private
+   */
+  handleKeyUp_(evt) {
+    if (!(evt instanceof KeyboardEvent)) {
+      return;
+    }
+
+    let updateScope = false;
+
+    // On any 'keyup', if no 'ctrl' (or 'meta' on mac) is pressed and
+    // there is a previous mode set, then set it as new active mode.
+    if (!(evt.metaKey || evt.ctrlKey) && this.previousMode_) {
+      this.mode = this.previousMode_;
+      this.previousMode_ = null;
+      updateScope = true;
+    }
+
+    // If the active action key was released, then restore the
+    // previous action.
+    const key = evt.key;
+    if (this.activeActionKey_ === key && this.previousAction_) {
+      this.action = this.previousAction_;
+      this.previousAction_ = null;
+      this.activeActionKey_ = null;
+      updateScope = true;
+    }
+
+    if (updateScope) {
+      this.rootScope_.$apply();
+    }
+  }
+}
+
+
+/**
+ * @type {angular.IModule}
+ * @hidden
+ */
+const module = angular.module('ngeoQueryModeSelector', [
+]);
+module.service('ngeoQueryModeSelector', QueryModeSelector);
+
+
+export default module;

--- a/src/query/component.js
+++ b/src/query/component.js
@@ -163,7 +163,7 @@ class QueryController {
    * Called on initialization of the controller.
    */
   $onInit() {
-    // Set default value of optionnal binding properties
+    // Set default value of optional binding properties
     this.autoclear = !!this.autoclear;
   }
 

--- a/src/query/component.js
+++ b/src/query/component.js
@@ -151,7 +151,7 @@ class QueryController {
       () => {
         let value = null;
         if (this.active) {
-          value = this.ngeoQueryModeSelector_.mode
+          value = this.ngeoQueryModeSelector_.mode;
         }
         return value;
       },

--- a/src/query/component.js
+++ b/src/query/component.js
@@ -1,0 +1,391 @@
+import angular from 'angular';
+
+import {unlistenByKeys as ngeoEventsUnlistenByKeys} from 'ngeo/events.js';
+import ngeoQueryMode from 'ngeo/query/Mode.js';
+import ngeoQueryModeSelector from 'ngeo/query/ModeSelector.js';
+import ngeoQueryMapQuerent from 'ngeo/query/MapQuerent.js';
+
+import {listen as olEventsListen} from 'ol/events.js';
+import {always as olEventsConditionAlways} from 'ol/events/condition.js';
+import olInteractionDraw, {
+  createBox as olInteractionDrawCreateBox
+} from 'ol/interaction/Draw.js';
+import {Vector as olLayerVector} from 'ol/layer.js';
+import MapBrowserEvent from 'ol/MapBrowserEvent.js';
+import {Vector as olSourceVector} from 'ol/source.js';
+
+/**
+ * @type {angular.IModule}
+ * @hidden
+ */
+const module = angular.module('ngeoQuery', [
+  ngeoQueryModeSelector.name,
+  ngeoQueryMapQuerent.name,
+]);
+
+
+/**
+ * @private
+ * @hidden
+ */
+class QueryController {
+
+  /**
+   * @param {import("ngeo/query/MapQuerent.js").MapQuerent}
+   *     ngeoMapQuerent The ngeo map querent service.
+   * @param {import("ngeo/query/ModeSelector.js").QueryModeSelector}
+   *     ngeoQueryModeSelector The ngeo query modeSelector service.
+   * @param {angular.auto.IInjectorService} $injector Main injector.
+   * @param {angular.IScope} $scope Scope.
+   * @private
+   * @ngInject
+   * @ngdoc controller
+   * @ngname NgeoQueryController
+   */
+  constructor(ngeoMapQuerent, ngeoQueryModeSelector, $injector, $scope) {
+
+    // === Binding properties ===
+
+    /**
+     * @type {boolean}
+     */
+    this.active;
+
+    /**
+     * @type {boolean}
+     */
+    this.autoclear;
+
+    /**
+     * @type {!import("ol/Map.js").default}
+     */
+    this.map;
+
+
+    // === Injected properties ===
+
+    /**
+     * @type {import("ngeo/query/MapQuerent.js").MapQuerent}
+     * @private
+     */
+    this.ngeoMapQuerent_ = ngeoMapQuerent;
+
+    /**
+     * @type {import("ngeo/query/ModeSelector.js").QueryModeSelector}
+     * @private
+     */
+    this.ngeoQueryModeSelector_ = ngeoQueryModeSelector;
+
+    const ngeoQueryOptions =
+      /** @type {import('ngeo/query/MapQuerent.js').QueryOptions} */ (
+        $injector.has('ngeoQueryOptions') ?
+          $injector.get('ngeoQueryOptions') :
+          {}
+      );
+
+    /**
+     * @type {import('ngeo/query/MapQuerent.js').QueryOptions}
+     * @private
+     */
+    this.ngeoQueryOptions_ = ngeoQueryOptions;
+
+    /**
+     * @type {angular.IScope}
+     * @private
+     */
+    this.scope_ = $scope;
+
+
+    // === Inner properties ===
+
+    /**
+     * @type {olSourceVector}
+     * @private
+     */
+    this.vectorSource_ = new olSourceVector({
+      wrapX: false
+    });
+
+    /**
+     * @type {olLayerVector}
+     * @private
+     */
+    this.vectorLayer_ = new olLayerVector({
+      source: this.vectorSource_
+    });
+
+    /**
+     * @type {olInteractionDraw}
+     * @private
+     */
+    this.drawBoxInteraction_ = new olInteractionDraw({
+      condition: olEventsConditionAlways,
+      geometryFunction: olInteractionDrawCreateBox(),
+      source: this.vectorSource_,
+      type: 'Circle'
+    });
+
+    /**
+     * The event keys of the currently active "mode".
+     *
+     * @type {Array<import('ol/events.js').EventsKey>}
+     * @private
+     */
+    this.listenerKeys_ = [];
+
+    /**
+     * @type {?string}
+     * @private
+     */
+    this.mode_ = null;
+
+
+    // === Event listeners that uses angular $scope
+
+    $scope.$watch(
+      () => this.active,
+      this.handleActiveChange_.bind(this)
+    );
+
+    $scope.$watch(
+      () => {
+        let value = null;
+        if (this.active) {
+          value = this.ngeoQueryModeSelector_.mode
+        }
+        return value;
+      },
+      this.enableMode_.bind(this)
+    );
+  }
+
+  /**
+   * Called on initialization of the controller.
+   */
+  $onInit() {
+    // Set default value of optionnal binding properties
+    this.autoclear = !!this.autoclear;
+  }
+
+  /**
+   * Called on destruction of the controller.
+   */
+  $onDestroy() {
+    this.enableMode_(null);
+  }
+
+  // === Mode enabling/disabling ===
+
+  /**
+   * Disable the current mode, then enable a new mode, i.e. add any
+   * interaction of that mode to the map.
+   *
+   * @param {?string} mode Mode to enable
+   * @private
+   */
+  enableMode_(mode) {
+    this.disableMode_();
+
+    // No need to do anything if there's no mode to enable
+    if (!mode) {
+      return;
+    }
+
+    // For debug purpose
+    // console.log(`mode enable: ${mode}`);
+
+    switch (mode) {
+      case ngeoQueryMode.CLICK:
+        this.listenerKeys_.push(
+          olEventsListen(
+            this.map,
+            'singleclick',
+            this.handleMapClick_,
+            this
+          )
+        );
+        if (this.ngeoQueryOptions_.cursorHover) {
+          this.listenerKeys_.push(
+            olEventsListen(
+              this.map,
+              'pointermove',
+              this.handleMapPointerMove_,
+              this
+            )
+          );
+        }
+        break;
+
+      case ngeoQueryMode.DRAW_BOX:
+        this.map.addLayer(this.vectorLayer_);
+        this.map.addInteraction(this.drawBoxInteraction_);
+        this.listenerKeys_.push(
+          olEventsListen(
+            this.drawBoxInteraction_,
+            'drawend',
+            this.handleDrawBoxInteractionDrawEnd_,
+            this
+          )
+        );
+        break;
+
+      default:
+        break;
+    }
+
+    this.mode_ = mode;
+  }
+
+  /**
+   * Disable the current mode, i.e. remove any interaction of that
+   * mode from the map.
+   * @private
+   */
+  disableMode_() {
+    // No need to do anything if there's no mode currently active
+    if (!this.mode_) {
+      return;
+    }
+
+    // For debug purpose
+    // console.log(`mode disable: ${this.mode_}`);
+
+    switch (this.mode_) {
+      case ngeoQueryMode.CLICK:
+        // Reset cursor, if required
+        if (this.ngeoQueryOptions_.cursorHover) {
+          this.map.getTargetElement().style.cursor = '';
+        }
+        break;
+
+      case ngeoQueryMode.DRAW_BOX:
+        this.map.removeLayer(this.vectorLayer_);
+        this.map.removeInteraction(this.drawBoxInteraction_);
+        break;
+
+      default:
+        break;
+    }
+
+    ngeoEventsUnlistenByKeys(this.listenerKeys_);
+
+    this.mode_ = null;
+  }
+
+  // === Utilities ===
+
+  /**
+   * The maximum number of features a query should return. Obtained
+   * from the options.
+   * @return {number|undefined}
+   * @private
+   */
+  getLimitOption_() {
+    return this.ngeoQueryOptions_ && this.ngeoQueryOptions_.limit ?
+      this.ngeoQueryOptions_.limit : undefined;
+  }
+
+
+  // === Handlers ===
+
+  /**
+   * Called when active property changes
+   * @param {boolean} active Whether this component is active or not.
+   * @private
+   */
+  handleActiveChange_(active) {
+    if (!active) {
+      if (this.autoclear) {
+        this.ngeoMapQuerent_.clear();
+      }
+    }
+  }
+
+  /**
+   * Called when a box is drawn on the map. Use it to issue a query.
+   * @param {Event|import("ol/events/Event.js").default} evt The draw
+   *     interaction drawend event being fired.
+   * @private
+   */
+  handleDrawBoxInteractionDrawEnd_(evt) {
+    const feature = evt.feature;
+
+    const action = this.ngeoQueryModeSelector_.action;
+    const extent = feature.getGeometry().getExtent();
+    const limit = this.getLimitOption_();
+    const map = this.map;
+
+    this.ngeoMapQuerent_.issue({
+      action,
+      extent,
+      limit,
+      map
+    }).then(() => {
+      this.vectorSource_.clear();
+    });
+  }
+
+  /**
+   * Called when the map is clicked while this component is active and
+   * the mode is "click". Issue a request to the query service using
+   * the coordinate that was clicked.
+   * @param {Event|import("ol/events/Event.js").default} evt The map
+   *     browser event being fired.
+   * @private
+   */
+  handleMapClick_(evt) {
+    if (!(evt instanceof MapBrowserEvent)) {
+      return;
+    }
+
+    const action = this.ngeoQueryModeSelector_.action;
+    const coordinate = evt.coordinate;
+    const map = this.map;
+
+    this.ngeoMapQuerent_.issue({
+      action,
+      coordinate,
+      map
+    });
+  }
+
+  /**
+   * Called when the pointer is moved over the map while this
+   * component is active and the mode is "click".  Change the
+   * mouse pointer when hovering a non-transparent pixel on the
+   * map.
+   * @param {Event|import("ol/events/Event.js").default} evt
+   *     The map browser event being fired.
+   */
+  handleMapPointerMove_(evt) {
+    // No need to do anything if user is dragging the map
+    if (!(evt instanceof MapBrowserEvent) || evt.dragging) {
+      return;
+    }
+
+    const pixel = this.map.getEventPixel(evt.originalEvent);
+
+    /**
+     * @param {import('ol/layer/Base').default} layer
+     */
+    const queryable = function(layer) {
+      const visible = layer.get('visible');
+      const sourceids = layer.get('querySourceIds');
+      return visible && !!sourceids;
+    };
+    const hit = this.map.forEachLayerAtPixel(
+      pixel, () => true, undefined, queryable);
+    this.map.getTargetElement().style.cursor = hit ? 'pointer' : '';
+  }
+}
+
+module.component('ngeoQuery', {
+  bindings: {
+    'active': '=',
+    'autoclear': '<?',
+    'map': '<'
+  },
+  controller: QueryController
+});
+
+export default module;

--- a/src/query/component.js
+++ b/src/query/component.js
@@ -99,7 +99,7 @@ class QueryController {
     // === Inner properties ===
 
     /**
-     * @type {olSourceVector}
+     * @type {olSourceVector<import("ol/geom/Polygon.js").default>}
      * @private
      */
     this.vectorSource_ = new olSourceVector({
@@ -308,6 +308,7 @@ class QueryController {
    * @private
    */
   handleDrawBoxInteractionDrawEnd_(evt) {
+    // @ts-ignore: evt should be of type {import('ol/interaction/Draw.js').DrawEvent but he is private
     const feature = evt.feature;
 
     const action = this.ngeoQueryModeSelector_.action;

--- a/src/query/component.js
+++ b/src/query/component.js
@@ -320,9 +320,13 @@ class QueryController {
       extent,
       limit,
       map
-    }).then(() => {
-      this.vectorSource_.clear();
-    });
+    })
+      .then(() => {})
+      .catch(() => {})
+      .then(() => {
+        // "finally"
+        this.vectorSource_.clear();
+      });
   }
 
   /**

--- a/src/query/component.js
+++ b/src/query/component.js
@@ -374,7 +374,12 @@ class QueryController {
       return visible && !!sourceids;
     };
     const hit = this.map.forEachLayerAtPixel(
-      pixel, () => true, undefined, queryable);
+      pixel,
+      () => true,
+      {
+        layerFilter: queryable
+      }
+    );
     this.map.getTargetElement().style.cursor = hit ? 'pointer' : '';
   }
 }

--- a/src/query/module.js
+++ b/src/query/module.js
@@ -1,15 +1,19 @@
 import angular from 'angular';
+import ngeoQueryModeSelector from 'ngeo/query/ModeSelector.js';
 import ngeoQueryQuerent from 'ngeo/query/Querent.js';
 import ngeoQueryMapQuerent from 'ngeo/query/MapQuerent.js';
 import ngeoQueryMapQueryComponent from 'ngeo/query/mapQueryComponent.js';
 import ngeoQueryBboxQueryComponent from 'ngeo/query/bboxQueryComponent.js';
+import ngeoQueryComponent from 'ngeo/query/component.js';
 
 /**
  * @type {angular.IModule}
  */
 export default angular.module('ngeoQueryModule', [
+  ngeoQueryModeSelector.name,
   ngeoQueryQuerent.name,
   ngeoQueryMapQuerent.name,
   ngeoQueryMapQueryComponent.name,
   ngeoQueryBboxQueryComponent.name,
+  ngeoQueryComponent.name,
 ]);


### PR DESCRIPTION
## GSGMF 1047 - phase 1 

This patch is the first step towards implementing a new way to query the map by drawing polygons.

This patch introduces:

* a new `QueryModeSelector` service that:
   * will replace the `QueryKeyboard` service
   * stores the **mode** of the queries, i.e. "click", "draw_box", "draw_polygon"
   * stores the **action** of the queries, i.e. "add", "remove", "replace"
   * listens to the keyboard key pressed to temporarily change the mode or action
* a new `<ngeo-query>` component that:
  * will replaces the `<ngeo-map-query>` and `<ngeo-bbox-query>` directives
  * uses the new query mode selector
  * uses a Draw interaction to draw the boxes (instead of DragBox in the original mapquery directive)
* a new ngeo "query" example that features the component, in which you can see it in action, with all the modes enabled

### Limit option

There is a `limit` option that can be set in the `ngeoQueryOptions` angular value.

There is also a `ngeo-bbox-query-limit` attribute that can be set in the `ngeo-bbox-query.

As part of this refactoring, I suggest that only the `limit` option in `ngeoQueryOptions` should be used.

### autoclear option

There is a `ngeo-map-query-autoclear` attribute that can be set in the `ngeo-map-query` directive.  It was added as a possible "binding attribute" in the new component.

I'm mentionning it, because we do have `ngeoQueryOptions` and it could go there instead.  If you think the option should go there instead, please let me know.

**Update**: it was decided that the autoclear option should go in the `ngeoQueryOptions` instead.  This will come in an other PR.

### Next step

The next step will be to remove the 2 old directives, examples and replace the query tool in all examples (ngeo, gmf) and applications (gmf).