### PR TITLE
Fix Firefox ctrl key

### DIFF
--- a/contribs/gmf/apps/desktop_alt/Controller.js
+++ b/contribs/gmf/apps/desktop_alt/Controller.js
@@ -37,6 +37,7 @@ import appBase from '../appmodule.js';
 import gmfImportModule from 'gmf/import/module.js';
 import gmfFloorModule from 'gmf/floor/module.js';
 import ngeoGooglestreetviewModule from 'ngeo/googlestreetview/module.js';
+import {isEventUsinCtrlKey} from 'ngeo/utils.js';
 import ngeoRoutingModule from 'ngeo/routing/module.js';
 import EPSG2056 from '@geoblocks/proj/src/EPSG_2056.js';
 import EPSG21781 from '@geoblocks/proj/src/EPSG_21781.js';
@@ -177,7 +178,7 @@ class Controller extends AbstractDesktopController {
    * @param {JQueryEventObject} event keydown event.
    */
   onKeydown(event) {
-    if (event && event.ctrlKey && event.key === 'p') {
+    if (event && isEventUsinCtrlKey(event) && event.key === 'p') {
       this.printPanelActive = true;
       event.preventDefault();
     }

--- a/src/grid/component.js
+++ b/src/grid/component.js
@@ -20,7 +20,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import angular from 'angular';
-import {isEventUsinCtrlKey} from 'ngeo/utils.js';
+import {isPlatformModifierKeyOnly, isShiftKeyOnly} from 'ngeo/utils.js';
 import ngeoMiscFilters from 'ngeo/misc/filters.js';
 import {getRowUid} from 'ngeo/grid/Config.js';
 
@@ -296,26 +296,6 @@ GridController.prototype.preventTextSelection = function (event) {
     event.preventDefault();
   }
 };
-
-/**
- * Same as `ol.events.condition.platformModifierKeyOnly` but for JQueryEventObject.
- * @param {JQueryEventObject} event Event.
- * @return {boolean} True if only the platform modifier key (ctrl) is pressed.
- * @private
- */
-function isPlatformModifierKeyOnly(event) {
-  return !event.altKey && isEventUsinCtrlKey(event) && !event.shiftKey;
-}
-
-/**
- * Same as `ol.events.condition.shiftKeyOnly` but for JQueryEventObject.
- * @param {JQueryEventObject} event Event.
- * @return {boolean} True if only the shift key is pressed.
- * @private
- */
-function isShiftKeyOnly(event) {
-  return !event.altKey && !isEventUsinCtrlKey(event) && event.shiftKey;
-}
 
 module.controller('ngeoGridController', GridController);
 

--- a/src/grid/component.js
+++ b/src/grid/component.js
@@ -20,9 +20,9 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import angular from 'angular';
+import {isEventUsinCtrlKey} from 'ngeo/utils.js';
 import ngeoMiscFilters from 'ngeo/misc/filters.js';
 import {getRowUid} from 'ngeo/grid/Config.js';
-import {MAC} from 'ol/has.js';
 
 import 'floatthead';
 import 'angular-float-thead';
@@ -298,23 +298,23 @@ GridController.prototype.preventTextSelection = function (event) {
 };
 
 /**
- * Same as `ol.events.condition.platformModifierKeyOnly`.
+ * Same as `ol.events.condition.platformModifierKeyOnly` but for JQueryEventObject.
  * @param {JQueryEventObject} event Event.
- * @return {boolean} True if only the platform modifier key is pressed.
+ * @return {boolean} True if only the platform modifier key (ctrl) is pressed.
  * @private
  */
 function isPlatformModifierKeyOnly(event) {
-  return !event.altKey && (MAC ? event.metaKey : event.ctrlKey) && !event.shiftKey;
+  return !event.altKey && isEventUsinCtrlKey(event) && !event.shiftKey;
 }
 
 /**
- * Same as `ol.events.condition.shiftKeyOnly`.
+ * Same as `ol.events.condition.shiftKeyOnly` but for JQueryEventObject.
  * @param {JQueryEventObject} event Event.
  * @return {boolean} True if only the shift key is pressed.
  * @private
  */
 function isShiftKeyOnly(event) {
-  return !event.altKey && !(event.metaKey || event.ctrlKey) && event.shiftKey;
+  return !event.altKey && !isEventUsinCtrlKey(event) && event.shiftKey;
 }
 
 module.controller('ngeoGridController', GridController);

--- a/src/query/ModeSelector.js
+++ b/src/query/ModeSelector.js
@@ -22,9 +22,9 @@
 import angular from 'angular';
 import ngeoQueryAction from 'ngeo/query/Action.js';
 import ngeoQueryMode from 'ngeo/query/Mode.js';
+import {isEventUsinCtrlKey} from 'ngeo/utils.js'
 
 import {listen as olEventsListen} from 'ol/events.js';
-import {MAC} from 'ol/has.js';
 
 /**
  * @hidden
@@ -230,7 +230,7 @@ export class QueryModeSelector {
         this.activeActionKey_ = key;
         this.rootScope_.$apply();
       }
-    } else if ((MAC ? evt.metaKey : evt.ctrlKey) && !this.previousMode_) {
+    } else if (isEventUsinCtrlKey(evt) && !this.previousMode_) {
       // The 'ctrl' (or 'meta' key) on mac was pressed
       this.previousMode_ = this.mode;
       this.mode = ngeoQueryMode.DRAW_BOX;
@@ -249,9 +249,9 @@ export class QueryModeSelector {
 
     let updateScope = false;
 
-    // On any 'keyup', if no 'ctrl' (or 'meta' on mac) is pressed and
+    // On any 'keyup', if it comes from a 'ctrl' (or 'meta' on mac) release and
     // there is a previous mode set, then set it as new active mode.
-    if (!(evt.metaKey || evt.ctrlKey) && this.previousMode_) {
+    if (isEventUsinCtrlKey(evt) && this.previousMode_) {
       if (this.pending) {
         this.wasPending_ = true;
       } else {

--- a/src/query/ModeSelector.js
+++ b/src/query/ModeSelector.js
@@ -22,7 +22,7 @@
 import angular from 'angular';
 import ngeoQueryAction from 'ngeo/query/Action.js';
 import ngeoQueryMode from 'ngeo/query/Mode.js';
-import {isEventUsinCtrlKey} from 'ngeo/utils.js'
+import {isEventUsinCtrlKey} from 'ngeo/utils.js';
 
 import {listen as olEventsListen} from 'ol/events.js';
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -38,8 +38,8 @@ export function isEventUsinCtrlKey(evt) {
   if (!evt) {
     return false;
   }
-  // Check also if the key equals 'Control' for Firefox as sometimes it doesn't assign the ctrlKey.
-  return evt.key === 'Control' || (MAC ? evt.metaKey : evt.ctrlKey);
+  // Do not use evt.ctrlKey (or evt.metaKey on Mac) Because Firefox sometimes doesn't assign the ctrlKey.
+  return MAC ? evt.key === 'Meta' : evt.key === 'Control';
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,7 +30,7 @@ import {getTopLeft, getTopRight, getBottomLeft, getBottomRight} from 'ol/extent.
 import {MAC} from 'ol/has.js';
 
 /**
- * Return wheter the passed event has the 'ctrl' key (or 'meta' key on Mac) pressed or not.
+ * Return whether the passed event has the 'ctrl' key (or 'meta' key on Mac) pressed or not.
  * @param {Event|import("ol/events/Event.js").default} evt Event.
  * @return {boolean}
  */
@@ -39,9 +39,27 @@ export function isEventUsinCtrlKey(evt) {
     return false;
   }
   // Check also if the key equals 'Control' for Firefox as sometimes it doesn't assign the ctrlKey.
-  const res = evt.key === 'Control' || (MAC ? evt.metaKey : evt.ctrlKey);
-  console.log(res);
-  return res;
+  return evt.key === 'Control' || (MAC ? evt.metaKey : evt.ctrlKey);
+}
+
+/**
+ * Same as `ol.events.condition.platformModifierKeyOnly` but for JQueryEventObject.
+ * @param {JQueryEventObject} event Event.
+ * @return {boolean} True if only the platform modifier key (ctrl) is pressed.
+ * @private
+ */
+export function isPlatformModifierKeyOnly(evt) {
+  return !evt.altKey && isEventUsinCtrlKey(evt) && !evt.shiftKey;
+}
+
+/**
+ * Same as `ol.events.condition.shiftKeyOnly` but for JQueryEventObject.
+ * @param {JQueryEventObject} event Event.
+ * @return {boolean} True if only the shift key is pressed.
+ * @private
+ */
+export function isShiftKeyOnly(evt) {
+  return !evt.altKey && !isEventUsinCtrlKey(evt) && evt.shiftKey;
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,6 +27,22 @@ import olGeomMultiPolygon from 'ol/geom/MultiPolygon.js';
 import olGeomPoint from 'ol/geom/Point.js';
 import olGeomPolygon from 'ol/geom/Polygon.js';
 import {getTopLeft, getTopRight, getBottomLeft, getBottomRight} from 'ol/extent.js';
+import {MAC} from 'ol/has.js';
+
+/**
+ * Return wheter the passed event has the 'ctrl' key (or 'meta' key on Mac) pressed or not.
+ * @param {Event|import("ol/events/Event.js").default} evt Event.
+ * @return {boolean}
+ */
+export function isEventUsinCtrlKey(evt) {
+  if (!evt) {
+    return false;
+  }
+  // Check also if the key equals 'Control' for Firefox as sometimes it doesn't assign the ctrlKey.
+  const res = evt.key === 'Control' || (MAC ? evt.metaKey : evt.ctrlKey);
+  console.log(res);
+  return res;
+}
 
 /**
  * Return whether the primary pointing device is coarse or 'false' if unsupported (Internet Explorer).


### PR DESCRIPTION
Fix point 3 of GSGMF-1405

I'll also provide a fix (at least for discussions) in ol. => https://github.com/openlayers/openlayers/pull/11693

`evt.ctrlKey` sometimes don't work on firefox (You can test on: https://codepen.io/ger-benjamin/pen/ZEOeyRb). I switch to use the W3C Modifier Keys Attributes value to detect ctrl key