### PR TITLE
Hide not fully working not c2c feature gmf-layertree-isexpanded

### DIFF
--- a/contribs/gmf/apps/desktop_alt/index.html.ejs
+++ b/contribs/gmf/apps/desktop_alt/index.html.ejs
@@ -46,8 +46,7 @@
         <div class="gmf-app-content">
           <gmf-layertree
             gmf-layertree-dimensions="mainCtrl.dimensions"
-            gmf-layertree-map="::mainCtrl.map"
-            gmf-layertree-isexpanded="::true">
+            gmf-layertree-map="::mainCtrl.map">
           </gmf-layertree>
         </div>
       </div>

--- a/contribs/gmf/src/layertree/component.js
+++ b/contribs/gmf/src/layertree/component.js
@@ -161,7 +161,7 @@ function gmfLayertreeTemplate($element, $attrs, gmfLayertreeTemplate) {
  *      (See also printLayers and queryLayers metadata for more granularity). For WMTS Layers.
  *  * `printLayers`: A WMS layer that will be used instead of the WMTS layers in the print.
  *  * `queryLayers`: The WMS layers used as references to query the WMTS layers. For WMTS layers.
- *  * `isExpanded`: Whether the layer group is expanded by default. For layer groups (only).
+ *  * `isExpanded`: [Experimental] Whether the layer group is expanded by default. For layer groups (only).
  *
  * @htmlAttribute {import("ol/Map.js").default} gmf-layertree-map The map.
  * @htmlAttribute {Object<string, string>|undefined} gmf-layertree-dimensions Global dimensions object.


### PR DESCRIPTION
Linked to Linked to https://jira.camptocamp.com/browse/GEO-3403

After discussion https://github.com/camptocamp/ngeo/pull/6082

The feature `gmf-layertree-isexpanded` (not developped by Camptocamp) is not fully working. Groups are expanded by default but:
> => all the group are open but the icon is on close position
open => close and open effect...

I hide it in our demo.
I also add the label "Experimental" in the commentaries (as for OpenLayers not stable things).