### PR TITLE
Introduce polygon query

### DIFF
--- a/src/datasource/OGC.js
+++ b/src/datasource/OGC.js
@@ -595,20 +595,27 @@ class OGC extends ngeoDatasourceDataSource {
   }
 
   /**
-   * @param {?string} layer The layer name.
+   * @param {string=} layer The layer name.
    * @return {?string} Geometry name
    */
   geometryName(layer) {
-    if (!this.ogcAttributes_ || !layer) {
-      return this.geometryName_;
-    }
-    const attributes = this.ogcAttributes_[layer];
-    for (const attribute in attributes) {
-      if (attributes[attribute].namespace == 'http://www.opengis.net/gml') {
-        return attribute;
+    let geometryName = null;
+
+    if (layer && this.ogcAttributes_) {
+      const attributes = this.ogcAttributes_[layer];
+      for (const attribute in attributes) {
+        if (attributes[attribute].namespace == 'http://www.opengis.net/gml') {
+          geometryName = attribute;
+          break;
+        }
       }
     }
-    return this.geometryName_;
+
+    if (!geometryName) {
+      geometryName = this.geometryName_;
+    }
+
+    return geometryName;
   }
 
   /**

--- a/src/filter/RuleHelper.js
+++ b/src/filter/RuleHelper.js
@@ -446,30 +446,12 @@ export class RuleHelper {
 
     if (options.incTime) {
       const timeFilter = this.createTimeFilterFromDataSource_(dataSource);
-      if (timeFilter) {
-        if (mainFilter) {
-          mainFilter = olFormatFilter.and.apply(
-            null,
-            [
-              mainFilter,
-              timeFilter
-            ]
-          );
-        } else {
-          mainFilter = timeFilter;
-        }
-      }
+      mainFilter = this.joinFilters(mainFilter, timeFilter);
     }
 
     if (options.incDimensions) {
       const dimensionsFilter = this.createDimensionsFilterFromDataSource_(dataSource);
-      if (dimensionsFilter) {
-        if (mainFilter) {
-          mainFilter = olFormatFilter.and.apply(null, [mainFilter, dimensionsFilter]);
-        } else {
-          mainFilter = dimensionsFilter;
-        }
-      }
+      mainFilter = this.joinFilters(mainFilter, dimensionsFilter);
     }
 
     return mainFilter;
@@ -488,6 +470,39 @@ export class RuleHelper {
       filterString = xmlSerializer.serializeToString(filterNode);
     }
     return filterString;
+  }
+
+  /**
+   * Join 2 filters together in an "And" filter, if both are set.
+   *
+   * If only one is set, then no need to create an "And"
+   * filter. Simply return the one that is set.
+   *
+   * If none are set, return null.
+   *
+   * @param {?import("ol/format/filter/Filter.js").default} filterA
+   *     First filter.
+   * @param {?import("ol/format/filter/Filter.js").default} filterB
+   *     Second filter.
+   * @return {?import("ol/format/filter/Filter.js").default} Filters
+   *     joined together.
+   */
+  joinFilters(filterA, filterB) {
+    let filter = null;
+    if (filterA && filterB) {
+      filter = olFormatFilter.and.apply(
+        null,
+        [
+          filterA,
+          filterB
+        ]
+      );
+    } else if (filterA) {
+      filter = filterA;
+    } else if (filterB) {
+      filter = filterB;
+    }
+    return filter;
   }
 
   /**

--- a/src/query/Querent.js
+++ b/src/query/Querent.js
@@ -62,7 +62,7 @@ import olSourceImageWMS from 'ol/source/ImageWMS.js';
  * @property {import("ol/format/filter/Filter.js").default} [filter] A filter to additionally use with the
  *    query. Only used by WFS requests.
  *    If a filter is defined, then it is used instead of the data source's filter rules.
- * @property {import("ol/geom/Geometry.js").Geometry} [geometry] The geometry to use as filter for the
+ * @property {import("ol/geom/Geometry.js").default} [geometry] The geometry to use as filter for the
  *    requests, which can end up with WFS requests only.
  * @property {number} [limit] The maximum number of features to get per request.
  * @property {import("ol/Map.js").default} map The ol3 map object. Used to fill some parameters of the

--- a/src/query/Querent.js
+++ b/src/query/Querent.js
@@ -648,7 +648,7 @@ export class Querent {
         // as well.
         if (options.geometry) {
           const spatialFilter = olFormatFilter.intersects(
-            dataSource.geometryName(null),
+            dataSource.geometryName(),
             options.geometry,
             srsName
           );

--- a/src/query/panelComponent.html
+++ b/src/query/panelComponent.html
@@ -19,6 +19,15 @@
   >
     <%=require('ngeo/icons/rectangle.svg?viewbox&height=1em')%>
   </button>
+  <button
+    data-toggle="tooltip"
+    title="{{'While active, click on the map multiple times to draw a polygon, which will issue a query using it' | translate}}"
+    class="btn btn-default"
+    ng-class="{active: qpCtrl.ngeoQueryModeSelector.mode === 'drawpolygon'}"
+    ng-click="qpCtrl.ngeoQueryModeSelector.mode = 'drawpolygon'"
+  >
+    <%=require('ngeo/icons/polygon.svg?viewbox&height=1em')%>
+  </button>
 </div>
 
 <div class="ngeo-query-panel-actions">


### PR DESCRIPTION
## GSGMF 1047 - phase 4

This patch is the last step towards implementing a new way to query the map by drawing polygons, as it is included in the patch.

The query component now includes a drawfeature interaction that uses polygon type. A button is also added in the query panel tool.

In the Querent service, the polygon is given as an option (like a coordinate or box could be given) and transformed into a Spatial Filter that is added to the WFS request sent.

In the filter/RuleHelper, a method is introduced to "join filters", i.e. given two filters (both of which can be null), wrap them in an AND filter, if necessary.