### PR TITLE
Fix travis 2 4

### DIFF
--- a/buildtools/travis-npm-publish.sh
+++ b/buildtools/travis-npm-publish.sh
@@ -18,7 +18,7 @@ then
         fi
         if [ "$PACKAGE_VERSION" = "$TRAVIS_TAG" ]
         then
-            $RUN npm publish --tag=version-${MAIN_BRANCH} $TAG
+            $RUN npm publish --quiet --tag=version-${MAIN_BRANCH} $TAG
         else
             echo "Skipping publication, the travis tag and package version differ"
         fi


### PR DESCRIPTION
Try to reduce length of logs because travis fail with "The job exceeded the maximum log length, and has been terminated."