### PR TITLE
Show loading screen after login while themes are loading

### DIFF
--- a/contribs/gmf/apps/desktop/index.html.ejs
+++ b/contribs/gmf/apps/desktop/index.html.ejs
@@ -120,6 +120,12 @@
               <gmf-authentication
                 gmf-authentication-info-message="mainCtrl.loginInfoMessage"
               ></gmf-authentication>
+              <div ng-if="mainCtrl.postLoading">
+                <i class="fa custom-spinner-connect fa-spin">
+                  <%=require('gmf/icons/spinner.svg?viewbox&height=1em')%>
+                </i>
+                {{'Loading themes, please wait...' | translate}}
+              </div>
             </div>
           </div>
           <div ng-show="mainCtrl.printPanelActive" class="row">

--- a/contribs/gmf/apps/desktop_alt/index.html.ejs
+++ b/contribs/gmf/apps/desktop_alt/index.html.ejs
@@ -126,6 +126,12 @@
               <gmf-authentication
                   gmf-authentication-info-message="mainCtrl.loginInfoMessage">
               </gmf-authentication>
+              <div ng-if="mainCtrl.postLoading">
+                <i class="fa custom-spinner-connect fa-spin">
+                  <%=require('gmf/icons/spinner.svg?viewbox&height=1em')%>
+                </i>
+                {{'Loading themes, please wait...' | translate}}
+              </div>
             </div>
           </div>
           <div ng-show="mainCtrl.printPanelActive" class="row">

--- a/contribs/gmf/src/controllers/AbstractAppController.js
+++ b/contribs/gmf/src/controllers/AbstractAppController.js
@@ -159,6 +159,13 @@ export function AbstractAppController(config, map, $scope, $injector) {
   });
 
   /**
+   * This property is set to `true` when the themes change after a
+   * successful login
+   * @type {boolean}
+   */
+  this.postLoading = false;
+
+  /**
    * Permalink service
    * @type {import("gmf/permalink/Permalink.js").PermalinkService}
    * @private

--- a/contribs/gmf/src/controllers/AbstractAppController.js
+++ b/contribs/gmf/src/controllers/AbstractAppController.js
@@ -145,16 +145,16 @@ export function AbstractAppController(config, map, $scope, $injector) {
   /**
    * Themes service
    * @type {import("gmf/theme/Themes.js").ThemesService}
-   * @private
+   * @protected
    */
-  this.gmfThemes_ = $injector.get('gmfThemes');
+  this.gmfThemes = $injector.get('gmfThemes');
 
   /**
    * Checks if the themes are loaded
    * @type {boolean}
    */
   this.loading = true;
-  this.gmfThemes_.getThemesObject().finally(() => {
+  this.gmfThemes.getThemesObject().finally(() => {
     this.loading = false;
   });
 
@@ -180,7 +180,7 @@ export function AbstractAppController(config, map, $scope, $injector) {
    * @private
    */
   this.updateHasEditableLayers_ = function() {
-    this.gmfThemes_.hasEditableLayers().then((hasEditableLayers) => {
+    this.gmfThemes.hasEditableLayers().then((hasEditableLayers) => {
       this.hasEditableLayers = hasEditableLayers;
     });
   };
@@ -236,7 +236,7 @@ export function AbstractAppController(config, map, $scope, $injector) {
 
     // Open filter panel if 'open_panel' is set in functionalities and
     // has 'layer_filter' as first value
-    this.gmfThemes_.getThemesObject().then((themes) => {
+    this.gmfThemes.getThemesObject().then((themes) => {
       if (functionalities &&
           functionalities.open_panel &&
           functionalities.open_panel[0] === 'layer_filter') {
@@ -249,7 +249,7 @@ export function AbstractAppController(config, map, $scope, $injector) {
     this.gmfThemeManager.setThemeName('', true);
 
     // Reload themes and background layer when login status changes.
-    this.gmfThemes_.loadThemes(roleId);
+    this.gmfThemes.loadThemes(roleId);
 
     if (evt.type !== 'ready') {
       const themeName = this.permalink_.defaultThemeNameFromFunctionalities();
@@ -523,7 +523,7 @@ export function AbstractAppController(config, map, $scope, $injector) {
   ngeoToolActivateMgr.registerTool(mapTools, routingPanelActive, false);
 
   $scope.$root.$on(ThemeEventType.THEME_NAME_SET, (event, name) => {
-    this.gmfThemes_.getThemeObject(name).then((theme) => {
+    this.gmfThemes.getThemeObject(name).then((theme) => {
       this.setDefaultBackground_(theme);
     });
   });
@@ -534,7 +534,7 @@ export function AbstractAppController(config, map, $scope, $injector) {
    * @private
    */
   this.updateCurrentBackgroundLayer_ = (skipPermalink) => {
-    this.gmfThemes_.getBgLayers().then((layers) => {
+    this.gmfThemes.getBgLayers().then((layers) => {
       let background;
       if (!skipPermalink) {
         // get the background from the permalink
@@ -795,7 +795,7 @@ AbstractAppController.prototype.initLanguage = function() {
  * @private
  */
 AbstractAppController.prototype.setDefaultBackground_ = function(theme) {
-  this.gmfThemes_.getBgLayers().then((layers) => {
+  this.gmfThemes.getBgLayers().then((layers) => {
     let layer;
 
     // get the background from the permalink

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -192,10 +192,15 @@ export class AbstractDesktopController extends AbstractAPIController {
      */
     this.profileLine = null;
 
-    // Close the login panel on successful login.
+    // Close the login panel on successful login, after the new themes
+    // have finished loading.
     $scope.$watch(() => this.gmfUser.username, (newVal) => {
       if (newVal !== null && this.loginActive) {
-        this.loginActive = false;
+        this.loading = true;
+        this.gmfThemes.getThemesObject().finally(() => {
+          this.loading = false;
+          this.loginActive = false;
+        });
       }
     });
 

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -196,9 +196,9 @@ export class AbstractDesktopController extends AbstractAPIController {
     // have finished loading.
     $scope.$watch(() => this.gmfUser.username, (newVal) => {
       if (newVal !== null && this.loginActive) {
-        this.loading = true;
+        this.postLoading = true;
         this.gmfThemes.getThemesObject().finally(() => {
-          this.loading = false;
+          this.postLoading = false;
           this.loginActive = false;
         });
       }


### PR DESCRIPTION
This patch introduces the following behaviour:  In the "desktop" applications, after the user successfully logs in, the "login" panel will stay open until:

 * the login is successful (as before)
 * and after the new themes have been loaded (this is new)

Also, after loging in, while the new themes are being loaded, a message is shown in the login panel along with a spinner.