### PR TITLE
While filter is active, change toolbar icon

### DIFF
--- a/contribs/gmf/apps/desktop/index.html.ejs
+++ b/contribs/gmf/apps/desktop/index.html.ejs
@@ -71,9 +71,11 @@
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Draw and Measure'|translate}}">
               <span class="fa fa-paint-brush"></span>
             </button>
-            <button ngeo-btn class="btn btn-default" ng-class="{'gmf-filter-active': mainCtrl.filterIsApplied}" ng-model="mainCtrl.filterSelectorActive"
+            <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.filterSelectorActive"
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Filter'|translate}}">
-              <span class="fa fa-filter"></span>
+              <span
+                class="fa"
+                ng-class="mainCtrl.gmfDataSourceBeingFiltered.dataSource && mainCtrl.gmfDataSourceBeingFiltered.dataSource.filterRules ? 'fa-funnel-dollar' : 'fa-filter'"></span>
             </button>
             <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.editFeatureActive"
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Editing'|translate}}"

--- a/contribs/gmf/apps/desktop/sass/desktop.scss
+++ b/contribs/gmf/apps/desktop/sass/desktop.scss
@@ -11,7 +11,3 @@ header {
     }
   }
 }
-
-.gmf-app-tools .gmf-app-bar .btn-group-vertical .btn.gmf-filter-active {
-  background-color: darken($brand-primary, 30%);
-}

--- a/contribs/gmf/apps/desktop_alt/index.html.ejs
+++ b/contribs/gmf/apps/desktop_alt/index.html.ejs
@@ -68,9 +68,12 @@
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Draw and Measure'|translate}}">
               <span class="fa fa-paint-brush"></span>
             </button>
-            <button ngeo-btn class="btn btn-default" ng-class="{'gmf-filter-active': mainCtrl.filterIsApplied}" ng-model="mainCtrl.filterSelectorActive"
+            <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.filterSelectorActive"
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Filter'|translate}}">
-              <span class="fa fa-filter"></span>
+              <span
+                class="fa"
+                ng-class="mainCtrl.gmfDataSourceBeingFiltered.dataSource && mainCtrl.gmfDataSourceBeingFiltered.dataSource.filterRules ? 'fa-funnel-dollar' : 'fa-filter'"></span>
+
             </button>
             <button ngeo-btn class="btn btn-default" ng-model="mainCtrl.editFeatureActive"
               data-toggle="tooltip" data-placement="left" data-original-title="{{'Editing'|translate}}"

--- a/contribs/gmf/apps/desktop_alt/sass/desktop_alt.scss
+++ b/contribs/gmf/apps/desktop_alt/sass/desktop_alt.scss
@@ -27,7 +27,3 @@ div .ngeo-displaywindow {
   right: initial;
   top: $topbar-height + $app-margin + 3 * $map-tools-size;
 }
-
-.gmf-app-tools .gmf-app-bar .btn-group-vertical .btn.gmf-filter-active {
-  background-color: darken($brand-primary, 30%);
-}

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -2,6 +2,7 @@ import angular from 'angular';
 import gmfControllersAbstractAPIController, {AbstractAPIController}
   from 'gmf/controllers/AbstractAPIController.js';
 import gmfContextualdataModule from 'gmf/contextualdata/module.js';
+import gmfDatasourceDataSourceBeingFiltered from 'gmf/datasource/DataSourceBeingFiltered.js';
 import gmfEditingModule from 'gmf/editing/module.js';
 import gmfPermalinkShareComponent from 'gmf/permalink/shareComponent.js';
 import gmfPrintModule from 'gmf/print/module.js';
@@ -138,6 +139,11 @@ export class AbstractDesktopController extends AbstractAPIController {
      * @type {import("ngeo/misc/ToolActivateMgr.js").ToolActivateMgr}
      */
     const ngeoToolActivateMgr = $injector.get('ngeoToolActivateMgr');
+
+    /**
+     * @type {import('gmf/datasource/DataSourceBeingFiltered.js').DataSourceBeingFiltered}
+     */
+    this.gmfDataSourceBeingFiltered = $injector.get('gmfDataSourceBeingFiltered');
 
     /**
      * The gmf layer being swipe.
@@ -279,6 +285,7 @@ const module = angular.module('GmfAbstractDesktopControllerModule', [
   ngeoQueryPanelComponent.name,
   gmfControllersAbstractAPIController.name,
   gmfContextualdataModule.name,
+  gmfDatasourceDataSourceBeingFiltered.name,
   gmfEditingModule.name,
   gmfPermalinkShareComponent.name,
   gmfPrintModule.name,


### PR DESCRIPTION
In the "desktop" and "desktop_alt" applications, when there is an actual filter being set onto a layer in the filter tool, then change the icon of the filter in the toolbar.

This replaces the behaviour of having the background being changed instead.

Also, the icon is only changed while the filter is in action, where the background color was always there even if the filter was not active.

##Technical details

In order to do so, we look for the "gmfDataSourceBeingFiltered.dataSource" value, which is the data source being filtered and if it has filters, then its `filterRules` won't be null.