### PR TITLE
1121-2- Remove spacing around arrows (WIP)

### DIFF
--- a/contribs/gmf/src/layertree/common.scss
+++ b/contribs/gmf/src/layertree/common.scss
@@ -194,6 +194,6 @@
     }
   }
   .gmf-layer-being-swipe {
-    margin: 0 15px;
+    display: inline-block;
   }
 }

--- a/contribs/gmf/src/layertree/component.html
+++ b/contribs/gmf/src/layertree/component.html
@@ -79,8 +79,8 @@
 
     <span
       ng-if="gmfLayertreeCtrl.gmfLayerBeingSwipe.layer && gmfLayertreeCtrl.gmfLayerBeingSwipe.layer === layertreeCtrl.layer"
-      class="fa fal fa-sort fa-rotate-90 gmf-layer-being-swipe"
-    ></span>
+      class="fa fal fa-sort fa-rotate-90 gmf-layer-being-swipe">
+    </span>
 
     <i
       class="gmf-layertree-zoom"


### PR DESCRIPTION
This patch removing extra padding around the 'arrows' symbol in the layer tree.