### PR TITLE
Revert regression introduced in ngeo displayWindow component

### DIFF
--- a/src/message/displaywindowComponent.js
+++ b/src/message/displaywindowComponent.js
@@ -79,7 +79,7 @@ class Controller {
     /**
      * @type {?string}
      */
-    this.content ;
+    this.content;
 
     /**
      * @type {?string}

--- a/src/message/displaywindowComponent.js
+++ b/src/message/displaywindowComponent.js
@@ -124,7 +124,7 @@ class Controller {
     /**
      * @type {?string}
      */
-    this.title ;
+    this.title;
 
     /**
      * @type {?string}

--- a/src/message/displaywindowComponent.js
+++ b/src/message/displaywindowComponent.js
@@ -74,67 +74,67 @@ class Controller {
     /**
      * @type {boolean}
      */
-    this.clearOnClose = false;
+    this.clearOnClose;
 
     /**
      * @type {?string}
      */
-    this.content = null;
+    this.content ;
 
     /**
      * @type {?string}
      */
-    this.contentTemplate = null;
+    this.contentTemplate;
 
     /**
      * @type {?angular.IScope}
      */
-    this.contentScope = null;
+    this.contentScope;
 
     /**
      * @type {boolean}
      */
-    this.draggable = false;
+    this.draggable;
 
     /**
      * @type {Element|string}
      */
-    this.draggableContainment = '';
+    this.draggableContainment;
 
     /**
      * @type {boolean}
      */
-    this.desktop = false;
+    this.desktop;
 
     /**
      * @type {string}
      */
-    this.height = '';
+    this.height;
 
     /**
      * @type {boolean}
      */
-    this.open = false;
+    this.open;
 
     /**
      * @type {boolean}
      */
-    this.resizable = false;
+    this.resizable;
 
     /**
      * @type {?string}
      */
-    this.title = null;
+    this.title ;
 
     /**
      * @type {?string}
      */
-    this.url = null;
+    this.url;
 
     /**
      * @type {string}
      */
-    this.width = '';
+    this.width;
 
 
     // === Injected Properties ===


### PR DESCRIPTION
This patch fixes an other regression introduced by the automatic changes in: 6d38eed1c249a8d3624eeb8ab2a3248c5b508d16

This time it's the ngeo `displayWindowComponent`.

## Explanation

An angular component gets its its binding properties (i.e. those defined in the html) being set their values in the $onInit method.  In the constructor, their values are not yet set but we do need to type them:

```
   /**
     * @type {boolean}
     */
    this.resizable;
```
The issue introduced by the auto-patch is that they got values assigned according to their type:

```
    /**
     * @type {boolean}
     */
    this.resizable = false;
```

This breaks the setting of the value by Angular in $onInit.  Therefore, we should not do that.  It's okay to leave the type as `boolean`, because the property itself in `this` will be set to a boolean in $onInit.  The angular option (through the biding) is optional but that doesn't matter.

There may be more regressions like this.