### PR TITLE
Close map swipe when layer is turned off or removed

### DIFF
--- a/contribs/gmf/src/layertree/component.js
+++ b/contribs/gmf/src/layertree/component.js
@@ -338,6 +338,11 @@ Controller.prototype.$onInit = function() {
   // watch any change on layers array to refresh the map
   this.scope_.$watchCollection(() => this.layers, () => {
     this.map.render();
+
+    // If the layer being swiped is removed, unset it
+    if (this.gmfLayerBeingSwipe.layer && !this.layers.includes(this.gmfLayerBeingSwipe.layer)) {
+      this.gmfLayerBeingSwipe.layer = null;
+    }
   });
 
   // watch any change on dimensions object to refresh the layers

--- a/src/map/swipe.js
+++ b/src/map/swipe.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import {listen, unlistenByKey} from 'ol/events.js';
+import {ObjectEvent} from 'ol/Object.js';
 import RenderEvent from 'ol/render/Event.js';
 
 import ResizeObserver from 'resize-observer-polyfill';
@@ -111,6 +112,7 @@ class SwipeController {
     this.swipeValue = this.swipeValue !== undefined ? this.swipeValue : 0.5;
     this.layerKeys_.push(listen(this.layer, 'prerender', this.handleLayerPrerender_, this));
     this.layerKeys_.push(listen(this.layer, 'postrender', this.handleLayerPostrender_, this));
+    this.layerKeys_.push(listen(this.layer, 'change:visible', this.handleLayerVisibleChange_, this));
 
     const halfDraggableWidth = this.draggableElement_.width() / 2;
 
@@ -173,6 +175,17 @@ class SwipeController {
         return;
       }
       ctx.restore();
+    }
+  }
+
+  /**
+   * Called when the visibility of the layer changes. If it is no
+   * longer visible, deactivate the swipe component.
+   * @private
+   */
+  handleLayerVisibleChange_() {
+    if (!this.layer.getVisible()) {
+      this.deactivate();
     }
   }
 

--- a/src/map/swipe.js
+++ b/src/map/swipe.js
@@ -1,6 +1,5 @@
 import angular from 'angular';
 import {listen, unlistenByKey} from 'ol/events.js';
-import {ObjectEvent} from 'ol/Object.js';
 import RenderEvent from 'ol/render/Event.js';
 
 import ResizeObserver from 'resize-observer-polyfill';


### PR DESCRIPTION
While a layer is being swiped (in the map swipe tool), if it is turned off (visible: false) or removed from the map, then deactivate the map swipe tool.