### PR TITLE
Fix GMF profile tooltips

### DIFF
--- a/contribs/gmf/src/profile/component.js
+++ b/contribs/gmf/src/profile/component.js
@@ -498,23 +498,21 @@ ProfileController.prototype.getDistanceOnALine_ = function(pointOnLine) {
  * @private
  */
 ProfileController.prototype.hoverCallback_ = function(point, dist, xUnits, elevationsRef, yUnits) {
-  if (this.measureTooltipElement_ && this.measureTooltip_) {
-    // Update information point.
-    const coordinate = [point.x, point.y];
+  // Update information point.
+  const coordinate = [point.x, point.y];
 
-    this.currentPoint.elevations = elevationsRef;
-    this.currentPoint.distance = dist;
-    this.currentPoint.xUnits = xUnits;
-    this.currentPoint.yUnits = yUnits;
-    this.currentPoint.coordinate = coordinate;
+  this.currentPoint.elevations = elevationsRef;
+  this.currentPoint.distance = dist;
+  this.currentPoint.xUnits = xUnits;
+  this.currentPoint.yUnits = yUnits;
+  this.currentPoint.coordinate = coordinate;
 
-    // Update hover.
-    const geom = new olGeomPoint(coordinate);
-    this.createMeasureTooltip_();
-    this.measureTooltipElement_.innerHTML = this.getTooltipHTML_();
-    this.measureTooltip_.setPosition(coordinate);
-    this.snappedPoint_.setGeometry(geom);
-  }
+  // Update hover.
+  const geom = new olGeomPoint(coordinate);
+  this.createMeasureTooltip_();
+  this.measureTooltipElement_.innerHTML = this.getTooltipHTML_();
+  this.measureTooltip_.setPosition(coordinate);
+  this.snappedPoint_.setGeometry(geom);
 };
 
 


### PR DESCRIPTION
This patch fixes the GMF profile tooltips, which were not working since a regression was introduced in 6d38eed1c249a8d3624eeb8ab2a3248c5b508d16.

The extra "if" makes no sense there, because the code that would create the elements is inside the if and therefore no tooltips were ever created.