### PR TITLE
Fts keep clear button when feature gsgmf 1348

### DIFF
--- a/contribs/gmf/src/search/component.html
+++ b/contribs/gmf/src/search/component.html
@@ -6,7 +6,7 @@
     ngeo-search-datasets="$ctrl.datasets"
     ngeo-search-listeners="$ctrl.listeners">
   <span class="gmf-clear-button ng-hide"
-    ng-hide="!$ctrl.clearButton || $ctrl.inputValue == '' && $ctrl.featureOverlay_.isEmpty() "
+    ng-hide="!$ctrl.clearButton || $ctrl.inputValue == '' && $ctrl.featureOverlay_.isEmpty()"
     ng-click="$ctrl.onClearButton()">
   </span>
 </div>

--- a/src/map/FeatureOverlay.js
+++ b/src/map/FeatureOverlay.js
@@ -20,7 +20,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import angular from 'angular';
-import {listen, unlistenByKey} from 'ol/events.js';
+import {listen} from 'ol/events.js';
 import {CollectionEvent} from 'ol/Collection.js';
 
 /**
@@ -35,12 +35,6 @@ export function FeatureOverlay(manager, index) {
    * @private
    */
   this.manager_ = manager;
-
-  /**
-   * @type {?import("ol/Collection.js").default<import('ol/Feature.js').default<import("ol/geom/Geometry.js").default>>}
-   * @private
-   */
-  this.features_ = null;
 
   /**
    * @type {number}
@@ -71,11 +65,11 @@ FeatureOverlay.prototype.removeFeature = function (feature) {
 };
 
 /**
- * Is empty.
- * @returns {boolean} Is empty.
+ * Check if featureOverlay has no features.
+ * @returns {boolean} True if there is no features. False otherwise.
  */
 FeatureOverlay.prototype.isEmpty = function () {
-  return !this.features_ || this.features_.getLength() == 0;
+  return this.manager_.isEmpty(this.index_);
 };
 
 /**
@@ -94,10 +88,6 @@ FeatureOverlay.prototype.clear = function () {
  * @param {import("ol/Collection.js").default<import('ol/Feature.js').default<import("ol/geom/Geometry.js").default>>} features Feature collection.
  */
 FeatureOverlay.prototype.setFeatures = function (features) {
-  if (this.features_ !== null) {
-    this.features_.clear();
-    this.listenerKeys_.forEach(unlistenByKey);
-  }
   if (features !== null) {
     features.forEach((feature) => {
       this.addFeature(feature);
@@ -105,7 +95,6 @@ FeatureOverlay.prototype.setFeatures = function (features) {
     this.listenerKeys_.push(listen(features, 'add', this.handleFeatureAdd_, this));
     this.listenerKeys_.push(listen(features, 'remove', this.handleFeatureRemove_, this));
   }
-  this.features_ = features;
 };
 
 /**

--- a/src/map/FeatureOverlay.js
+++ b/src/map/FeatureOverlay.js
@@ -20,7 +20,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import angular from 'angular';
-import {listen} from 'ol/events.js';
+import {listen, unlistenByKey} from 'ol/events.js';
 import {CollectionEvent} from 'ol/Collection.js';
 
 /**
@@ -88,10 +88,16 @@ FeatureOverlay.prototype.clear = function () {
  * @param {import("ol/Collection.js").default<import('ol/Feature.js').default<import("ol/geom/Geometry.js").default>>} features Feature collection.
  */
 FeatureOverlay.prototype.setFeatures = function (features) {
+  // Remove old features collection.
+  this.clear();
+  this.listenerKeys_.forEach(unlistenByKey);
+
+  // Add new feature collection.
   if (features !== null) {
     features.forEach((feature) => {
       this.addFeature(feature);
     });
+    // Listen collection to sync features in the manager.
     this.listenerKeys_.push(listen(features, 'add', this.handleFeatureAdd_, this));
     this.listenerKeys_.push(listen(features, 'remove', this.handleFeatureRemove_, this));
   }

--- a/src/map/FeatureOverlayMgr.js
+++ b/src/map/FeatureOverlayMgr.js
@@ -90,6 +90,16 @@ export function FeatureOverlayMgr() {
 }
 
 /**
+ * @param {number} groupIndex The group groupIndex.
+ * @returns {@boolean} True if the group has no features. False otherwise.
+ */
+FeatureOverlayMgr.prototype.isEmpty = function (groupIndex) {
+  console.assert(groupIndex >= 0);
+  console.assert(groupIndex < this.groups_.length);
+  return isEmpty(this.groups_[groupIndex].features);
+};
+
+/**
  * @param {import('ol/Feature.js').default<import('ol/geom/Geometry.js').default>} feature The feature to add.
  * @param {number} groupIndex The group groupIndex.
  */

--- a/test/spec/services/featureoverlay.spec.js
+++ b/test/spec/services/featureoverlay.spec.js
@@ -148,13 +148,36 @@ describe('ngeo.map.FeatureOverlayMgr', () => {
       });
     });
 
+    it('Check is the collection is empty', () => {
+      // Has 2 features per default: not empty.
+      expect(layer.getSource().getFeatures().length).toBe(2);
+      expect(overlay.isEmpty()).toBeFalsy();
+
+      // Remove features: empty.
+      features.clear();
+      expect(layer.getSource().getFeatures().length).toBe(0);
+      expect(overlay.isEmpty()).toBeTruthy();
+
+      // Add one feature: not empty.
+      features.push(new olFeature());
+      expect(layer.getSource().getFeatures().length).toBe(1);
+      expect(overlay.isEmpty()).toBeFalsy();
+
+      // Set features with no collection: empty.
+      overlay.setFeatures(null);
+      expect(layer.getSource().getFeatures().length).toBe(0);
+      expect(overlay.isEmpty()).toBeTruthy();
+    });
+
     describe('replace the collection by another one', () => {
       it('uses the new collection and ignores the old one', () => {
         const newFeatures = new olCollection();
         overlay.setFeatures(newFeatures);
         expect(layer.getSource().getFeatures().length).toBe(0);
+
         newFeatures.push(new olFeature());
         expect(layer.getSource().getFeatures().length).toBe(1);
+
         features.push(new olFeature());
         expect(layer.getSource().getFeatures().length).toBe(1);
       });


### PR DESCRIPTION
Fix https://github.com/camptocamp/ngeo/pull/6034 and https://jira.camptocamp.com/browse/GSGMF-1348

The isEmpty function was not working as expected.

I remove the features in the overlay. Features exist also in the featureOverlayManager and looks managed by this one. Within our code, the features_ variable in the FeatureOverlay looked absolutely useless.