### PR TITLE
Do not unregister already unregistered file datasources

### DIFF
--- a/src/datasource/FileGroup.js
+++ b/src/datasource/FileGroup.js
@@ -104,6 +104,9 @@ export default class extends ngeoDatasourceGroup {
    */
   removeDataSource(dataSource) {
     super.removeDataSource(dataSource);
+    if (!this.unregister_.hasOwnProperty(dataSource.id)) {
+      return;
+    }
     if (!(dataSource instanceof ngeoDatasourceFile)) {
       throw new Error('Wrong datasource type');
     }


### PR DESCRIPTION
GSGMF-1354

All external datasources are conserved in the background during the session. All of them are tried to be suppressed even if they aready are.