### PR TITLE
Fix duplicated STYLES parameter in print requests

### DIFF
--- a/src/print/Service.js
+++ b/src/print/Service.js
@@ -299,6 +299,7 @@ PrintService.prototype.encodeWmsLayer_ = function(arr, layer, url, params) {
   delete customParams['FORMAT'];
   delete customParams['SERVERTYPE'];
   delete customParams['VERSION'];
+  delete customParams['STYLES'];
 
   /** @type {import('ngeo/print/mapfish-print-v3.js').MapFishPrintWmsLayer} */
   const object = {
@@ -311,6 +312,7 @@ PrintService.prototype.encodeWmsLayer_ = function(arr, layer, url, params) {
     opacity: this.getOpacityOrInherited_(layer),
     version: params['VERSION'],
     useNativeAngle: this.printNativeAngle_,
+    styles: 'STYLES' in params ? params['STYLES'].split(',') : [''],
   };
   arr.push(object);
 };

--- a/test/spec/services/print.spec.js
+++ b/test/spec/services/print.spec.js
@@ -126,7 +126,8 @@ describe('ngeo.print.Service', () => {
                 opacity: 1,
                 serverType: undefined,
                 version: undefined,
-                useNativeAngle: true
+                useNativeAngle: true,
+                styles: ['']
               }]
             },
             foo: 'fooval',
@@ -187,7 +188,8 @@ describe('ngeo.print.Service', () => {
                 opacity: 1,
                 serverType: undefined,
                 version: undefined,
-                useNativeAngle: true
+                useNativeAngle: true,
+                styles: ['']
               }]
             },
             foo: 'fooval',


### PR DESCRIPTION
As for now STYLES param is passed in the print requests in the ``customParams`` object. This leads to having a duplicated STYLES parameter in the GetMap requests sent by the print tool.
It seems no problem with Mapserver but causes a "Can't parse XML request." error with ESRI.