### PR TITLE
Export csv in querywindow

### DIFF
--- a/contribs/gmf/examples/displayquerygrid.html
+++ b/contribs/gmf/examples/displayquerygrid.html
@@ -21,7 +21,8 @@
         <span>Theme:
         <select
             class="form-control"
-            ng-model="ctrl.treeSource"
+            ng-model="ctrl.selectedTheme"
+            ng-change="ctrl.updateTheme()"
             ng-options="theme.name for theme in ctrl.themes">
         </select>
         </span>

--- a/contribs/gmf/examples/displayquerygrid.js
+++ b/contribs/gmf/examples/displayquerygrid.js
@@ -149,8 +149,15 @@ function MainController(gmfThemes, gmfDataSourcesManager, ngeoFeatureOverlayMgr)
     }),
   });
 
+  /**
+   * @type {Object<string, string>}
+   */
+  this.dimensions = {};
+
   // Init the datasources with our map.
   gmfDataSourcesManager.setDatasourceMap(this.map);
+  // Give the dimensions to the gmfDataSourcesManager
+  gmfDataSourcesManager.setDimensions(this.dimensions);
 
   /**
    * @type {Object[]|undefined}

--- a/contribs/gmf/examples/displayquerygrid.js
+++ b/contribs/gmf/examples/displayquerygrid.js
@@ -31,6 +31,7 @@ import gmfMapComponent from 'gmf/map/component.js';
 
 import gmfQueryGridComponent from 'gmf/query/gridComponent.js';
 
+import gmfThemeManager from 'gmf/theme/Manager.js';
 import gmfThemeThemes from 'gmf/theme/Themes.js';
 import ngeoGridModule from 'ngeo/grid/module.js';
 import ngeoMapModule from 'ngeo/map/module.js';
@@ -56,6 +57,7 @@ const module = angular.module('gmfapp', [
   gmfLayertreeComponent.name,
   gmfMapComponent.name,
   gmfQueryGridComponent.name,
+  gmfThemeManager.name,
   gmfThemeThemes.name,
   ngeoGridModule.name,
   ngeoMapModule.name, // for ngeo.map.FeatureOverlay, perhaps remove me
@@ -70,7 +72,8 @@ module.constant('ngeoQueryOptions', {
 
 module.constant('gmfTreeUrl', appURL.GMF_THEMES);
 
-module.constant('defaultTheme', 'Demo');
+const defaultTheme = 'Demo';
+module.constant('defaultTheme', defaultTheme);
 module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
 
 /**
@@ -110,9 +113,10 @@ module.controller('gmfappQueryresultController', QueryresultController);
  *     data sources manager service.
  * @param {import("ngeo/map/FeatureOverlayMgr.js").FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *   overlay manager service.
+ * @param {import("gmf/theme/Manager.js").ThemeManagerService} gmfThemeManager gmf Theme Manager service.
  * @ngInject
  */
-function MainController(gmfThemes, gmfDataSourcesManager, ngeoFeatureOverlayMgr) {
+function MainController(gmfThemes, gmfDataSourcesManager, ngeoFeatureOverlayMgr, gmfThemeManager) {
   gmfThemes.loadThemes();
 
   const fill = new olStyleFill({color: [255, 170, 0, 0.6]});
@@ -160,20 +164,24 @@ function MainController(gmfThemes, gmfDataSourcesManager, ngeoFeatureOverlayMgr)
   gmfDataSourcesManager.setDimensions(this.dimensions);
 
   /**
+   * @type {boolean}
+   */
+  this.queryActive = true;
+
+  /**
    * @type {Object[]|undefined}
    * export
    */
   this.themes = undefined;
 
   /**
-   * @type {Object|undefined}
+   * @type {import('gmf/themes.js').GmfTheme} The selected theme.
    */
-  this.treeSource = undefined;
+  this.selectedTheme = null;
 
-  /**
-   * @type {boolean}
-   */
-  this.queryActive = true;
+  this.updateTheme = function () {
+    gmfThemeManager.addTheme(this.selectedTheme);
+  };
 
   /**
    * @type {boolean}
@@ -183,7 +191,14 @@ function MainController(gmfThemes, gmfDataSourcesManager, ngeoFeatureOverlayMgr)
   gmfThemes.getThemesObject().then((themes) => {
     if (themes) {
       this.themes = themes;
-      this.treeSource = themes[3];
+
+      // Select default theme;
+      themes.forEach((theme) => {
+        if (theme.name === defaultTheme) {
+          this.selectedTheme = theme;
+          return;
+        }
+      });
     }
   });
 

--- a/contribs/gmf/examples/displayquerywindow.html
+++ b/contribs/gmf/examples/displayquerywindow.html
@@ -21,7 +21,8 @@
         <span>Theme:
         <select
             class="form-control"
-            ng-model="ctrl.treeSource"
+            ng-model="ctrl.selectedTheme"
+            ng-change="ctrl.updateTheme()"
             ng-options="theme.name for theme in ctrl.themes">
         </select>
         </span>

--- a/contribs/gmf/examples/displayquerywindow.js
+++ b/contribs/gmf/examples/displayquerywindow.js
@@ -151,8 +151,15 @@ function MainController(gmfThemes, gmfDataSourcesManager, ngeoFeatureOverlayMgr)
     }),
   });
 
+  /**
+   * @type {Object<string, string>}
+   */
+  this.dimensions = {};
+
   // Init the datasources with our map.
   gmfDataSourcesManager.setDatasourceMap(this.map);
+  // Give the dimensions to the gmfDataSourcesManager
+  gmfDataSourcesManager.setDimensions(this.dimensions);
 
   /**
    * @type {Object[]|undefined}

--- a/contribs/gmf/examples/displayquerywindow.js
+++ b/contribs/gmf/examples/displayquerywindow.js
@@ -31,6 +31,7 @@ import gmfMapComponent from 'gmf/map/component.js';
 
 import gmfQueryWindowComponent from 'gmf/query/windowComponent.js';
 
+import gmfThemeManager from 'gmf/theme/Manager.js';
 import gmfThemeThemes from 'gmf/theme/Themes.js';
 import ngeoMiscBtnComponent from 'ngeo/misc/btnComponent.js';
 import EPSG2056 from '@geoblocks/proj/src/EPSG_2056.js';
@@ -55,6 +56,7 @@ const module = angular.module('gmfapp', [
   gmfLayertreeComponent.name,
   gmfMapComponent.name,
   gmfQueryWindowComponent.name,
+  gmfThemeManager.name,
   gmfThemeThemes.name,
   ngeoMapModule.name, // for ngeo.map.FeatureOverlay, perhaps remove me
   ngeoMiscBtnComponent.name,
@@ -67,7 +69,8 @@ module.value('ngeoQueryOptions', {
 
 module.value('gmfTreeUrl', appURL.GMF_THEMES);
 
-module.constant('defaultTheme', 'Demo');
+const defaultTheme = 'Demo';
+module.constant('defaultTheme', defaultTheme);
 module.constant('angularLocaleScript', '../build/angular-locale_{{locale}}.js');
 
 /**
@@ -107,9 +110,10 @@ module.controller('AppQueryresultController', QueryresultController);
  *     data sources manager service.
  * @param {import("ngeo/map/FeatureOverlayMgr.js").FeatureOverlayMgr} ngeoFeatureOverlayMgr The ngeo feature
  *   overlay manager service.
+ * @param {import("gmf/theme/Manager.js").ThemeManagerService} gmfThemeManager gmf Theme Manager service.
  * @ngInject
  */
-function MainController(gmfThemes, gmfDataSourcesManager, ngeoFeatureOverlayMgr) {
+function MainController(gmfThemes, gmfDataSourcesManager, ngeoFeatureOverlayMgr, gmfThemeManager) {
   gmfThemes.loadThemes();
 
   /**
@@ -162,25 +166,36 @@ function MainController(gmfThemes, gmfDataSourcesManager, ngeoFeatureOverlayMgr)
   gmfDataSourcesManager.setDimensions(this.dimensions);
 
   /**
+   * @type {boolean}
+   */
+  this.queryActive = true;
+
+  /**
    * @type {Object[]|undefined}
    * export
    */
   this.themes = undefined;
 
   /**
-   * @type {Object|undefined}
+   * @type {import('gmf/themes.js').GmfTheme} The selected theme.
    */
-  this.treeSource = undefined;
+  this.selectedTheme = null;
 
-  /**
-   * @type {boolean}
-   */
-  this.queryActive = true;
+  this.updateTheme = function () {
+    gmfThemeManager.addTheme(this.selectedTheme);
+  };
 
   gmfThemes.getThemesObject().then((themes) => {
     if (themes) {
       this.themes = themes;
-      this.treeSource = themes[3];
+
+      // Select default theme;
+      themes.forEach((theme) => {
+        if (theme.name === defaultTheme) {
+          this.selectedTheme = theme;
+          return;
+        }
+      });
     }
   });
 

--- a/contribs/gmf/src/query/window.scss
+++ b/contribs/gmf/src/query/window.scss
@@ -1,9 +1,9 @@
 @import '~gmf/sass/vars.scss';
 
-$displayquerywindow-tablet-width: 8 * $map-tools-size;
+$displayquerywindow-tablet-width: 9 * $map-tools-size;
 $displayquerywindow-detailed-header-height: 3.12rem;
 $displayquerywindow-detailed-details-line-height: 1.25rem;
-$displayquerywindow-detailed-details-height: 8 * $displayquerywindow-detailed-details-line-height;
+$displayquerywindow-detailed-details-height: 9 * $displayquerywindow-detailed-details-line-height;
 
 div.gmf-displayquerywindow {
   pointer-events: none;

--- a/contribs/gmf/src/query/windowComponent.html
+++ b/contribs/gmf/src/query/windowComponent.html
@@ -86,6 +86,7 @@
         <span>{{ctrl.currentResult + 1}}</span>
         <span>/</span>
         <span>{{ctrl.getResultLength()}}</span>
+
         <div
           ng-show="::ctrl.desktop"
           class="dropup">
@@ -134,31 +135,33 @@
             </li>
           </ul>
         </div>
-      </div>
 
-      <div>
-        <button
-          type="button"
-          class="btn btn-default dropdown-toggle"
-          data-toggle="dropdown"
-          aria-expanded="false">
-          <span class="fa fa-download"></span>
-        </button>
+        <div
+          ng-show="::ctrl.desktop"
+          class="dropup">
 
-        <ul
-          class="dropdown-menu dropdown-menu-right"
-          role="menu">
+          <button
+            type="button"
+            class="btn btn-default dropdown-toggle"
+            data-toggle="dropdown"
+            aria-expanded="false">
+            <span class="fa fa-download"></span>
+          </button>
 
-          <li
-            ng-repeat-start="source in ctrl.ngeoQueryResult.sources" ng-repeat-end
-            ng-class="{'disabled': source.features.length <= 0}">
-            <a
-              href="#"
-              ng-click="ctrl.downloadCSV(source)">
-              <span>{{'Export' | translate}} {{source.label | translate}}</span>
-            </a>
-          </li>
-        </ul>
+          <ul
+            class="dropdown-menu dropdown-menu-right"
+            role="menu">
+            <li
+              ng-repeat-start="source in ctrl.ngeoQueryResult.sources" ng-repeat-end
+              ng-class="{'disabled': source.features.length <= 0}">
+              <a
+                href="#"
+                ng-click="ctrl.downloadCSV(source)">
+                <span>{{'Export' | translate}} {{source.label | translate}}</span>
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
 
       <div class="placeholder">

--- a/contribs/gmf/src/query/windowComponent.html
+++ b/contribs/gmf/src/query/windowComponent.html
@@ -136,6 +136,31 @@
         </div>
       </div>
 
+      <div>
+        <button
+          type="button"
+          class="btn btn-default dropdown-toggle"
+          data-toggle="dropdown"
+          aria-expanded="false">
+          <span class="fa fa-download"></span>
+        </button>
+
+        <ul
+          class="dropdown-menu dropdown-menu-right"
+          role="menu">
+
+          <li
+            ng-repeat-start="source in ctrl.ngeoQueryResult.sources" ng-repeat-end
+            ng-class="{'disabled': source.features.length <= 0}">
+            <a
+              href="#"
+              ng-click="ctrl.downloadCSV(source)">
+              <span>{{'Export' | translate}} {{source.label | translate}}</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+
       <div class="placeholder">
         <button
           type="button"

--- a/contribs/gmf/src/query/windowComponent.js
+++ b/contribs/gmf/src/query/windowComponent.js
@@ -365,7 +365,7 @@ QueryWindowController.prototype.$onInit = function () {
     windowContainer.resizable({
       handles: 'all',
       minHeight: 240,
-      minWidth: 240,
+      minWidth: 260,
     });
   }
 };

--- a/contribs/gmf/test/spec/directives/displayquerywindow.spec.js
+++ b/contribs/gmf/test/spec/directives/displayquerywindow.spec.js
@@ -59,10 +59,13 @@ describe('gmf.query.windowComponent', () => {
         {
           features: [
             new olFeature({
+              bar: undefined,
               foo: 'bar',
+              empty: undefined,
             }),
             new olFeature({
               bar: 'baz',
+              empty: undefined,
             }),
           ],
           id: 123,
@@ -214,6 +217,27 @@ describe('gmf.query.windowComponent', () => {
       expect(displayQueriesController.getResultLength()).toBe(4);
       expect(displayQueriesController.source).toBe(ngeoQueryResult.sources[0]);
       expect(displayQueriesController.feature).toBe(ngeoQueryResult.sources[0].features[0]);
+    });
+
+    it('Get csv data', () => {
+      expect(displayQueriesController.getCSVData_(null)).toBeUndefined();
+
+      expect(displayQueriesController.getCSVData_({features: []})).toBeUndefined();
+
+      expect(displayQueriesController.getCSVData_(sources[0])).toEqual([
+        {bar: undefined, foo: 'bar', empty: undefined},
+        {bar: 'baz', empty: undefined},
+      ]);
+    });
+
+    it('Get csv header définition', () => {
+      expect(displayQueriesController.getCSVHeaderDefinition_(null)).toBeUndefined();
+
+      const data = [
+        {bar: undefined, foo: 'bar', empty: undefined},
+        {bar: 'baz', empty: undefined},
+      ];
+      expect(displayQueriesController.getCSVHeaderDefinition_(data)).toEqual([{name: 'foo'}, {name: 'bar'}]);
     });
   });
 });

--- a/contribs/gmf/test/spec/directives/displayquerywindow.spec.js
+++ b/contribs/gmf/test/spec/directives/displayquerywindow.spec.js
@@ -33,6 +33,8 @@ describe('gmf.query.windowComponent', () => {
   let $scope;
   /** @type {angular.IScope} */
   let $rootScope;
+  /** @type {Array<import('ngeo/statemanager/WfsPermalink.js').QueryResultSource>} */
+  let sources;
 
   beforeEach(
     angular.mock.inject((_$controller_, _$rootScope_, _ngeoQueryResult_) => {
@@ -52,55 +54,8 @@ describe('gmf.query.windowComponent', () => {
           return undefined;
         },
       };
-      displayQueriesController = $controller('GmfDisplayquerywindowController', {$element, $scope}, data);
-    })
-  );
 
-  describe('#show', () => {
-    it('deals with no sources', () => {
-      ngeoQueryResult.total = 0;
-      ngeoQueryResult.sources = [];
-      $rootScope.$digest();
-      expect(displayQueriesController.open).toBe(false);
-    });
-
-    it('deals with a single source', () => {
-      ngeoQueryResult.total = 2;
-      ngeoQueryResult.sources = [
-        {
-          features: [
-            new olFeature({
-              foo: 'bar',
-            }),
-            new olFeature({
-              bar: 'baz',
-            }),
-          ],
-          id: 123,
-          label: 'Test',
-          pending: false,
-          queried: true,
-        },
-      ];
-      $rootScope.$digest();
-      expect(displayQueriesController.open).toBe(true);
-      expect(displayQueriesController.source).toBe(ngeoQueryResult.sources[0]);
-      expect(displayQueriesController.feature).toBe(ngeoQueryResult.sources[0].features[0]);
-
-      // toggle through features
-      displayQueriesController.next();
-      expect(displayQueriesController.feature).toBe(ngeoQueryResult.sources[0].features[1]);
-      displayQueriesController.next();
-      expect(displayQueriesController.feature).toBe(ngeoQueryResult.sources[0].features[0]);
-      displayQueriesController.previous();
-      expect(displayQueriesController.feature).toBe(ngeoQueryResult.sources[0].features[1]);
-      displayQueriesController.previous();
-      expect(displayQueriesController.feature).toBe(ngeoQueryResult.sources[0].features[0]);
-    });
-
-    it('deals with multiple sources', () => {
-      ngeoQueryResult.total = 5;
-      ngeoQueryResult.sources = [
+      sources = [
         {
           features: [
             new olFeature({
@@ -138,6 +93,41 @@ describe('gmf.query.windowComponent', () => {
           queried: true,
         },
       ];
+
+      displayQueriesController = $controller('GmfDisplayquerywindowController', {$element, $scope}, data);
+    })
+  );
+
+  describe('#show', () => {
+    it('deals with no sources', () => {
+      ngeoQueryResult.total = 0;
+      ngeoQueryResult.sources = [];
+      $rootScope.$digest();
+      expect(displayQueriesController.open).toBe(false);
+    });
+
+    it('deals with a single source', () => {
+      ngeoQueryResult.total = 2;
+      ngeoQueryResult.sources = [sources[0]];
+      $rootScope.$digest();
+      expect(displayQueriesController.open).toBe(true);
+      expect(displayQueriesController.source).toBe(ngeoQueryResult.sources[0]);
+      expect(displayQueriesController.feature).toBe(ngeoQueryResult.sources[0].features[0]);
+
+      // toggle through features
+      displayQueriesController.next();
+      expect(displayQueriesController.feature).toBe(ngeoQueryResult.sources[0].features[1]);
+      displayQueriesController.next();
+      expect(displayQueriesController.feature).toBe(ngeoQueryResult.sources[0].features[0]);
+      displayQueriesController.previous();
+      expect(displayQueriesController.feature).toBe(ngeoQueryResult.sources[0].features[1]);
+      displayQueriesController.previous();
+      expect(displayQueriesController.feature).toBe(ngeoQueryResult.sources[0].features[0]);
+    });
+
+    it('deals with multiple sources', () => {
+      ngeoQueryResult.total = 5;
+      ngeoQueryResult.sources = sources;
       $rootScope.$digest();
       expect(displayQueriesController.open).toBe(true);
       expect(displayQueriesController.source).toBe(ngeoQueryResult.sources[0]);
@@ -169,44 +159,7 @@ describe('gmf.query.windowComponent', () => {
 
     it('deals with selected sources', () => {
       ngeoQueryResult.total = 5;
-      ngeoQueryResult.sources = [
-        {
-          features: [
-            new olFeature({
-              foo: 'bar',
-            }),
-            new olFeature({
-              bar: 'baz',
-            }),
-          ],
-          id: 123,
-          label: 'Test 1',
-          pending: false,
-          queried: true,
-        },
-        {
-          features: [],
-          id: 234,
-          label: 'Test 2',
-          pending: false,
-          queried: true,
-        },
-        {
-          features: [
-            new olFeature({
-              foo: 'bar',
-            }),
-            new olFeature(),
-            new olFeature({
-              bar: 'baz',
-            }),
-          ],
-          id: 345,
-          label: 'Test 3',
-          pending: false,
-          queried: true,
-        },
-      ];
+      ngeoQueryResult.sources = sources;
       $rootScope.$digest();
       expect(displayQueriesController.open).toBe(true);
       expect(displayQueriesController.source).toBe(ngeoQueryResult.sources[0]);


### PR DESCRIPTION
For GSGMF-1298

- Add export csv (layer per layer) in querywindow component.
- Add tests
- Adjust styles
- Correct GMF query examples.

Example: https://camptocamp.github.io/ngeo/export_csv_in_querywindow_gsgmf-1298/examples/contribs/gmf/apps/desktop.html

I've some doubts on the css:
 - The popup menu is not aligned (as before, as for the filter popup), I wonder if we have to do better, it's not trvial
 - I follow the mock-up and repeat "Export <layer>". That's not so nice, can't we have a header "Export CSV" then a list of layer ?
 - The button is a little bit different on the mockup, I've prefered to follow the style of the filter button. It is okay ?

Also, this feature is desktop only, right ?