### PR TITLE
Fix query example projection - 2056

### DIFF
--- a/examples/query.js
+++ b/examples/query.js
@@ -1,7 +1,7 @@
 import angular from 'angular';
 import {MAPSERVER_PROXY, MAPSERVER_WFS_FEATURE_NS} from './url.js';
 import './query.css';
-import EPSG21781 from '@geoblocks/proj/src/EPSG_21781.js';
+import EPSG2056 from '@geoblocks/proj/src/EPSG_2056.js';
 
 import ngeoDatasourceDataSources from 'ngeo/datasource/DataSources.js';
 import ngeoDatasourceOGC from 'ngeo/datasource/OGC.js';
@@ -149,9 +149,9 @@ function MainController(
       busStopLayer
     ],
     view: new olView({
-      projection: EPSG21781,
+      projection: EPSG2056,
       resolutions: [200, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5],
-      center: [537635, 152640],
+      center: [2536660, 1153009],
       zoom: 4
     })
   });


### PR DESCRIPTION
This patch fixes the ngeo query example to use projection 2056.