### PR TITLE
Do not copy 'visible' property for WMTS layers

### DIFF
--- a/contribs/gmf/src/layertree/SyncLayertreeMap.js
+++ b/contribs/gmf/src/layertree/SyncLayertreeMap.js
@@ -403,7 +403,7 @@ SyncLayertreeMap.prototype.createWMTSLayer_ = function(gmfLayerWMTS) {
     minResolution,
     maxResolution
   ).then((layer) => {
-    newLayer.setProperties(layer.getProperties());
+    this.layerHelper_.copyProperties(layer, newLayer, ['visible']);
   });
   return newLayer;
 };

--- a/contribs/gmf/src/permalink/Permalink.js
+++ b/contribs/gmf/src/permalink/Permalink.js
@@ -1342,16 +1342,6 @@ PermalinkService.prototype.initLayers_ = function() {
             }
             this.gmfLayerBeingSwipe_.layer = treeCtrl.layer;
           }
-
-          if (
-            treeCtrl.layer.getLayers &&
-            treeCtrl.layer.getLayers().item(0) &&
-            treeCtrl.layer.getLayers().item(0).get('layerNodeName') === 'ch.are.alpenkonvention'
-          ) {
-            treeCtrl.layer.getLayers().item(0).on('change:visible', (e) => {
-              console.log(e);
-            });
-          }
         }
 
         if (treeCtrl.parent.node && parentGroupNode.mixed && groupNode.children == undefined) {

--- a/contribs/gmf/src/permalink/Permalink.js
+++ b/contribs/gmf/src/permalink/Permalink.js
@@ -1342,6 +1342,16 @@ PermalinkService.prototype.initLayers_ = function() {
             }
             this.gmfLayerBeingSwipe_.layer = treeCtrl.layer;
           }
+
+          if (
+            treeCtrl.layer.getLayers &&
+            treeCtrl.layer.getLayers().item(0) &&
+            treeCtrl.layer.getLayers().item(0).get('layerNodeName') === 'ch.are.alpenkonvention'
+          ) {
+            treeCtrl.layer.getLayers().item(0).on('change:visible', (e) => {
+              console.log(e);
+            });
+          }
         }
 
         if (treeCtrl.parent.node && parentGroupNode.mixed && groupNode.children == undefined) {

--- a/src/map/LayerHelper.js
+++ b/src/map/LayerHelper.js
@@ -63,6 +63,36 @@ const REFRESH_PARAM = 'random';
 
 
 /**
+ * Copy each properties from a layer onto an other layer, with the
+ * option to exclude specific ones.
+ *
+ * @param {import("ol/layer/Layer.js").default} layerFrom The layer
+ *     from which to copy the properties.
+ * @param {import("ol/layer/Layer.js").default} layerTo The layer onto
+ *     which the properties are copied.
+ * @param {string[]=} opt_excludes A list of properties that should
+ *     not be copied.
+ */
+LayerHelper.prototype.copyProperties = function(
+  layerFrom, layerTo, opt_excludes
+) {
+  const properties = layerFrom.getProperties();
+  if (opt_excludes) {
+    const excludes = opt_excludes;
+    const keys = Object.keys(properties);
+    for (const key of keys) {
+      if (excludes.includes(key)) {
+        continue;
+      }
+      layerTo.set(key, properties[key]);
+    }
+  } else {
+    layerTo.setProperties(properties);
+  }
+};
+
+
+/**
  * Create and return a basic WMS layer with only a source URL and a comma
  * separated layers names (see {@link import("ol/source/ImageWMS.js").default}).
  *


### PR DESCRIPTION
The WMTS layers are created in a way that their properties get asynchronously set, i.e. after WMTS capabilities are obtained.

The setting of the layer's initial visibility can be done before that, which can result in an issue of overriding the visibility after the capabilities are read, i.e. the created layer while reading the capabilities has its visible property set to true, but the original one may have its visible property to false.

To fix this issue, an utility method was added in the LayerHelper of ngeo to be able to exclude the keys we know we don't want to copy.