### PR TITLE
Prepare (clean) groups to support disclaimer

### DIFF
--- a/contribs/gmf/src/disclaimer/component.js
+++ b/contribs/gmf/src/disclaimer/component.js
@@ -234,6 +234,7 @@ DisclaimerController.prototype.registerLayer_ = function (layer) {
     layer.getLayers().forEach((layer) => {
       this.registerLayer_(layer);
     });
+    this.update_(layer);
   } else {
     if (this.layerVisibility) {
       // Show disclaimer messages for this layer
@@ -333,12 +334,13 @@ DisclaimerController.prototype.closeAll_ = function (layer) {
  */
 DisclaimerController.prototype.showAll_ = function (layer) {
   const disclaimers = layer.get('disclaimers');
-  if (disclaimers) {
-    const layerUid = olUtilGetUid(layer);
-    for (const key in disclaimers) {
-      const uid = `${layerUid}-${key}`;
-      this.showDisclaimerMessage_(uid, disclaimers[key]);
-    }
+  if (!disclaimers) {
+    return;
+  }
+  const layerUid = olUtilGetUid(layer);
+  for (const key in disclaimers) {
+    const uid = `${layerUid}-${key}`;
+    this.showDisclaimerMessage_(uid, disclaimers[key]);
   }
 };
 
@@ -348,24 +350,25 @@ DisclaimerController.prototype.showAll_ = function (layer) {
  */
 DisclaimerController.prototype.update_ = function (layer) {
   const disclaimers = layer.get('disclaimers');
-  if (disclaimers) {
-    if ('all' in disclaimers) {
-      // the disclaimer is for all the layers, WMS or WMTS.
-      console.assert(Object.keys(disclaimers).length === 1);
-      this.showAll_(layer);
-    } else {
-      const layerWMS = /** @type {import("ol/layer/Layer.js").default<import("ol/source/ImageWMS.js").default>} */ (layer);
-      const sourceWMS = layerWMS.getSource();
-      if (sourceWMS.getParams) {
-        const layers = sourceWMS.getParams()['LAYERS'];
-        const layerUid = olUtilGetUid(layer);
-        for (const key in disclaimers) {
-          const uid = `${layerUid}-${key}`;
-          if (layers.indexOf(key) !== -1) {
-            this.showDisclaimerMessage_(uid, disclaimers[key]);
-          } else {
-            this.closeDisclaimerMessage_(uid, disclaimers[key]);
-          }
+  if (!disclaimers) {
+    return;
+  }
+  if ('all' in disclaimers) {
+    // the disclaimer is for all the layers, WMS or WMTS.
+    console.assert(Object.keys(disclaimers).length === 1);
+    this.showAll_(layer);
+  } else {
+    const layerWMS = /** @type {import("ol/layer/Layer.js").default<import("ol/source/ImageWMS.js").default>} */ (layer);
+    const sourceWMS = layerWMS.getSource();
+    if (sourceWMS.getParams) {
+      const layers = sourceWMS.getParams()['LAYERS'];
+      const layerUid = olUtilGetUid(layer);
+      for (const key in disclaimers) {
+        const uid = `${layerUid}-${key}`;
+        if (layers.indexOf(key) !== -1) {
+          this.showDisclaimerMessage_(uid, disclaimers[key]);
+        } else {
+          this.closeDisclaimerMessage_(uid, disclaimers[key]);
         }
       }
     }

--- a/contribs/gmf/src/disclaimer/component.js
+++ b/contribs/gmf/src/disclaimer/component.js
@@ -234,7 +234,6 @@ DisclaimerController.prototype.registerLayer_ = function (layer) {
     layer.getLayers().forEach((layer) => {
       this.registerLayer_(layer);
     });
-    this.update_(layer);
   } else {
     if (this.layerVisibility) {
       // Show disclaimer messages for this layer

--- a/contribs/gmf/src/layertree/SyncLayertreeMap.js
+++ b/contribs/gmf/src/layertree/SyncLayertreeMap.js
@@ -247,7 +247,6 @@ SyncLayertreeMap.prototype.createLayerFromGroup_ = function (treeCtrl, mixed) {
   if (mixed) {
     // Will be one ol.layer per each node.
     layer = this.layerHelper_.createBasicGroup();
-    this.updateLayerReferences_(treeCtrl.node, layer);
   } else {
     // Will be one ol.layer for multiple WMS nodes.
     if (!this.ogcServersObject_) {

--- a/contribs/gmf/src/layertree/SyncLayertreeMap.js
+++ b/contribs/gmf/src/layertree/SyncLayertreeMap.js
@@ -247,6 +247,7 @@ SyncLayertreeMap.prototype.createLayerFromGroup_ = function (treeCtrl, mixed) {
   if (mixed) {
     // Will be one ol.layer per each node.
     layer = this.layerHelper_.createBasicGroup();
+    this.updateLayerReferences_(treeCtrl.node, layer);
   } else {
     // Will be one ol.layer for multiple WMS nodes.
     if (!this.ogcServersObject_) {
@@ -281,7 +282,7 @@ SyncLayertreeMap.prototype.createLayerFromGroup_ = function (treeCtrl, mixed) {
     let hasActiveChildren = false;
     treeCtrl.traverseDepthFirst((ctrl) => {
       // Update layer information and tree state.
-      this.updateLayerReferences_(/** @type {import('gmf/themes.js').GmfLayer} */ (ctrl.node), layer);
+      this.updateLayerReferences_(/** @type {import('gmf/themes.js').GmfBaseNode} */ (ctrl.node), layer);
       if (ctrl.node.metadata.isChecked) {
         ctrl.setState('on', false);
         this.updateLayerState_(/** @type {import("ol/layer/Image.js").default} */ (layer), ctrl);
@@ -425,26 +426,28 @@ SyncLayertreeMap.prototype.createWMTSLayer_ = function (gmfLayerWMTS) {
 
 /**
  * Update properties of a layer with the node of a given leafNode.
- * @param {import('gmf/themes.js').GmfLayer|import('gmf/themes.js').GmfLayerWMS} leafNode a leaf node.
+ * @param {import('gmf/themes.js').GmfBaseNode} node a tree node.
  * @param {import("ol/layer/Base.js").default} layer A layer.
  * @private
  */
-SyncLayertreeMap.prototype.updateLayerReferences_ = function (leafNode, layer) {
-  const id = olUtilGetUid(leafNode);
+SyncLayertreeMap.prototype.updateLayerReferences_ = function (node, layer) {
+  // Set query source
+  const id = olUtilGetUid(node);
   const querySourceIds = layer.get('querySourceIds') || [];
   querySourceIds.push(id);
   layer.set('querySourceIds', querySourceIds);
 
-  const disclaimer = leafNode.metadata.disclaimer;
+  // Set disclaimer
+  const disclaimer = node.metadata.disclaimer;
   if (disclaimer) {
     const disclaimers = layer.get('disclaimers') || {};
 
     // 'all' means that the disclaimer is for all the layer.
     let layers = 'all';
-    if ('layers' in leafNode) {
-      layers = /** @type {import('gmf/themes.js').GmfLayerWMS} */ (leafNode).layers;
+    if ('layers' in node) {
+      layers = /** @type {import('gmf/themes.js').GmfLayerWMS} */ (node).layers;
     }
-    disclaimers[layers] = leafNode.metadata.disclaimer;
+    disclaimers[layers] = disclaimer;
     layer.set('disclaimers', disclaimers);
   }
 };


### PR DESCRIPTION
Was done for GSGMF-1364

I can close it, or merge it as it only:
 - Do some cleaning and correction
 - Prepare groups to have a disclaimer and so, be able to be displayed by the disclaimer system. (The disclaimer directive must be updated to know when the disclaimer must be shown on a group)

But the last commit removes the second point. So **this PR only do some cleaning**.