### PR TITLE
Fix request abort 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - CHROME_BIN=/opt/google/chrome/chrome
   - DISPLAY=:99.0
   - MAIN_BRANCH=master
+  - CI=true
 
 addons:
   apt:

--- a/examples/elevationProfile.js
+++ b/examples/elevationProfile.js
@@ -40,10 +40,10 @@ function MainController($http, $scope) {
   const source = new olSourceVector();
   const source2 = new olSourceImageWMS({
     projection: undefined, // should be removed in next OL version
-    url: 'http://wms.geo.admin.ch/',
+    url: 'https://wms.geo.admin.ch/',
     crossOrigin: 'anonymous',
     attributions: '&copy; ' +
-      '<a href="http://www.geo.admin.ch/internet/geoportal/' +
+      '<a href="https://www.geo.admin.ch/internet/geoportal/' +
       'en/home.html">Pixelmap 1:500000 / geo.admin.ch</a>',
     params: {
       'LAYERS': 'ch.swisstopo.pixelkarte-farbe-pk1000.noscale',


### PR DESCRIPTION
* Don't cancel request when it's used in a checker.
* Better fileMock.
* Remove `process.exit(2);` in request finish.
* Use https for wms.geo.admin.ch.
* `request.abort('aborted');` => `request.abort('failed');` to have errors...