### PR TITLE
Do not emit click on drawend queries

### DIFF
--- a/src/query/component.js
+++ b/src/query/component.js
@@ -132,6 +132,7 @@ class QueryController {
       condition: olEventsConditionAlways,
       geometryFunction: olInteractionDrawCreateBox(),
       source: this.vectorSource_,
+      stopClick: true,
       type: 'Circle',
     });
 
@@ -142,6 +143,7 @@ class QueryController {
     this.drawPolygonInteraction_ = new olInteractionDraw({
       condition: olEventsConditionAlways,
       source: this.vectorSource_,
+      stopClick: true,
       type: 'Polygon',
     });
 


### PR DESCRIPTION
Fix GSGMF-1353

Drawend was emitting a "click" event. Releasing the "ctrl" key too kick was enabling the "onClick" listener quickly enough to catch this "click" event. I disable this event emitting. 