### PR TITLE
Introduce pending in query ModeSelector

### DIFF
--- a/src/query/component.js
+++ b/src/query/component.js
@@ -352,6 +352,8 @@ class QueryController {
     const limit = this.getLimitOption_();
     const map = this.map;
 
+    this.ngeoQueryModeSelector_.pending = true;
+
     this.ngeoMapQuerent_.issue({
       action,
       extent,
@@ -363,6 +365,7 @@ class QueryController {
       .then(() => {
         // "finally"
         this.vectorSource_.clear();
+        this.ngeoQueryModeSelector_.pending = false;
       });
   }
 
@@ -381,6 +384,8 @@ class QueryController {
     const limit = this.getLimitOption_();
     const map = this.map;
 
+    this.ngeoQueryModeSelector_.pending = true;
+
     this.ngeoMapQuerent_.issue({
       action,
       geometry,
@@ -392,6 +397,7 @@ class QueryController {
       .then(() => {
         // "finally"
         this.vectorSource_.clear();
+        this.ngeoQueryModeSelector_.pending = false;
       });
   }
 
@@ -412,11 +418,19 @@ class QueryController {
     const coordinate = evt.coordinate;
     const map = this.map;
 
+    this.ngeoQueryModeSelector_.pending = true;
+
     this.ngeoMapQuerent_.issue({
       action,
       coordinate,
       map
-    });
+    })
+      .then(() => {})
+      .catch(() => {})
+      .then(() => {
+        // "finally"
+        this.ngeoQueryModeSelector_.pending = false;
+      });
   }
 
   /**


### PR DESCRIPTION
This patch introduces a `pending` property in the ngeo query ModeSelector to manage the changing of query mode while a request is already pending.

The idea is to keep the mode "active" while the request is pending to prevent the issue that was occuring while pressing the Ctrl key to draw a box, make the query tool issue a request and while it was still pending releasing the Ctrl key immediately changed the mode.