### PR TITLE
Fix spatial filter issue

### DIFF
--- a/src/filter/ruleComponent.js
+++ b/src/filter/ruleComponent.js
@@ -414,8 +414,7 @@ class RuleController {
         if (!this.rule) {
           throw new Error('Missing rule');
         }
-        this.rule.active;
-        return false;
+        return this.rule.active;
       },
       this.handleActiveChange_.bind(this)
     );


### PR DESCRIPTION
In the filter tool, drawing a feature on the map did nothing  The issue comes from the RuleComponent, which is not longer doing anything upon being activated.

The watcher on the "active" property of the rule has been wrongly changed to always return `false` instead of the intended value.  This regression was introduced in 6d38eed1c249a8d3624eeb8ab2a3248c5b508d16

This patch fixes the issue.