### PR TITLE
Fix Translate and Modify interactions

### DIFF
--- a/src/interaction/Modify.js
+++ b/src/interaction/Modify.js
@@ -189,12 +189,13 @@ export default class extends olInteractionInteraction {
    */
   setState_() {
     const map = this.getMap();
-    if (!map) {
-      return;
-    }
     const active = this.getActive();
     const interactions = this.interactions_;
     const keys = this.listenerKeys_;
+
+    if (!interactions || !keys) {
+      return;
+    }
 
     interactions.forEach((interaction) => {
       interaction.setActive(active && !!map);

--- a/src/interaction/Translate.js
+++ b/src/interaction/Translate.js
@@ -160,15 +160,13 @@ export default class extends olInteractionTranslate {
    */
   setState_() {
     const map = this.getMap();
-    if (!map) {
-      return;
-    }
     const active = this.getActive();
     const features = this.myFeatures_;
-    if (!features) {
-      throw new Error('Missing features');
-    }
     const keys = this.listenerKeys_;
+
+    if (!features || !keys) {
+      return;
+    }
 
     if (map && active && features) {
       features.forEach(feature => this.addFeature_(feature));


### PR DESCRIPTION
Fix bug with Translate and Modify interactions in ngeo (regression introduced by: d207fc7788791bf9db5b4989ad9a04f1343fd0b3)

In the setState methods of these interactions, both the map and active properties are checked to unregister events.  An extra check was made for the map, and when falsy the method did nothing, while it had to (unregister events).  The cause was that upon selecting a feature in the draw tool, new events were incrementing and the clicked features was being "selected" 1 extra time everytime, cummulatively.

This fixes this issue.

Also, I don't understand how it can be possible the the interactions and listenerKeys properties can be `undefined` when the method is called since they are initialized in the constructor, but they can!  The extra "if" takes care of that very odd issue.