### PR TITLE
Enable to change the xy order on getFeature GML format

### DIFF
--- a/contribs/gmf/src/datasource/Manager.js
+++ b/contribs/gmf/src/datasource/Manager.js
@@ -565,6 +565,7 @@ export class DatasourceManager {
     const snappingTolerance = meta.snappingConfig ? meta.snappingConfig.tolerance : undefined;
     const snappingToEdges = meta.snappingConfig ? meta.snappingConfig.edge : undefined;
     const snappingToVertice = meta.snappingConfig ? meta.snappingConfig.vertex : undefined;
+    const snappingInvertXY = meta.snappingConfig ? meta.snappingConfig.invertXY : undefined;
 
     // (7) Dimensions
     const dimensions = this.dimensions_;
@@ -615,6 +616,7 @@ export class DatasourceManager {
       snappingTolerance,
       snappingToEdges,
       snappingToVertice,
+      snappingInvertXY,
       timeAttributeName,
       timeLowerValue,
       timeProperty,

--- a/contribs/gmf/src/editing/Snapping.js
+++ b/contribs/gmf/src/editing/Snapping.js
@@ -553,7 +553,18 @@ EditingSnappingService.prototype.loadItemFeatures_ = function(item) {
 
       // (3) Read features from request response and add them to the item
       const readFeatures = new olFormatWFS().readFeatures(response.data);
+      const me = this;
       if (readFeatures) {
+        if (item.snappingConfig.invertXY) {
+          readFeatures.forEach(function(f) {
+            const geom = f.getGeometry();
+            if (geom) {
+              const coordinates = geom.getCoordinates();
+              me.switchXY_(coordinates);
+              f.getGeometry().setCoordinates(coordinates);
+            }
+          });
+        }
         item.features.extend(readFeatures);
         this.refreshSnappingSource_();
       }
@@ -561,6 +572,17 @@ EditingSnappingService.prototype.loadItemFeatures_ = function(item) {
 
 };
 
+
+/**
+ * Change the order of xy. This is to deal with the GML output format
+ * from qgisServer that returns inverted coordinates
+ * https://gis.stackexchange.com/questions/296239/gml-axis-order-problem-in-qgis
+ * Loops over all coordinates and only swap X and Y
+ * @private
+ */
+EditingSnappingService.prototype.switchXY_ = function(c) {
+  return Array.isArray(c[0]) ? c.forEach(this.switchXY_) : [c[0], c[1]] = [c[1], c[0]];
+};
 
 /**
  * Called when the map view changes. Load all active cache items after a small

--- a/contribs/gmf/src/editing/Snapping.js
+++ b/contribs/gmf/src/editing/Snapping.js
@@ -553,14 +553,13 @@ EditingSnappingService.prototype.loadItemFeatures_ = function(item) {
 
       // (3) Read features from request response and add them to the item
       const readFeatures = new olFormatWFS().readFeatures(response.data);
-      const me = this;
       if (readFeatures) {
         if (item.snappingConfig.invertXY) {
-          readFeatures.forEach(function(f) {
+          readFeatures.forEach(f => {
             const geom = f.getGeometry();
             if (geom) {
               const coordinates = geom.getCoordinates();
-              me.switchXY_(coordinates);
+              this.switchXY_(coordinates);
               f.getGeometry().setCoordinates(coordinates);
             }
           });
@@ -578,10 +577,13 @@ EditingSnappingService.prototype.loadItemFeatures_ = function(item) {
  * from qgisServer that returns inverted coordinates
  * https://gis.stackexchange.com/questions/296239/gml-axis-order-problem-in-qgis
  * Loops over all coordinates and only swap X and Y
+ * @property {coordinates} OpenLayers coordinates
+ * @return coordinates OpenLayers coordinates
  * @private
  */
-EditingSnappingService.prototype.switchXY_ = function(c) {
-  return Array.isArray(c[0]) ? c.forEach(this.switchXY_) : [c[0], c[1]] = [c[1], c[0]];
+EditingSnappingService.prototype.switchXY_ = function(coordinates) {
+  return Array.isArray(coordinates[0]) ? coordinates.forEach(this.switchXY_) :
+    [coordinates[0], coordinates[1]] = [coordinates[1], coordinates[0]];
 };
 
 /**

--- a/contribs/gmf/src/themes.js
+++ b/contribs/gmf/src/themes.js
@@ -238,6 +238,7 @@
  * @property {number} [tolerance=10] The tolerance in pixels the snapping should occur for the node layer.
  * @property {boolean} [vertex=true] Determines whethers the vertices of features from the node layer can be
  * snapped or not.
+ * @property {boolean} [invertXY=false] Switches coordinates while reading a GML getFeature request
  */
 
 

--- a/src/datasource/OGC.js
+++ b/src/datasource/OGC.js
@@ -113,6 +113,7 @@ export const WMSInfoFormat = {
  * @property {boolean} [snappingToVertice] Determines whether external features can be snapped to the
  *    vertice of features from this data source or not. Defaults to `true`. Requires `snappable` to be set.
  * @property {number} [snappingTolerance=10] The tolerance in pixels the snapping should occur.
+ * @property {boolean} [snappingInvertXY=false] Whether to switch X and Y coordinates
  * @property {string} [timeAttributeName]  The name of the time attribute.
  * @property {number} [timeLowerValue] The time lower value, which can be combined with the time upper value
  *    to determine a range.
@@ -362,6 +363,14 @@ class OGC extends ngeoDatasourceDataSource {
      * @private
      */
     this.snappingTolerance_ = options.snappingTolerance !== undefined ? options.snappingTolerance : 10;
+
+    /**
+     * Determines whether to switch X and Y coordinates upon reading a GML formatted
+     * getFeature request
+     * @type {boolean}
+     * @private
+     */
+    this.snappingInvertXY_ = options.snappingInvertXY === true;
 
     /**
      * The name of the time attribute.
@@ -668,6 +677,13 @@ class OGC extends ngeoDatasourceDataSource {
    */
   get snappingTolerance() {
     return this.snappingTolerance_;
+  }
+
+  /**
+   * @return {boolean} InvertXY
+   */
+  get snappingInvertXY() {
+    return this.snappingInvertXY_;
   }
 
   /**


### PR DESCRIPTION
QGIS server does not completly support GML. When doing a getFeatureRequest asking for GML. 
QGIS returns coordinates in the wrong order.
The GMF Snapping tool uses the GML format

see
- http://lists.osgeo.org/pipermail/standards/2016-October/000994.html
- https://tools.ietf.org/html/rfc5165
- http://www.ogcnetwork.net/axisorder


This PR enables to invert X and Y in the ol coordinates array. When adding in the snapping config 
`invertXY : true`

I am not sure what is the way to update the documentation....
This affects ftth_tirol project that is using 31254 