### PR TITLE
Fix theme selectior css

### DIFF
--- a/contribs/gmf/src/controllers/desktop.scss
+++ b/contribs/gmf/src/controllers/desktop.scss
@@ -300,7 +300,7 @@ gmf-search {
 
 gmf-themeselector {
   width: $half-app-margin * 2 + $theme-selector-columns * $theme-selector-column-width;
-  width: calc(#{$half-app-margin} * 2 + var(--theme-selector-columns) * var(--theme-selector-column-width));
+  width: calc(#{$half-app-margin} * 2 + var(--theme-selector-columns, #{$theme-selector-columns}) * var(--theme-selector-column-width, #{$theme-selector-column-width}));
   max-height: $theme-selector-height;
   overflow: hidden;
   overflow-y: auto;
@@ -316,7 +316,7 @@ gmf-backgroundlayerselector {
 .gmf-theme-selector li {
   float: left;
   width: calc((100% - #{$theme-selector-columns} * 2 * #{$half-app-margin}) / #{$theme-selector-columns});
-  width: calc((100% - var(--theme-selector-columns) * 2 * #{$half-app-margin}) / var(--theme-selector-columns));
+  width: calc((100% - var(--theme-selector-columns, #{$theme-selector-columns}) * 2 * #{$half-app-margin}) / var(--theme-selector-columns, #{$theme-selector-columns}));
 }
 .gmf-backgroundlayerselector {
   margin-bottom: 0;


### PR DESCRIPTION
May be a good practice to always put the sass variable as default value in var() instead of duplicting the rule.
Seems that var parameter declaration-value is there exactly for that.