### PR TITLE
Revert regression introduced in ngeo WfsPermalink service

### DIFF
--- a/src/statemanager/WfsPermalink.js
+++ b/src/statemanager/WfsPermalink.js
@@ -252,7 +252,7 @@ WfsPermalinkService.prototype.issueRequest_ = function(wfsType, filter, map, sho
 
     // zoom to features
     const size = map.getSize();
-    if (size !== undefined && this.pointRecenterZoom_ !== undefined) {
+    if (size !== undefined) {
       const maxZoom = this.pointRecenterZoom_;
       const padding = [10, 10, 10, 10];
       map.getView().fit(this.getExtent_(features), {size, maxZoom, padding});


### PR DESCRIPTION
The following change was made automatically by 6d38eed1c249a8d3624eeb8ab2a3248c5b508d16:

```
 -   if (size !== undefined) {
 +   if (size !== undefined && this.pointRecenterZoom_ !== undefined) {
```

This change breaks the recentering on a feature in the WFS service due to the fact that `pointRecenterZoom_` becomes mandatory.  It should stay optionnal.

This patch reverts this change, fixing the issue.