### PR TITLE
[Backport 2.5] Fix getFeaturesFromIds

### DIFF
--- a/api/src/Querent.js
+++ b/api/src/Querent.js
@@ -71,14 +71,20 @@ export function getFeaturesFromIds(layer, ids) {
         return;
       }
 
-      const featureIds = ids.map((id) => `${layer}.${id}`);
+      const gmfLayer = /** @type import('gmf/themes.js').GmfLayerWMS */ (overlayDef.layer);
+      const childLayerNames = [];
+      let featureIds = [];
+      for (const childLayer of gmfLayer.childLayers) {
+        childLayerNames.push(childLayer.name);
+        featureIds = featureIds.concat(ids.map((id) => `${childLayer.name}.${id}`));
+      }
 
       const params = {
         'FEATUREID': featureIds.join(','),
-        'MAXFEATURES': ids.length,
+        'MAXFEATURES': featureIds.length,
         'REQUEST': 'GetFeature',
         'SERVICE': 'WFS',
-        'TYPENAME': layer,
+        'TYPENAME': childLayerNames.join(','),
         'VERSION': '1.0.0',
       };
       const url = olUriAppendParams(overlayDef.ogcServer.urlWfs, params);


### PR DESCRIPTION
For GMF layers with multiple child layers.

Backport of #5553