### PR TITLE
Allow setting permalink zoom with map_zoom param

### DIFF
--- a/contribs/gmf/src/permalink/Permalink.js
+++ b/contribs/gmf/src/permalink/Permalink.js
@@ -857,6 +857,7 @@ PermalinkService.prototype.registerMap_ = function(map, oeFeature) {
 
   const view = map.getView();
   let center;
+  let zoom;
 
   // (1) Initialize the map view with either:
   //     a) the given ObjectEditing feature
@@ -880,7 +881,7 @@ PermalinkService.prototype.registerMap_ = function(map, oeFeature) {
       if (center) {
         view.setCenter(center);
       }
-      const zoom = this.getMapZoom();
+      zoom = this.getMapZoom();
       if (zoom !== undefined) {
         view.setZoom(zoom);
       }
@@ -919,7 +920,7 @@ PermalinkService.prototype.registerMap_ = function(map, oeFeature) {
   // (6) check for a wfs permalink
   const wfsPermalinkData = this.getWfsPermalinkData_();
   if (wfsPermalinkData !== null && this.ngeoWfsPermalink_) {
-    this.ngeoWfsPermalink_.issue(wfsPermalinkData, map);
+    this.ngeoWfsPermalink_.issue(wfsPermalinkData, map, zoom);
   }
 };
 

--- a/src/statemanager/WfsPermalink.js
+++ b/src/statemanager/WfsPermalink.js
@@ -260,7 +260,7 @@ WfsPermalinkService.prototype.issueRequest_ = function(
     // zoom to features
     const size = map.getSize();
     if (size !== undefined) {
-      const maxZoom = zoomLevel || this.pointRecenterZoom_;
+      const maxZoom = zoomLevel === undefined ? this.pointRecenterZoom_ : zoomLevel;
       const padding = [10, 10, 10, 10];
       map.getView().fit(this.getExtent_(features), {size, maxZoom, padding});
     }

--- a/src/statemanager/WfsPermalink.js
+++ b/src/statemanager/WfsPermalink.js
@@ -196,8 +196,9 @@ WfsPermalinkService.prototype.clear = function() {
  *
  * @param {WfsPermalinkData} queryData Query data for the WFS request.
  * @param {import("ol/Map.js").default} map The ol3 map object to get the current projection from.
+ * @param {number} [zoomLevel] The level to zoom on when recentering on features.
  */
-WfsPermalinkService.prototype.issue = function(queryData, map) {
+WfsPermalinkService.prototype.issue = function(queryData, map, zoomLevel = undefined) {
   console.assert(this.url_,
     'url is not set. to use the wfs permalink service, ' +
       'set the value `ngeoWfsPermalinkOptions`');
@@ -214,7 +215,7 @@ WfsPermalinkService.prototype.issue = function(queryData, map) {
     return;
   }
 
-  this.issueRequest_(wfsType, filters, map, queryData.showFeatures);
+  this.issueRequest_(wfsType, filters, map, queryData.showFeatures, zoomLevel);
 };
 
 
@@ -223,9 +224,16 @@ WfsPermalinkService.prototype.issue = function(queryData, map) {
  * @param {import("ol/format/filter/Filter.js").default} filter Filter.
  * @param {import("ol/Map.js").default} map The ol3 map object to get the current projection from.
  * @param {boolean} showFeatures Show features or only zoom to feature extent?
+ * @param {number} [zoomLevel] The level to zoom on when recentering on features.
  * @private
  */
-WfsPermalinkService.prototype.issueRequest_ = function(wfsType, filter, map, showFeatures) {
+WfsPermalinkService.prototype.issueRequest_ = function(
+  wfsType,
+  filter,
+  map,
+  showFeatures,
+  zoomLevel = undefined
+) {
   const wfsFormat = new olFormatWFS();
   const featureRequestXml = wfsFormat.writeGetFeature({
     srsName: map.getView().getProjection().getCode(),
@@ -252,7 +260,7 @@ WfsPermalinkService.prototype.issueRequest_ = function(wfsType, filter, map, sho
     // zoom to features
     const size = map.getSize();
     if (size !== undefined) {
-      const maxZoom = this.pointRecenterZoom_;
+      const maxZoom = zoomLevel || this.pointRecenterZoom_;
       const padding = [10, 10, 10, 10];
       map.getView().fit(this.getExtent_(features), {size, maxZoom, padding});
     }


### PR DESCRIPTION
Allow to set the zoom level with the parameter **map_zoom** in the URL for a WFS-Permalink.