### PR TITLE
Change loading spinner for iframe api interface

### DIFF
--- a/contribs/gmf/apps/iframe_api/index.html.ejs
+++ b/contribs/gmf/apps/iframe_api/index.html.ejs
@@ -13,7 +13,9 @@
   </head>
   <body>
     <div ng-show="mainCtrl.loading" class="loading-mask">
-      <i class="fa fa-spinner fa-spin spinner-loading-mask"></i>
+      <i class="fa custom-spinner-loading fa-spin spinner-loading-mask">
+        <%=require('gmf/icons/spinner.svg?viewbox&height=1em')%>
+      </i>
     </div>
     <main>
       <div class="gmf-app-map-container" ng-class="{'gmf-app-infobar-active': mainCtrl.showInfobar}">


### PR DESCRIPTION
https://jira.camptocamp.com/browse/GSGMF-1192
I added the new loading notification for the missing iframe API interface.

@sbrunner Do you know if there is any other missing spinner ?