### PR TITLE
WMTS layers get metadata limits

### DIFF
--- a/contribs/gmf/src/layertree/SyncLayertreeMap.js
+++ b/contribs/gmf/src/layertree/SyncLayertreeMap.js
@@ -1,5 +1,5 @@
 import angular from 'angular';
-import gmfThemeThemes from 'gmf/theme/Themes.js';
+import gmfThemeThemes, {getNodeMinResolution, getNodeMaxResolution} from 'gmf/theme/Themes.js';
 import ngeoLayertreeController, {LayertreeVisitorDecision} from 'ngeo/layertree/Controller.js';
 import ngeoMiscWMSTime from 'ngeo/misc/WMSTime.js';
 import {getUid as olUtilGetUid} from 'ol/util.js';
@@ -391,10 +391,19 @@ SyncLayertreeMap.prototype.createWMTSLayer_ = function(gmfLayerWMTS) {
   if (!gmfLayerWMTS.layer) {
     throw new Error('Missing gmfLayerWMTS.layer');
   }
-  this.layerHelper_.createWMTSLayerFromCapabilitites(gmfLayerWMTS.url,
-    gmfLayerWMTS.layer, gmfLayerWMTS.matrixSet, gmfLayerWMTS.dimensions).then((layer) => {
-    newLayer.setSource(layer.getSource());
-    newLayer.set('capabilitiesStyles', layer.get('capabilitiesStyles'));
+  const minResolution = getNodeMinResolution(gmfLayerWMTS);
+  const maxResolution = getNodeMaxResolution(gmfLayerWMTS);
+
+  this.layerHelper_.createWMTSLayerFromCapabilitites(
+    gmfLayerWMTS.url,
+    gmfLayerWMTS.layer,
+    gmfLayerWMTS.matrixSet,
+    gmfLayerWMTS.dimensions,
+    undefined,
+    minResolution,
+    maxResolution
+  ).then((layer) => {
+    newLayer.setProperties(layer.getProperties());
   });
   return newLayer;
 };

--- a/contribs/gmf/src/theme/Themes.js
+++ b/contribs/gmf/src/theme/Themes.js
@@ -164,12 +164,16 @@ export class ThemesService extends olEventsEventTarget {
         if (!gmfLayerWMTS.url) {
           throw 'Layer URL is required';
         }
+        const minResolution = getNodeMinResolution(gmfLayerWMTS);
+        const maxResolution = getNodeMaxResolution(gmfLayerWMTS);
         const layer = layerHelper.createWMTSLayerFromCapabilitites(
           gmfLayerWMTS.url,
           gmfLayerWMTS.layer || '',
           gmfLayerWMTS.matrixSet,
           gmfLayer.dimensions,
-          gmfLayerWMTS.metadata.customOpenLayersOptions
+          gmfLayerWMTS.metadata.customOpenLayersOptions,
+          minResolution,
+          maxResolution
         ).then(callback.bind(null, gmfLayer)).then(null, (response) => {
           let message = `Unable to build layer "${gmfLayerWMTS.layer}" `
             + `from WMTSCapabilities: ${gmfLayerWMTS.url}\n`;

--- a/contribs/gmf/src/theme/Themes.js
+++ b/contribs/gmf/src/theme/Themes.js
@@ -586,15 +586,13 @@ export function getSnappingConfig(node) {
 /**
  * Get the maximal resolution defined for this layer. Looks in the
  *     layer itself before to look into its metadata.
- * @param {import('gmf/themes.js').GmfLayerWMS} gmfLayer the GeoMapFish Layer. WMTS layer is
- *     also allowed (the type is defined as GmfLayerWMS only to avoid some
- *     useless tests to know if a maxResolutionHint property can exist
- *     on the node).
+ * @param {import('gmf/themes.js').GmfLayerWMS|import('gmf/themes.js').GmfLayerWMTS} gmfLayer the GeoMapFish Layer.
  * @return {number|undefined} the max resolution or undefined if any.
  * @hidden
  */
 export function getNodeMaxResolution(gmfLayer) {
   const metadata = gmfLayer.metadata;
+  // @ts-ignore: ignore error about maxResolutionHint no present in GmfLayerWMTS typedef
   let maxResolution = gmfLayer.maxResolutionHint;
   if (maxResolution === undefined && metadata !== undefined) {
     maxResolution = metadata.maxResolution;
@@ -606,15 +604,13 @@ export function getNodeMaxResolution(gmfLayer) {
 /**
  * Get the minimal resolution defined for this layer. Looks in the
  *     layer itself before to look into its metadata.
- * @param {import('gmf/themes.js').GmfLayerWMS} gmfLayer the GeoMapFish Layer. WMTS layer is
- *     also allowed (the type is defined as GmfLayerWMS only to avoid some
- *     useless tests to know if a minResolutionHint property can exist
- *     on the node).
+ * @param {import('gmf/themes.js').GmfLayerWMS|import('gmf/themes.js').GmfLayerWMTS} gmfLayer the GeoMapFish Layer.
  * @return {number|undefined} the min resolution or undefined if any.
  * @hidden
  */
 export function getNodeMinResolution(gmfLayer) {
   const metadata = gmfLayer.metadata;
+  // @ts-ignore: ignore error about minResolutionHint no present in GmfLayerWMTS typedef
   let minResolution = gmfLayer.minResolutionHint;
   if (minResolution === undefined && metadata !== undefined) {
     minResolution = metadata.minResolution;

--- a/src/map/LayerHelper.js
+++ b/src/map/LayerHelper.js
@@ -167,15 +167,25 @@ LayerHelper.prototype.createBasicWMSLayerFromDataSource = function(
  * @param {string=} opt_matrixSet Optional WMTS matrix set.
  * @param {Object<string, ?string>=} opt_dimensions WMTS dimensions.
  * @param {Object=} opt_customOptions Some initial options.
+ * @param {number|undefined} opt_minResolution WMTS minimum resolution.
+ * @param {number|undefined} opt_maxResolution WMTS maximum resolution.
  * @return {angular.IPromise<import("ol/layer/Tile.js").default>} A Promise with a layer (with source) on
  *    success, no layer else.
  */
 LayerHelper.prototype.createWMTSLayerFromCapabilitites = function(
-  capabilitiesURL, layerName, opt_matrixSet, opt_dimensions, opt_customOptions
+  capabilitiesURL,
+  layerName,
+  opt_matrixSet,
+  opt_dimensions,
+  opt_customOptions,
+  opt_minResolution,
+  opt_maxResolution
 ) {
   const parser = new olFormatWMTSCapabilities();
   const layer = new olLayerTile({
-    preload: this.tilesPreloadingLimit_
+    preload: this.tilesPreloadingLimit_,
+    minResolution: opt_minResolution,
+    maxResolution: opt_maxResolution
   });
   const $q = this.$q_;
 


### PR DESCRIPTION
When creating WMTS layer, the min/max resolutions are set as min/max resolutions metadata. In the desktop_alt application, the 'Alpine convention' layer has a minResolution of 10 and a maxResolution of 100.