### PR TITLE
Fix legend show/collapse, and legend for QGIS

### DIFF
--- a/contribs/gmf/src/layertree/component.html
+++ b/contribs/gmf/src/layertree/component.html
@@ -145,7 +145,7 @@
       class="gmf-layertree-node-menu-btn"
       href=""
       ng-if="::gmfLayertreeCtrl.supportsCustomization(layertreeCtrl)"
-      ng-click="::gmfLayertreeCtrl.toggleNodeLegend('#gmf-layertree-node-menu-' + layertreeCtrl.uid)">
+      ng-click="::gmfLayertreeCtrl.toggleNodeMenu('#gmf-layertree-node-menu-' + layertreeCtrl.uid)">
       <span class="fa fa-cog"></span>
     </a>
 

--- a/contribs/gmf/src/layertree/component.js
+++ b/contribs/gmf/src/layertree/component.js
@@ -643,16 +643,19 @@ Controller.prototype.getLegendsObject = function(treeCtrl) {
     const scale = this.getScale_();
     // QGIS can handle multiple layers natively. Use Multiple URLs for other map
     // servers
-    if (gmfOgcServer.type !== ServerType.QGISSERVER) {
-      const layerNamesList = layersNames.split(',');
-      layerNamesList.forEach((layerName) => {
-        const wmtsLegendURL = this.layerHelper_.getWMSLegendURL(gmfOgcServer.url, layerName, scale);
-        if (!wmtsLegendURL) {
-          throw new Error('Missing wmtsLegendURL');
-        }
-        legendsObject[layerName] = wmtsLegendURL;
-      });
+    let layerNamesList;
+    if (gmfOgcServer.type === ServerType.QGISSERVER) {
+      layerNamesList = [layersNames];
+    } else {
+      layerNamesList = layersNames.split(',');
     }
+    layerNamesList.forEach((layerName) => {
+      const wmtsLegendURL = this.layerHelper_.getWMSLegendURL(gmfOgcServer.url, layerName, scale);
+      if (!wmtsLegendURL) {
+        throw new Error('Missing wmtsLegendURL');
+      }
+      legendsObject[layerName] = wmtsLegendURL;
+    });
     return legendsObject;
   }
 };
@@ -933,7 +936,7 @@ Controller.prototype.toggleSwipeLayer = function(treeCtrl) {
 Controller.prototype.toggleNodeLegend = function(legendNodeId) {
   const div = document.querySelector(legendNodeId);
   if (div) {
-    div.classList.toggle('d-none');
+    div.classList.toggle('show');
   }
 };
 

--- a/contribs/gmf/src/layertree/component.js
+++ b/contribs/gmf/src/layertree/component.js
@@ -942,6 +942,18 @@ Controller.prototype.toggleNodeLegend = function(legendNodeId) {
 
 
 /**
+ * Toggle the menu for a node
+ * @param {string} legendNodeId The DOM node menu id to toggle
+ */
+Controller.prototype.toggleNodeMenu = function(menuNodeId) {
+  const div = document.querySelector(menuNodeId);
+  if (div) {
+    div.classList.toggle('d-none');
+  }
+};
+
+
+/**
  * @param {import("gmf/datasource/OGC.js").default} ds Data source to filter.
  */
 Controller.prototype.toggleFiltrableDataSource = function(ds) {


### PR DESCRIPTION
Fixes the regression introduced in dd38023b8ad9a45370babc90e18a215c9f161d57 that caused the show/hide to no longer works for any legend in the layer tree. (@llienher Please, check what I restored and see if/why the change was made).

Then, this patch also fixes the issue with QGIS legends.  It was simply a matter of nothing being handled for them at all.