### PR TITLE
Debug print timezone

### DIFF
--- a/contribs/gmf/src/print/component.js
+++ b/contribs/gmf/src/print/component.js
@@ -833,11 +833,8 @@ export class PrintController {
       if (!attribute.clientParams) {
         const name = `${attribute.name}`;
 
-        // Special case for timezone, hide it and fill it with browser timezone.
+        // Special case for timezone, fill it with browser timezone.
         if (name == 'timezone') {
-          if (this.options.hiddenAttributes.includes('timezone')) {
-            this.options.hiddenAttributes.push('timezone');
-          }
           this.layoutInfo.simpleAttributes.push({
             name: 'timezone',
             type: 'text',


### PR DESCRIPTION
Fix https://github.com/camptocamp/ngeo/pull/6456

I remove two line concerning the timezone. It makes no sens like that and throw an error on the desktop interface (includes on a not existing options.hiddenAttributes element => error and unable to print anymore).

I think you can still hide the timezone input by adding this `timezone` in the vars of <interface>->print->hiddenattributes.