### PR TITLE
Fix node menu in mobile layertree to open and close

### DIFF
--- a/contribs/gmf/src/layertree/component.html
+++ b/contribs/gmf/src/layertree/component.html
@@ -226,9 +226,8 @@
 </div>
 
 <div
-  class="gmf-layertree-node-menu"
+  class="gmf-layertree-node-menu d-none"
   id="gmf-layertree-node-menu-{{::layertreeCtrl.uid}}"
-  style="display:none;"
   ng-if="::gmfLayertreeCtrl.supportsCustomization(layertreeCtrl)">
 
   <div ng-if="::gmfLayertreeCtrl.supportsOpacityChange(layertreeCtrl)">

--- a/contribs/gmf/src/layertree/component.js
+++ b/contribs/gmf/src/layertree/component.js
@@ -933,7 +933,7 @@ Controller.prototype.toggleSwipeLayer = function(treeCtrl) {
 Controller.prototype.toggleNodeLegend = function(legendNodeId) {
   const div = document.querySelector(legendNodeId);
   if (div) {
-    div.classList.toggle('show');
+    div.classList.toggle('d-none');
   }
 };
 


### PR DESCRIPTION
https://jira.camptocamp.com/browse/GSGMF-1212

~~"Show" class was never applied... And I tried to put everything into the css files but that worked only using the inline "display: none" style, so I kept it that way...~~

Bootstrap 4 changes the "show"/"hide" classes to become:
```
The classes are named using the format:
- .d-{value} for xs
- .d-{breakpoint}-{value} for sm, md, lg, and xl.

Where value is one of:
- none
- inline
- inline-block
- block
- table
- table-cell
- table-row
- flex
- inline-flex
```

https://getbootstrap.com/docs/4.1/utilities/display/