### PR TITLE
Export controllers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013-2020 Camptocamp SA
+Copyright (c) 2013-2021 Camptocamp SA
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/api/src/Map.js
+++ b/api/src/Map.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/api/src/Querent.js
+++ b/api/src/Querent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/api/src/Search.js
+++ b/api/src/Search.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2020 Camptocamp SA
+// Copyright (c) 2020-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/api/src/Themes.js
+++ b/api/src/Themes.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/api/src/constants.js
+++ b/api/src/constants.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/buildtools/check-example.js
+++ b/buildtools/check-example.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/buildtools/compile-catalog.js
+++ b/buildtools/compile-catalog.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/buildtools/copyright/index.js
+++ b/buildtools/copyright/index.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2020 Camptocamp SA
+// Copyright (c) 2020-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/buildtools/extract-messages.js
+++ b/buildtools/extract-messages.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/buildtools/generate-xml-from-tokens.js
+++ b/buildtools/generate-xml-from-tokens.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/buildtools/ls.js
+++ b/buildtools/ls.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2020 Camptocamp SA
+// Copyright (c) 2020-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/buildtools/svg-viewbox-loader.js
+++ b/buildtools/svg-viewbox-loader.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/buildtools/webpack.api.js
+++ b/buildtools/webpack.api.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/buildtools/webpack.commons.js
+++ b/buildtools/webpack.commons.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/buildtools/webpack.config.dll.js
+++ b/buildtools/webpack.config.dll.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/buildtools/webpack.dev.js
+++ b/buildtools/webpack.dev.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/buildtools/webpack.gmfapps.js
+++ b/buildtools/webpack.gmfapps.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/buildtools/webpack.gmfexamples.js
+++ b/buildtools/webpack.gmfexamples.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/buildtools/webpack.ngeoexamples.js
+++ b/buildtools/webpack.ngeoexamples.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/buildtools/webpack.plugin.js
+++ b/buildtools/webpack.plugin.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/buildtools/webpack.prod.js
+++ b/buildtools/webpack.prod.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/buildtools/webpack.scss-loader.js
+++ b/buildtools/webpack.scss-loader.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/apps/appmodule.js
+++ b/contribs/gmf/apps/appmodule.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/apps/desktop/Controller.js
+++ b/contribs/gmf/apps/desktop/Controller.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/apps/desktop_alt/Controller.js
+++ b/contribs/gmf/apps/desktop_alt/Controller.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/apps/iframe_api/Controller.js
+++ b/contribs/gmf/apps/iframe_api/Controller.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/apps/mobile/Controller.js
+++ b/contribs/gmf/apps/mobile/Controller.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/apps/mobile_alt/Controller.js
+++ b/contribs/gmf/apps/mobile_alt/Controller.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/apps/oeedit/Controller.js
+++ b/contribs/gmf/apps/oeedit/Controller.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/authentication.js
+++ b/contribs/gmf/examples/authentication.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/backgroundlayerselector.js
+++ b/contribs/gmf/examples/backgroundlayerselector.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/contextualdata.js
+++ b/contribs/gmf/examples/contextualdata.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/datepicker.js
+++ b/contribs/gmf/examples/datepicker.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/displayquerygrid.js
+++ b/contribs/gmf/examples/displayquerygrid.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/displayquerywindow.js
+++ b/contribs/gmf/examples/displayquerywindow.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/drawfeature.js
+++ b/contribs/gmf/examples/drawfeature.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/editfeature.js
+++ b/contribs/gmf/examples/editfeature.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/editfeatureselector.js
+++ b/contribs/gmf/examples/editfeatureselector.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/elevation.js
+++ b/contribs/gmf/examples/elevation.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/featurestyle.js
+++ b/contribs/gmf/examples/featurestyle.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/filterselector.js
+++ b/contribs/gmf/examples/filterselector.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/importdatasource.js
+++ b/contribs/gmf/examples/importdatasource.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/layertree.js
+++ b/contribs/gmf/examples/layertree.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/layertreeadd.js
+++ b/contribs/gmf/examples/layertreeadd.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/lidarprofile.js
+++ b/contribs/gmf/examples/lidarprofile.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/mobilemeasure.js
+++ b/contribs/gmf/examples/mobilemeasure.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/mouseposition.js
+++ b/contribs/gmf/examples/mouseposition.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/objectediting.js
+++ b/contribs/gmf/examples/objectediting.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/objecteditinghub.js
+++ b/contribs/gmf/examples/objecteditinghub.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/permalink.js
+++ b/contribs/gmf/examples/permalink.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/print.js
+++ b/contribs/gmf/examples/print.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/profile.js
+++ b/contribs/gmf/examples/profile.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/search.js
+++ b/contribs/gmf/examples/search.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/share.js
+++ b/contribs/gmf/examples/share.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/simple.js
+++ b/contribs/gmf/examples/simple.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/themeselector.js
+++ b/contribs/gmf/examples/themeselector.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/timeslider.js
+++ b/contribs/gmf/examples/timeslider.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/wfspermalink.js
+++ b/contribs/gmf/examples/wfspermalink.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/examples/xsdattributes.js
+++ b/contribs/gmf/examples/xsdattributes.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/authentication/Service.js
+++ b/contribs/gmf/src/authentication/Service.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/authentication/component.js
+++ b/contribs/gmf/src/authentication/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/authentication/component.js
+++ b/contribs/gmf/src/authentication/component.js
@@ -140,10 +140,9 @@ module.value('gmfAuthenticationTemplateUrl', gmfAuthenticationTemplateUrl_);
 module.component('gmfAuthentication', authenticationComponent);
 
 /**
- * @private
  * @hidden
  */
-class AuthenticationController {
+export class AuthenticationController {
   /**
    * @param {angular.IScope} $scope Scope.
    * @param {JQuery} $element Element.

--- a/contribs/gmf/src/authentication/module.js
+++ b/contribs/gmf/src/authentication/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/backgroundlayerselector/component.js
+++ b/contribs/gmf/src/backgroundlayerselector/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/backgroundlayerselector/component.js
+++ b/contribs/gmf/src/backgroundlayerselector/component.js
@@ -112,7 +112,6 @@ module.component('gmfBackgroundlayerselector', backgroundlayerselectorComponent)
 
 /**
  * @constructor
- * @private
  * @hidden
  * @param {angular.IScope} $scope Angular scope.
  * @param {import("ngeo/map/BackgroundLayerMgr.js").MapBackgroundLayerManager} ngeoBackgroundLayerMgr
@@ -122,7 +121,7 @@ module.component('gmfBackgroundlayerselector', backgroundlayerselectorComponent)
  * @ngdoc controller
  * @ngname GmfBackgroundlayerselectorController
  */
-function Controller($scope, ngeoBackgroundLayerMgr, gmfThemes) {
+export function Controller($scope, ngeoBackgroundLayerMgr, gmfThemes) {
   /**
    * @type {?import("ol/Map.js").default}
    */

--- a/contribs/gmf/src/backgroundlayerselector/module.js
+++ b/contribs/gmf/src/backgroundlayerselector/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/contextualdata/component.js
+++ b/contribs/gmf/src/contextualdata/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/contextualdata/module.js
+++ b/contribs/gmf/src/contextualdata/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/controllers/AbstractAPIController.js
+++ b/contribs/gmf/src/controllers/AbstractAPIController.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/controllers/AbstractAppController.js
+++ b/contribs/gmf/src/controllers/AbstractAppController.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/controllers/AbstractMobileController.js
+++ b/contribs/gmf/src/controllers/AbstractMobileController.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/controllers/bootstrap.js
+++ b/contribs/gmf/src/controllers/bootstrap.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/datasource/DataSourceBeingFiltered.js
+++ b/contribs/gmf/src/datasource/DataSourceBeingFiltered.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/datasource/ExternalDataSourcesManager.js
+++ b/contribs/gmf/src/datasource/ExternalDataSourcesManager.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/datasource/Helper.js
+++ b/contribs/gmf/src/datasource/Helper.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/datasource/LayerBeingSwipe.js
+++ b/contribs/gmf/src/datasource/LayerBeingSwipe.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/datasource/Manager.js
+++ b/contribs/gmf/src/datasource/Manager.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/datasource/OGC.js
+++ b/contribs/gmf/src/datasource/OGC.js
@@ -97,7 +97,6 @@ import ngeoDatasourceOGC from 'ngeo/datasource/OGC.js';
  */
 
 /**
- * @private
  * @hidden
  */
 class GmfDatasourceOGC extends ngeoDatasourceOGC {

--- a/contribs/gmf/src/datasource/OGC.js
+++ b/contribs/gmf/src/datasource/OGC.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/datasource/WFSAliases.js
+++ b/contribs/gmf/src/datasource/WFSAliases.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/datasource/module.js
+++ b/contribs/gmf/src/datasource/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/disclaimer/component.js
+++ b/contribs/gmf/src/disclaimer/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/disclaimer/component.js
+++ b/contribs/gmf/src/disclaimer/component.js
@@ -76,7 +76,7 @@ const module = angular.module('gmfDisclaimer', [
  * @ngdoc controller
  * @ngname GmfDisclaimerController
  */
-function DisclaimerController(
+export function DisclaimerController(
   $element,
   $sce,
   $timeout,

--- a/contribs/gmf/src/disclaimer/module.js
+++ b/contribs/gmf/src/disclaimer/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/drawing/drawFeatureComponent.js
+++ b/contribs/gmf/src/drawing/drawFeatureComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -125,7 +125,14 @@ module.directive('gmfDrawfeature', drawinfDrawFeatureComponent);
  * @ngdoc controller
  * @ngname GmfDrawfeatureController
  */
-export function Controller($scope, $timeout, gettextCatalog, ngeoFeatureHelper, ngeoFeatures, ngeoToolActivateMgr) {
+export function Controller(
+  $scope,
+  $timeout,
+  gettextCatalog,
+  ngeoFeatureHelper,
+  ngeoFeatures,
+  ngeoToolActivateMgr
+) {
   /**
    * @type {?import("ol/Map.js").default}
    */

--- a/contribs/gmf/src/drawing/drawFeatureComponent.js
+++ b/contribs/gmf/src/drawing/drawFeatureComponent.js
@@ -120,13 +120,12 @@ module.directive('gmfDrawfeature', drawinfDrawFeatureComponent);
  * @param {import("ngeo/misc/ToolActivateMgr.js").ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate
  *    manager service.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname GmfDrawfeatureController
  */
-function Controller($scope, $timeout, gettextCatalog, ngeoFeatureHelper, ngeoFeatures, ngeoToolActivateMgr) {
+export function Controller($scope, $timeout, gettextCatalog, ngeoFeatureHelper, ngeoFeatures, ngeoToolActivateMgr) {
   /**
    * @type {?import("ol/Map.js").default}
    */

--- a/contribs/gmf/src/drawing/drawFeatureOptionsComponent.js
+++ b/contribs/gmf/src/drawing/drawFeatureOptionsComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/drawing/drawFeatureOptionsComponent.js
+++ b/contribs/gmf/src/drawing/drawFeatureOptionsComponent.js
@@ -59,10 +59,9 @@ module.run(
 );
 
 /**
- * @private
  * @hidden
  */
-class DrawFeatureOptionsController {
+export class DrawFeatureOptionsController {
   /**
    * @param {angular.IScope} $scope Scope.
    * @private

--- a/contribs/gmf/src/drawing/featureStyleComponent.js
+++ b/contribs/gmf/src/drawing/featureStyleComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/drawing/featureStyleComponent.js
+++ b/contribs/gmf/src/drawing/featureStyleComponent.js
@@ -80,13 +80,12 @@ module.directive('gmfFeaturestyle', drawingDrawFeatureComponent);
  * @param {angular.IScope} $scope Angular scope.
  * @param {import("ngeo/misc/FeatureHelper.js").FeatureHelper} ngeoFeatureHelper Gmf feature helper service.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname GmfFeaturestyleController
  */
-function Controller($scope, ngeoFeatureHelper) {
+export function Controller($scope, ngeoFeatureHelper) {
   /**
    * @type {string}
    */

--- a/contribs/gmf/src/drawing/module.js
+++ b/contribs/gmf/src/drawing/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/editing/EditFeature.js
+++ b/contribs/gmf/src/editing/EditFeature.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/editing/EnumerateAttribute.js
+++ b/contribs/gmf/src/editing/EnumerateAttribute.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/editing/Snapping.js
+++ b/contribs/gmf/src/editing/Snapping.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/editing/Snapping.js
+++ b/contribs/gmf/src/editing/Snapping.js
@@ -156,7 +156,7 @@ export function EditingSnappingService(
     : undefined;
 }
 
-class CustomSnap extends olInteractionSnap {
+export class CustomSnap extends olInteractionSnap {
   /**
    * @param {import('ol/interaction/Snap.js').Options} options
    */

--- a/contribs/gmf/src/editing/XSDAttributes.js
+++ b/contribs/gmf/src/editing/XSDAttributes.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/editing/editFeatureComponent.js
+++ b/contribs/gmf/src/editing/editFeatureComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/editing/editFeatureComponent.js
+++ b/contribs/gmf/src/editing/editFeatureComponent.js
@@ -224,13 +224,12 @@ module.directive('gmfEditfeature', editingEditFeatureComponent);
  * @param {import("ngeo/misc/ToolActivateMgr.js").ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate
  *    manager service.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname GmfEditfeatureController
  */
-function Controller(
+export function Controller(
   $element,
   $q,
   $scope,

--- a/contribs/gmf/src/editing/editFeatureSelectorComponent.js
+++ b/contribs/gmf/src/editing/editFeatureSelectorComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/editing/editFeatureSelectorComponent.js
+++ b/contribs/gmf/src/editing/editFeatureSelectorComponent.js
@@ -107,13 +107,12 @@ module.directive('gmfEditfeatureselector', editingEditFeatureComponent);
  * @param {import("gmf/layertree/TreeManager.js").LayertreeTreeManager} gmfTreeManager The gmf TreeManager
  *    service.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname GmfEditfeatureselectorController
  */
-function Controller($scope, $timeout, gmfThemes, gmfTreeManager) {
+export function Controller($scope, $timeout, gmfThemes, gmfTreeManager) {
   // === Directive options ===
 
   /**

--- a/contribs/gmf/src/editing/module.js
+++ b/contribs/gmf/src/editing/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/filters/SavedFilters.js
+++ b/contribs/gmf/src/filters/SavedFilters.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/filters/filterselectorComponent.js
+++ b/contribs/gmf/src/filters/filterselectorComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/filters/filterselectorComponent.js
+++ b/contribs/gmf/src/filters/filterselectorComponent.js
@@ -110,7 +110,7 @@ function gmfFilterselectorTemplateUrl($attrs, gmfFilterselectorTemplateUrl) {
  *      Note: although this is a list, only one can be defined.
  *  * `filterable_layers`: A list of layer names that can be filtered, if empty the component will be hidden.
  */
-class FilterSelectorController {
+export class FilterSelectorController {
   /**
    * @param {angular.IScope} $scope Angular scope.
    * @param {angular.ITimeoutService} $timeout Angular timeout service.

--- a/contribs/gmf/src/filters/module.js
+++ b/contribs/gmf/src/filters/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/floor/floorselectorComponent.js
+++ b/contribs/gmf/src/floor/floorselectorComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/floor/floorselectorComponent.js
+++ b/contribs/gmf/src/floor/floorselectorComponent.js
@@ -64,10 +64,9 @@ function gmfFloorselectorTemplateUrl($attrs, gmfFloorselectorTemplateUrl) {
 }
 
 /**
- * @private
  * @hidden
  */
-class Controller {
+export class Controller {
   /**
    * @param {angular.IScope} $scope Angular scope.
    * @param {JQuery} $element Element.

--- a/contribs/gmf/src/floor/module.js
+++ b/contribs/gmf/src/floor/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/import/importdatasourceComponent.js
+++ b/contribs/gmf/src/import/importdatasourceComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/import/importdatasourceComponent.js
+++ b/contribs/gmf/src/import/importdatasourceComponent.js
@@ -96,10 +96,9 @@ const Mode = {
 };
 
 /**
- * @private
  * @hidden
  */
-class Controller {
+export class Controller {
   /**
    * @param {JQuery} $element Element.
    * @param {angular.IFilterService} $filter Angular filter.

--- a/contribs/gmf/src/import/module.js
+++ b/contribs/gmf/src/import/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/import/wmsCapabilityLayertreeComponent.js
+++ b/contribs/gmf/src/import/wmsCapabilityLayertreeComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/import/wmsCapabilityLayertreeComponent.js
+++ b/contribs/gmf/src/import/wmsCapabilityLayertreeComponent.js
@@ -78,10 +78,9 @@ function gmfWmscapabilitylayertreenodeTemplateUrl($attrs, gmfWmscapabilitylayert
 }
 
 /**
- * @private
  * @hidden
  */
-class Controller {
+export class Controller {
   /**
    * @param {import("gmf/datasource/ExternalDataSourcesManager.js").ExternalDatSourcesManager}
    *     gmfExternalDataSourcesManager GMF service responsible of managing

--- a/contribs/gmf/src/import/wmtsCapabilityLayertreeComponent.js
+++ b/contribs/gmf/src/import/wmtsCapabilityLayertreeComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/import/wmtsCapabilityLayertreeComponent.js
+++ b/contribs/gmf/src/import/wmtsCapabilityLayertreeComponent.js
@@ -75,10 +75,9 @@ function gmfWmtscapabilitylayertreTemplateUrl($attrs, gmfWmtscapabilitylayertreT
 }
 
 /**
- * @private
  * @hidden
  */
-class Controller {
+export class Controller {
   /**
    * @param {import("gmf/datasource/ExternalDataSourcesManager.js").ExternalDatSourcesManager}
    *     gmfExternalDataSourcesManager GMF service responsible of managing

--- a/contribs/gmf/src/index.js
+++ b/contribs/gmf/src/index.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/layertree/SyncLayertreeMap.js
+++ b/contribs/gmf/src/layertree/SyncLayertreeMap.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/layertree/TreeManager.js
+++ b/contribs/gmf/src/layertree/TreeManager.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/layertree/component.js
+++ b/contribs/gmf/src/layertree/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/layertree/component.js
+++ b/contribs/gmf/src/layertree/component.js
@@ -225,13 +225,12 @@ module.component('gmfLayertree', layertreeComponent);
  * @param {import("gmf/theme/Themes.js").ThemesService} gmfThemes The gmf Themes service.
  * @param {angular.ITimeoutService} $timeout Angular timeout service.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname gmfLayertreeController
  */
-function Controller(
+export function Controller(
   $element,
   $scope,
   ngeoLayerHelper,

--- a/contribs/gmf/src/layertree/datasourceGroupTreeComponent.js
+++ b/contribs/gmf/src/layertree/datasourceGroupTreeComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/layertree/datasourceGroupTreeComponent.js
+++ b/contribs/gmf/src/layertree/datasourceGroupTreeComponent.js
@@ -69,10 +69,9 @@ function gmfLayertreeDatasourceGroupTreeTemplateUrl($attrs, gmfLayertreeDatasour
 }
 
 /**
- * @private
  * @hidden
  */
-class Controller {
+export class Controller {
   /**
    * @param {angular.IScope} $scope Angular scope.
    * @param {import("ngeo/datasource/DataSources.js").DataSource} ngeoDataSources Ngeo data sources

--- a/contribs/gmf/src/layertree/module.js
+++ b/contribs/gmf/src/layertree/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/layertree/timeSliderComponent.js
+++ b/contribs/gmf/src/layertree/timeSliderComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/layertree/timeSliderComponent.js
+++ b/contribs/gmf/src/layertree/timeSliderComponent.js
@@ -143,13 +143,12 @@ module.directive('gmfTimeSlider', layertreeTimeSliderComponent);
  * @param {import("ngeo/misc/WMSTime.js").WMSTime} ngeoWMSTime WMSTime service.
  * @param {import("ngeo/misc/debounce.js").miscDebounce<function(): void>} ngeoDebounce ngeo Debounce factory.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname gmfTimeSliderController
  */
-function Controller(ngeoWMSTime, ngeoDebounce) {
+export function Controller(ngeoWMSTime, ngeoDebounce) {
   /**
    * @type {import("ngeo/misc/WMSTime.js").WMSTime}
    * @private

--- a/contribs/gmf/src/lidarprofile/Config.js
+++ b/contribs/gmf/src/lidarprofile/Config.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/lidarprofile/Manager.js
+++ b/contribs/gmf/src/lidarprofile/Manager.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/lidarprofile/Measure.js
+++ b/contribs/gmf/src/lidarprofile/Measure.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/lidarprofile/Plot.js
+++ b/contribs/gmf/src/lidarprofile/Plot.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/lidarprofile/Utils.js
+++ b/contribs/gmf/src/lidarprofile/Utils.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/lidarprofile/component.js
+++ b/contribs/gmf/src/lidarprofile/component.js
@@ -90,10 +90,9 @@ const lidarprofileComponent = {
 module.component('gmfLidarprofile', lidarprofileComponent);
 
 /**
- * @private
  * @hidden
  */
-class Controller {
+export class Controller {
   /**
    * @param {angular.IScope} $scope Angular scope.
    * @private

--- a/contribs/gmf/src/lidarprofile/component.js
+++ b/contribs/gmf/src/lidarprofile/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/lidarprofile/module.js
+++ b/contribs/gmf/src/lidarprofile/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/lidarprofile/panelComponent.js
+++ b/contribs/gmf/src/lidarprofile/panelComponent.js
@@ -110,10 +110,9 @@ const lidarprofilePanelComponent = {
 module.component('gmfLidarprofilePanel', lidarprofilePanelComponent);
 
 /**
- * @private
  * @hidden
  */
-class Controller {
+export class Controller {
   /**
    * @param {angular.IScope} $scope Angular scope.
    * @param {import("gmf/lidarprofile/Manager.js").LidarprofileManager} gmfLidarprofileManager gmf

--- a/contribs/gmf/src/lidarprofile/panelComponent.js
+++ b/contribs/gmf/src/lidarprofile/panelComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/mainmodule.js
+++ b/contribs/gmf/src/mainmodule.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/map/component.js
+++ b/contribs/gmf/src/map/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/map/component.js
+++ b/contribs/gmf/src/map/component.js
@@ -86,13 +86,12 @@ module.directive('gmfMap', gmfMapComponent);
  * @param {import("gmf/permalink/Permalink.js").PermalinkService} gmfPermalink The gmf permalink service.
  * @param {import("gmf/editing/Snapping.js").EditingSnappingService} gmfSnapping The gmf snapping service.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname GmfMapController
  */
-function Controller(ngeoFeatureOverlayMgr, gmfPermalink, gmfSnapping) {
+export function Controller(ngeoFeatureOverlayMgr, gmfPermalink, gmfSnapping) {
   // Scope properties
 
   /**

--- a/contribs/gmf/src/map/module.js
+++ b/contribs/gmf/src/map/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/map/mousepositionComponent.js
+++ b/contribs/gmf/src/map/mousepositionComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/map/mousepositionComponent.js
+++ b/contribs/gmf/src/map/mousepositionComponent.js
@@ -111,13 +111,12 @@ module.component('gmfMouseposition', mapMousepositionComponent);
  * @param {angular.IScope} $scope Angular scope.
  * @param {angular.gettext.gettextCatalog} gettextCatalog Gettext catalog.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname gmfMousepositionController
  */
-function Controller($element, $filter, $scope, gettextCatalog) {
+export function Controller($element, $filter, $scope, gettextCatalog) {
   /**
    * @type {?import("ol/Map.js").default}
    */

--- a/contribs/gmf/src/mobile/measure/areaComponent.js
+++ b/contribs/gmf/src/mobile/measure/areaComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/mobile/measure/areaComponent.js
+++ b/contribs/gmf/src/mobile/measure/areaComponent.js
@@ -107,10 +107,9 @@ function mobileMeasureAreaComponent(gmfMobileMeasureAreaTemplateUrl) {
 module.directive('gmfMobileMeasurearea', mobileMeasureAreaComponent);
 
 /**
- * @private
  * @hidden
  */
-class Controller extends MeasueMobileBaseController {
+export class Controller extends MeasueMobileBaseController {
   /**
    * @param {angular.IScope} $scope Angular scope.
    * @param {angular.IFilterService} $filter Angular filter

--- a/contribs/gmf/src/mobile/measure/baseComponent.js
+++ b/contribs/gmf/src/mobile/measure/baseComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/mobile/measure/lengthComponent.js
+++ b/contribs/gmf/src/mobile/measure/lengthComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/mobile/measure/lengthComponent.js
+++ b/contribs/gmf/src/mobile/measure/lengthComponent.js
@@ -107,10 +107,9 @@ function mobileMeasureLenthComponent(gmfMobileMeasureLengthTemplateUrl) {
 module.directive('gmfMobileMeasurelength', mobileMeasureLenthComponent);
 
 /**
- * @private
  * @hidden
  */
-class Controller extends MeasueMobileBaseController {
+export class Controller extends MeasueMobileBaseController {
   /**
    * @param {angular.IScope} $scope Angular scope.
    * @param {angular.IFilterService} $filter Angular filter

--- a/contribs/gmf/src/mobile/measure/module.js
+++ b/contribs/gmf/src/mobile/measure/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/mobile/measure/pointComponent.js
+++ b/contribs/gmf/src/mobile/measure/pointComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/mobile/navigation/component.js
+++ b/contribs/gmf/src/mobile/navigation/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/mobile/navigation/component.js
+++ b/contribs/gmf/src/mobile/navigation/component.js
@@ -104,13 +104,12 @@ module.directive('gmfMobileNav', mobileNavigationComponent);
 
 /**
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname gmfMobileNavController
  */
-function Controller() {
+export function Controller() {
   /**
    * Stack of slid-in items.
    * @private

--- a/contribs/gmf/src/mobile/navigation/module.js
+++ b/contribs/gmf/src/mobile/navigation/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/objectediting/Manager.js
+++ b/contribs/gmf/src/objectediting/Manager.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/objectediting/Query.js
+++ b/contribs/gmf/src/objectediting/Query.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/objectediting/component.js
+++ b/contribs/gmf/src/objectediting/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/objectediting/component.js
+++ b/contribs/gmf/src/objectediting/component.js
@@ -188,13 +188,12 @@ module.component('gmfObjectediting', objecteditingComponent);
  * @param {import("ngeo/misc/ToolActivateMgr.js").ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate
  *    manager service.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname GmfObjecteditingController
  */
-function Controller(
+export function Controller(
   $scope,
   $timeout,
   gettextCatalog,

--- a/contribs/gmf/src/objectediting/coordinate.js
+++ b/contribs/gmf/src/objectediting/coordinate.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/objectediting/coordinate.js
+++ b/contribs/gmf/src/objectediting/coordinate.js
@@ -47,10 +47,9 @@ export function coordinatesToXY0(coordinates) {
  * @param {T[]} coordinates Coordinates
  * @param {number} nesting Nesting level.
  * @return {T[]} Converted coordinates.
- * @private
  * @hidden
  */
-function toXY(coordinates, nesting) {
+export function toXY(coordinates, nesting) {
   if (nesting === 0) {
     return /** @type {T[]} */ (coordinatesToXY0(/** @type {Coordinate} */ (coordinates)));
   } else {

--- a/contribs/gmf/src/objectediting/geom.js
+++ b/contribs/gmf/src/objectediting/geom.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/objectediting/getWMSFeatureComponent.js
+++ b/contribs/gmf/src/objectediting/getWMSFeatureComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/objectediting/getWMSFeatureComponent.js
+++ b/contribs/gmf/src/objectediting/getWMSFeatureComponent.js
@@ -76,13 +76,12 @@ module.directive('gmfObjecteditinggetwmsfeature', objectEditingGetWMSFeatureComp
  * @param {import("gmf/objectediting/Query.js").ObjectEditingQuery} gmfObjectEditingQuery GMF ObjectEditing
  *     query service.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname GmfObjecteditinggetwmsfeatureController
  */
-function Controller($scope, gmfObjectEditingQuery) {
+export function Controller($scope, gmfObjectEditingQuery) {
   // Scope properties
 
   /**

--- a/contribs/gmf/src/objectediting/module.js
+++ b/contribs/gmf/src/objectediting/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/objectediting/toolsComponent.js
+++ b/contribs/gmf/src/objectediting/toolsComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/objectediting/toolsComponent.js
+++ b/contribs/gmf/src/objectediting/toolsComponent.js
@@ -164,13 +164,12 @@ const NAMESPACE = 'oet';
  * @param {import("ngeo/misc/ToolActivateMgr.js").ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate
  *    manager service.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname GmfObjecteditingtoolsController
  */
-function Controller($injector, $scope, ngeoToolActivateMgr) {
+export function Controller($injector, $scope, ngeoToolActivateMgr) {
   // == Scope properties ==
 
   /**

--- a/contribs/gmf/src/permalink/Permalink.js
+++ b/contribs/gmf/src/permalink/Permalink.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/permalink/ShareService.js
+++ b/contribs/gmf/src/permalink/ShareService.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/permalink/module.js
+++ b/contribs/gmf/src/permalink/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/permalink/shareComponent.js
+++ b/contribs/gmf/src/permalink/shareComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/permalink/shareComponent.js
+++ b/contribs/gmf/src/permalink/shareComponent.js
@@ -88,10 +88,9 @@ const permalinkShareComponent = {
 module.component('gmfShare', permalinkShareComponent);
 
 /**
- * @private
  * @hidden
  */
-class ShareComponentController {
+export class ShareComponentController {
   /**
    * The controller for the share component
    * @param {angular.IScope} $scope Scope.

--- a/contribs/gmf/src/print/component.js
+++ b/contribs/gmf/src/print/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/print/module.js
+++ b/contribs/gmf/src/print/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/profile/component.js
+++ b/contribs/gmf/src/profile/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/profile/component.js
+++ b/contribs/gmf/src/profile/component.js
@@ -170,7 +170,6 @@ module.component('gmfProfile', profileComponent);
  * @param {string} gmfProfileJsonUrl URL of GMF service JSON profile.
  * @param {import("ngeo/download/Csv.js").DownloadCsvService} ngeoCsvDownload CSV Download service.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller

--- a/contribs/gmf/src/profile/drawLineComponent.js
+++ b/contribs/gmf/src/profile/drawLineComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/profile/drawLineComponent.js
+++ b/contribs/gmf/src/profile/drawLineComponent.js
@@ -80,13 +80,12 @@ module.directive('gmfDrawprofileline', profileDarwLineComponent);
  * @param {import("ngeo/map/FeatureOverlayMgr.js").FeatureOverlayMgr} ngeoFeatureOverlayMgr Feature overlay
  *    manager.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname gmfDrawprofilelineController
  */
-function Controller($scope, $timeout, ngeoFeatureOverlayMgr) {
+export function Controller($scope, $timeout, ngeoFeatureOverlayMgr) {
   /**
    * @type {?import("ol/geom/LineString.js").default}
    */

--- a/contribs/gmf/src/profile/module.js
+++ b/contribs/gmf/src/profile/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/query/extraModule.js
+++ b/contribs/gmf/src/query/extraModule.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/query/gridComponent.js
+++ b/contribs/gmf/src/query/gridComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/query/windowComponent.js
+++ b/contribs/gmf/src/query/windowComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/raster/RasterService.js
+++ b/contribs/gmf/src/raster/RasterService.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/raster/component.js
+++ b/contribs/gmf/src/raster/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/raster/component.js
+++ b/contribs/gmf/src/raster/component.js
@@ -158,13 +158,12 @@ module.directive('gmfElevation', rasterComponent);
  * @param {import("gmf/raster/RasterService.js").RasterService} gmfRaster Gmf Raster service
  * @param {angular.gettext.gettextCatalog} gettextCatalog Gettext catalog.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname gmfElevationController
  */
-function Controller($scope, $filter, ngeoDebounce, gmfRaster, gettextCatalog) {
+export function Controller($scope, $filter, ngeoDebounce, gmfRaster, gettextCatalog) {
   /**
    * @private
    */
@@ -382,11 +381,10 @@ module.component('gmfElevationwidget', rasterWidgetComponent);
 
 /**
  * @constructor
- * @private
  * @hidden
  * @ngdoc controller
  */
-function WidgetController() {
+export function WidgetController() {
   /**
    * @type {?import("ol/Map.js").default}
    */

--- a/contribs/gmf/src/raster/module.js
+++ b/contribs/gmf/src/raster/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/search/FulltextSearch.js
+++ b/contribs/gmf/src/search/FulltextSearch.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/search/component.js
+++ b/contribs/gmf/src/search/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/search/component.js
+++ b/contribs/gmf/src/search/component.js
@@ -240,12 +240,10 @@ module.value('gmfSearchTemplateUrl', gmfSearchTemplateUrl_);
 module.component('gmfSearch', searchComponent);
 
 /**
- * @private
  * @hidden
  */
-class SearchController {
+export class SearchController {
   /**
-   * @private
    * @param {JQuery} $element Element.
    * @param {angular.IScope} $scope The component's scope.
    * @param {angular.ICompileService} $compile Angular compile service.

--- a/contribs/gmf/src/search/module.js
+++ b/contribs/gmf/src/search/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/spinner/directive.js
+++ b/contribs/gmf/src/spinner/directive.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/spinner/module.js
+++ b/contribs/gmf/src/spinner/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/theme/Manager.js
+++ b/contribs/gmf/src/theme/Manager.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/theme/Themes.js
+++ b/contribs/gmf/src/theme/Themes.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/theme/module.js
+++ b/contribs/gmf/src/theme/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/theme/selectorComponent.js
+++ b/contribs/gmf/src/theme/selectorComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/src/theme/selectorComponent.js
+++ b/contribs/gmf/src/theme/selectorComponent.js
@@ -120,13 +120,12 @@ module.component('gmfThemeselector', themeSelectorComponent);
  * @param {import("gmf/theme/Manager.js").ThemeManagerService} gmfThemeManager Tree manager service.
  * @param {import("gmf/theme/Themes.js").ThemesService} gmfThemes Themes service.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname gmfThemeselectorController
  */
-function Controller($scope, gmfThemeManager, gmfThemes) {
+export function Controller($scope, gmfThemeManager, gmfThemes) {
   /**
    * @type {import("gmf/theme/Manager.js").ThemeManagerService}
    */

--- a/contribs/gmf/src/themes.js
+++ b/contribs/gmf/src/themes.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/test/spec/all.js
+++ b/contribs/gmf/test/spec/all.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/test/spec/beforeeach.js
+++ b/contribs/gmf/test/spec/beforeeach.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/test/spec/controllers/gmfprintcontroller.spec.js
+++ b/contribs/gmf/test/spec/controllers/gmfprintcontroller.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/test/spec/data/printcapabilities.js
+++ b/contribs/gmf/test/spec/data/printcapabilities.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/test/spec/data/themes.js
+++ b/contribs/gmf/test/spec/data/themes.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/test/spec/data/themescapabilities.js
+++ b/contribs/gmf/test/spec/data/themescapabilities.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/test/spec/directives/contextualdata.spec.js
+++ b/contribs/gmf/test/spec/directives/contextualdata.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/test/spec/directives/displayquerygrid.spec.js
+++ b/contribs/gmf/test/spec/directives/displayquerygrid.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/test/spec/directives/displayquerywindow.spec.js
+++ b/contribs/gmf/test/spec/directives/displayquerywindow.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/test/spec/directives/profile.spec.js
+++ b/contribs/gmf/test/spec/directives/profile.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/test/spec/services/authenticationservice.spec.js
+++ b/contribs/gmf/test/spec/services/authenticationservice.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/test/spec/services/permalinkservice.spec.js
+++ b/contribs/gmf/test/spec/services/permalinkservice.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/test/spec/services/share.spec.js
+++ b/contribs/gmf/test/spec/services/share.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/test/spec/services/syncLayertreeMap.spec.js
+++ b/contribs/gmf/test/spec/services/syncLayertreeMap.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/test/spec/services/thememanager.spec.js
+++ b/contribs/gmf/test/spec/services/thememanager.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/test/spec/services/themesservice.spec.js
+++ b/contribs/gmf/test/spec/services/themesservice.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/contribs/gmf/test/spec/services/treemanager.spec.js
+++ b/contribs/gmf/test/spec/services/treemanager.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/animation.js
+++ b/examples/animation.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/asitvd.js
+++ b/examples/asitvd.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/attributes.js
+++ b/examples/attributes.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/backgroundlayer.js
+++ b/examples/backgroundlayer.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/backgroundlayerdropdown.js
+++ b/examples/backgroundlayerdropdown.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/colorpicker.js
+++ b/examples/colorpicker.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/control.js
+++ b/examples/control.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/createfeature.js
+++ b/examples/createfeature.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/datepicker.js
+++ b/examples/datepicker.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/datetimepicker.js
+++ b/examples/datetimepicker.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/disclaimer.js
+++ b/examples/disclaimer.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/displaywindow.js
+++ b/examples/displaywindow.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/drawfeature.js
+++ b/examples/drawfeature.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/elevationProfile.js
+++ b/examples/elevationProfile.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/error.js
+++ b/examples/error.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/googlestreetview.js
+++ b/examples/googlestreetview.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/grid.js
+++ b/examples/grid.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/importfeatures.js
+++ b/examples/importfeatures.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/interactionbtngroup.js
+++ b/examples/interactionbtngroup.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/layerorder.js
+++ b/examples/layerorder.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/layertree.js
+++ b/examples/layertree.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/locationsearch.js
+++ b/examples/locationsearch.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/mapfishprint.js
+++ b/examples/mapfishprint.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/mapswipe.js
+++ b/examples/mapswipe.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/mobilegeolocation.js
+++ b/examples/mobilegeolocation.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/modal.js
+++ b/examples/modal.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/modifycircle.js
+++ b/examples/modifycircle.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/modifyrectangle.js
+++ b/examples/modifyrectangle.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/notification.js
+++ b/examples/notification.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/offline.js
+++ b/examples/offline.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/permalink.js
+++ b/examples/permalink.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/popover.js
+++ b/examples/popover.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/popupservice.js
+++ b/examples/popupservice.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/query.js
+++ b/examples/query.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/recenter.js
+++ b/examples/recenter.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/rotate.js
+++ b/examples/rotate.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/routing.js
+++ b/examples/routing.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/scaleselector.js
+++ b/examples/scaleselector.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/search.js
+++ b/examples/search.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/simple3d.js
+++ b/examples/simple3d.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/svg.js
+++ b/examples/svg.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/examples/toolActivate.js
+++ b/examples/toolActivate.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/CustomEvent.js
+++ b/src/CustomEvent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/GeometryType.js
+++ b/src/GeometryType.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/WFSDescribeFeatureType.js
+++ b/src/WFSDescribeFeatureType.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/array.js
+++ b/src/array.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/datasource/DataSource.js
+++ b/src/datasource/DataSource.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/datasource/DataSources.js
+++ b/src/datasource/DataSources.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/datasource/File.js
+++ b/src/datasource/File.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/datasource/FileGroup.js
+++ b/src/datasource/FileGroup.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/datasource/Group.js
+++ b/src/datasource/Group.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/datasource/Helper.js
+++ b/src/datasource/Helper.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/datasource/OGC.js
+++ b/src/datasource/OGC.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/datasource/OGCGroup.js
+++ b/src/datasource/OGCGroup.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/datasource/WMSGroup.js
+++ b/src/datasource/WMSGroup.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/datasource/module.js
+++ b/src/datasource/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/download/Csv.js
+++ b/src/download/Csv.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/download/module.js
+++ b/src/download/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/download/service.js
+++ b/src/download/service.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/download/service.js
+++ b/src/download/service.js
@@ -40,10 +40,9 @@ const module = angular.module('ngeoDownload', []);
  * @return {Download} The download function.
  * @ngdoc service
  * @ngname ngeoDownload
- * @private
  * @hidden
  */
-function factory() {
+export function factory() {
   /**
    * @param {string} content The file content.
    * @param {string} fileName The file name.

--- a/src/draw/Controller.js
+++ b/src/draw/Controller.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/draw/component.js
+++ b/src/draw/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/draw/features.js
+++ b/src/draw/features.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/draw/module.js
+++ b/src/draw/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/draw/point.js
+++ b/src/draw/point.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/draw/rectangle.js
+++ b/src/draw/rectangle.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/draw/text.js
+++ b/src/draw/text.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/editing/attributesComponent.js
+++ b/src/editing/attributesComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/editing/attributesComponent.js
+++ b/src/editing/attributesComponent.js
@@ -108,13 +108,12 @@ module.component('ngeoAttributes', editingAttributeComponent);
  * @param {angular.IScope} $scope Angular scope.
  * @param {import("ngeo/misc/EventHelper.js").EventHelper} ngeoEventHelper Ngeo event helper service
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname ngeoAttributesController
  */
-function Controller($scope, ngeoEventHelper) {
+export function Controller($scope, ngeoEventHelper) {
   /**
    * The list of attributes to create the form with.
    * @type {Array<import('ngeo/format/Attribute.js').Attribute>}

--- a/src/editing/createfeatureComponent.js
+++ b/src/editing/createfeatureComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/editing/createfeatureComponent.js
+++ b/src/editing/createfeatureComponent.js
@@ -101,13 +101,12 @@ module.directive('ngeoCreatefeature', editingCreateFeatureComponent);
  * @param {angular.ITimeoutService} $timeout Angular timeout service.
  * @param {import("ngeo/misc/EventHelper.js").EventHelper} ngeoEventHelper Ngeo event helper service
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname ngeoCreatefeatureController
  */
-function Controller(gettextCatalog, $compile, $filter, $injector, $scope, $timeout, ngeoEventHelper) {
+export function Controller(gettextCatalog, $compile, $filter, $injector, $scope, $timeout, ngeoEventHelper) {
   /**
    * @type {boolean}
    */

--- a/src/editing/createregularpolygonfromclickComponent.js
+++ b/src/editing/createregularpolygonfromclickComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/editing/createregularpolygonfromclickComponent.js
+++ b/src/editing/createregularpolygonfromclickComponent.js
@@ -95,13 +95,12 @@ module.directive('ngeoCreateregularpolygonfromclick', editingCreateRegularPolygo
 /**
  * @param {angular.IScope} $scope Scope.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname ngeoCreateregularpolygonfromclickController
  */
-function Controller($scope) {
+export function Controller($scope) {
   // == Scope properties ==
 
   /**

--- a/src/editing/exportfeaturesComponent.js
+++ b/src/editing/exportfeaturesComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/editing/exportfeaturesComponent.js
+++ b/src/editing/exportfeaturesComponent.js
@@ -71,13 +71,12 @@ module.directive('ngeoExportfeatures', editingExportFeaturesComponent);
  * @param {angular.IScope} $scope Angular scope.
  * @param {import("ngeo/misc/FeatureHelper.js").FeatureHelper} ngeoFeatureHelper Ngeo feature helper service.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname ngeoExportfeaturesController
  */
-function Controller($element, $injector, $scope, ngeoFeatureHelper) {
+export function Controller($element, $injector, $scope, ngeoFeatureHelper) {
   /**
    * @type {?import("ol/Collection.js").default<import('ol/Feature.js').default<import("ol/geom/Geometry.js").default>>}
    * @private

--- a/src/editing/extraModule.js
+++ b/src/editing/extraModule.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/editing/module.js
+++ b/src/editing/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/events.js
+++ b/src/events.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/filter/Condition.js
+++ b/src/filter/Condition.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/filter/RuleHelper.js
+++ b/src/filter/RuleHelper.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/filter/component.js
+++ b/src/filter/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/filter/component.js
+++ b/src/filter/component.js
@@ -104,10 +104,9 @@ module.component('ngeoFilter', {
 });
 
 /**
- * @private
  * @hidden
  */
-class FilterController {
+export class FilterController {
   /**
    * @param {angular.gettext.gettextCatalog} gettextCatalog Gettext service.
    * @param {angular.IScope} $scope Angular scope.

--- a/src/filter/module.js
+++ b/src/filter/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/filter/ruleComponent.js
+++ b/src/filter/ruleComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/filter/ruleComponent.js
+++ b/src/filter/ruleComponent.js
@@ -108,10 +108,9 @@ function ngeoRuleTemplateUrl($attrs, ngeoRuleTemplateUrl) {
 }
 
 /**
- * @private
  * @hidden
  */
-class RuleController {
+export class RuleController {
   /**
    * @param {angular.gettext.gettextCatalog} gettextCatalog Gettext service.
    * @param {angular.IScope} $scope Angular scope.

--- a/src/format/ArcGISGeoJSON.js
+++ b/src/format/ArcGISGeoJSON.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/format/Attribute.js
+++ b/src/format/Attribute.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/format/AttributeType.js
+++ b/src/format/AttributeType.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/format/FeatureHash.js
+++ b/src/format/FeatureHash.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/format/FeatureHashStyleType.js
+++ b/src/format/FeatureHashStyleType.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/format/FeatureProperties.js
+++ b/src/format/FeatureProperties.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/format/WFSAttribute.js
+++ b/src/format/WFSAttribute.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/format/XSDAttribute.js
+++ b/src/format/XSDAttribute.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/format/filter.js
+++ b/src/format/filter.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2020 Camptocamp SA
+// Copyright (c) 2020-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/geolocation/component.js
+++ b/src/geolocation/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/geolocation/component.js
+++ b/src/geolocation/component.js
@@ -98,7 +98,6 @@ module.directive('ngeoGeolocation', geolocationComponent);
 
 /**
  * @constructor
- * @private
  * @hidden
  * @param {angular.IScope} $scope The directive's scope.
  * @param {JQuery} $element Element.
@@ -111,7 +110,7 @@ module.directive('ngeoGeolocation', geolocationComponent);
  * @ngdoc controller
  * @ngname ngeoGeolocationController
  */
-function Controller($scope, $element, gettextCatalog, ngeoFeatureOverlayMgr, ngeoNotification) {
+export function Controller($scope, $element, gettextCatalog, ngeoFeatureOverlayMgr, ngeoNotification) {
   $element.on('click', this.toggleTracking.bind(this));
 
   // @ts-ignore

--- a/src/geolocation/module.js
+++ b/src/geolocation/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/googlestreetview/component.js
+++ b/src/googlestreetview/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/googlestreetview/component.js
+++ b/src/googlestreetview/component.js
@@ -80,7 +80,7 @@ function ngeoGooglestreetviewTemplateUrl($attrs, ngeoGooglestreetviewTemplateUrl
  *                 map="mainCtrl.map">
  *             </ngeo-googlestreetview>
  */
-class GoogleStreetviewController {
+export class GoogleStreetviewController {
   /**
    * @param {JQuery} $element Element.
    * @param {angular.IScope} $scope Scope.

--- a/src/googlestreetview/module.js
+++ b/src/googlestreetview/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/grid/Config.js
+++ b/src/grid/Config.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/grid/component.js
+++ b/src/grid/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/grid/module.js
+++ b/src/grid/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/interaction/DrawAzimut.js
+++ b/src/interaction/DrawAzimut.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/interaction/DrawRegularPolygonFromClick.js
+++ b/src/interaction/DrawRegularPolygonFromClick.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/interaction/Measure.js
+++ b/src/interaction/Measure.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/interaction/Measure.js
+++ b/src/interaction/Measure.js
@@ -579,7 +579,7 @@ export function getFormattedPoint(point, decimals, format, opt_template) {
  * @hidden
  * @this {Measure}
  */
-function handleEvent_(evt) {
+export function handleEvent_(evt) {
   if (evt.type != 'pointermove' || evt.dragging) {
     return true;
   }

--- a/src/interaction/MeasureArea.js
+++ b/src/interaction/MeasureArea.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/interaction/MeasureAreaMobile.js
+++ b/src/interaction/MeasureAreaMobile.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/interaction/MeasureAzimut.js
+++ b/src/interaction/MeasureAzimut.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/interaction/MeasureAzimut.js
+++ b/src/interaction/MeasureAzimut.js
@@ -127,10 +127,9 @@ export function getAzimut(line) {
  * @param {number|undefined} decimals Decimals.
  * @param {import('ngeo/misc/filters.js').formatNumber} format The format function.
  * @return {string} Formatted measure.
- * @private
  * @hidden
  */
-function getFormattedAzimut(line, decimals, format) {
+export function getFormattedAzimut(line, decimals, format) {
   const azimut = getAzimut(line);
   return `${format(azimut, decimals)}°`;
 }

--- a/src/interaction/MeasureBaseOptions.js
+++ b/src/interaction/MeasureBaseOptions.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/interaction/MeasureLength.js
+++ b/src/interaction/MeasureLength.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/interaction/MeasureLengthMobile.js
+++ b/src/interaction/MeasureLengthMobile.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/interaction/MeasurePointMobile.js
+++ b/src/interaction/MeasurePointMobile.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/interaction/MobileDraw.js
+++ b/src/interaction/MobileDraw.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/interaction/Modify.js
+++ b/src/interaction/Modify.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/interaction/ModifyCircle.js
+++ b/src/interaction/ModifyCircle.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/interaction/ModifyRectangle.js
+++ b/src/interaction/ModifyRectangle.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/interaction/Rotate.js
+++ b/src/interaction/Rotate.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/interaction/Translate.js
+++ b/src/interaction/Translate.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/interaction/common.js
+++ b/src/interaction/common.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/layertree/Controller.js
+++ b/src/layertree/Controller.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/layertree/component.js
+++ b/src/layertree/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/layertree/module.js
+++ b/src/layertree/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/mainmodule.js
+++ b/src/mainmodule.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/map/BackgroundLayerMgr.js
+++ b/src/map/BackgroundLayerMgr.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/map/FeatureOverlay.js
+++ b/src/map/FeatureOverlay.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/map/FeatureOverlayMgr.js
+++ b/src/map/FeatureOverlayMgr.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/map/LayerHelper.js
+++ b/src/map/LayerHelper.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/map/component.js
+++ b/src/map/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/map/extraModule.js
+++ b/src/map/extraModule.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/map/module.js
+++ b/src/map/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/map/recenter.js
+++ b/src/map/recenter.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/map/resizemap.js
+++ b/src/map/resizemap.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/map/scaleselector.js
+++ b/src/map/scaleselector.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/map/scaleselector.js
+++ b/src/map/scaleselector.js
@@ -125,10 +125,9 @@ const mapScaleselectorComponent = function (ngeoScaleselectorTemplateUrl) {
 module.directive('ngeoScaleselector', mapScaleselectorComponent);
 
 /**
- * @private
  * @hidden
  */
-class ScaleselectorController {
+export class ScaleselectorController {
   /**
    * @param {angular.IScope} $scope Directive scope.
    * @param {JQuery} $element Element.

--- a/src/map/swipe.js
+++ b/src/map/swipe.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/map/swipe.js
+++ b/src/map/swipe.js
@@ -70,7 +70,7 @@ function ngeoMapswipeTemplateUrl($attrs, ngeoMapswipeTemplateUrl) {
 /**
  * The controller for the Mapswipe component.
  */
-class SwipeController {
+export class SwipeController {
   /**
    * @param {angular.IScope} $scope Angular scope.
    * @param {JQuery} $element Element.

--- a/src/measure/area.js
+++ b/src/measure/area.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/measure/azimut.js
+++ b/src/measure/azimut.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/measure/length.js
+++ b/src/measure/length.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/measure/module.js
+++ b/src/measure/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/message/Disclaimer.js
+++ b/src/message/Disclaimer.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/message/Message.js
+++ b/src/message/Message.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/message/Notification.js
+++ b/src/message/Notification.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/message/Popup.js
+++ b/src/message/Popup.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/message/Popup.js
+++ b/src/message/Popup.js
@@ -254,10 +254,9 @@ MessagePopup.prototype.open = function (options) {
  * @param {angular.ITimeoutService} $timeout Angular timeout service.
  * @return {PopupFactory} The function to create a popup.
  * @ngInject
- * @private
  * @hidden
  */
-function Factory($compile, $rootScope, $sce, $timeout) {
+export function Factory($compile, $rootScope, $sce, $timeout) {
   return (
     /**
      * @return {MessagePopup} The popup instance.

--- a/src/message/displaywindowComponent.js
+++ b/src/message/displaywindowComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/message/displaywindowComponent.js
+++ b/src/message/displaywindowComponent.js
@@ -69,10 +69,9 @@ function ngeoMessageDisplaywindowTemplateUrl($attrs, ngeoMessageDisplaywindowTem
 }
 
 /**
- * @private
  * @hidden
  */
-class Controller {
+export class Controller {
   /**
    * @param {JQuery} $element Element.
    * @param {angular.ISCEService} $sce Angular sce service.

--- a/src/message/extraModule.js
+++ b/src/message/extraModule.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/message/modalComponent.js
+++ b/src/message/modalComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/message/modalComponent.js
+++ b/src/message/modalComponent.js
@@ -90,10 +90,9 @@ const messageModalComponent = {
 module.component('ngeoModal', messageModalComponent);
 
 /**
- * @private
  * @hidden
  */
-class Controller {
+export class Controller {
   /**
    * @ngInject
    * @param {angular.IScope} $scope Scope.

--- a/src/message/popoverComponent.js
+++ b/src/message/popoverComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/message/popoverComponent.js
+++ b/src/message/popoverComponent.js
@@ -132,10 +132,9 @@ function messagePopoverContentComponent() {
  * @ngdoc controller
  * @ngname NgeoPopoverController
  * @param {angular.IScope} $scope Scope.
- * @private
  * @hidden
  */
-function PopoverController($scope) {
+export function PopoverController($scope) {
   /**
    * The state of the popover (displayed or not)
    * @type {boolean}

--- a/src/message/popupComponent.js
+++ b/src/message/popupComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/AutoProjection.js
+++ b/src/misc/AutoProjection.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/EventHelper.js
+++ b/src/misc/EventHelper.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/FeatureHelper.js
+++ b/src/misc/FeatureHelper.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/File.js
+++ b/src/misc/File.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/Time.js
+++ b/src/misc/Time.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/ToolActivate.js
+++ b/src/misc/ToolActivate.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/ToolActivateMgr.js
+++ b/src/misc/ToolActivateMgr.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/WMSTime.js
+++ b/src/misc/WMSTime.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/btnComponent.js
+++ b/src/misc/btnComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/btnComponent.js
+++ b/src/misc/btnComponent.js
@@ -98,11 +98,10 @@ function buttonGroupComponent($parse) {
 module.directive('ngeoBtnGroup', buttonGroupComponent);
 
 /**
- * @private
  * @hidden
  * @type {angular.IController}
  */
-class BtnGroupController {
+export class BtnGroupController {
   /**
    * @param {angular.IScope} $scope Scope.
    * @ngInject

--- a/src/misc/colorpickerComponent.js
+++ b/src/misc/colorpickerComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/colorpickerComponent.js
+++ b/src/misc/colorpickerComponent.js
@@ -125,13 +125,12 @@ const DEFAULT_COLORS = [
 
 /**
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname NgeoScaleselectorController
  */
-function Controller() {
+export function Controller() {
   /**
    * The set of color
    * @type {string[][]}

--- a/src/misc/controlComponent.js
+++ b/src/misc/controlComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/datepickerComponent.js
+++ b/src/misc/datepickerComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/datepickerComponent.js
+++ b/src/misc/datepickerComponent.js
@@ -144,13 +144,12 @@ module.directive('ngeoDatePicker', datePickerComponent);
  * @param {import("ngeo/misc/Time.js").Time} ngeoTime time service.
  * @param {angular.gettext.gettextCatalog} gettextCatalog service.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname ngeoDatePickerController
  */
-function Controller($scope, ngeoTime, gettextCatalog) {
+export function Controller($scope, ngeoTime, gettextCatalog) {
   /**
    * @type {import("ngeo/misc/Time.js").Time}
    * @private

--- a/src/misc/datetimepickerComponent.js
+++ b/src/misc/datetimepickerComponent.js
@@ -61,13 +61,12 @@ module.directive('ngeoDatetimepicker', dateTimeComponent);
  * @param {JQuery} $element Element.
  * @param {angular.gettext.gettextCatalog} gettextCatalog service.
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname ngeoDatetimepickerController
  */
-function Controller($element, gettextCatalog) {
+export function Controller($element, gettextCatalog) {
   /**
    * @const {JQuery}
    * @private

--- a/src/misc/datetimepickerComponent.js
+++ b/src/misc/datetimepickerComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/debounce.js
+++ b/src/misc/debounce.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/decorate.js
+++ b/src/misc/decorate.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/extraModule.js
+++ b/src/misc/extraModule.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/filereaderComponent.js
+++ b/src/misc/filereaderComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/filters.js
+++ b/src/misc/filters.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/filters.js
+++ b/src/misc/filters.js
@@ -103,7 +103,7 @@ const module = angular.module('ngeoAngularFilters', []);
  * @ngdoc filter
  * @ngname ngeoScalify
  */
-function ScalifyFilter($filter) {
+export function ScalifyFilter($filter) {
   const numberFilter = $filter('ngeoNumber');
   /**
    * @param {number} scale
@@ -142,7 +142,7 @@ module.filter('ngeoScalify', ScalifyFilter);
  * @ngdoc filter
  * @ngname ngeoNumber
  */
-function NumberFilter($locale) {
+export function NumberFilter($locale) {
   const formats = $locale.NUMBER_FORMATS;
 
   /**
@@ -224,7 +224,7 @@ module.filter('ngeoNumber', NumberFilter);
  * @ngdoc filter
  * @ngname ngeoUnitPrefix
  */
-function UnitPrefixFilter($filter) {
+export function UnitPrefixFilter($filter) {
   /** @type {function(number, number=): string} */
   const numberFilter = $filter('ngeoNumber');
   const standardPrefix = ['', 'k', 'M', 'G', 'T', 'P'];
@@ -294,7 +294,7 @@ module.filter('ngeoUnitPrefix', UnitPrefixFilter);
  * @ngdoc filter
  * @ngname ngeoNumberCoordinates
  */
-function NumberCoordinatesFilter($filter) {
+export function NumberCoordinatesFilter($filter) {
   /**
    * @param {import("ol/coordinate.js").Coordinate} coordinates Array of two numbers.
    * @param {(number|string)=} opt_fractionDigits Optional number of digit.
@@ -337,7 +337,7 @@ module.filter('ngeoNumberCoordinates', NumberCoordinatesFilter);
  * @ngdoc filter
  * @ngname ngeoDMSCoordinates
  */
-function DMSCoordinatesFilter() {
+export function DMSCoordinatesFilter() {
   /**
    * @param {number} degrees
    * @param {string} hemispheres
@@ -394,7 +394,7 @@ module.filter('ngeoDMSCoordinates', DMSCoordinatesFilter);
  * @param {angular.ISCEService} $sce Angular sce service.
  * @ngname ngeoTrustHtml
  */
-function trustHtmlFilter($sce) {
+export function trustHtmlFilter($sce) {
   return function (input) {
     if (input !== undefined && input !== null) {
       return $sce.trustAsHtml(`${input}`);
@@ -424,7 +424,7 @@ module.filter('ngeoTrustHtml', trustHtmlFilter);
  *     ngeoStringToHtmlReplacements List of replacements for string to html.
  * @ngname ngeoTrustHtmlAuto
  */
-function trustHtmlAutoFilter($sce, ngeoStringToHtmlReplacements) {
+export function trustHtmlAutoFilter($sce, ngeoStringToHtmlReplacements) {
   return function (input) {
     if (input !== undefined && input !== null) {
       if (typeof input === 'string') {
@@ -463,7 +463,7 @@ module.filter('ngeoTrustHtmlAuto', trustHtmlAutoFilter);
  * @ngdoc filter
  * @ngname ngeoDuration
  */
-function DurationFilter(gettextCatalog) {
+export function DurationFilter(gettextCatalog) {
   // time unit enum
   const TimeUnits = Object.freeze({
     SECONDS: Symbol('seconds'),
@@ -579,7 +579,7 @@ module.constant('ngeoStringToHtmlReplacements', StringToHtmlReplacements);
  * @ngname ngeoDuration
  * @hidden
  */
-const removeCDATA = function () {
+export const removeCDATA = function () {
   return function (input) {
     if (input && input.replace) {
       return input.replace(/<!\[CDATA\[(.*)\]\]>/, '$1');

--- a/src/misc/php-date-formatter.js
+++ b/src/misc/php-date-formatter.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/sortableComponent.js
+++ b/src/misc/sortableComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/swipe.js
+++ b/src/misc/swipe.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/syncArrays.js
+++ b/src/misc/syncArrays.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/misc/syncArrays.js
+++ b/src/misc/syncArrays.js
@@ -47,7 +47,6 @@
  * @param {function(T):boolean} filter Filter function.
  * @return {function()} Function to call to stop synchronization
  * @template T
- * @private
  * @hidden
  */
 function syncArrays(arr1, arr2, reverse, scope, filter) {

--- a/src/offline/AbstractLocalforageWrapper.js
+++ b/src/offline/AbstractLocalforageWrapper.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/offline/Configuration.js
+++ b/src/offline/Configuration.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/offline/Downloader.js
+++ b/src/offline/Downloader.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/offline/LocalforageAndroidWrapper.js
+++ b/src/offline/LocalforageAndroidWrapper.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/offline/LocalforageCordovaWrapper.js
+++ b/src/offline/LocalforageCordovaWrapper.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/offline/LocalforageIosWrapper.js
+++ b/src/offline/LocalforageIosWrapper.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/offline/Mask.js
+++ b/src/offline/Mask.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/offline/Mode.js
+++ b/src/offline/Mode.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/offline/NetworkStatus.js
+++ b/src/offline/NetworkStatus.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/offline/Restorer.js
+++ b/src/offline/Restorer.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/offline/SerializerDeserializer.js
+++ b/src/offline/SerializerDeserializer.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/offline/ServiceManager.js
+++ b/src/offline/ServiceManager.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/offline/TilesDownloader.js
+++ b/src/offline/TilesDownloader.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/offline/component.js
+++ b/src/offline/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/offline/index.js
+++ b/src/offline/index.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/offline/module.js
+++ b/src/offline/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/offline/utils.js
+++ b/src/offline/utils.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/olcs/Manager.js
+++ b/src/olcs/Manager.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/olcs/Manager.js
+++ b/src/olcs/Manager.js
@@ -22,7 +22,6 @@
 import olcsContribManager from 'olcs/contrib/Manager.js';
 
 /**
- * @private
  * @hidden
  */
 class Manager extends olcsContribManager {

--- a/src/olcs/Service.js
+++ b/src/olcs/Service.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/olcs/constants.js
+++ b/src/olcs/constants.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/olcs/controls3d.js
+++ b/src/olcs/controls3d.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/olcs/controls3d.js
+++ b/src/olcs/controls3d.js
@@ -44,10 +44,9 @@ function shouldUpdate(older, newer) {
 }
 
 /**
- * @private
  * @hidden
  */
-const Controller = class {
+export const Controller = class {
   /**
    * @ngInject
    * @param {JQuery} $element The element

--- a/src/olcs/olcsModule.js
+++ b/src/olcs/olcsModule.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/print/Mask.js
+++ b/src/print/Mask.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/print/Service.js
+++ b/src/print/Service.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/print/Service.js
+++ b/src/print/Service.js
@@ -567,10 +567,9 @@ PrintService.prototype.getCapabilities = function (opt_httpConfig) {
  * @ngInject
  * @ngdoc service
  * @ngname ngeoCreatePrint
- * @private
  * @hidden
  */
-function createPrintServiceFactory($http, gettextCatalog, ngeoLayerHelper) {
+export function createPrintServiceFactory($http, gettextCatalog, ngeoLayerHelper) {
   return (
     /**
      * @param {string} url URL to MapFish print service.

--- a/src/print/Utils.js
+++ b/src/print/Utils.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/print/VectorEncoder.js
+++ b/src/print/VectorEncoder.js
@@ -30,7 +30,6 @@ import {asArray as asColorArray} from 'ol/color.js';
 
 /**
  * @constructor
- * @private
  * @hidden
  */
 function VectorEncoder() {

--- a/src/print/VectorEncoder.js
+++ b/src/print/VectorEncoder.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/print/mapfish-print-v3.js
+++ b/src/print/mapfish-print-v3.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/print/module.js
+++ b/src/print/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/profile/d3Elevation.js
+++ b/src/profile/d3Elevation.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/profile/elevationComponent.js
+++ b/src/profile/elevationComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/profile/module.js
+++ b/src/profile/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/query/Action.js
+++ b/src/query/Action.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/query/MapQuerent.js
+++ b/src/query/MapQuerent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/query/Mode.js
+++ b/src/query/Mode.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/query/ModeSelector.js
+++ b/src/query/ModeSelector.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/query/Querent.js
+++ b/src/query/Querent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/query/component.js
+++ b/src/query/component.js
@@ -40,10 +40,9 @@ import {Vector as olSourceVector} from 'ol/source.js';
 const module = angular.module('ngeoQuery', [ngeoQueryModeSelector.name, ngeoQueryMapQuerent.name]);
 
 /**
- * @private
  * @hidden
  */
-class QueryController {
+export class QueryController {
   /**
    * @param {import("ngeo/query/MapQuerent.js").MapQuerent}
    *     ngeoMapQuerent The ngeo map querent service.

--- a/src/query/component.js
+++ b/src/query/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/query/module.js
+++ b/src/query/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/query/panelComponent.js
+++ b/src/query/panelComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/query/panelComponent.js
+++ b/src/query/panelComponent.js
@@ -68,10 +68,9 @@ function ngeoQueryPanelTemplateUrl($attrs, ngeoQueryPanelTemplateUrl) {
 }
 
 /**
- * @private
  * @hidden
  */
-class QueryPanelController {
+export class QueryPanelController {
   /**
    * @param {import("ngeo/query/ModeSelector.js").QueryModeSelector}
    *     ngeoQueryModeSelector The ngeo query modeSelector service.

--- a/src/routing/NominatimInputComponent.js
+++ b/src/routing/NominatimInputComponent.js
@@ -77,13 +77,12 @@ function ngeoRoutingNominatimInputComponentTemplateUrl(
  * @param {import("ngeo/routing/NominatimService.js").NominatimService} ngeoNominatimService service for
  *    Nominatim
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname NgeoNominatimInputController
  */
-function Controller($element, $scope, ngeoNominatimService) {
+export function Controller($element, $scope, ngeoNominatimService) {
   /**
    * @type {JQuery}
    * @private

--- a/src/routing/NominatimInputComponent.js
+++ b/src/routing/NominatimInputComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/routing/NominatimService.js
+++ b/src/routing/NominatimService.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/routing/RoutingComponent.js
+++ b/src/routing/RoutingComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/routing/RoutingComponent.js
+++ b/src/routing/RoutingComponent.js
@@ -92,10 +92,9 @@ function ngeoRoutingTemplateUrl($attrs, ngeoRoutingTemplateUrl) {
 
 /**
  * The controller for the routing directive.
- * @private
  * @hidden
  */
-class Controller {
+export class Controller {
   /**
    * @param {angular.auto.IInjectorService} $injector Main injector.
    * @param {angular.IScope} $scope Scope.

--- a/src/routing/RoutingFeatureComponent.js
+++ b/src/routing/RoutingFeatureComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/routing/RoutingFeatureComponent.js
+++ b/src/routing/RoutingFeatureComponent.js
@@ -87,13 +87,12 @@ function ngeoRoutingFeatureTemplateUrl($attrs, ngeoRoutingFeatureTemplateUrl) {
  * @param {import("ngeo/routing/NominatimService.js").NominatimService} ngeoNominatimService service for
  *    Nominatim
  * @constructor
- * @private
  * @hidden
  * @ngInject
  * @ngdoc controller
  * @ngname NgeoRoutingFeatureController
  */
-class Controller {
+export class Controller {
   /**
    * @param {angular.IScope} $scope
    * @param {angular.ITimeoutService} $timeout

--- a/src/routing/RoutingService.js
+++ b/src/routing/RoutingService.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/routing/module.js
+++ b/src/routing/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/rule/Date.js
+++ b/src/rule/Date.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/rule/Geometry.js
+++ b/src/rule/Geometry.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/rule/Rule.js
+++ b/src/rule/Rule.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/rule/Select.js
+++ b/src/rule/Select.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/rule/Text.js
+++ b/src/rule/Text.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/search/createGeoJSONBloodhound.js
+++ b/src/search/createGeoJSONBloodhound.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/search/createLocationSearchBloodhound.js
+++ b/src/search/createLocationSearchBloodhound.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/search/createLocationSearchBloodhound.js
+++ b/src/search/createLocationSearchBloodhound.js
@@ -72,10 +72,9 @@ import 'corejs-typeahead';
 /**
  * @param {LocationSearchOptions=} opt_options Options.
  * @return {Bloodhound<olFeature<import('ol/geom/Geometry.js').default>[]>} The Bloodhound object.
- * @private
  * @hidden
  */
-function createLocationSearchBloodhound(opt_options) {
+export function createLocationSearchBloodhound(opt_options) {
   /** @type {LocationSearchOptions} */
   const options = opt_options || {};
 

--- a/src/search/module.js
+++ b/src/search/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/search/searchDirective.js
+++ b/src/search/searchDirective.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/source/AsitVD.js
+++ b/src/source/AsitVD.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/statemanager/Location.js
+++ b/src/statemanager/Location.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/statemanager/Location.js
+++ b/src/statemanager/Location.js
@@ -347,10 +347,9 @@ StatemanagerLocation.prototype.setPath = function (path) {
  * @param {angular.IWindowService} $window Angular window service.
  * @return {StatemanagerLocation} The ngeo location service.
  * @ngInject
- * @private
  * @hidden
  */
-function LocationFactory($rootScope, $window) {
+export function LocationFactory($rootScope, $window) {
   const history = $window.history;
   const service = new StatemanagerLocation($window.location, $window.history);
 

--- a/src/statemanager/Service.js
+++ b/src/statemanager/Service.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/statemanager/WfsPermalink.js
+++ b/src/statemanager/WfsPermalink.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/statemanager/extraModule.js
+++ b/src/statemanager/extraModule.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/statemanager/module.js
+++ b/src/statemanager/module.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2020 Camptocamp SA
+// Copyright (c) 2017-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/all.js
+++ b/test/spec/all.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2020 Camptocamp SA
+// Copyright (c) 2018-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/beforeeach.js
+++ b/test/spec/beforeeach.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/data/geoAdminLocationSearch.js
+++ b/test/spec/data/geoAdminLocationSearch.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/data/msGMLOutputBusStop.js
+++ b/test/spec/data/msGMLOutputBusStop.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/data/msGMLOutputBusStopAndInformation.js
+++ b/test/spec/data/msGMLOutputBusStopAndInformation.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/data/msGMLOutputBusStopWfs.js
+++ b/test/spec/data/msGMLOutputBusStopWfs.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/data/msGMLOutputFuel.js
+++ b/test/spec/data/msGMLOutputFuel.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/data/msGMLOutputInformationHitsWfs.js
+++ b/test/spec/data/msGMLOutputInformationHitsWfs.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/data/msGMLOutputInformationWfs.js
+++ b/test/spec/data/msGMLOutputInformationWfs.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/data/wmtsCapabilities.js
+++ b/test/spec/data/wmtsCapabilities.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/directives/filereader.spec.js
+++ b/test/spec/directives/filereader.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/directives/grid.spec.js
+++ b/test/spec/directives/grid.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/directives/layertree.spec.js
+++ b/test/spec/directives/layertree.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/directives/scaleselector.spec.js
+++ b/test/spec/directives/scaleselector.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/ngeo/getbrowserlanguage.spec.js
+++ b/test/spec/ngeo/getbrowserlanguage.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2020 Camptocamp SA
+// Copyright (c) 2019-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/ol-ext/format/featurehash.spec.js
+++ b/test/spec/ol-ext/format/featurehash.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/search/createlocationsearchbloodhound.spec.js
+++ b/test/spec/search/createlocationsearchbloodhound.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/services/autoprojection.spec.js
+++ b/test/spec/services/autoprojection.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/services/backgroundlayermgr.spec.js
+++ b/test/spec/services/backgroundlayermgr.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/services/csvdownload.spec.js
+++ b/test/spec/services/csvdownload.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/services/debounce.spec.js
+++ b/test/spec/services/debounce.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/services/decoratelayer.spec.js
+++ b/test/spec/services/decoratelayer.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/services/decoratelayerloading.spec.js
+++ b/test/spec/services/decoratelayerloading.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/services/featureoverlay.spec.js
+++ b/test/spec/services/featureoverlay.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/services/filters.spec.js
+++ b/test/spec/services/filters.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/services/layerHelper.spec.js
+++ b/test/spec/services/layerHelper.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/services/location.spec.js
+++ b/test/spec/services/location.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2020 Camptocamp SA
+// Copyright (c) 2014-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/services/print.spec.js
+++ b/test/spec/services/print.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/services/printutils.spec.js
+++ b/test/spec/services/printutils.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/services/syncarrays.spec.js
+++ b/test/spec/services/syncarrays.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/services/toolActivateMgr.spec.js
+++ b/test/spec/services/toolActivateMgr.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2020 Camptocamp SA
+// Copyright (c) 2015-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/services/wfspermalink.spec.js
+++ b/test/spec/services/wfspermalink.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/test/spec/services/wmstime.spec.js
+++ b/test/spec/services/wmstime.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2020 Camptocamp SA
+// Copyright (c) 2016-2021 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Add some export, mainly for `controllers` classes.
It doesn't cost anything (or perhaps only a little bit in code comprehension) and it make easier the customization of the application.
For instance, with an exported class, we can import it in a customer application and modify slightly one method.
To do the same without the export, we have to redefine the whole component AND the html partials where the component is called. 

I've also suppressed some `@private` tag on exported class.
They looks not useful (and 1/3 are already missing...)