### PR TITLE
Corrections after release v2.4.2 geo 3403

### DIFF
--- a/contribs/gmf/apps/desktop_alt/Controller.js
+++ b/contribs/gmf/apps/desktop_alt/Controller.js
@@ -194,7 +194,12 @@ const module = angular.module('Appdesktop_alt', [
 
 module.controller('AlternativeDesktopController', Controller);
 
-module.value('gmfLayertreeOptions', {'legendIcon': {'width': '30', 'height': '30'}});
+module.value('gmfLayertreeOptions', {
+  legendIcon: {
+    width: '30',
+    height: '30'
+  }
+});
 
 module.value('gmfPermalinkOptions', /** @type {import('gmf/permalink/Permalink.js').PermalinkOptions} */ ({
   crosshairStyle: [

--- a/contribs/gmf/apps/desktop_alt/index.html.ejs
+++ b/contribs/gmf/apps/desktop_alt/index.html.ejs
@@ -46,7 +46,8 @@
         <div class="gmf-app-content">
           <gmf-layertree
             gmf-layertree-dimensions="mainCtrl.dimensions"
-            gmf-layertree-map="::mainCtrl.map">
+            gmf-layertree-map="::mainCtrl.map"
+            gmf-layertree-isexpanded="::true">
           </gmf-layertree>
         </div>
       </div>


### PR DESCRIPTION
After: GEO-3403

# commit 1
In upgrade of a GeoMapFish project, the line:
```
module.value('gmfLayertreeOptions', {'legendIcon': {'width': '30', 'height': '30'}});
```
becomes (with two slashes at the end):
```
module.value('gmfLayertreeOptions', {'legendIcon': {'width': '30', 'height': '30'\}\});
```
I try to correct that, but I think the real problem is not in ngeo.

# commit 2
Add an example in desktop_alt in https://github.com/camptocamp/ngeo/pull/5971