### PR TITLE
Data sources without dimension filters are considered equal

### DIFF
--- a/src/datasource/OGC.js
+++ b/src/datasource/OGC.js
@@ -1166,11 +1166,8 @@ class OGC extends ngeoDatasourceDataSource {
    * @override
    */
   haveTheSameActiveDimensionsFilters(dataSource) {
-    const myConfig = this.dimensionsFiltersConfig;
-    const itsConfig = dataSource.dimensionsFiltersConfig;
-    if (myConfig === null || itsConfig === null) {
-      return false;
-    }
+    const myConfig = this.dimensionsFiltersConfig  || {};
+    const itsConfig = dataSource.dimensionsFiltersConfig || {};
 
     const equals = (key) => {
       const myKeyConfig = myConfig[key];

--- a/src/datasource/OGC.js
+++ b/src/datasource/OGC.js
@@ -1166,7 +1166,7 @@ class OGC extends ngeoDatasourceDataSource {
    * @override
    */
   haveTheSameActiveDimensionsFilters(dataSource) {
-    const myConfig = this.dimensionsFiltersConfig  || {};
+    const myConfig = this.dimensionsFiltersConfig || {};
     const itsConfig = dataSource.dimensionsFiltersConfig || {};
 
     const equals = (key) => {


### PR DESCRIPTION
When 2 OGC data sources don't have dimension filters set, they should be considered as having the same filters.

This patch makes it so.