### PR TITLE
Avoid crash on malformed urls

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -83,7 +83,11 @@ ngeo.utils.decodeQueryString = function(queryString) {
       if (indexOfEquals >= 0) {
         const name = pair.substring(0, indexOfEquals);
         const value = pair.substring(indexOfEquals + 1);
-        queryData[decodeURIComponent(name)] = decodeURIComponent(value);
+        try {
+          queryData[decodeURIComponent(name)] = decodeURIComponent(value);
+        } catch (err) {
+          console.error(err);
+        }
       } else {
         queryData[pair] = '';
       }


### PR DESCRIPTION
GEO-2501

For 2.2, and to report in 2.3, 2.4, master.

Fix crash on malformed url. You can try with a `%` symbol on any ngeo app.
Example: https://geomapfish-demo-2-4.camptocamp.com/theme/Demo?lang=fr%
