### PR TITLE
Click tolerence per layer

### DIFF
--- a/contribs/gmf/src/datasource/Manager.js
+++ b/contribs/gmf/src/datasource/Manager.js
@@ -641,6 +641,7 @@ export class DatasourceManager {
     const copyable = meta.copyable;
     const identifierAttribute = meta.identifierAttributeField;
     const name = gmfLayer.name;
+    const queryIconPosition = meta.queryIconPosition;
     const timeAttributeName = meta.timeAttribute;
     const visible = meta.isChecked === true;
     const ogcAttributes = ogcServer ? ogcServer.attributes : null;
@@ -656,6 +657,7 @@ export class DatasourceManager {
       name,
       ogcType,
       ogcAttributes,
+      queryIconPosition,
       snappable,
       timeAttributeName,
       visible,
@@ -673,17 +675,8 @@ export class DatasourceManager {
     if (ogcImageType) {
       options.ogcImageType = ogcImageType;
     }
-    if (wmsLayers) {
-      options.wmsLayers = wmsLayers;
-    }
-    if (wfsLayers) {
-      options.wfsLayers = wfsLayers;
-    }
     if (ogcServerType) {
       options.ogcServerType = ogcServerType;
-    }
-    if (wfsFeatureNS) {
-      options.wfsFeatureNS = wfsFeatureNS;
     }
     if (snappingTolerance) {
       options.snappingTolerance = snappingTolerance;
@@ -703,11 +696,20 @@ export class DatasourceManager {
     if (timeUpperValue) {
       options.timeUpperValue = timeUpperValue;
     }
+    if (wfsFeatureNS) {
+      options.wfsFeatureNS = wfsFeatureNS;
+    }
+    if (wfsLayers) {
+      options.wfsLayers = wfsLayers;
+    }
     if (wfsUrl) {
       options.wfsUrl = wfsUrl;
     }
     if (wmsIsSingleTile) {
       options.wmsIsSingleTile = wmsIsSingleTile;
+    }
+    if (wmsLayers) {
+      options.wmsLayers = wmsLayers;
     }
     if (wmsUrl) {
       options.wmsUrl = wmsUrl;

--- a/contribs/gmf/src/datasource/OGC.js
+++ b/contribs/gmf/src/datasource/OGC.js
@@ -55,6 +55,9 @@ import ngeoDatasourceOGC from 'ngeo/datasource/OGC.js';
  * @property {string} [ogcType] The type data source. Can be: 'WMS' or 'WMTS'.
  * @property {?Object<string, Object<string, import('gmf/themes.js').GmfOgcServerAttribute>>} [ogcAttributes]
  *    The attributes of the OGC server.
+ * @property {number[]} [queryIconPosition] values to define the shape (bbox) to use to query
+ *    the layer. The values are used like a padding in css with 1, 2, 3 or 4 comma separated
+ *    values: all / top-bottom, left-right / top, right-left, bottom / top, right, bottom, left.
  * @property {boolean} [snappable] Whether the geometry from this data source can be used to snap the geometry
  *    of features from other data sources that are being edited. Defaults to `false`.
  * @property {boolean} [snappingToEdges] Determines whether external features can be snapped to the edges of

--- a/contribs/gmf/src/themes.js
+++ b/contribs/gmf/src/themes.js
@@ -234,6 +234,9 @@
  * @property {number} [minQueryResolution] The min resolution where the layer is queryable. For WMTS layers.
  * @property {number} [minResolution] The min resolution where the layer is visible. For WMS layers.
  *      On WMTS layers it will have an effect on the node in the layertree but not on the layer directly.
+ * @property {number[]} [queryIconPosition] values to define the shape (bbox) to use to query
+ *      the layer. The values are used like a padding in css with 1, 2, 3 or 4 comma separated
+ *      values: all / top-bottom, left-right / top, right-left, bottom / top, right, bottom, left.
  * @property {string} [ogcServer] The corresponding OGC server for a WMTS layer. For WMTS layers.
  * @property {number} [opacity=1.0] Layer opacity. 1.0 means fully visible, 0 means invisible, For WMS and
  *      WMTS layers.

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "moment": "2.29.1",
     "node-sass": "4.14.1",
     "node-sass-importer": "1.0.0",
-    "ol": "6.4.3",
+    "ol": "6.4.4-dev.1606258895715",
     "ol-cesium": "2.11.3",
     "ol-layerswitcher": "3.8.1",
     "parse-absolute-css-unit": "1.0.2",

--- a/src/datasource/OGC.js
+++ b/src/datasource/OGC.js
@@ -122,6 +122,9 @@ export const WMSInfoFormat = {
  * @property {string} [ogcType] The type data source. Can be: 'WMS' or 'WMTS'.
  * @property {?Object<string, Object<string, import('gmf/themes.js').GmfOgcServerAttribute>>} [ogcAttributes]
  *    The attributes of the OGC server.
+ * @property {number[]} [queryIconPosition] values to define the shape (bbox) to use to query
+ *    the layer. The values are used like a padding in css with 1, 2, 3 or 4 comma separated
+ *    values: all / top-bottom, left-right / top, right-left, bottom / top, right, bottom, left.
  * @property {boolean} [snappable] Whether the geometry from this data source can be used to snap the geometry
  *    of features from other data sources that are being edited. Defaults to `false`.
  * @property {boolean} [snappingToEdges] Determines whether external features can be snapped to the edges of
@@ -338,6 +341,14 @@ export class OGC extends ngeoDatasourceDataSource {
      * @private
      */
     this.ogcAttributes_ = options.ogcAttributes;
+
+    /**
+     * Values to define the shape (bbox) to use to query the layer. The values work like a css
+     * padding.
+     * @type {number[]}
+     * @private
+     */
+    this.queryIconPosition_ = options.queryIconPosition;
 
     /**
      * Whether the geometry from this data source can be used to snap the
@@ -676,6 +687,13 @@ export class OGC extends ngeoDatasourceDataSource {
    */
   get ogcType() {
     return this.ogcType_;
+  }
+
+  /**
+   * @return {number[]} The queryIconPosition
+   */
+  get queryIconPosition() {
+    return this.queryIconPosition_;
   }
 
   /**

--- a/src/filter/RuleHelper.js
+++ b/src/filter/RuleHelper.js
@@ -468,9 +468,10 @@ export class RuleHelper {
    */
   createFilterString(options) {
     let filterString = null;
+    const defaultWFSVersion = '1.1.0';
     const filter = this.createFilter(options);
     if (filter) {
-      const filterNode = writeFilter(filter);
+      const filterNode = writeFilter(filter, defaultWFSVersion);
       const xmlSerializer = new XMLSerializer();
       filterString = xmlSerializer.serializeToString(filterNode);
     }

--- a/src/options.js
+++ b/src/options.js
@@ -179,8 +179,8 @@ export function buildStyle(styleDescriptor) {
  *    Use this if you have more than one source bound to a layer.
  * @property {number} [tolerance=3] When issuing an identify feature request at a click position, either a
  *    WMS GetFeatureInfo or a WFS GetFeature request will be used. For GetFeature requests a bbox is built
- *    around the position. This `tolerance` in pixel determines the size of the bbox.
- * @property {number} [toleranceTouch=10] The tolerance on touch devices.
+ *    around the position. This `tolerance` in pixel determines the minimal size of the bbox.
+ * @property {number} [toleranceTouch=10] Same as `tolerance` but for touch devices.
  * @property {string} [featureNS='http://mapserver.gis.umn.edu/mapserver'] The feature namespace for WFS
  *    GetFeature requests.
  * @property {string} [featurePrefix='feature'] The feature prefix for WFS GetFeature requests.

--- a/src/query/MapQuerent.js
+++ b/src/query/MapQuerent.js
@@ -119,12 +119,12 @@ export class MapQuerent {
      * @type {number}
      * @private
      */
-    this.tolerancePx_;
+    this.tolerance_;
 
     if (hasCoarsePointingDevice()) {
-      this.tolerancePx_ = options.toleranceTouch !== undefined ? options.toleranceTouch : 10;
+      this.tolerance_ = options.toleranceTouch !== undefined ? options.toleranceTouch : 10;
     } else {
-      this.tolerancePx_ = options.tolerance !== undefined ? options.tolerance : 3;
+      this.tolerance_ = options.tolerance !== undefined ? options.tolerance : 3;
     }
 
     /**
@@ -173,7 +173,7 @@ export class MapQuerent {
     Object.assign(options, {
       queryableDataSources: queryableDataSources,
       limit: limit,
-      tolerancePx: this.tolerancePx_,
+      tolerance: this.tolerance_,
       wfsCount: this.queryCountFirst_,
       bboxAsGETParam: this.bboxAsGETParam_,
     });

--- a/src/query/Querent.js
+++ b/src/query/Querent.js
@@ -658,7 +658,7 @@ export class Querent {
         // as well.
         if (options.geometry) {
           const spatialFilter = olFormatFilter.intersects(
-            dataSource.geometryName(),
+            geometryName,
             options.geometry,
             srsName
           );

--- a/src/query/Querent.js
+++ b/src/query/Querent.js
@@ -67,8 +67,6 @@ import olSourceImageWMS from 'ol/source/ImageWMS.js';
  *    - `replace`: newly queried features are used as result
  *    - `add`:     newly queried features are added to the existing ones
  *    - `remove`:  newly queried features are removed from the existing ones
- * @property {import("ol/extent.js").Extent} [bbox] The bbox to issue the requests with,
- *    which will end up with a WFS request.
  * @property {import("ol/coordinate.js").Coordinate} [coordinate] The coordinate to issue the requests with,
  *    which can end up with either WMS or WFS requests.
  * @property {Array<import('ngeo/datasource/DataSource.js').default>} [dataSources] list of data sources to

--- a/src/query/Querent.js
+++ b/src/query/Querent.js
@@ -672,7 +672,7 @@ export class Querent {
           let queryIconPosition;
           if (dataSource.queryIconPosition) {
             hasAtLeastOneQueryIconPosition = true;
-            queryIconPosition = this.extendBboxWithQueryIconPosition_(
+            queryIconPosition = this.bufferBboxWithQueryIconPosition_(
               dataSource.queryIconPosition,
               resolution,
               olExtent.createOrUpdateFromCoordinate(coordinate)
@@ -799,19 +799,18 @@ export class Querent {
   }
 
   /**
-   * Extend the given bbox with the queryIconPosition values.
+   * Add a buffer (based on the queryIconPosition values) around the given bbox.
    * @param {!number[]} queryIconPosition The values in px to buffer the bbox.
    * @param {number} resolution The map view resolution to define the px size correctly.
-   * @param {!import("ol/extent.js").Extent} bbox The bbox to extend.
-   * @return {!import("ol/extent.js").Extent} The extended bbox or null if the queryIconPosition param
+   * @param {!import("ol/extent.js").Extent} bbox The bbox to buffer.
+   * @return {!import("ol/extent.js").Extent} The new bbox or null if the queryIconPosition param
    * is not valid.
    * @private
    */
-  extendBboxWithQueryIconPosition_(queryIconPosition, resolution, bbox) {
+  bufferBboxWithQueryIconPosition_(queryIconPosition, resolution, bbox) {
     const buffers = queryIconPosition.map((value) => value * resolution);
     const length = buffers.length;
     if (!length || length > 4) {
-      // Bad format.
       return null;
     }
     if (length === 1) {
@@ -823,9 +822,11 @@ export class Querent {
       bbox[0] - buffers[0], // bbox[0] is top, always set with buffer[0];
       // bbox[1] is right, always set with buffer[1] for length > 1;
       bbox[1] - buffers[1],
-      // bbox[2] is bottom. Length === 2 is top-bottom and right-left. Length > 2 defines the bottom value.
+      // bbox[2] is bottom. For length === 2 (top-bottom, right-left), use buffer[0] (top).
+      // For length === 3 (top, right-left, bottom) or length === 4, use buffer[2] (specific bottom).
       bbox[2] + (length === 2 ? buffers[0] : buffers[2]),
-      // bbox[3] is left. Length === 4 is each side defined and the only manner to define the left value.
+      // bbox[3] is left. For length === 4 (top, right, bottom, left), use buffer[3] (specific left).
+      // For length === 2 (top-bottom, right-left) or length === 3 (top, right-left, bottom), use buffer[1].
       bbox[3] + (length === 4 ? buffers[3] : buffers[1]),
     ];
   }

--- a/test/spec/all.js
+++ b/test/spec/all.js
@@ -43,6 +43,7 @@ import './services/location.spec.js';
 import './services/printutils.spec.js';
 import './services/autoprojection.spec.js';
 import './services/debounce.spec.js';
+import './services/querent.spec.js';
 import './ol-ext/format/featurehash.spec.js';
 import './directives/filereader.spec.js';
 import './directives/scaleselector.spec.js';

--- a/test/spec/services/querent.spec.js
+++ b/test/spec/services/querent.spec.js
@@ -32,29 +32,29 @@ describe('ngeo.Querent', () => {
     });
   });
 
-  it('Extends bbox with queryIconPosition', () => {
+  it('Buffers bbox with queryIconPosition', () => {
     const resolution = 10;
     const bbox = [50, 51, 52, 53];
 
-    let result = ngeoQuerent.extendBboxWithQueryIconPosition_([], resolution, bbox);
+    let result = ngeoQuerent.bufferBboxWithQueryIconPosition_([], resolution, bbox);
     expect(result).toBe(null);
 
-    result = ngeoQuerent.extendBboxWithQueryIconPosition_([1], resolution, bbox);
+    result = ngeoQuerent.bufferBboxWithQueryIconPosition_([1], resolution, bbox);
     expect(result).toEqual([40, 41, 62, 63]);
 
-    result = ngeoQuerent.extendBboxWithQueryIconPosition_([1, 2], resolution, bbox);
+    result = ngeoQuerent.bufferBboxWithQueryIconPosition_([1, 2], resolution, bbox);
     expect(result).toEqual([40, 31, 62, 73]);
 
-    result = ngeoQuerent.extendBboxWithQueryIconPosition_([1, 2, 3], resolution, bbox);
+    result = ngeoQuerent.bufferBboxWithQueryIconPosition_([1, 2, 3], resolution, bbox);
     expect(result).toEqual([40, 31, 82, 73]);
 
-    result = ngeoQuerent.extendBboxWithQueryIconPosition_([1, 2, 3, 4], resolution, bbox);
+    result = ngeoQuerent.bufferBboxWithQueryIconPosition_([1, 2, 3, 4], resolution, bbox);
     expect(result).toEqual([40, 31, 82, 93]);
 
-    result = ngeoQuerent.extendBboxWithQueryIconPosition_([0, 0, 0, 4], resolution, bbox);
+    result = ngeoQuerent.bufferBboxWithQueryIconPosition_([0, 0, 0, 4], resolution, bbox);
     expect(result).toEqual([50, 51, 52, 93]);
 
-    result = ngeoQuerent.extendBboxWithQueryIconPosition_([1, 2, 3, 4, 5], resolution, bbox);
+    result = ngeoQuerent.bufferBboxWithQueryIconPosition_([1, 2, 3, 4, 5], resolution, bbox);
     expect(result).toBe(null);
   });
 });

--- a/test/spec/services/querent.spec.js
+++ b/test/spec/services/querent.spec.js
@@ -1,0 +1,60 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Camptocamp SA
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// @ts-nocheck
+import angular from 'angular';
+
+describe('ngeo.Querent', () => {
+  /** @type {import('ngeo/query/Querent').Querent} */
+  let ngeoQuerent;
+
+  beforeEach(() => {
+    angular.mock.inject((_ngeoQuerent_) => {
+      ngeoQuerent = _ngeoQuerent_;
+    });
+  });
+
+  it('Extends bbox with queryIconPosition', () => {
+    const resolution = 10;
+    const bbox = [50, 51, 52, 53];
+
+    let result = ngeoQuerent.extendBboxWithQueryIconPosition_([], resolution, bbox);
+    expect(result).toBe(null);
+
+    result = ngeoQuerent.extendBboxWithQueryIconPosition_([1], resolution, bbox);
+    expect(result).toEqual([40, 41, 62, 63]);
+
+    result = ngeoQuerent.extendBboxWithQueryIconPosition_([1, 2], resolution, bbox);
+    expect(result).toEqual([40, 31, 62, 73]);
+
+    result = ngeoQuerent.extendBboxWithQueryIconPosition_([1, 2, 3], resolution, bbox);
+    expect(result).toEqual([40, 31, 82, 73]);
+
+    result = ngeoQuerent.extendBboxWithQueryIconPosition_([1, 2, 3, 4], resolution, bbox);
+    expect(result).toEqual([40, 31, 82, 93]);
+
+    result = ngeoQuerent.extendBboxWithQueryIconPosition_([0, 0, 0, 4], resolution, bbox);
+    expect(result).toEqual([50, 51, 52, 93]);
+
+    result = ngeoQuerent.extendBboxWithQueryIconPosition_([1, 2, 3, 4, 5], resolution, bbox);
+    expect(result).toBe(null);
+  });
+});

--- a/test/spec/services/querent.spec.js
+++ b/test/spec/services/querent.spec.js
@@ -32,29 +32,29 @@ describe('ngeo.Querent', () => {
     });
   });
 
-  it('Buffers bbox with queryIconPosition', () => {
+  it('Buffers coordinates with queryIconPosition', () => {
     const resolution = 10;
-    const bbox = [50, 51, 52, 53];
+    const coordinate = [50, 51];
 
-    let result = ngeoQuerent.bufferBboxWithQueryIconPosition_([], resolution, bbox);
+    let result = ngeoQuerent.makeBboxWithQueryIconPosition_([], resolution, coordinate);
     expect(result).toBe(null);
 
-    result = ngeoQuerent.bufferBboxWithQueryIconPosition_([1], resolution, bbox);
-    expect(result).toEqual([40, 41, 62, 63]);
+    result = ngeoQuerent.makeBboxWithQueryIconPosition_([1], resolution, coordinate);
+    expect(result).toEqual([40, 41, 60, 61]);
 
-    result = ngeoQuerent.bufferBboxWithQueryIconPosition_([1, 2], resolution, bbox);
-    expect(result).toEqual([40, 31, 62, 73]);
+    result = ngeoQuerent.makeBboxWithQueryIconPosition_([1, 2], resolution, coordinate);
+    expect(result).toEqual([30, 41, 70, 61]);
 
-    result = ngeoQuerent.bufferBboxWithQueryIconPosition_([1, 2, 3], resolution, bbox);
-    expect(result).toEqual([40, 31, 82, 73]);
+    result = ngeoQuerent.makeBboxWithQueryIconPosition_([1, 2, 3], resolution, coordinate);
+    expect(result).toEqual([30, 41, 70, 81]);
 
-    result = ngeoQuerent.bufferBboxWithQueryIconPosition_([1, 2, 3, 4], resolution, bbox);
-    expect(result).toEqual([40, 31, 82, 93]);
+    result = ngeoQuerent.makeBboxWithQueryIconPosition_([1, 2, 3, 4], resolution, coordinate);
+    expect(result).toEqual([30, 41, 90, 81]);
 
-    result = ngeoQuerent.bufferBboxWithQueryIconPosition_([0, 0, 0, 4], resolution, bbox);
-    expect(result).toEqual([50, 51, 52, 93]);
+    result = ngeoQuerent.makeBboxWithQueryIconPosition_([0, 0, 0, 4], resolution, coordinate);
+    expect(result).toEqual([50, 51, 90, 51]);
 
-    result = ngeoQuerent.bufferBboxWithQueryIconPosition_([1, 2, 3, 4, 5], resolution, bbox);
+    result = ngeoQuerent.makeBboxWithQueryIconPosition_([1, 2, 3, 4, 5], resolution, coordinate);
     expect(result).toBe(null);
   });
 });


### PR DESCRIPTION
For GSGMF-1294

### Variation from the specs
I've named the `queryTouchMin` option to `toleranceTouch` to be coherant with the `tolerance` for desktop and `tolerance`for the edition (which is use basically for the the same behavior).
I've not seen any `queryToleranceTouch` to remove.

### OpenLayers:
Done, PR here : https://github.com/openlayers/openlayers/pull/11740
**We have to wait on a new ol realease**

### C2cgeoportal:
It looks already done: https://github.com/camptocamp/c2cgeoportal/pull/6512/files
There is no `tolerance` or `toleranceTouch` in ngeoQueryOptions from constants of CONST_vars.yaml . And none is needed. A default value exists in ngeo (the same default value as before).

### Ngeo:
I've take care of: https://github.com/camptocamp/ngeo/pull/4570 (still and always send the simple click with tolerance bbox as GET parameter. A custom bbox can be done at the mapserver side, and I won't sent one bbox per layer).
