### PR TITLE
Use getDataSource to check if layer is filtrable

### DIFF
--- a/contribs/gmf/src/layertree/component.html
+++ b/contribs/gmf/src/layertree/component.html
@@ -192,7 +192,7 @@
               {{'Swipe with this layer'| translate}}
             </a>
           </li>
-          <li ng-if="::gmfLayertreeCtrl.isFiltrable(layertreeCtrl)">
+          <li ng-if="gmfLayertreeCtrl.isFiltrable(layertreeCtrl)">
             <i class="fa fa-filter fa-fw"></i>
             <a
               ng-click="gmfLayertreeCtrl.toggleFiltrableDataSource(layertreeCtrl.getDataSource())"

--- a/contribs/gmf/src/layertree/component.html
+++ b/contribs/gmf/src/layertree/component.html
@@ -192,7 +192,7 @@
               {{'Swipe with this layer'| translate}}
             </a>
           </li>
-          <li ng-if="::gmfLayertreeCtrl.isFiltrable(layertreeCtrl)">
+          <li ng-if="layertreeCtrl.getDataSource() && layertreeCtrl.getDataSource().filtrable">
             <i class="fa fa-filter fa-fw"></i>
             <a
               ng-click="gmfLayertreeCtrl.toggleFiltrableDataSource(layertreeCtrl.getDataSource())"

--- a/contribs/gmf/src/layertree/component.html
+++ b/contribs/gmf/src/layertree/component.html
@@ -192,7 +192,7 @@
               {{'Swipe with this layer'| translate}}
             </a>
           </li>
-          <li ng-if="layertreeCtrl.getDataSource() && layertreeCtrl.getDataSource().filtrable">
+          <li ng-if="::gmfLayertreeCtrl.isFiltrable(layertreeCtrl)">
             <i class="fa fa-filter fa-fw"></i>
             <a
               ng-click="gmfLayertreeCtrl.toggleFiltrableDataSource(layertreeCtrl.getDataSource())"


### PR DESCRIPTION
Hi, it seems that since PR #6009, the filter button which appears next to the layer (when clicking the gear icon) does not work for some layer, although they still appear in the drop down menu in the right panel. See for example in the demo the layer "OSM map" in the group "Filters mixed". Thanks to @RenataMuellerC2C we found out that the button re-appears by reverting one change of the commit b37759d78d048d173138a8fa6a294c49817741ae