### PR TITLE
Better work around for ctrlKey events

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -38,8 +38,9 @@ export function isEventUsinCtrlKey(evt) {
   if (!evt) {
     return false;
   }
-  // Do not use evt.ctrlKey (or evt.metaKey on Mac) Because Firefox sometimes doesn't assign the ctrlKey.
-  return MAC ? evt.key === 'Meta' : evt.key === 'Control';
+  // Check also evt.key because Firefox on Ubuntu sometimes doesn't assign the ctrlKey flag.
+  // Don't check only the evt.key because pressing multiples keys at once shows only one key.
+  return (MAC ? evt.metaKey : evt.ctrlKey) || evt.key === 'Control';
 }
 
 /**


### PR DESCRIPTION
Post #6397 and for point 3 of GSGMF-1405

My last workaround was a bad workaround.
I realized that the key string contains always only one key. That means, if you press ctrl and alt at the same time, there is still two events, one with key ctrl, one with key alt (**but not both !**). The first have only one flag to true, the second have both flag activated.

The best workaround I found is to continue to check the ctrlKey flag, but also check the key to minimize errors in Firefox.
This workaround looks strong enough, I can't reproduce a ctrlKey malfunction in the application.
Thus, the ctrlKey flag bug looks only append on Firefox for Ubuntu (and maybe only Ubuntu 18) (see: https://bugzilla.mozilla.org/show_bug.cgi?id=1673362)

For the same reasons, I give up to provide a fix in openlayers.