### PR TITLE
Gui for swipe on layertree groups gsgmf 1336

### DIFF
--- a/contribs/gmf/src/layertree/common.scss
+++ b/contribs/gmf/src/layertree/common.scss
@@ -4,6 +4,11 @@
   padding: $micro-app-margin;
 }
 
+.more-options-info {
+  font-style: italic;
+  color: $color;
+}
+
 .gmf-layertree-node {
   /**
    * Style rules for treenodes in the layertree

--- a/contribs/gmf/src/layertree/component.html
+++ b/contribs/gmf/src/layertree/component.html
@@ -191,13 +191,16 @@
               {{'Swipe with this layer'| translate}}
             </a>
           </li>
-          <li ng-if="layertreeCtrl.getDataSource() && layertreeCtrl.getDataSource().filtrable">
+          <li ng-if="::gmfLayertreeCtrl.isFiltrable(layertreeCtrl)">
             <i class="fa fa-filter fa-fw"></i>
             <a
               ng-click="gmfLayertreeCtrl.toggleFiltrableDataSource(layertreeCtrl.getDataSource())"
               href="">
               {{'Filter'|translate}}
             </a>
+          </li>
+          <li class="more-options-info" ng-if="::gmfLayertreeCtrl.getFirstParentWithLayerFunctions(layertreeCtrl) !== null">
+            <span>{{'More options at the group level'||translate}}</span>
           </li>
         </ul>
       </div>
@@ -229,6 +232,10 @@
   class="gmf-layertree-node-menu d-none"
   id="gmf-layertree-node-menu-{{::layertreeCtrl.uid}}"
   ng-if="::gmfLayertreeCtrl.supportsCustomization(layertreeCtrl)">
+
+  <div class="more-options-info" ng-if="::gmfLayertreeCtrl.getFirstParentWithLayerFunctions(layertreeCtrl) !== null">
+     <span>{{'More options at the group level'||translate}}</span>
+  </div>
 
   <div ng-if="::gmfLayertreeCtrl.supportsOpacityChange(layertreeCtrl)">
     <i class="fa fa-tint fa-fw"></i>

--- a/contribs/gmf/src/layertree/component.html
+++ b/contribs/gmf/src/layertree/component.html
@@ -162,7 +162,7 @@
 
       <div ngeo-popover-content>
         <ul>
-          <li ng-if="::(layertreeCtrl.depth === 1 && !layertreeCtrl.node.mixed) || (layertreeCtrl.depth > 1 && layertreeCtrl.parent.node.mixed)">
+          <li ng-if="::gmfLayertreeCtrl.supportsOpacityChange(layertreeCtrl)">
             <i class="fa fa-tint fa-fw"></i>
             <span>{{'Opacity'|translate}}</span>
             <input

--- a/contribs/gmf/src/layertree/component.js
+++ b/contribs/gmf/src/layertree/component.js
@@ -965,9 +965,9 @@ Controller.prototype.supportsLegend = function (treeCtrl) {
  */
 Controller.prototype.supportsOpacityChange = function (treeCtrl) {
   const node = /** @type {import('gmf/themes.js').GmfGroup} */ (treeCtrl.node);
-  const parentNode = /** @type {import('gmf/themes.js').GmfGroup} */ (treeCtrl.parent.node);
   return (
-    !!treeCtrl.layer && ((treeCtrl.depth === 1 && !node.mixed) || (treeCtrl.depth > 1 && parentNode.mixed))
+    !!treeCtrl.layer &&
+    ((treeCtrl.depth === 1 && !node.mixed) || (treeCtrl.depth > 1 && treeCtrl.parent.node.mixed))
   );
 };
 

--- a/contribs/gmf/src/layertree/component.js
+++ b/contribs/gmf/src/layertree/component.js
@@ -971,6 +971,31 @@ Controller.prototype.supportsOpacityChange = function (treeCtrl) {
   );
 };
 
+/**
+ * @param {import("ngeo/layertree/Controller.js").LayertreeController} treeCtrl Ngeo tree controller.
+ * @return {boolean} Whether the layer tree controller has a filtrable datasource or not.
+ */
+Controller.prototype.isFiltrable = function (treeCtrl) {
+  const datasource = treeCtrl.getDataSource();
+  return datasource ? datasource.filtrable : false;
+};
+
+/**
+ * @param {import("ngeo/layertree/Controller.js").LayertreeController} treeCtrl Ngeo tree controller.
+ * @return {import("ngeo/layertree/Controller.js").LayertreeController} first parent that supports
+ *     opacity change or is filtrable. Or null if there is any parent with layer functions.
+ */
+Controller.prototype.getFirstParentWithLayerFunctions = function (treeCtrl) {
+  const parentTreeCtrl = /** @type {import("ngeo/layertree/Controller.js"} */ (treeCtrl.parent);
+  if (!parentTreeCtrl) {
+    return null;
+  }
+  if (this.supportsOpacityChange(parentTreeCtrl) || this.isFiltrable(parentTreeCtrl)) {
+    return parentTreeCtrl;
+  }
+  return this.getFirstParentWithLayerFunctions(parentTreeCtrl);
+};
+
 module.controller('GmfLayertreeController', Controller);
 
 export default module;


### PR DESCRIPTION
FIX GSGMF-1336

It's not easy to open a popup on the parent node with a link. I give up to achieve that for now.

I add the message `More options at the group level` for layers with parents having a "filter" possibility or a "set opacity" possibility.
Is the message understandable ?

I add this message as first option item in the mobile because the legend must be last.

UPDATE
Tests are failing, but It looks like it's not this PR fault. I've done a fix here: https://github.com/camptocamp/ngeo/pull/6013
And that could be good to have too: https://github.com/camptocamp/ngeo/pull/6002