### PR TITLE
Support defining size of features in GMF draw tool

### DIFF
--- a/contribs/gmf/src/controllers/desktop.scss
+++ b/contribs/gmf/src/controllers/desktop.scss
@@ -482,6 +482,10 @@ hr.gmf-drawfeature-separator {
   margin-top: $app-margin;
 }
 
+gmf-drawfeatureoptions label {
+  margin: 1rem 0 0 0;
+}
+
 
 /**
  * NGEO DrawFeature directive & map tooltips

--- a/contribs/gmf/src/controllers/desktop.scss
+++ b/contribs/gmf/src/controllers/desktop.scss
@@ -482,7 +482,8 @@ hr.gmf-drawfeature-separator {
   margin-top: $app-margin;
 }
 
-gmf-drawfeatureoptions label {
+gmf-drawfeatureoptions label,
+.gmf-drawfeatureoptions-help-rectangle {
   margin: 1rem 0 0 0;
 }
 

--- a/contribs/gmf/src/drawing/drawFeatureComponent.html
+++ b/contribs/gmf/src/drawing/drawFeatureComponent.html
@@ -3,6 +3,7 @@
     class="btn-group"
     ngeo-drawfeature-active="efCtrl.drawActive"
     ngeo-drawfeature-map="efCtrl.map"
+    ngeo-drawfeature-uid="efCtrl.ngeoDrawFeatureUid"
     ngeo-drawfeature-showmeasure="efCtrl.showMeasure">
   <a
     data-toggle="tooltip"
@@ -76,40 +77,68 @@
 
   <hr class="gmf-drawfeature-separator" ng-show="efCtrl.getFeaturesArray().length > 0">
   <div ng-switch-when="null">
-    <div ng-show="efCtrl.getFeaturesArray().length > 0">
-      <div class="ngeo-drawfeature-actionbuttons">
-        <button
-            type="button"
-            data-toggle="dropdown"
-            aria-haspopup="true"
-            aria-expanded="false"
-            ngeo-exportfeatures
-            ngeo-exportfeatures-features="efCtrl.features"
-            class="btn btn-link btn-sm dropdown-toggle">
-          <span class="fa fa-file-export"></span>
-          {{'Export' | translate}}
-        </button>
-        <button
-            ng-click="efCtrl.clearFeatures()"
-            class="btn btn-link btn-sm">
-          <span class="fa fa-trash"></span>
-          {{'Delete All' | translate}}
-        </button>
+
+    <div ng-switch="efCtrl.drawActive">
+
+      <div ng-switch-when="true">
+        <!-- adube! -->
+        <gmf-drawfeatureoptions
+            ng-if="efCtrl.measureLength && efCtrl.measureLength.active"
+            measure-length="::efCtrl.measureLength"
+            map="::efCtrl.map">
+        </gmf-drawfeatureoptions>
+        <gmf-drawfeatureoptions
+            ng-if="efCtrl.measureArea && efCtrl.measureArea.active"
+            measure-area="::efCtrl.measureArea"
+            map="::efCtrl.map">
+        </gmf-drawfeatureoptions>
+        <gmf-drawfeatureoptions
+            ng-if="efCtrl.measureAzimut && efCtrl.measureAzimut.active"
+            measure-azimut="::efCtrl.measureAzimut"
+            map="::efCtrl.map">
+        </gmf-drawfeatureoptions>
+        <gmf-drawfeatureoptions
+            ng-if="efCtrl.drawRectangle && efCtrl.drawRectangle.active"
+            draw-rectangle="::efCtrl.drawRectangle"
+            map="::efCtrl.map">
+        </gmf-drawfeatureoptions>
       </div>
 
-      <div class="gmf-eol"></div>
-
-      <div class="gmf-drawfeature-featurelist list-group list-group-sm">
-        <button
-            role="button"
-            class="list-group-item"
-            ng-repeat="feature in efCtrl.getFeaturesArray()"
-            ng-click="efCtrl.selectFeatureFromList(feature);">
-          {{ feature.get(efCtrl.nameProperty) }}
-        </button>
+      <div
+        ng-show="efCtrl.getFeaturesArray().length > 0"
+        ng-switch-default
+      >
+        <div class="ngeo-drawfeature-actionbuttons">
+          <button
+              type="button"
+              data-toggle="dropdown"
+              aria-haspopup="true"
+              aria-expanded="false"
+              ngeo-exportfeatures
+              ngeo-exportfeatures-features="efCtrl.features"
+              class="btn btn-link btn-sm dropdown-toggle">
+            <span class="fa fa-file-export"></span>
+            {{'Export' | translate}}
+          </button>
+          <button
+              ng-click="efCtrl.clearFeatures()"
+              class="btn btn-link btn-sm">
+            <span class="fa fa-trash"></span>
+            {{'Delete All' | translate}}
+          </button>
+        </div>
+        <div class="gmf-eol"></div>
+        <div class="gmf-drawfeature-featurelist list-group list-group-sm">
+          <button
+              role="button"
+              class="list-group-item"
+              ng-repeat="feature in efCtrl.getFeaturesArray()"
+              ng-click="efCtrl.selectFeatureFromList(feature);">
+            {{ feature.get(efCtrl.nameProperty) }}
+          </button>
+        </div>
       </div>
     </div>
-
   </div>
 
   <div ng-switch-default>

--- a/contribs/gmf/src/drawing/drawFeatureOptionsComponent.html
+++ b/contribs/gmf/src/drawing/drawFeatureOptionsComponent.html
@@ -1,0 +1,36 @@
+<div ng-if="$ctrl.drawRectangle">
+  <label>{{'Height:' | translate}}</label>
+  <div class="input-group">
+    <input
+        class="form-control"
+        min="1"
+        ng-model="$ctrl.height"
+        type="number">
+    </input>
+    <select
+        class="form-control"
+        ng-model="$ctrl.heightUnits">
+      <option value="m">{{'m (meters)' | translate}}</option>
+      <option value="km">{{'km (kilometers)' | translate}}</option>
+    </select>
+  </div>
+</div>
+
+<div ng-switch="::(!!$ctrl.measureAzimut)">
+  <label ng-switch-when="true">{{'Radius:' | translate}}</label>
+  <label ng-switch-default>{{'Length:' | translate}}</label>
+</div>
+<div class="input-group">
+  <input
+      class="form-control"
+      min="1"
+      ng-model="$ctrl.length"
+      type="number">
+  </input>
+  <select
+      class="form-control"
+      ng-model="$ctrl.lengthUnits">
+    <option value="m">{{'m (meters)' | translate}}</option>
+    <option value="km">{{'km (kilometers)' | translate}}</option>
+  </select>
+</div>

--- a/contribs/gmf/src/drawing/drawFeatureOptionsComponent.html
+++ b/contribs/gmf/src/drawing/drawFeatureOptionsComponent.html
@@ -34,3 +34,8 @@
     <option value="km">{{'km (kilometers)' | translate}}</option>
   </select>
 </div>
+
+<p
+    class="gmf-drawfeatureoptions-help-rectangle"
+    ng-if="$ctrl.drawRectangle"
+>{{ 'Note: drawing a rectangle of a specific size requires both height and length to be defined.' | translate}}</p>

--- a/contribs/gmf/src/drawing/drawFeatureOptionsComponent.js
+++ b/contribs/gmf/src/drawing/drawFeatureOptionsComponent.js
@@ -1,0 +1,517 @@
+import angular from 'angular';
+
+import {listen as olEventsListen} from 'ol/events.js';
+import OLFeature from 'ol/Feature.js';
+import {
+  Circle as OLGeomCircle,
+  GeometryCollection as OLGeomGeometryCollection,
+  LineString as OLGeomLineString,
+  Polygon as OLGeomPolygon
+} from 'ol/geom.js';
+import {fromExtent as olGeomPolygonFromExtent} from 'ol/geom/Polygon.js';
+import OLInteractionDraw from 'ol/interaction/Draw.js';
+import OLInteractionPointer from 'ol/interaction/Pointer.js';
+import OLInteractionSnap from 'ol/interaction/Snap.js';
+import OLMapBrowserEvent from 'ol/MapBrowserEvent.js';
+import OLSourceVector from 'ol/source/Vector.js';
+
+import {unlistenByKeys as ngeoEventsUnlistenByKeys} from 'ngeo/events.js';
+
+/**
+ * @type {angular.IModule}
+ * @hidden
+ */
+const module = angular.module('GmfDrawFeatureOptionsComponent', [
+]);
+
+
+module.run(
+  /**
+   * @ngInject
+   * @param {angular.ITemplateCacheService} $templateCache
+   */
+  ($templateCache) => {
+    $templateCache.put(
+      'gmf/drawing/drawFeatureOptionsComponent',
+      // @ts-ignore: webpack
+      require('./drawFeatureOptionsComponent.html')
+    );
+  }
+);
+
+
+/**
+ * @private
+ * @hidden
+ */
+class DrawFeatureOptionsController {
+
+  /**
+   * @param {angular.IScope} $scope Scope.
+   * @private
+   * @ngInject
+   * @ngdoc controller
+   * @ngname GmfDrawFeatureOptionsController
+   */
+  constructor($scope) {
+    // === Binding properties ===
+
+    /**
+     * @type {!import("ol/Map.js").default}
+     */
+    this.map;
+
+    // Note: only one of the 4 interactions below should be set
+
+    /**
+     * @type {?import("ngeo/interaction/MeasureLength.js").default}
+     */
+    this.measureLength = null;
+
+    /**
+     * @type {?import("ngeo/interaction/MeasureArea.js").default}
+     */
+    this.measureArea = null;
+
+    /**
+     * @type {?import("ngeo/interaction/MeasureAzimut.js").default}
+     */
+    this.measureAzimut = null;
+
+    /**
+     * @type {?OLInteractionDraw}
+     */
+    this.drawRectangle = null;
+
+    // === Injected properties ===
+
+    /**
+     * @type {angular.IScope}
+     * @private
+     */
+    this.scope_ = $scope;
+
+    // === Inner properties ===
+
+    /**
+     * The length is used to determine:
+     * - the length of a line segment to draw (for length and area measurements)
+     * - the width of a rectangle to draw
+     * - the radius of a circle to draw (for azimut measurements)
+     * @type {number}
+     */
+    this.length = NaN;
+
+    /**
+     * Measure unit for the length.  Possible values are: 'm', 'km'.
+     * @type {string}
+     */
+    this.lengthUnits = 'm';
+
+    /**
+     * The height is used to determine:
+     * - the height of the rectangle to draw
+     * @type {number}
+     */
+    this.height = NaN;
+
+    /**
+     * Measure unit for the height.  Possible values are: 'm', 'km'.
+     * @type {string}
+     */
+    this.heightUnits = 'm';
+
+    // === Private properties ===
+
+    /**
+     * The draw interaction that was given.
+     * @type {?OLInteractionDraw}
+     * @private
+     */
+    this.drawInteraction_ = null;
+
+    /**
+     * The feature being drawn. Set when the 'drawstart' event is
+     * fired by the draw interaction.
+     * @type {?OLFeature<import("ol/geom/Geometry.js").default>}
+     * @private
+     */
+    this.feature_ = null;
+
+    /**
+     * @type {import("ol/events.js").EventsKey[]}
+     * @private
+     */
+    this.listenerKeys_ = [];
+
+    /**
+     * Used to keep track of the current number of vertices while
+     * drawing a LineString or a Polygon. Why? Because the only way to
+     * keep track of the changes that occur within their geometry is
+     * with the 'change' event, which occurs while the mouse is
+     * moving.
+     *
+     * If at any moment, while drawing, this number becomes different
+     * than the actual number of vertices in the geometry, then we
+     * need to update the snap feature.
+     * @type {number}
+     */
+    this.verticesCounter_ = 2;
+
+    /**
+     * @type {!OLFeature<import("ol/geom/Geometry.js").default>}
+     * @private
+     */
+    this.snapFeature_ = new OLFeature();
+
+    /**
+     * @type {!OLSourceVector<import("ol/geom/Geometry.js").default>}
+     * @private
+     */
+    this.snapSource_ = new OLSourceVector({
+      features: [this.snapFeature_]
+    });
+
+    /**
+     * @type {!OLInteractionSnap}
+     * @private
+     */
+    this.snapInteraction_ = new OLInteractionSnap({
+      // @ts-ignore: webpack
+      handleEvent: this.snapInteractionHandleEvent_.bind(this),
+      pixelTolerance: 10000,
+      source: this.snapSource_
+    });
+
+    /**
+     * Flag used to manually stop drawing after a double
+     * click. See explanations where used.
+     * @type {boolean}
+     * @private
+     */
+    this.shouldStopDrawing_ = false;
+  }
+
+  /**
+   * Called on initialization of the controller.
+   */
+  $onInit() {
+    // Find which measure/draw interaction was set, then get its draw
+    // interaction
+    let requiresHeight = false;
+    let drawInteraction;
+    if (this.measureLength) {
+      drawInteraction = this.measureLength.getDrawInteraction();
+    } else if (this.measureArea) {
+      drawInteraction = this.measureArea.getDrawInteraction();
+    } else if (this.measureAzimut) {
+      drawInteraction = this.measureAzimut.getDrawInteraction();
+    } else if (this.drawRectangle) {
+      drawInteraction = this.drawRectangle;
+      requiresHeight = true;
+    }
+
+    if (drawInteraction instanceof OLInteractionDraw) {
+      this.drawInteraction_ = drawInteraction;
+    } else {
+      throw 'No draw interaction given to DrawFeatureOptions component';
+    }
+
+    this.map.addInteraction(this.snapInteraction_);
+
+    this.listenerKeys_.push(
+      olEventsListen(
+        drawInteraction,
+        'drawstart',
+        this.handleDrawInteractionDrawStart_,
+        this
+      ),
+      olEventsListen(
+        this.map,
+        'singleclick',
+        this.handleMapSingleClick_,
+        this
+      ),
+      olEventsListen(
+        this.map,
+        'dblclick',
+        this.handleMapDoubleClick_,
+        this
+      )
+    );
+
+    if (requiresHeight) {
+      this.scope_.$watch(
+        () => {
+          let ret = null;
+          if (this.length && this.feature_ && this.height) {
+            ret = `${this.length}${this.lengthUnits}${this.height}${this.heightUnits}`;
+          }
+          return ret;
+        },
+        (newVal, oldVal) => {
+          if (newVal) {
+            this.adjustSnapFeature_(
+              this.length,
+              this.lengthUnits,
+              this.height,
+              this.heightUnits
+            );
+          } else {
+            this.resetSnapFeature_();
+          }
+        }
+      );
+    } else {
+      this.scope_.$watch(
+        () => {
+          let ret = null;
+          if (this.length && this.feature_) {
+            ret = `${this.length}${this.lengthUnits}$`;
+          }
+          return ret;
+        },
+        (newVal, oldVal) => {
+          if (newVal) {
+            this.adjustSnapFeature_(
+              this.length,
+              this.lengthUnits,
+            );
+          } else {
+            this.resetSnapFeature_();
+          }
+        }
+      );
+    }
+  }
+
+  /**
+   * Called on destruction of the controller.
+   */
+  $onDestroy() {
+    if (!this.drawInteraction_) {
+      return;
+    }
+
+    ngeoEventsUnlistenByKeys(this.listenerKeys_);
+
+    this.map.removeInteraction(this.snapInteraction_);
+    this.snapSource_.clear();
+  }
+
+  /**
+   * When the draw interaction starts drawing, the feature being drawn
+   * is stored.
+   * @param {Event|import('ol/events/Event.js').default} evt Event.
+   * @private
+   */
+  handleDrawInteractionDrawStart_(evt) {
+    // evt.feature - ol.interaction.Draw - DrawEvent not exported by OL
+    // evt.detail.feature - ngeo.interaction.DrawAzimut
+    // @ts-ignore: webpack
+    const feature = evt.feature || evt.detail.feature;
+
+    this.feature_ = feature;
+
+    // For measureLength and measureArea, changing geometry needs to update
+    if (this.measureLength || this.measureArea) {
+      const geometry = feature.getGeometry();
+      this.listenerKeys_.push(
+        olEventsListen(
+          geometry,
+          'change',
+          this.handleFeatureGeometryChange_,
+          this
+        )
+      );
+    }
+  }
+
+  /**
+   * Called every time the geometry of the feature being drawn changes
+   * @private
+   */
+  handleFeatureGeometryChange_() {
+    let adjust = false;
+
+    if (this.measureLength) {
+      // Length, i.e. LineString
+      const lineStringGeometry = this.feature_.getGeometry();
+      if (lineStringGeometry instanceof OLGeomLineString) {
+        const coordinates = lineStringGeometry.getCoordinates();
+        if (this.verticesCounter_ !== coordinates.length) {
+          this.verticesCounter_ = coordinates.length;
+          adjust = true;
+        }
+      }
+    } else if (this.measureArea) {
+      // Area, i.e. Polygon
+      const polygonGeometry = this.feature_.getGeometry();
+      if (polygonGeometry instanceof OLGeomPolygon) {
+        const coordinates = polygonGeometry.getCoordinates()[0];
+        if (this.verticesCounter_ !== coordinates.length) {
+          this.verticesCounter_ = coordinates.length;
+          adjust = true;
+        }
+      }
+    }
+
+    // Adjust snap feature if the number of vertices changed
+    if (adjust && this.length && this.feature_) {
+      this.adjustSnapFeature_(this.length, this.lengthUnits);
+    }
+  }
+
+  /**
+   * Reset the snap feature's geometry.
+   * @private
+   */
+  resetSnapFeature_() {
+    this.snapFeature_.setGeometry(undefined);
+  }
+
+  /**
+   * Adjust the snap feature's geometry depending on the given arguments.
+   *
+   * @param {number} length Length
+   * @param {string} lengthUnits Length units
+   * @param {number=} opt_height Height
+   * @param {string=} opt_heightUnits Height units
+   * @private
+   */
+  adjustSnapFeature_(length, lengthUnits, opt_height, opt_heightUnits) {
+    const lengthMeters = lengthUnits === 'm' ? length : length * 1000;
+    const heightMeters = opt_height && opt_heightUnits ?
+      opt_heightUnits === 'm' ? opt_height : opt_height * 1000 :
+      null;
+
+    let snapGeometry;
+
+    if (this.measureLength) {
+      // Length, i.e. LineString
+      const lineStringGeometry = this.feature_.getGeometry();
+      if (lineStringGeometry instanceof OLGeomLineString) {
+        const coordinates = lineStringGeometry.getCoordinates();
+        const center = coordinates[this.verticesCounter_ - 2];
+        snapGeometry = new OLGeomCircle(center, lengthMeters);
+      }
+    } else if (this.measureArea && this.verticesCounter_ !== 2) {
+      // Area, i.e. Polygon
+      const polygonGeometry = this.feature_.getGeometry();
+      if (polygonGeometry instanceof OLGeomPolygon) {
+        const coordinates = polygonGeometry.getCoordinates()[0];
+        const center = coordinates[this.verticesCounter_ - 3];
+        snapGeometry = new OLGeomCircle(center, lengthMeters);
+      }
+    } else if (this.measureAzimut) {
+      // Azimut, i.e. Circle
+      const geometryCollection = this.feature_.getGeometry();
+      if (geometryCollection instanceof OLGeomGeometryCollection) {
+        const circleGeometry = geometryCollection.getGeometries()[1];
+        if (circleGeometry instanceof OLGeomCircle) {
+          const center = circleGeometry.getCenter();
+          snapGeometry = new OLGeomCircle(center, lengthMeters);
+        }
+      }
+    } else if (this.drawRectangle && heightMeters) {
+      // Rectangle
+      const polygonGeometry = this.feature_.getGeometry();
+      if (polygonGeometry instanceof OLGeomPolygon) {
+        const center = polygonGeometry.getCoordinates()[0][0];
+        console.assert(typeof center[0] === 'number');
+        console.assert(typeof center[1] === 'number');
+        snapGeometry = olGeomPolygonFromExtent(
+          [
+            Number(center[0]) - lengthMeters,
+            Number(center[1]) - heightMeters,
+            Number(center[0]) + lengthMeters,
+            Number(center[1]) + heightMeters
+          ]
+        );
+      }
+    }
+
+    if (snapGeometry) {
+      this.snapFeature_.setGeometry(snapGeometry);
+    }
+  }
+
+  /**
+   * Override handler method of the map browser event for the snap
+   * interaction. If the event is 'pointerup', if the following map
+   * browser event is 'dblclick', then we should stop drawing.
+   * @param {import("ol/MapBrowserEvent.js").default} evt Map browser event.
+   * @return {boolean} `false` to stop event propagation.
+   * @private
+   */
+  snapInteractionHandleEvent_(evt) {
+    const result = this.snapInteraction_.snapTo(evt.pixel, evt.coordinate, evt.map);
+    if (result.snapped) {
+      evt.coordinate = result.vertex.slice(0, 2);
+      evt.pixel = result.vertexPixel;
+
+      // We should stop drawing if a 'dblclick' event comes next
+      if (evt.type === 'pointerup') {
+        this.shouldStopDrawing_ = true;
+      }
+    }
+
+    return OLInteractionPointer.prototype.handleEvent.call(this.snapInteraction_, evt);
+  }
+
+  /**
+   * If a 'singleclick' event occur on the map after a snap, then we
+   * can continue drawing.
+   * @param {Event|import('ol/events/Event.js').default} evt Event.
+   * @private
+   */
+  handleMapSingleClick_(evt) {
+    if (!(evt instanceof OLMapBrowserEvent)) {
+      return;
+    }
+
+    this.shouldStopDrawing_ = false;
+  }
+
+  /**
+   * If a 'dblclick' event occur on the map after a snap, then we
+   * should stop drawing.
+   *
+   * Note: double clicking to end drawing only occurs while measuring
+   * length or area, i.e. while drawing a LineString or Polygon. When
+   * that happens while snapping, then we need to manually force the
+   * drawing to finish and also remove the last point that has been
+   * added as a consequence of the snap still being active and causing
+   * an unwanted point to be added.
+   *
+   * @param {Event|import('ol/events/Event.js').default} evt Event.
+   * @private
+   */
+  handleMapDoubleClick_(evt) {
+    if (!(evt instanceof OLMapBrowserEvent)) {
+      return;
+    }
+
+    if (this.shouldStopDrawing_) {
+      this.drawInteraction_.removeLastPoint();
+      this.drawInteraction_.finishDrawing();
+    }
+  }
+}
+
+
+module.component('gmfDrawfeatureoptions', {
+  bindings: {
+    'map': '<',
+    // Note - only one of the below properties should be set at a time
+    'drawRectangle': '<?',
+    'measureArea': '<?',
+    'measureAzimut': '<?',
+    'measureLength': '<?'
+  },
+  controller: DrawFeatureOptionsController,
+  templateUrl: 'gmf/drawing/drawFeatureOptionsComponent'
+});
+
+
+export default module;

--- a/contribs/gmf/src/drawing/module.js
+++ b/contribs/gmf/src/drawing/module.js
@@ -2,6 +2,7 @@
  */
 import angular from 'angular';
 import gmfDrawingDrawFeatureComponent from 'gmf/drawing/drawFeatureComponent.js';
+import gmfDrawingDrawFeatureOptionsComponent from 'gmf/drawing/drawFeatureOptionsComponent.js';
 import gmfDrawingFeatureStyleComponent from 'gmf/drawing/featureStyleComponent.js';
 
 /**
@@ -9,5 +10,6 @@ import gmfDrawingFeatureStyleComponent from 'gmf/drawing/featureStyleComponent.j
  */
 export default angular.module('gmfDrawingModule', [
   gmfDrawingDrawFeatureComponent.name,
+  gmfDrawingDrawFeatureOptionsComponent.name,
   gmfDrawingFeatureStyleComponent.name,
 ]);

--- a/src/draw/Controller.js
+++ b/src/draw/Controller.js
@@ -46,6 +46,11 @@ export class DrawController {
     this.showMeasure = false;
 
     /**
+     * @type {?string}
+     */
+    this.uid = null;
+
+    /**
      * @type {angular.gettext.gettextCatalog}
      * @private
      */

--- a/src/draw/component.js
+++ b/src/draw/component.js
@@ -92,6 +92,10 @@ const module = angular.module('ngeoDrawfeature', [
  * @htmlAttribute {boolean} ngeo-drawfeature-showmeasure. Checks the
  *      checkbox in order to display the feature measurements as a label.
  *      Default to false.
+ * @htmlAttribute {string=} ngeo-drawfeature-uid A prefix to use to
+ *      create unique ids for each created draw interaction as
+ *      property. Used to find those draw interactions later on from the
+ *      map, using the property set.
  * @return {angular.IDirective} The directive specs.
  * @ngInject
  * @ngdoc directive
@@ -105,7 +109,8 @@ function drawComponent() {
       'active': '=ngeoDrawfeatureActive',
       'features': '=?ngeoDrawfeatureFeatures',
       'map': '=ngeoDrawfeatureMap',
-      'showMeasure': '=?ngeoDrawfeatureShowmeasure'
+      'showMeasure': '=?ngeoDrawfeatureShowmeasure',
+      'uid': '<?ngeoDrawfeatureUid'
     }
   };
 }

--- a/src/draw/point.js
+++ b/src/draw/point.js
@@ -36,6 +36,13 @@ function drawPointComponent() {
         type: /** @type {import("ol/geom/GeometryType.js").default} */ ('Point')
       });
 
+      if (drawFeatureCtrl.uid) {
+        drawPoint.set(
+          'ngeo-interaction-draw-uid',
+          `${drawFeatureCtrl.uid}-point`
+        );
+      }
+
       drawFeatureCtrl.registerInteraction(drawPoint);
       drawFeatureCtrl.drawPoint = drawPoint;
 

--- a/src/draw/rectangle.js
+++ b/src/draw/rectangle.js
@@ -55,6 +55,13 @@ function drawRectangleComponent() {
         maxPoints: 2
       });
 
+      if (drawFeatureCtrl.uid) {
+        drawRectangle.set(
+          'ngeo-interaction-draw-uid',
+          `${drawFeatureCtrl.uid}-rectangle`
+        );
+      }
+
       drawFeatureCtrl.registerInteraction(drawRectangle);
       drawFeatureCtrl.drawRectangle = drawRectangle;
 

--- a/src/draw/text.js
+++ b/src/draw/text.js
@@ -36,6 +36,13 @@ function drawTextComponent() {
         type: /** @type {import("ol/geom/GeometryType.js").default} */ ('Point')
       });
 
+      if (drawFeatureCtrl.uid) {
+        drawText.set(
+          'ngeo-interaction-draw-uid',
+          `${drawFeatureCtrl.uid}-text`
+        );
+      }
+
       drawFeatureCtrl.registerInteraction(drawText);
       drawFeatureCtrl.drawText = drawText;
 

--- a/src/measure/area.js
+++ b/src/measure/area.js
@@ -55,6 +55,13 @@ function measureAreaComponent($compile, gettextCatalog, $filter, $injector) {
       }
       const measureArea = new ngeoInteractionMeasureArea($filter('ngeoUnitPrefix'), gettextCatalog, options);
 
+      if (drawFeatureCtrl.uid) {
+        measureArea.set(
+          'ngeo-interaction-draw-uid',
+          `${drawFeatureCtrl.uid}-area`
+        );
+      }
+
       drawFeatureCtrl.registerInteraction(measureArea);
       drawFeatureCtrl.measureArea = measureArea;
 

--- a/src/measure/azimut.js
+++ b/src/measure/azimut.js
@@ -62,6 +62,13 @@ function measureAzimutComponent($compile, gettextCatalog, $filter, $injector) {
       const measureAzimut = new ngeoInteractionMeasureAzimut(
         $filter('ngeoUnitPrefix'), $filter('number'), options);
 
+      if (drawFeatureCtrl.uid) {
+        measureAzimut.set(
+          'ngeo-interaction-draw-uid',
+          `${drawFeatureCtrl.uid}-azimut`
+        );
+      }
+
       drawFeatureCtrl.registerInteraction(measureAzimut);
       drawFeatureCtrl.measureAzimut = measureAzimut;
 

--- a/src/measure/length.js
+++ b/src/measure/length.js
@@ -65,6 +65,13 @@ function measureLengthComponent($compile, gettextCatalog, $filter, $injector) {
         $filter('ngeoUnitPrefix'), gettextCatalog, options
       );
 
+      if (drawFeatureCtrl.uid) {
+        measureLength.set(
+          'ngeo-interaction-draw-uid',
+          `${drawFeatureCtrl.uid}-length`
+        );
+      }
+
       drawFeatureCtrl.registerInteraction(measureLength);
       drawFeatureCtrl.measureLength = measureLength;
 


### PR DESCRIPTION
This patch introduces a new component in GMF to specify sizes (length, width, height, radius) while drawing features in the draw tool.

## gmf-drawfeatureoptions

A new component is born: gmf-drawfeatureoptions

The parameters it must have are:

 * the OpenLayers map
 * a single interaction responsible to draw the feature (can be a measure interaction from ngeo, or an OpenLayers Draw interaction directly)

The behaves according to the type of interaction it was given.  The possible ones are:

 * the ngeo length measure interaction
 * the ngeo area measure interaction
 * the ngeo azimut measure interaction
 * a draw interaction (used to draw rectangles)

## Use of the Snap interaction

The Snap interaction of OpenLayers is used as main way to force the drawing tool to "snap" to an invisible grid while drawing and while sizes are set.

A single feature is created and its geometry is set in a way that the mouse always snaps to it while drawing.  This is done using an enormous pixel tolerance of 10,000 pixels.

## Hack to allow draw end on double-click

Double-clicking ends the drawing of a LineString or Polygon.  While snapping with a 10,000 pixel tolerance, the event is eaten up by the Snap interaction, and messes with the Draw interaction.

To fix this, we manually end the drawing on double clicking, when necessary.

## All Draw interactions are required

In order for the feature used by the Snap interaction to have its geometry created, we need to have access to the feature being drawn.  A feature being drawn is only accessible from its Draw interaction.

There was currently no way to have access to those, which are created and nested in the NGEO drawfeature directive.

To obtain them, they were given unique ids, and then obtained through the map itself, in the GMF drawfeature directive, by using their given unique ids as a way to find them.