### PR TITLE
Fix datetime filter

### DIFF
--- a/src/datasource/Helper.js
+++ b/src/datasource/Helper.js
@@ -245,7 +245,7 @@ export class DatasourceHelper {
         // method below. If the type is not any geometry one, then set
         // the one that was given.
         if (!ngeoAttributeSetGeometryType(attribute, `gml:${type}`)) {
-          attribute.type = type;
+          attribute.type = type.toLowerCase();
         }
 
         attributes.push(attribute);


### PR DESCRIPTION
In ngeo, the list of attributes of a data source are no longer fetched using a WFS DescribeFeatureType request.  Instead, we use the attributes that are in the themes.

The attribute types in there are camel cased, like this: `dateTime`.  The Attribute format that was used to create the attributes from the describe response was used to create the attributes, and converted all types as lowercase.  So, the type in an attribute is "datetime", not "dateTime".

This patch fixes the issue when creating the attributes from the themes.