### PR TITLE
Revert regression in gmf print component

### DIFF
--- a/contribs/gmf/src/print/component.js
+++ b/contribs/gmf/src/print/component.js
@@ -779,12 +779,8 @@ export class PrintController {
 
     this.updateCustomFields_();
 
-    const hasLegend = this.layoutInfo.attributes.includes('legend');
-    if (hasLegend) {
-      this.fieldValues.legend = this.fieldValues.legend;
-    } else {
-      delete this.fieldValues.legend;
-    }
+    this.layoutInfo.legend = this.layoutInfo.attributes.includes('legend') ?
+      this.fieldValues['legend'] !== false : undefined;
     this.layoutInfo.scales = clientInfo.scales || [];
     this.layoutInfo.dpis = clientInfo.dpiSuggestions || [];
 


### PR DESCRIPTION
A regression was introduced in the gmf print component by the following "auto-replace" commit: 6d38eed1c249a8d3624eeb8ab2a3248c5b508d16

The code it replaced broke the logic of how the legend in the print component is included.  This patch reverts it to its original state, which restores the feature properly.