### PR TITLE
Disable query wfsCount

### DIFF
--- a/src/query/Querent.js
+++ b/src/query/Querent.js
@@ -543,7 +543,14 @@ export class Querent {
     const resolution = view.getResolution();
     const projection = view.getProjection();
     const srsName = projection.getCode();
-    const wfsCount = options.wfsCount === true;
+
+    // === NOTE - TEMPORARY FIX ===
+    // The wfsCount property (a.k.a. "queryCountFirst" option of the
+    // query tool) has been temporarily disabled to allow WFS queries
+    // to always be made until we come up with a better fix.
+    //const wfsCount = options.wfsCount === true;
+    const wfsCount = false;
+
     if (resolution === undefined) {
       throw new Error('Missing resolution');
     }


### PR DESCRIPTION
This patch disables the `wfsCount` setting of the query tool (Querent).

In other words, the query `queryCountFirst` is forced to false as part of this patch as a temporary mean to force WFS queries to be always made, even if they would exceed their "limit" set.

This change should be reverted the day we come up with a better solution to allow queries onto WFS layers that would exceed their limit.