### PR TITLE
Remove typecheck to show wmts layer name

### DIFF
--- a/contribs/gmf/src/datasource/ExternalDataSourcesManager.js
+++ b/contribs/gmf/src/datasource/ExternalDataSourcesManager.js
@@ -412,8 +412,8 @@ export class ExternalDatSourcesManager {
       dataSource = this.extDataSources_[id];
     } else {
 
-      const name = typeof layer['Title'];
-      const wmtsLayer = typeof layer['Identifier'];
+      const name = layer['Title'];
+      const wmtsLayer = layer['Identifier'];
 
       // TODO - MaxScaleDenominator
       // TODO - MinScaleDenominator


### PR DESCRIPTION
Hello,

When using the "import external WMS" functionality, the layername won't be displayed correctly if a WMTS layer is chosen :

![image](https://user-images.githubusercontent.com/36037102/78333394-0d761300-758a-11ea-8d25-035902595ae5.png)

This small change should allow the WMTS layername to be displayed instead of just "string".

Thanks,

