### PR TITLE
Revert "Bump jquery from 3.4.1 to 3.5.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "fs-extra": "9.0.0",
     "html-webpack-plugin": "3.2.0",
     "jasmine-core": "3.5.0",
-    "jquery": "3.5.0",
+    "jquery": "3.4.1",
     "jquery-datetimepicker": "2.5.21",
     "jquery-mousewheel": "3.1.13",
     "jquery-ui": "1.12.1",


### PR DESCRIPTION
This reverts commit 3fe026839ca879be394a233fe740a602f17fa129.

Fix: https://jira.camptocamp.com/browse/GSGMF-1261