### PR TITLE
Auto fill timezone attribute in print

### DIFF
--- a/contribs/gmf/src/print/component.js
+++ b/contribs/gmf/src/print/component.js
@@ -829,8 +829,23 @@ export class PrintController {
     // The attributes without 'clientParams' are the custom layout information (defined by end user).
     this.layout_.attributes.forEach((attribute) => {
       this.layoutInfo.attributes.push(attribute.name);
+
       if (!attribute.clientParams) {
         const name = `${attribute.name}`;
+
+        // Special case for timezone, hide it and fill it with browser timezone.
+        if (name == 'timezone') {
+          if (this.options.hiddenAttributes.includes('timezone')) {
+            this.options.hiddenAttributes.push('timezone');
+          }
+          this.layoutInfo.simpleAttributes.push({
+            name: 'timezone',
+            type: 'text',
+            value: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          });
+          return;
+        }
+
         const defaultValue = attribute.default;
         /** @type {string} */
         let value =


### PR DESCRIPTION
Here is a proposition to fill timezone in print.
This solution only fill timezone if attribute is present in layout.

I firstly think to add it directly in print service in ngeo part (easier), but this may raise errors in case attribute is not present in print config but throwErrorOnExtraParameters is activated.

May be discussed before merge.