### PR TITLE
Retablish query without queryIconPosition

### DIFF
--- a/src/query/Querent.js
+++ b/src/query/Querent.js
@@ -703,6 +703,9 @@ export class Querent {
         // not used. Delete them for clarity.
         delete getFeatureCommonOptions.bbox;
         delete getFeatureCommonOptions.geometryName;
+      } else {
+        // If there is no queryIconPosition, use a simple array of names and a common geom.
+        getFeatureCommonOptions.featureTypes = featureTypesNames;
       }
 
       if (!url) {


### PR DESCRIPTION
Fix GSGMF-1435 and https://github.com/camptocamp/ngeo/pull/6445

Oups... : If there is no queryIconPosition, use a simple array of names and a common geom.
We can query every queriable layer again now.