### PR TITLE
Debug openLinksInNewWindow

### DIFF
--- a/contribs/gmf/src/layertree/component.html
+++ b/contribs/gmf/src/layertree/component.html
@@ -219,7 +219,7 @@
         </a>
       </span>
 
-      <span ng-if="!(::gmfLayertreeCtrl.options.openLinksInNewWindow === true)">
+      <span ng-if="::gmfLayertreeCtrl.options.openLinksInNewWindow !== true">
         <a
           title="{{'More information'|translate}}"
           href="" ng-click="gmfLayertreeCtrl.displayMetadata(layertreeCtrl)">


### PR DESCRIPTION
For GSGMF-1402

Don't solve the problem, but another one with the `openLinksInNewWindow` (the html-angular syntax was not correct)

---

**For Chorme**
@sbrunner  in fact, **we can't login** properly anymore on localhost or gh-pages.

When we login in, we looks logged but **we don't have any cookie created.**

On request response header, on cookie, we have the message:

```
Indicate whether a cookie is intended to be set in a cross-site context by specifying its SameSite 
attributeBecause a cookie's SameSite attribute was not set or is invalid, it defaults to SameSite=Lax, 
which prevents the cookie from being set in a cross-site context. This behavior protects user data from 
accidentally leaking to third parties and cross-site request forgery.Resolve this issue by updating the 
attributes of the cookie:Specify SameSite=None and Secure if the cookie is intended to be set in 
cross-site contexts. Note that only cookies sent over HTTPS may use the Secure attribute.
Specify SameSite=Strict or SameSite=Lax if the cookie should not be set by cross-site requests
```

https://success.outsystems.com/Support/Enterprise_Customers/Maintenance_and_Operations/Upcoming_changes_in_cookie_handling_in_Google_Chrome

I guess chrome was updated and we need to set SameSite to None instead of Lax now.

Can you confirm ? (And do the change, I'm not very available today)