### PR TITLE
Don't hide color picker when clearing the search input

### DIFF
--- a/contribs/gmf/src/search/component.js
+++ b/contribs/gmf/src/search/component.js
@@ -986,7 +986,6 @@ class SearchController {
     $(inputs[1]).typeahead('val', '');
     ttmenu.children('.tt-dataset').empty();
     this.setTTDropdownVisibility_();
-    this.displayColorPicker = false;
   }
 
 


### PR DESCRIPTION
demo: https://camptocamp.github.io/ngeo/GSGMF-1206/examples/contribs/gmf/apps/desktop_alt.html