### PR TITLE
Support snapping on features from Draw and Import tools

### DIFF
--- a/contribs/gmf/src/datasource/ExternalDataSourcesManager.js
+++ b/contribs/gmf/src/datasource/ExternalDataSourcesManager.js
@@ -30,6 +30,7 @@ import ngeoDatasourceDataSources from 'ngeo/datasource/DataSources.js';
 import ngeoDatasourceFile from 'ngeo/datasource/File.js';
 import ngeoDatasourceFileGroup from 'ngeo/datasource/FileGroup.js';
 import ngeoDatasourceOGC, {Type, WMSInfoFormat} from 'ngeo/datasource/OGC.js';
+import gmfDatasourceFileGroup from 'gmf/datasource/fileGroup.js';
 import gmfExternalDatasourceOGC from 'gmf/datasource/ExternalOGC.js';
 import ngeoDatasourceOGCGroup from 'ngeo/datasource/OGCGroup.js';
 import ngeoDatasourceWMSGroup from 'ngeo/datasource/WMSGroup.js';
@@ -60,6 +61,7 @@ export class ExternalDatSourcesManager {
    * @param {angular.auto.IInjectorService} $injector Main injector.
    * @param {angular.IQService} $q The Angular $q service.
    * @param {angular.IScope} $rootScope The rootScope provider.
+   * @param {import('gmf/datasource/fileGroup.js').DataSourceFileGroup} gmfDatasourceFileGroup Group that contains file data sources.
    * @param {import("ngeo/datasource/DataSources.js").DataSource} ngeoDataSources Ngeo data sources service.
    * @param {import("ngeo/misc/File.js").FileService} ngeoFile Ngeo file.
    * @param {import("ngeo/map/LayerHelper.js").LayerHelper} ngeoLayerHelper Ngeo layer helper service.
@@ -67,7 +69,16 @@ export class ExternalDatSourcesManager {
    * @ngdoc service
    * @ngname gmfExternalDataSourcesManager
    */
-  constructor(gettextCatalog, $injector, $q, $rootScope, ngeoDataSources, ngeoFile, ngeoLayerHelper) {
+  constructor(
+    gettextCatalog,
+    $injector,
+    $q,
+    $rootScope,
+    gmfDatasourceFileGroup,
+    ngeoDataSources,
+    ngeoFile,
+    ngeoLayerHelper
+) {
     // === Injected properties ===
 
     /**
@@ -146,6 +157,7 @@ export class ExternalDatSourcesManager {
       injector: this.injector_,
       title: gettextCatalog.getString('Local files'),
     });
+    gmfDatasourceFileGroup.fileGroup = this.fileGroup_;
 
     /**
      * Collection of WMS groups.
@@ -738,6 +750,7 @@ function getId(layer) {
  * @hidden
  */
 const module = angular.module('gmfExternalDataSourcesManager', [
+  gmfDatasourceFileGroup.name,
   ngeoMapLayerHelper.name,
   ngeoMiscFile.name,
   ngeoDatasourceDataSources.name,

--- a/contribs/gmf/src/datasource/ExternalDataSourcesManager.js
+++ b/contribs/gmf/src/datasource/ExternalDataSourcesManager.js
@@ -78,7 +78,7 @@ export class ExternalDatSourcesManager {
     ngeoDataSources,
     ngeoFile,
     ngeoLayerHelper
-) {
+  ) {
     // === Injected properties ===
 
     /**

--- a/contribs/gmf/src/datasource/fileGroup.js
+++ b/contribs/gmf/src/datasource/fileGroup.js
@@ -1,0 +1,18 @@
+import angular from 'angular';
+
+/**
+ * @type {angular.IModule}
+ * @hidden
+ */
+const module = angular.module('gmfDatasourceFileGroup', []);
+
+/**
+ * @typedef {Object} DatasourceFileGroup
+ * @property {import("ngeo/datasource/FileGroup.js").default|null} fileGroup
+ */
+
+module.value('gmfDatasourceFileGroup', {
+  fileGroup: null,
+});
+
+export default module;

--- a/contribs/gmf/src/datasource/fileGroup.js
+++ b/contribs/gmf/src/datasource/fileGroup.js
@@ -1,3 +1,24 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Camptocamp SA
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 import angular from 'angular';
 
 /**

--- a/contribs/gmf/src/datasource/fileGroup.js
+++ b/contribs/gmf/src/datasource/fileGroup.js
@@ -28,6 +28,13 @@ import angular from 'angular';
 const module = angular.module('gmfDatasourceFileGroup', []);
 
 /**
+ * The "gmfDatasourceFileGroup" angular value serves as a placeholder
+ * for the ngeo FileGroup data source that is created when the user
+ * adds geospatial files to the map (KML files, for example).
+ *
+ * It is used in the GMF Snapping to be able for drawn/edited features
+ * to be snapped onto features that were imported in such a manner.
+ *
  * @typedef {Object} DatasourceFileGroup
  * @property {import("ngeo/datasource/FileGroup.js").default|null} fileGroup
  */

--- a/contribs/gmf/src/datasource/module.js
+++ b/contribs/gmf/src/datasource/module.js
@@ -22,6 +22,7 @@
 import angular from 'angular';
 import gmfDatasourceDataSourceBeingFiltered from 'gmf/datasource/DataSourceBeingFiltered.js';
 import gmfDatasourceExternalDataSourcesManager from 'gmf/datasource/ExternalDataSourcesManager.js';
+import gmfDatasourceFileGroup from 'gmf/datasource/fileGroup.js';
 import gmfDatasourceHelper from 'gmf/datasource/Helper.js';
 import gmfDatasourceManager from 'gmf/datasource/Manager.js';
 import gmfDatasourceWFSAliases from 'gmf/datasource/WFSAliases.js';
@@ -32,6 +33,7 @@ import gmfDatasourceWFSAliases from 'gmf/datasource/WFSAliases.js';
 export default angular.module('gmfDatasourceModule', [
   gmfDatasourceDataSourceBeingFiltered.name,
   gmfDatasourceExternalDataSourcesManager.name,
+  gmfDatasourceFileGroup.name,
   gmfDatasourceHelper.name,
   gmfDatasourceManager.name,
   gmfDatasourceWFSAliases.name,

--- a/contribs/gmf/src/drawing/drawFeatureComponent.js
+++ b/contribs/gmf/src/drawing/drawFeatureComponent.js
@@ -114,6 +114,7 @@ module.directive('gmfDrawfeature', drawinfDrawFeatureComponent);
  * @param {angular.IScope} $scope Angular scope.
  * @param {angular.ITimeoutService} $timeout Angular timeout service.
  * @param {angular.gettext.gettextCatalog} gettextCatalog Gettext catalog.
+ * @param {import("gmf/editing/Snapping.js").EditingSnappingService} gmfSnapping The gmf snapping service.
  * @param {import("ngeo/misc/FeatureHelper.js").FeatureHelper} ngeoFeatureHelper Ngeo feature helper service.
  * @param {import("ol/Collection.js").default<Feature<import("ol/geom/Geometry.js").default>>} ngeoFeatures Collection
  *    of features.
@@ -126,7 +127,15 @@ module.directive('gmfDrawfeature', drawinfDrawFeatureComponent);
  * @ngdoc controller
  * @ngname GmfDrawfeatureController
  */
-function Controller($scope, $timeout, gettextCatalog, ngeoFeatureHelper, ngeoFeatures, ngeoToolActivateMgr) {
+function Controller(
+  $scope,
+  $timeout,
+  gettextCatalog,
+  gmfSnapping,
+  ngeoFeatureHelper,
+  ngeoFeatures,
+  ngeoToolActivateMgr
+) {
   /**
    * @type {?import("ol/Map.js").default}
    */
@@ -179,6 +188,12 @@ function Controller($scope, $timeout, gettextCatalog, ngeoFeatureHelper, ngeoFea
    * @private
    */
   this.timeout_ = $timeout;
+
+  /**
+   * @type {import("gmf/editing/Snapping.js").EditingSnappingService}
+   * @private
+   */
+  this.gmfSnapping_ = gmfSnapping;
 
   /**
    * @type {import("ngeo/misc/FeatureHelper.js").FeatureHelper}
@@ -345,6 +360,7 @@ function Controller($scope, $timeout, gettextCatalog, ngeoFeatureHelper, ngeoFea
           this.featureHelper_.fitMapToFeature(newFeature, this.map);
           this.listSelectionInProgress_ = false;
         }
+        this.gmfSnapping_.ensureSnapInteractionsOnTop();
       } else {
         this.closeMenu_();
       }

--- a/contribs/gmf/src/editing/Snapping.js
+++ b/contribs/gmf/src/editing/Snapping.js
@@ -66,6 +66,8 @@ class CustomSnap extends olInteractionSnap {
  * @param {angular.auto.IInjectorService} $injector Angular injector.
  * @param {angular.ITimeoutService} $timeout Angular timeout service.
  * @param {import('gmf/datasource/fileGroup.js').DataSourceFileGroup} gmfDatasourceFileGroup Group that contains file data sources.
+ * @param {import('gmf/themes.js').GmfSnappingConfig} gmfSnappingConfig Snapping configuration options for the
+ *     features in the Draw tool and in the "Layer Import / Local" tool.
  * @param {import("gmf/theme/Themes.js").ThemesService} gmfThemes The gmf Themes service.
  * @param {import("gmf/layertree/TreeManager.js").LayertreeTreeManager} gmfTreeManager The gmf TreeManager
  *    service.
@@ -83,6 +85,7 @@ export function EditingSnappingService(
   $injector,
   $timeout,
   gmfDatasourceFileGroup,
+  gmfSnappingConfig,
   gmfThemes,
   gmfTreeManager,
   ngeoFeatures
@@ -124,6 +127,12 @@ export function EditingSnappingService(
    * @private
    */
   this.gmfDatasourceFileGroup_ = gmfDatasourceFileGroup;
+
+  /**
+   * @type {import('gmf/themes.js').GmfSnappingConfig}
+   * @private
+   */
+  this.gmfSnappingConfig_ = gmfSnappingConfig;
 
   /**
    * @type {import("gmf/theme/Themes.js").ThemesService}
@@ -189,7 +198,10 @@ export function EditingSnappingService(
    * @private
    */
   this.ngeoFeaturesSnapInteraction_ = new CustomSnap({
+    edge: gmfSnappingConfig.edge,
     features: ngeoFeatures,
+    pixelTolerance: gmfSnappingConfig.tolerance,
+    vertex: gmfSnappingConfig.vertex,
   });
 
   /**
@@ -749,8 +761,12 @@ EditingSnappingService.prototype.handleFileGroupDataSourcesCollectionAdd_ = func
   // (1) Create Snap interaction and give it the features collection
   //     of the data source.
   const features = fileDataSource.featuresCollection;
+  const gmfSnappingConfig = this.gmfSnappingConfig_;
   const interaction = new CustomSnap({
+    edge: gmfSnappingConfig.edge,
     features,
+    pixelTolerance: gmfSnappingConfig.tolerance,
+    vertex: gmfSnappingConfig.vertex,
   });
 
   // (2) Watch the visible property of the data source. When ON, the
@@ -887,5 +903,10 @@ const module = angular.module('gmfSnapping', [
   ngeoLayertreeController.name,
 ]);
 module.service('gmfSnapping', EditingSnappingService);
+
+// Note: the gmfSnappingConfig are used for features from:
+// - the Draw tool
+// - the Layer Import / Local tool
+module.value('gmfSnappingConfig', {});
 
 export default module;

--- a/contribs/gmf/src/editing/Snapping.js
+++ b/contribs/gmf/src/editing/Snapping.js
@@ -811,6 +811,9 @@ EditingSnappingService.prototype.handleFileGroupDataSourcesCollectionRemove_ = f
 };
 
 /**
+ * Called when the "visible" property of a File data source
+ * changes. Add or remove the Snap interaction for that data source
+ * depending on the property value.
  * @private
  */
 EditingSnappingService.prototype.handleFileDataSourceVisibleChange_ = function (fileDataSource) {

--- a/contribs/gmf/src/editing/Snapping.js
+++ b/contribs/gmf/src/editing/Snapping.js
@@ -308,7 +308,7 @@ EditingSnappingService.prototype.setMap = function (map) {
     // (4) Listen when File data sources are added to the File Group
     //     (i.e. when vector files are imported using the Import tool,
     //     they create File data sources, which contain features that have
-    //     to be snaped on)
+    //     to be snapped on)
     const fileGroup = this.gmfDatasourceFileGroup_.fileGroup;
     if (fileGroup) {
       keys.push(


### PR DESCRIPTION
This patch introduces the support of snapping to features from the Draw/Measure tool and from the imported vector files (Import Layer / Local).

## What we currently have

Before detailing the changes of this patch, I would like to first describe what we had that handled the Snapping.

In GMF, we have a service called `Snapping` (in contrib/gmf/src/editing).  It hooks with the layer tree root node to get all the tree controlers that have node (i.e. layer node from theme) with the "snappingConfig" metadata.  The nodes that have it are WMS, and support WFS.  When snapping to those, WFS is used to fetch the features.


## Changes in this patch

### Support features from the draw tool

The features from the gmf Draw tool are added in the ngeoFeatures collection, which is also an "angular value" that can be injected from anywhere.  That part was the easy one, as we only needed to add a Snap interaction bound to this features collection and that was it.

### Support features from "Import Layer / Local"

That as the tricky part.  There was nothing that could be hooked onto to get those features.

Introducing: `gmfDatasourceFileGroup`, as an "angular value" that can be injected from anywhere to get the FileGroup data source in which File data sources are added when adding vector files (kml, etc.) using the "Import Layer / Local" tool.

The FileGroup data source is still initialized where it was created, and it also sets it in the `gmfDatasourceFileGroup` "angular value".

Then, in Snapping, we hook on the FileGroup and listen to when File data sources are added/removed in order to bind a Snap interaction for each one of them.  That's pretty much the idea behind this.  Like their WMS counterparts, File data source are registered a watcher in Snapping onto their "visible" property, to make sure that the snapping only occurs on the features of an imported data source only if the data source (and OpenLayers layer) is visible.


## Snaping while editing

In the GSGMF-1292 task, this was asked:

>Not available in the editing

As it turns out, the Snapping service does not currently differenciate when we draw/edit using the Draw or Edit tool.  In other words, even prior this patch, it was possible to "snap" to features on the map while editing or drawing (using both tools).

So, this patch introduces the same logic, i.e. it is possible to "snap" on features that were drawn using the Draw tool or on features that were imported from a file, regardless of the tool we're using (both Draw and Edit).

This behaviour is the opposite of what was asked for the Edit tool, i.e. "Not available in the editing".

**Question**: It would require more efforts to prevent snapping for the edit tool.  Do we need to put efforts into this?


## Todo

 * [x] implement gmfSnappingConfig (only used by features from the Draw tool and from the "Import Layer / Local")
 * [x] fix all issues reported by Travis
 * [x] reply to the **Question** in the "Snapping while editing" section (see above)