### PR TITLE
Additional search actions

### DIFF
--- a/contribs/gmf/src/search/component.js
+++ b/contribs/gmf/src/search/component.js
@@ -346,12 +346,6 @@ class SearchController {
     this.searchActionCallback;
 
     /**
-     * @type {function(): void}
-     * @private
-     */
-    this.executeSearchAction_;
-
-    /**
      * Whether or not to show a button to clear the search text.
      * Default to true.
      * @type {boolean}
@@ -455,9 +449,6 @@ class SearchController {
    * Called on initialization of the controller.
    */
   $onInit() {
-    if (this.searchActionCallback) {
-      this.executeSearchAction_ = this.searchActionCallback();
-    }
     const gettextCatalog = this.gettextCatalog_;
     this.clearButton = this.clearButton !== false;
     this.colorChooser = this.colorChooser === true;
@@ -1010,8 +1001,8 @@ class SearchController {
             this.gmfTreeManager_.addGroupByLayerName(actionData, true, silent);
           }
         } else {
-          if (this.executeSearchAction_) {
-            this.executeSearchAction_(action);
+          if (this.searchActionCallback) {
+            this.searchActionCallback(action);
           }
         }
       }

--- a/contribs/gmf/src/search/component.js
+++ b/contribs/gmf/src/search/component.js
@@ -181,6 +181,7 @@ function gmfSearchTemplateUrl($element, $attrs, gmfSearchTemplateUrl) {
  *    change the style of the feature on the map. Default is false.
  * @htmlAttribute {number=} gmf-search-maxzoom Optional maximum zoom we will zoom on result, default is 16.
  * @htmlAttribute {function=} gmf-search-on-init Optional function called when the component is initialized.
+ * @htmlAttribute {function=} gmf-search-action Optional function called when no default action is defined.
  * @ngdoc component
  * @ngname gmfSearch
  */
@@ -198,7 +199,8 @@ const searchComponent = {
     'additionalListeners': '<gmfSearchListeners',
     'maxZoom': '<?gmfSearchMaxzoom',
     'delay': '<?gmfSearchDelay',
-    'onInitCallback': '<?gmfSearchOnInit'
+    'onInitCallback': '<?gmfSearchOnInit',
+    'searchActionCallback': '&?gmfSearchAction'
   },
   controller: 'gmfSearchController',
   templateUrl: gmfSearchTemplateUrl
@@ -339,6 +341,17 @@ class SearchController {
     this.onInitCallback;
 
     /**
+     * @type {function(): void}
+     */
+    this.searchActionCallback;
+
+    /**
+     * @type {function(): void}
+     * @private
+     */
+    this.executeSearchAction_;
+
+    /**
      * Whether or not to show a button to clear the search text.
      * Default to true.
      * @type {boolean}
@@ -442,6 +455,9 @@ class SearchController {
    * Called on initialization of the controller.
    */
   $onInit() {
+    if (this.searchActionCallback) {
+      this.executeSearchAction_ = this.searchActionCallback();
+    }
     const gettextCatalog = this.gettextCatalog_;
     this.clearButton = this.clearButton !== false;
     this.colorChooser = this.colorChooser === true;
@@ -992,6 +1008,10 @@ class SearchController {
           if (datasourcesActionsHaveAddLayer) {
             const silent = !!featureGeometry;
             this.gmfTreeManager_.addGroupByLayerName(actionData, true, silent);
+          }
+        } else {
+          if (this.executeSearchAction_) {
+            this.executeSearchAction_(action);
           }
         }
       }

--- a/contribs/gmf/src/search/component.js
+++ b/contribs/gmf/src/search/component.js
@@ -341,7 +341,7 @@ class SearchController {
     this.onInitCallback;
 
     /**
-     * @type {function(): void}
+     * @type {function(any): void}
      */
     this.searchActionCallback;
 


### PR DESCRIPTION
As discussed with @sbrunner we from Basel-Stadt are creating a pull request to get this additional gmf functionality within our project.

Our aim is to include tools to the search so a user can search for a tool and with a click on the search result the tool will be opened. The implementation in our project can be found here: https://github.com/camptocamp/baselstadt_mapbs/commit/a2d95c78976a8fa30d4ecb47c71699429ac3e18e

How do we have to proceed to get this to GMF 2.5 as base functionality for futher versions?