### PR TITLE
Permalink have the map swipe value.

### DIFF
--- a/contribs/gmf/apps/desktop/index.html.ejs
+++ b/contribs/gmf/apps/desktop/index.html.ejs
@@ -230,7 +230,8 @@
         <ngeo-mapswipe
           ng-if="mainCtrl.gmfLayerBeingSwipe.layer != null"
           map="::mainCtrl.map"
-          layer="::mainCtrl.gmfLayerBeingSwipe.layer">
+          layer="::mainCtrl.gmfLayerBeingSwipe.layer"
+          swipe-value="mainCtrl.gmfLayerBeingSwipe.swipeValue">
         </ngeo-mapswipe>
         <ngeo-displaywindow
           content="mainCtrl.displaywindowContent"

--- a/contribs/gmf/apps/desktop_alt/index.html.ejs
+++ b/contribs/gmf/apps/desktop_alt/index.html.ejs
@@ -278,7 +278,8 @@
         <ngeo-mapswipe
           ng-if="mainCtrl.gmfLayerBeingSwipe.layer != null"
           map="::mainCtrl.map"
-          layer="::mainCtrl.gmfLayerBeingSwipe.layer">
+          layer="::mainCtrl.gmfLayerBeingSwipe.layer"
+          swipe-value="mainCtrl.gmfLayerBeingSwipe.swipeValue">
         </ngeo-mapswipe>
         <ngeo-displaywindow
           content="mainCtrl.displaywindowContent"

--- a/contribs/gmf/src/datasource/LayerBeingSwipe.js
+++ b/contribs/gmf/src/datasource/LayerBeingSwipe.js
@@ -6,6 +6,7 @@ import angular from 'angular';
  * @property {import('ol/Map.js').default} map
  * @property {?import("ol/layer/Layer.js").default<import('ol/source/Source.js').default>
  * |import("ol/layer/Group.js").default} layer;
+ * @property {number} swipeValue;
  */
 
 /**
@@ -14,7 +15,8 @@ import angular from 'angular';
  */
 const module = angular.module('gmfLayerBeingSwipe', []);
 module.value('gmfLayerBeingSwipe', {
-  layer: null
+  layer: null,
+  swipeValue: null
 });
 
 export default module;

--- a/contribs/gmf/src/index.js
+++ b/contribs/gmf/src/index.js
@@ -31,6 +31,7 @@ export const PermalinkParam = {
   FEATURES: 'rl_features',
   MAP_CROSSHAIR: 'map_crosshair',
   MAP_SWIPE: 'map_swipe',
+  MAP_SWIPE_VALUE: 'map_swipe_value',
   MAP_TOOLTIP: 'map_tooltip',
   MAP_X: 'map_x',
   MAP_Y: 'map_y',

--- a/contribs/gmf/src/permalink/Permalink.js
+++ b/contribs/gmf/src/permalink/Permalink.js
@@ -641,6 +641,11 @@ export function PermalinkService(
     () => this.gmfLayerBeingSwipe_.layer,
     this.handleLayerBeingSwipeChange_.bind(this));
 
+  // Watch map swipe value.
+  this.rootScope_.$watch(
+    () => this.gmfLayerBeingSwipe_.swipeValue,
+    this.handleMapSwipeValue_.bind(this));
+
   // External DataSources
 
   /**
@@ -711,11 +716,26 @@ PermalinkService.prototype.handleLayerBeingSwipeChange_ = function(layer, oldLay
     const object = {};
     const dataSourceId = layer.get('dataSourceId');
     object[PermalinkParam.MAP_SWIPE] = dataSourceId;
-    object[PermalinkParam.MAP_SWIPE_VALUE] = this.gmfLayerBeingSwipe_.swipeValue;
     this.ngeoStateManager_.updateState(object);
   } else {
     this.ngeoStateManager_.deleteParam(PermalinkParam.MAP_SWIPE);
+    this.ngeoStateManager_.deleteParam(PermalinkParam.MAP_SWIPE_VALUE);
   }
+};
+
+/**
+ * Called when map swipe value change.
+ * @private
+ */
+PermalinkService.prototype.handleMapSwipeValue_ = function() {
+  const mapSwipeValue = this.gmfLayerBeingSwipe_.swipeValue;
+  /** @type {Object<string, object>} */
+  const object = {};
+  if (mapSwipeValue === undefined || mapSwipeValue === null) {
+    return;
+  }
+  object[PermalinkParam.MAP_SWIPE_VALUE] = mapSwipeValue;
+  this.ngeoStateManager_.updateState(object);
 };
 
 // === Map X, Y, Z ===
@@ -1313,6 +1333,9 @@ PermalinkService.prototype.initLayers_ = function() {
           // === Set the gmfLayerBeingSwipe layer ===
           if (layerBeingSwipeValue !== null && layerBeingSwipeValue !== undefined
             && treeCtrl.layer.get('dataSourceId') === layerBeingSwipeValue) {
+            if (mapSwipeValue !== undefined) {
+              this.gmfLayerBeingSwipe_.swipeValue = mapSwipeValue;
+            }
             this.gmfLayerBeingSwipe_.layer = treeCtrl.layer;
           }
         }

--- a/contribs/gmf/src/permalink/Permalink.js
+++ b/contribs/gmf/src/permalink/Permalink.js
@@ -711,6 +711,7 @@ PermalinkService.prototype.handleLayerBeingSwipeChange_ = function(layer, oldLay
     const object = {};
     const dataSourceId = layer.get('dataSourceId');
     object[PermalinkParam.MAP_SWIPE] = dataSourceId;
+    object[PermalinkParam.MAP_SWIPE_VALUE] = this.gmfLayerBeingSwipe_.swipeValue;
     this.ngeoStateManager_.updateState(object);
   } else {
     this.ngeoStateManager_.deleteParam(PermalinkParam.MAP_SWIPE);
@@ -1284,6 +1285,10 @@ PermalinkService.prototype.initLayers_ = function() {
       // Get the layerBeingSwipe value from Permalink.
       const layerBeingSwipeValue = this.ngeoStateManager_.getInitialNumberValue(
         PermalinkParam.MAP_SWIPE);
+      // Get the map swipe value from Permalink.
+      const mapSwipeValue = this.ngeoStateManager_.getInitialNumberValue(
+        PermalinkParam.MAP_SWIPE_VALUE
+      );
       /**
        * Enable the layers and set the opacity
        * @param {import('ngeo/layertree/Controller.js').LayertreeController} treeCtrl Controller

--- a/src/map/swipe.js
+++ b/src/map/swipe.js
@@ -179,7 +179,8 @@ module.component('ngeoMapswipe', {
   controller: SwipeController,
   bindings: {
     map: '<',
-    layer: '<'
+    layer: '<',
+    swipeValue: '=?'
   },
   templateUrl: ngeoMapswipeTemplateUrl
 });

--- a/src/map/swipe.js
+++ b/src/map/swipe.js
@@ -82,7 +82,7 @@ class SwipeController {
     /**
      * @type {number}
      */
-    this.swipeValue = 0.5;
+    this.swipeValue;
 
     /**
      * @type {JQuery}
@@ -108,6 +108,7 @@ class SwipeController {
    * Init the controller
    */
   $onInit() {
+    this.swipeValue = this.swipeValue !== undefined ? this.swipeValue : 0.5;
     this.layerKeys_.push(listen(this.layer, 'prerender', this.handleLayerPrerender_, this));
     this.layerKeys_.push(listen(this.layer, 'postrender', this.handleLayerPostrender_, this));
 
@@ -180,7 +181,7 @@ module.component('ngeoMapswipe', {
   bindings: {
     map: '<',
     layer: '<',
-    swipeValue: '=?'
+    swipeValue: '='
   },
   templateUrl: ngeoMapswipeTemplateUrl
 });


### PR DESCRIPTION
This patch introduce the value of the swiper into the permalink.
When the swiper being change, its value is set into the permalink. Refreshing this page and the swiper will be set at the same place.  Remove it and refresh the page, the swiper will not appear.
