### PR TITLE
Expand group in tree for imported WMS layers

### DIFF
--- a/contribs/gmf/src/layertree/datasourceGroupTreeComponent.html
+++ b/contribs/gmf/src/layertree/datasourceGroupTreeComponent.html
@@ -33,7 +33,7 @@
 
 <ul
   id="gmf-layertree-layer-group-{{::$ctrl.getGroupUid()}}"
-  class="collapse in"
+  class="collapse in show"
 >
   <li
     class="gmf-layertree-node gmf-layertree-depth-2"


### PR DESCRIPTION
This patch makes the node of a datasourceGroupTreeComponent opened by default.

This component is only used by the GMF import tool.  The behaviour of the regular "groups" that are defined in the themes and the other groups in the layer tree remain unchanged.  The metadata "isExpanded" still works as usual.

For the datasourceGroupTreeComponent, a "WMSGroup" data source is created, in which there's no metadata, i.e. no concept of "isExpanded".  Therefore, the change proposed here should be safe.