### PR TITLE
Read queryLayers metadata for WMS data source

### DIFF
--- a/contribs/gmf/src/datasource/Manager.js
+++ b/contribs/gmf/src/datasource/Manager.js
@@ -524,19 +524,40 @@ export class DatasourceManager {
           break;
         }
       }
+
+      // Read 'meta.queryLayers' for WMS data source to set 'getData'
+      //
+      // If a WMS data source has the `queryLayers` property set in
+      // its metadata, then it lists the layers that should be used
+      // when queries are issued with that data source, i.e. when a
+      // WFS GetFeature request is issued. The 'queryable' property
+      // still needs to be true for the purpose of the filter tool to
+      // work properly, i.e. a data source must be queryable to be
+      // filtrable.
+
+      const queryLayers = meta.queryLayers ? meta.queryLayers.split(',') : null;
+
       wmsLayers = gmfLayerWMS.layers.split(',').map((childLayer) => {
-        return {
+        const item = {
           name: childLayer,
           queryable: queryable,
         };
+        if (queryLayers && !queryLayers.includes(childLayer)) {
+          item.getData = false;
+        }
+        return item;
       });
       wfsLayers = gmfLayerWMS.childLayers.map((childLayer) => {
-        return {
+        const item = {
           maxResolution: childLayer.maxResolutionHint,
           minResolution: childLayer.minResolutionHint,
           name: childLayer.name,
           queryable: childLayer.queryable
         };
+        if (queryLayers && !queryLayers.includes(childLayer.name)) {
+          item.getData = false;
+        }
+        return item;
       });
 
       // OGC Server

--- a/contribs/gmf/src/themes.js
+++ b/contribs/gmf/src/themes.js
@@ -137,6 +137,8 @@
 /**
  * Additional attributes related on a WMS layers (or WFS features type).
  * @typedef {Object} GmfLayerChildLayer
+ * @property {boolean|undefined} [getData] If the layer is queryable and this property is set to
+ *     false, then the layer won't be used in queries issued. Defaults to `true`.
  * @property {number} maxResolutionHint The min resolution where the layer is visible.
  * @property {number} minResolutionHint The max resolution where the layer is visible.
  * @property {string} name
@@ -222,8 +224,8 @@
  *      WMTS layers.
  * @property {string} [printLayers] A WMS layer that will be used instead of the WMTS layers in the print.
  *      Used to increase quality of printed WMTS layers. For WMTS layers.
- * @property {string} [queryLayers] The WMS layers used as references to query the WMTS layers. For WMTS
- *      layers.
+ * @property {string} [queryLayers] The WMS layers used as references to query the WMTS layers (for WMTS
+ *      layers) or the WFS layers that should be queried only in case of a WFS GetFeature request.
  * @property {string} [thumbnail] The icon visible in the background selector. For WMS and WMTS layers.
  * @property {string} [timeAttribute] The name of the time attribute. For WMS(-T) layers.
  * @property {GmfSnappingConfig} [snappingConfig] The snapping configuration for the leaf. If set, the

--- a/src/datasource/OGC.js
+++ b/src/datasource/OGC.js
@@ -1014,7 +1014,13 @@ class OGC extends ngeoDatasourceDataSource {
 
     if (this.wmsLayers) {
       for (const wmsLayer of this.wmsLayers) {
-        if (!queryableOnly || wmsLayer.queryable) {
+        if (
+          !queryableOnly ||
+          (
+            wmsLayer.queryable &&
+            wmsLayer.getData !== false
+          )
+        ) {
           layerNames.push(wmsLayer.name);
         }
       }
@@ -1043,7 +1049,16 @@ class OGC extends ngeoDatasourceDataSource {
         const inMaxRange = maxRes === undefined || res <= maxRes;
         const inRange = inMinRange && inMaxRange;
 
-        if (inRange && (!queryableOnly || wfsLayer.queryable)) {
+        if (
+          inRange &&
+          (
+            !queryableOnly ||
+            (
+              wfsLayer.queryable &&
+              wfsLayer.getData !== false
+            )
+          )
+        ) {
           layerNames.push(wfsLayer.name);
         }
       }
@@ -1064,7 +1079,13 @@ class OGC extends ngeoDatasourceDataSource {
 
     if (this.wfsLayers) {
       for (const wfsLayer of this.wfsLayers) {
-        if (!queryableOnly || wfsLayer.queryable) {
+        if (
+          !queryableOnly ||
+          (
+            wfsLayer.queryable &&
+            wfsLayer.getData !== false
+          )
+        ) {
           layerNames.push(wfsLayer.name);
         }
       }
@@ -1075,15 +1096,20 @@ class OGC extends ngeoDatasourceDataSource {
 
   /**
    * Returns the filtrable WFS layer name. This methods asserts that
-   * the name exists and is filtrable.
+   * the name exists and is filtrable. It also asserts that there
+   * should be only one layer (if it has many) that "gets data" for
+   * data data source.
    * @return {string} WFS layer name.
    */
   getFiltrableWFSLayerName() {
     if (!this.filtrable) {
       throw new Error('Missing filtrable');
     }
-    const layerNames = this.getWFSLayerNames();
-    console.assert(layerNames.length === 1);
+    const layerNames = this.getWFSLayerNames(true);
+    console.assert(
+      layerNames.length === 1,
+      'Only one layer should be filtrable, i.e. should be able to get data.'
+    );
     return layerNames[0];
   }
 

--- a/src/datasource/OGC.js
+++ b/src/datasource/OGC.js
@@ -1095,10 +1095,14 @@ class OGC extends ngeoDatasourceDataSource {
   }
 
   /**
-   * Returns the filtrable WFS layer name. This methods asserts that
-   * the name exists and is filtrable. It also asserts that there
-   * should be only one layer (if it has many) that "gets data" for
-   * data data source.
+   * Returns the filtrable WFS layer name.
+   *
+   * Although a data source may contain multiple WFS wfs layers, only
+   * the first one is returned. We don't need to return more than one,
+   * since in that case a group is used in the WMS GetMap query, and
+   * each queryable layers will end up being used in WFS GetData
+   * queries sent.
+   *
    * @return {string} WFS layer name.
    */
   getFiltrableWFSLayerName() {
@@ -1106,10 +1110,6 @@ class OGC extends ngeoDatasourceDataSource {
       throw new Error('Missing filtrable');
     }
     const layerNames = this.getWFSLayerNames(true);
-    console.assert(
-      layerNames.length === 1,
-      'Only one layer should be filtrable, i.e. should be able to get data.'
-    );
     return layerNames[0];
   }
 
@@ -1171,6 +1171,11 @@ class OGC extends ngeoDatasourceDataSource {
    * Collect the ogc attributes that are shared among the given
    * layers, i.e. only the attributes that are in all the given layers
    * are returned.
+   *
+   * Among the attributes, geometry columns are returned as
+   * well. Therefore, if there are no attributes with a geometry name
+   * returned, then the Filter tool have the possibilily to filter the
+   * data source using spatial filters.
    *
    * @param {Array<string>} layerNames List of layer names
    * @return {?Object<string, import('gmf/themes.js').GmfOgcServerAttribute>}


### PR DESCRIPTION
## Issue

With the introduction of #5250 (Support layer group filtering), a WMS data source that use a "group" as WMS layer can have multiple inner WFS layers, each of which get filtered properly.

However, an issue occurs when we try to query such a data source: we get duplicate records.  More precisely, we have 1 set or records per WFS layer.  For example, in a group "hotel_filter", which groups 2 layers: "hotel" and "hotel_layer", we have 2 sets of results, one for "hotel" and one for "hotel_layer".

We should have only one.

## Assumption

~~It is assumed that a WMS data source that uses a group layer should only have ONE of its inner WFS layer to return data when queries are issued.~~ It's okay to have multiple inner layers within a group that can return data.

It is assumed that all WFS layer within a group can be filtered through the WMS layer in the map.

## Fix

This patch implements a way to only have 1 set of records returned for a WMS data source that use a group: by using the `queryLayers` metadata.

This metadata was already introduced for WMTS, and used to be only used by WMTS.  Now, if defined in a WMS data source, it means that only the layers defined in there should be queried.

That metadata is read in the GMF data source manager, and is translated as a new property of the `GmfLayerChildLayer` object: `getData`.  That new property is not an official property supported by the Themes service, but is rather a calculated value to have a nice way to know at the "child layer level" if it is queryable and can have data fetched (i.e. if it can be used to issue requests).  That property is assumed to be `true`, if not defined.