### PR TITLE
Support ArcGIS WMS GetFeatureInfo requests using GeoJSON format

### DIFF
--- a/src/datasource/OGC.js
+++ b/src/datasource/OGC.js
@@ -908,7 +908,7 @@ class OGC extends ngeoDatasourceDataSource {
   }
 
   /**
-   * @return {?import("ol/format/WMSGetFeatureInfo.js").default} WMS format.
+   * @return {?olFormatWMSGetFeatureInfo|olFormatGeoJSON} WMS format.
    */
   get wmsFormat() {
     return this.wmsFormat_;

--- a/src/datasource/OGC.js
+++ b/src/datasource/OGC.js
@@ -1,7 +1,7 @@
 import ngeoDatasourceDataSource from 'ngeo/datasource/DataSource.js';
 import ngeoFilterCondition from 'ngeo/filter/Condition.js';
+import ngeoFormatArcGISGeoJSON from 'ngeo/format/ArcGISGeoJSON.js';
 import ngeoFormatAttributeType from 'ngeo/format/AttributeType.js';
-import olFormatGeoJSON from 'ol/format/GeoJSON.js';
 import olFormatGML2 from 'ol/format/GML2.js';
 import olFormatGML3 from 'ol/format/GML3.js';
 import olFormatWFS from 'ol/format/WFS.js';
@@ -523,12 +523,16 @@ class OGC extends ngeoDatasourceDataSource {
           layers: wmsLayers
         });
       } else if (this.wmsInfoFormat === WMSInfoFormat.GEOJSON) {
-        wmsFormat = new olFormatGeoJSON();
+        if (this.ogcServerType_ === ServerType.ARCGIS) {
+          wmsFormat = new ngeoFormatArcGISGeoJSON({
+            layers: wmsLayers
+          });
+        }
       }
     }
 
     /**
-     * @type {?olFormatWMSGetFeatureInfo|olFormatGeoJSON}
+     * @type {?olFormatWMSGetFeatureInfo|ngeoFormatArcGISGeoJSON}
      * @private
      */
     this.wmsFormat_ = wmsFormat;
@@ -908,7 +912,7 @@ class OGC extends ngeoDatasourceDataSource {
   }
 
   /**
-   * @return {?olFormatWMSGetFeatureInfo|olFormatGeoJSON} WMS format.
+   * @return {?olFormatWMSGetFeatureInfo|ngeoFormatArcGISGeoJSON} WMS format.
    */
   get wmsFormat() {
     return this.wmsFormat_;

--- a/src/datasource/OGC.js
+++ b/src/datasource/OGC.js
@@ -1,6 +1,7 @@
 import ngeoDatasourceDataSource from 'ngeo/datasource/DataSource.js';
 import ngeoFilterCondition from 'ngeo/filter/Condition.js';
 import ngeoFormatAttributeType from 'ngeo/format/AttributeType.js';
+import olFormatGeoJSON from 'ol/format/GeoJSON.js';
 import olFormatGML2 from 'ol/format/GML2.js';
 import olFormatGML3 from 'ol/format/GML3.js';
 import olFormatWFS from 'ol/format/WFS.js';
@@ -19,6 +20,7 @@ import olFormatWMSGetFeatureInfo from 'ol/format/WMSGetFeatureInfo.js';
  * @hidden
  */
 export const ServerType = {
+  ARCGIS: 'arcgis',
   GEOSERVER: 'geoserver',
   MAPSERVER: 'mapserver',
   QGISSERVER: 'qgisserver'
@@ -64,6 +66,7 @@ export const WFSOutputFormat = {
  * @hidden
  */
 export const WMSInfoFormat = {
+  GEOJSON: 'application/geojson',
   GML: 'application/vnd.ogc.gml'
 };
 
@@ -417,12 +420,23 @@ class OGC extends ngeoDatasourceDataSource {
      */
     this.wfsUrl_ = options.wfsUrl;
 
+    let wmsInfoFormat;
+    if (options.wmsInfoFormat) {
+      wmsInfoFormat = options.wmsInfoFormat;
+    } else {
+      if (this.ogcServerType_ === ServerType.ARCGIS) {
+        wmsInfoFormat = WMSInfoFormat.GEOJSON;
+      } else {
+        wmsInfoFormat = WMSInfoFormat.GML;
+      }
+    }
+
     /**
      * The InfoFormat to use with WMS requests.
      * @type {string}
      * @private
      */
-    this.wmsInfoFormat_ = options.wmsInfoFormat || WMSInfoFormat.GML;
+    this.wmsInfoFormat_ = wmsInfoFormat;
 
     /**
      * Whether the (WMS) images returned by this data source
@@ -508,12 +522,13 @@ class OGC extends ngeoDatasourceDataSource {
         wmsFormat = new olFormatWMSGetFeatureInfo({
           layers: wmsLayers
         });
+      } else if (this.wmsInfoFormat === WMSInfoFormat.GEOJSON) {
+        wmsFormat = new olFormatGeoJSON();
       }
-      // Todo, support more formats for WMS
     }
 
     /**
-     * @type {?import("ol/format/WMSGetFeatureInfo.js").default}
+     * @type {?olFormatWMSGetFeatureInfo|olFormatGeoJSON}
      * @private
      */
     this.wmsFormat_ = wmsFormat;

--- a/src/format/ArcGISGeoJSON.js
+++ b/src/format/ArcGISGeoJSON.js
@@ -13,8 +13,8 @@ import olFormatGeoJSON from 'ol/format/GeoJSON.js';
  * // Properties for ArcGISGeoJSON
  * @property {Array<string>} [layers] If set, only features of the given layers will be returned by the format when read.
  * // Properties from GeoJSON
- * @property {import("../proj.js").ProjectionLike} [dataProjection='EPSG:4326'] Default data projection.
- * @property {import("../proj.js").ProjectionLike} [featureProjection] Projection for features read or
+ * @property {import("ol/proj.js").ProjectionLike} [dataProjection='EPSG:4326'] Default data projection.
+ * @property {import("ol/proj.js").ProjectionLike} [featureProjection] Projection for features read or
  * written by the format.  Options passed to read or write methods will take precedence.
  * @property {string} [geometryName] Geometry name to use when creating features.
  * @property {boolean} [extractGeometryName=false] Certain GeoJSON providers include
@@ -64,11 +64,15 @@ class ArcGISGeoJSON extends olFormatGeoJSON {
   }
 
   /**
-   * @inheritDoc
+   * @param {Object} object Object.
+   * @param {import("ol/format/Feature.js").ReadOptions=} opt_options Read options.
+   * @protected
+   * @return {Array<import('ol/Feature.js').default<import("ol/geom/Geometry.js").default>>} Features.
+   * @override
    */
   readFeaturesFromObject(object, opt_options) {
     const geoJSONObject = /** @type {GeoJSONObject} */ (object);
-    /** @type {Array<import("../Feature.js").default>} */
+    /** @type {Array<import('ol/Feature.js').default<import("ol/geom/Geometry.js").default>>} */
     const features = [];
     let geoJSONFeatures = null;
     if (geoJSONObject['type'] === 'FeatureCollection') {

--- a/src/format/ArcGISGeoJSON.js
+++ b/src/format/ArcGISGeoJSON.js
@@ -1,0 +1,93 @@
+import {includes as olArrayIncludes} from 'ol/array.js';
+import olFormatGeoJSON from 'ol/format/GeoJSON.js';
+
+
+/**
+ * @typedef {import("geojson").GeoJSON} GeoJSONObject
+ * @typedef {import("geojson").FeatureCollection} GeoJSONFeatureCollection
+ */
+
+
+/**
+ * @typedef {Object} Options
+ * // Properties for ArcGISGeoJSON
+ * @property {Array<string>} [layers] If set, only features of the given layers will be returned by the format when read.
+ * // Properties from GeoJSON
+ * @property {import("../proj.js").ProjectionLike} [dataProjection='EPSG:4326'] Default data projection.
+ * @property {import("../proj.js").ProjectionLike} [featureProjection] Projection for features read or
+ * written by the format.  Options passed to read or write methods will take precedence.
+ * @property {string} [geometryName] Geometry name to use when creating features.
+ * @property {boolean} [extractGeometryName=false] Certain GeoJSON providers include
+ * the geometry_name field in the feature GeoJSON. If set to `true` the GeoJSON reader
+ * will look for that field to set the geometry name. If both this field is set to `true`
+ * and a `geometryName` is provided, the `geometryName` will take precedence.
+ */
+
+
+/**
+ * @const
+ * @type {string}
+ */
+const layerIdentifier = 'layerName';
+
+
+class ArcGISGeoJSON extends olFormatGeoJSON {
+
+  /**
+   * @param {Options=} opt_options Options.
+   */
+  constructor(opt_options) {
+
+    const options = opt_options ? opt_options : {};
+
+    super(opt_options);
+
+    /**
+     * @private
+     * @type {Array<string>}
+     */
+    this.layers_ = options.layers ? options.layers : null;
+  }
+
+  /**
+   * @return {Array<string>} layers
+   */
+  getLayers() {
+    return this.layers_;
+  }
+
+  /**
+   * @param {Array<string>} layers Layers to parse.
+   */
+  setLayers(layers) {
+    this.layers_ = layers;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  readFeaturesFromObject(object, opt_options) {
+    const geoJSONObject = /** @type {GeoJSONObject} */ (object);
+    /** @type {Array<import("../Feature.js").default>} */
+    const features = [];
+    let geoJSONFeatures = null;
+    if (geoJSONObject['type'] === 'FeatureCollection') {
+      const geoJSONFeatureCollection = /** @type {GeoJSONFeatureCollection} */ (object);
+      geoJSONFeatures = geoJSONFeatureCollection['features'];
+    } else {
+      geoJSONFeatures = [object];
+    }
+    for (let i = 0, ii = geoJSONFeatures.length; i < ii; ++i) {
+      const layerName = geoJSONFeatures[i][layerIdentifier];
+      // Exclude feature if its layer name is not set among the layers
+      if (this.layers_ && !olArrayIncludes(this.layers_, layerName)) {
+        continue;
+      }
+      features.push(this.readFeatureFromObject(geoJSONFeatures[i], opt_options));
+    }
+    return features;
+  }
+}
+
+
+export default ArcGISGeoJSON;

--- a/src/query/Querent.js
+++ b/src/query/Querent.js
@@ -3,9 +3,7 @@ import ngeoDatasourceOGC from 'ngeo/datasource/OGC.js';
 import ngeoFilterRuleHelper from 'ngeo/filter/RuleHelper.js';
 import ngeoMiscWMSTime from 'ngeo/misc/WMSTime.js';
 import * as olFormatFilter from 'ol/format/filter.js';
-import olFormatGeoJSON from 'ol/format/GeoJSON.js';
 import olFormatWFS from 'ol/format/WFS.js';
-import olFormatWMSGetFeatureInfo from 'ol/format/WMSGetFeatureInfo.js';
 import ngeoWFSDescribeFeatureType from 'ngeo/WFSDescribeFeatureType.js';
 import olFormatWMSCapabilities from 'ol/format/WMSCapabilities.js';
 import olFormatWMTSCapabilities from 'ol/format/WMTSCapabilities.js';
@@ -513,22 +511,10 @@ export class Querent {
       if (!dataSource.wmsFormat) {
         throw new Error('Missing wmsFormat');
       }
-      // WMS GetFeatureInfo format supports reading features with a
-      // specific type (i.e. a layer name)
-      if (dataSource.wmsFormat instanceof olFormatWMSGetFeatureInfo) {
-        if (opt_types) {
-          dataSource.wmsFormat.setLayers(opt_types);
-        }
-        types = dataSource.wmsFormat.getLayers();
-      } else if (dataSource.wmsFormat instanceof olFormatGeoJSON) {
-        // GeoJSON doesn't support this, but we still need to do this
-        // so get the type names (layer names) from the data source
-        // itself
-        const layers = wfs ? dataSource.wfsLayers : dataSource.wmsLayers;
-        types = layers.map((layer) => {
-          return layer.name;
-        });
+      if (opt_types) {
+        dataSource.wmsFormat.setLayers(opt_types);
       }
+      types = dataSource.wmsFormat.getLayers();
     }
     if (!types) {
       return [];

--- a/src/query/Querent.js
+++ b/src/query/Querent.js
@@ -3,7 +3,9 @@ import ngeoDatasourceOGC from 'ngeo/datasource/OGC.js';
 import ngeoFilterRuleHelper from 'ngeo/filter/RuleHelper.js';
 import ngeoMiscWMSTime from 'ngeo/misc/WMSTime.js';
 import * as olFormatFilter from 'ol/format/filter.js';
+import olFormatGeoJSON from 'ol/format/GeoJSON.js';
 import olFormatWFS from 'ol/format/WFS.js';
+import olFormatWMSGetFeatureInfo from 'ol/format/WMSGetFeatureInfo.js';
 import ngeoWFSDescribeFeatureType from 'ngeo/WFSDescribeFeatureType.js';
 import olFormatWMSCapabilities from 'ol/format/WMSCapabilities.js';
 import olFormatWMTSCapabilities from 'ol/format/WMTSCapabilities.js';
@@ -511,10 +513,22 @@ export class Querent {
       if (!dataSource.wmsFormat) {
         throw new Error('Missing wmsFormat');
       }
-      if (opt_types) {
-        dataSource.wmsFormat.setLayers(opt_types);
+      // WMS GetFeatureInfo format supports reading features with a
+      // specific type (i.e. a layer name)
+      if (dataSource.wmsFormat instanceof olFormatWMSGetFeatureInfo) {
+        if (opt_types) {
+          dataSource.wmsFormat.setLayers(opt_types);
+        }
+        types = dataSource.wmsFormat.getLayers();
+      } else if (dataSource.wmsFormat instanceof olFormatGeoJSON) {
+        // GeoJSON doesn't support this, but we still need to do this
+        // so get the type names (layer names) from the data source
+        // itself
+        const layers = wfs ? dataSource.wfsLayers : dataSource.wmsLayers;
+        types = layers.map((layer) => {
+          return layer.name;
+        });
       }
-      types = dataSource.wmsFormat.getLayers();
     }
     if (!types) {
       return [];


### PR DESCRIPTION
This patch introduces the support of WMS GetFeatureInfo requests made on WMS layers served by ArcGIS.

A GeoJSON format is used as INFO_FORMAT, since it seems to be the only one supported by ArcGIS.  The format returns a `layerName` property for each feature, which identifies the layer it corresponds to.  In order to read that information, a custom `ngeo.format.ArcGISGeoJSON` format is created in this patch.

## How to test this patch

 * run the desktop_all app
 * clear all layers
 * select the "Demo" theme
 * remove all groups with the exception of "Externals"
 * set visible the following layer: NPA localite noWFS
 * zoom out / pan the map until you see the layer (yellow lines)
 * click on features
 * --> you should get results in the grid below

## Known limitation

ArcGIS (at least with the layer used in the test above) does not return geometry.  Therefore, it's hard to see where those features are as you need to remember where you clicked.

## Known issue

While working on this patch, I found an issue: sometimes results are duplicated.  This is not caused by this patch, therefore a separate PR should come soon to fix this.