### PR TITLE
Support layer group filtering

### DIFF
--- a/contribs/gmf/src/themes.js
+++ b/contribs/gmf/src/themes.js
@@ -150,6 +150,9 @@
 
 /**
  * @typedef {Object} GmfOgcServerAttribute
+ * @property {string} [alias] The attribute alias.
+ * @property {string} [minOccurs] If not '0', then the attribute is
+ *     considered required.
  * @property {string} namespace The attribute namespace.
  * @property {string} type The attribute type (in namspace).
  */

--- a/src/datasource/Helper.js
+++ b/src/datasource/Helper.js
@@ -1,6 +1,7 @@
 import angular from 'angular';
 import ngeoDatasourceDataSource from 'ngeo/datasource/DataSource.js';
 import ngeoDatasourceDataSources from 'ngeo/datasource/DataSources.js';
+import {setGeometryType as ngeoAttributeSetGeometryType} from 'ngeo/format/Attribute.js';
 import ngeoFormatWFSAttribute from 'ngeo/format/WFSAttribute.js';
 import ngeoQueryQuerent from 'ngeo/query/Querent.js';
 import {listen} from 'ol/events.js';
@@ -210,12 +211,22 @@ export class DatasourceHelper {
         const required = ogcAttribute.minOccurs != '0';
         const type = ogcAttribute.type;
 
-        attributes.push({
+        const attribute = {
           alias,
           name,
           required,
-          type,
-        });
+        };
+
+        // Set the type of attribute. If the type is any geometry one,
+        // then the attribute type is set to geometry and geomType is
+        // set depending on the geometry type. This is handled by the
+        // method below. If the type is not any geometry one, then set
+        // the one that was given.
+        if (!ngeoAttributeSetGeometryType(attribute, `gml:${type}`)) {
+          attribute.type = type;
+        }
+
+        attributes.push(attribute);
       }
     }
 


### PR DESCRIPTION
The main goal of this patch is to introduce the support of filtering a WMS layer that uses a group as layer name.

To accomplish this, the following change was made.

The creation of attributes within an OGC data source object is made by first checking if there are attributes set for the layers used by the data source in the inner `ogcLayers_` property.  Then, they are combined together, i.e. only the attributes that are commonly shared in all layers are kept.

From there, the rest works as usual.

## Known issue

~~There is an issue with this approach.  To resume: it is currently not supported by MapServer to give the name of the group in the LAYERS parameter while giving only one filter in the FILTER property.  Therefore, this patch breaks the MapServer WMS layers in those cases.~~

~~More about this issue in GSGMF-1133.~~

The above issue has been fixed in MapServer: https://github.com/mapserver/mapserver/commit/ba27152e140f881e11fc1a97b60086ec4d7d1ee3