### PR TITLE
Group legend

### DIFF
--- a/contribs/gmf/src/layertree/SyncLayertreeMap.js
+++ b/contribs/gmf/src/layertree/SyncLayertreeMap.js
@@ -22,6 +22,7 @@
 import angular from 'angular';
 import gmfThemeThemes, {getNodeMinResolution, getNodeMaxResolution} from 'gmf/theme/Themes.js';
 import ngeoLayertreeController, {LayertreeVisitorDecision} from 'ngeo/layertree/Controller.js';
+import {LAYER_NODE_NAME_KEY} from 'ngeo/map/LayerHelper.js';
 import ngeoMiscWMSTime from 'ngeo/misc/WMSTime.js';
 import {getUid as olUtilGetUid} from 'ol/util.js';
 import olLayerImage from 'ol/layer/Image.js';
@@ -268,7 +269,8 @@ SyncLayertreeMap.prototype.createLayerFromGroup_ = function (treeCtrl, mixed) {
       ogcServer.type,
       timeParam,
       undefined, // WMS parameters
-      ogcServer.credential ? 'use-credentials' : 'anonymous'
+      ogcServer.credential ? 'use-credentials' : 'anonymous',
+      undefined // Source options
     );
 
     layer.set('dataSourceId', groupNode.id);
@@ -285,8 +287,8 @@ SyncLayertreeMap.prototype.createLayerFromGroup_ = function (treeCtrl, mixed) {
       }
     });
     layer.setVisible(hasActiveChildren);
-    layer.set('layerNodeName', groupNode.name); //Really useful ?
   }
+  layer.set(LAYER_NODE_NAME_KEY, groupNode.name);
   return layer;
 };
 
@@ -341,7 +343,7 @@ SyncLayertreeMap.prototype.createLeafInAMixedGroup_ = function (treeCtrl, map) {
   }
   layer.set('dataSourceId', gmfLayer.id);
   // Update layer information and tree state.
-  layer.set('layerNodeName', gmfLayer.name); // Really useful ?
+  layer.set(LAYER_NODE_NAME_KEY, gmfLayer.name);
   this.updateLayerReferences_(gmfLayer, layer);
   const checked = gmfLayer.metadata.isChecked === true;
   if (checked) {

--- a/contribs/gmf/src/permalink/Permalink.js
+++ b/contribs/gmf/src/permalink/Permalink.js
@@ -41,8 +41,8 @@ import {Permalink3dParam} from 'ngeo/olcs/constants.js';
 import ngeoFormatFeatureHash from 'ngeo/format/FeatureHash.js';
 import ngeoFormatFeatureProperties from 'ngeo/format/FeatureProperties.js';
 
+import {LAYER_NODE_NAME_KEY} from 'ngeo/map/LayerHelper.js';
 import ngeoMiscDebounce from 'ngeo/misc/debounce.js';
-
 import ngeoMiscEventHelper from 'ngeo/misc/EventHelper.js';
 import ngeoStatemanagerModule from 'ngeo/statemanager/module.js';
 import ngeoStatemanagerService from 'ngeo/statemanager/Service.js';
@@ -1724,7 +1724,7 @@ PermalinkService.prototype.containsLayerName = function (layer, name) {
     }
     return false;
   } else {
-    return layer.get('layerNodeName') == name;
+    return layer.get(LAYER_NODE_NAME_KEY) == name;
   }
 };
 

--- a/contribs/gmf/src/print/LegendMapFishPrintV3.js
+++ b/contribs/gmf/src/print/LegendMapFishPrintV3.js
@@ -1,0 +1,350 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2021 Camptocamp SA
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import {DATALAYERGROUP_NAME} from 'gmf/index.js';
+import {findGroupByLayerNodeName, findObjectByName} from 'gmf/theme/Themes.js';
+import olLayerTile from 'ol/layer/Tile.js';
+import ImageWMS from 'ol/source/ImageWMS.js';
+import ExternalOGC from 'gmf/datasource/ExternalOGC.js';
+import {dpi as screenDpi} from 'ngeo/utils.js';
+
+/**
+ * Get the print legend for MapFishPrint V3 from the OpenLayers map and the GMF Layertree.
+ * @hidden
+ */
+export default class LegendMapFishPrintV3 {
+  /**
+   * @param {angular.gettext.gettextCatalog} gettextCatalog Gettext catalog.
+   * @param {import("ngeo/map/LayerHelper.js").LayerHelper} ngeoLayerHelper The ngeo Layer Helper service.
+   * @param {import("gmf/datasource/ExternalDataSourcesManager.js").ExternalDatSourcesManager} gmfExternalDataSourcesManager The manager of external datasources.
+   * @param {import('gmf/options.js').OptionsLegendType} legendOptions The options for the legend.
+   * @param {import("ol/Map.js").default} map the map to extract the legend from.
+   */
+  constructor(gettextCatalog, ngeoLayerHelper, gmfExternalDataSourcesManager, legendOptions, map) {
+    /**
+     * @type {angular.gettext.gettextCatalog}
+     * @private
+     */
+    this.gettextCatalog_ = gettextCatalog;
+
+    /**
+     * @type {import("ngeo/map/LayerHelper.js").LayerHelper}
+     * @private
+     */
+    this.ngeoLayerHelper_ = ngeoLayerHelper;
+
+    /**
+     * @type {import("gmf/datasource/ExternalDataSourcesManager.js").ExternalDatSourcesManager}
+     * @private
+     */
+    this.gmfExternalDataSourcesManager_ = gmfExternalDataSourcesManager;
+
+    /**
+     * @type {import('gmf/options.js').OptionsLegendType}
+     * @private
+     */
+    this.gmfLegendOptions_ = {
+      useBbox: true,
+      label: {},
+      params: {},
+    };
+    if (legendOptions) {
+      Object.assign(this.gmfLegendOptions_, legendOptions);
+    }
+
+    /**
+     * @type {import("ol/Map.js").default}
+     * @private
+     */
+    this.map_ = map;
+  }
+
+  /**
+   * Return a legend for MapFishPrint V3 based on the map and the GMF layertree.
+   * @param {Array<import('gmf/themes.js').GmfTheme>} currentThemes the current themes.
+   * @param {number} scale The scale to get the legend (for wms layers only).
+   * @param {number} dpi The DPI.
+   * @param {number[]} bbox The bbox.
+   * @return {unknown?} Legend object for print report or null.
+   */
+  getLegend(currentThemes, scale, dpi, bbox) {
+    /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} */
+    const legendInternal = this.getInternalLegendItems_(currentThemes, scale, dpi, bbox);
+    /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} */
+    const externalLegend = this.getExternalLegendItems_(scale);
+
+    /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegend} */
+    const legend = {classes: [...legendInternal, ...externalLegend]};
+
+    return legend.classes.length > 0 ? legend : null;
+  }
+
+  /**
+   * Get legend classes from the layertree only.
+   * @param {Array<import('gmf/themes.js').GmfTheme>} currentThemes the current themes.
+   * @param {number} scale The scale to get the legend.
+   * @param {number} dpi The DPI.
+   * @param {number[]} bbox The bbox.
+   * @return {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} Legend classes.
+   * @private
+   */
+  getInternalLegendItems_(currentThemes, scale, dpi, bbox) {
+    /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} */
+    const legendClasses = [];
+    const dataLayerGroup = this.ngeoLayerHelper_.getGroupFromMap(this.map_, DATALAYERGROUP_NAME);
+    const layers = this.ngeoLayerHelper_.getFlatLayers(dataLayerGroup);
+
+    // For each visible layer in reverse order, get the legend url.
+    layers.reverse().forEach((layer) => {
+      /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} */
+      const classes = [];
+      if (layer.getVisible() && layer.getSource()) {
+        // For WMTS layers.
+        if (layer instanceof olLayerTile) {
+          this.addClassItemToArray_(classes, this.getLegendItemFromTileLayer_(currentThemes, layer, dpi));
+        } else {
+          const legendItem = this.getLegendItemFromWMSLayer_(
+            currentThemes,
+            /** @type {import("ol/layer/Layer.js").default<import("ol/source/ImageWMS.js").default>} */ (layer),
+            scale,
+            dpi,
+            bbox
+          );
+          this.addClassItemToArray_(classes, legendItem);
+        }
+      }
+      legendClasses.push(...classes);
+    });
+
+    return legendClasses;
+  }
+
+  /**
+   * Get legend classes from external datasources.
+   * @param {number} scale The scale to get the legend.
+   * @return {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} Legend classes.
+   * @private
+   */
+  getExternalLegendItems_(scale) {
+    // Get external layers
+    const wmsGroups = this.gmfExternalDataSourcesManager_.wmsGroups;
+
+    /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} */
+    const classes = [];
+
+    wmsGroups.forEach((group) => {
+      group.dataSourcesCollection.forEach((dataSource) => {
+        this.addClassItemToArray_(classes, this.getLegendItemFromExternalDatasource_(dataSource, scale));
+      });
+    });
+
+    return classes;
+  }
+
+  /**
+   * Add a class to a class array if the class to add is not null.
+   * @param {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} classes Array to add an element.
+   * @param {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass} classItem The class to add.
+   * @private
+   */
+  addClassItemToArray_(classes, classItem) {
+    if (classItem) {
+      classes.push(classItem);
+    }
+  }
+
+  /**
+   * Create a legend item from the given WMTS layer.
+   * @param {Array<import('gmf/themes.js').GmfTheme>} currentThemes the current themes.
+   * @param {import("ol/layer/Tile.js").default} layer The layer to extract the legend from.
+   * @param {number} dpi The DPI.
+   * @return {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass} Legend object for print report
+   * or null.
+   * @private
+   */
+  getLegendItemFromTileLayer_(currentThemes, layer, dpi) {
+    const gettextCatalog = this.gettextCatalog_;
+    const layerName = `${layer.get('layerNodeName')}`;
+    let icon_dpi = this.getMetadataLegendImage_(currentThemes, layerName, dpi);
+    if (!icon_dpi) {
+      const url = this.ngeoLayerHelper_.getWMTSLegendURL(layer);
+      if (url) {
+        icon_dpi = {
+          url: url,
+          dpi: screenDpi(),
+        };
+      }
+    }
+    // Add only classes without legend url.
+    if (icon_dpi) {
+      return {
+        name: gettextCatalog.getString(layerName),
+        icons: [icon_dpi.url],
+      };
+    }
+    return null;
+  }
+
+  /**
+   * Create a legend item from the given WMS layer.
+   * @param {Array<import('gmf/themes.js').GmfTheme>} currentThemes the current themes.
+   * @param {import("ol/layer/Layer.js").default<import("ol/source/ImageWMS.js").default>} layer The layer
+   * to extract the legend from.
+   * @param {number} scale The scale to get the legend.
+   * @param {number} dpi The DPI.
+   * @param {number[]} bbox The bbox.
+   * @return {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass} Legend object for print report
+   * or null.
+   * @private
+   */
+  getLegendItemFromWMSLayer_(currentThemes, layer, scale, dpi, bbox) {
+    const gettextCatalog = this.gettextCatalog_;
+    const source = layer.getSource();
+    if (!(source instanceof ImageWMS)) {
+      throw new Error('Wrong source type');
+    }
+    // @ts-ignore: private...
+    if (!source.serverType_) {
+      throw new Error('Missing source.serverType_');
+    }
+    // For each name in a WMS layer.
+    const layerNames = /** @type {string} */ (source.getParams().LAYERS).split(',');
+    /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} */
+    const layerLegendClasses = [];
+    layerNames.forEach((name) => {
+      // Don't add classes without legend url or from layers without any
+      // active name.
+      if (name.length !== 0) {
+        let icon_dpi = this.getMetadataLegendImage_(currentThemes, name, dpi);
+        // @ts-ignore: private...
+        const type = icon_dpi ? 'image' : source.serverType_;
+        if (!icon_dpi) {
+          const url = this.ngeoLayerHelper_.getWMSLegendURL(
+            source.getUrl(),
+            name,
+            scale,
+            undefined,
+            undefined,
+            undefined,
+            // @ts-ignore: private...
+            source.serverType_,
+            dpi,
+            this.gmfLegendOptions_.useBbox ? bbox : undefined,
+            this.map_.getView().getProjection().getCode(),
+            // @ts-ignore: private...
+            this.gmfLegendOptions_.params[source.serverType_]
+          );
+          if (!url) {
+            throw new Error('Missing url');
+          }
+          icon_dpi = {
+            url: url,
+            dpi: type === 'qgis' ? dpi : screenDpi(),
+          };
+        }
+        const classItem = {
+          name: this.gmfLegendOptions_.label[type] === false ? '' : gettextCatalog.getString(name),
+          icons: [icon_dpi.url],
+        };
+        if (icon_dpi.dpi != screenDpi()) {
+          Object.assign(classItem, {dpi: icon_dpi.dpi});
+        }
+        layerLegendClasses.push(classItem);
+      }
+    });
+    return {classes: layerLegendClasses};
+  }
+
+  /**
+   * Create a legend item from the given external datasource.
+   * @param {import("ngeo/datasource/DataSource.js").default} dataSource The datasource to extract the legend
+   * from.
+   * @param {number} scale The scale to get the legend.
+   * @return {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass} Legend object for print report
+   * or null.
+   * @private
+   */
+  getLegendItemFromExternalDatasource_(dataSource, scale) {
+    if (dataSource instanceof ExternalOGC && dataSource.visible) {
+      const url = this.ngeoLayerHelper_.getWMSLegendURL(dataSource.legend.url, dataSource.legend.name, scale);
+      return {
+        name: dataSource.legend.title,
+        icons: [url],
+      };
+    }
+  }
+
+  /**
+   * @typedef {Object} LegendURLDPI
+   * @property {string} url The URL
+   * @property {number} dpi The DPI
+   */
+
+  /**
+   * Return the metadata legendImage of a layer from the found corresponding node
+   * or undefined.
+   * @param {string} layerName a layer name.
+   * @param {number} [dpi=96] the image DPI.
+   * @param {Array<import('gmf/themes.js').GmfTheme>} currentThemes the current themes.
+   * @return {LegendURLDPI|undefined} The legendImage with selected DPI or undefined.
+   * @private
+   */
+  getMetadataLegendImage_(currentThemes, layerName, dpi = -1) {
+    if (dpi == -1) {
+      dpi = screenDpi();
+    }
+    const groupNode = findGroupByLayerNodeName(currentThemes, layerName);
+    let found_dpi = dpi;
+    let node;
+    if (groupNode && groupNode.children) {
+      node = findObjectByName(groupNode.children, layerName);
+    }
+    let legendImage;
+    let hiDPILegendImages;
+    if (node && node.metadata) {
+      legendImage = node.metadata.legendImage;
+      hiDPILegendImages = node.metadata.hiDPILegendImages;
+    }
+    let dist = Number.MAX_VALUE;
+    if (legendImage) {
+      dist = Math.abs(Math.log(screenDpi() / dpi));
+      found_dpi = screenDpi();
+    }
+    if (hiDPILegendImages) {
+      for (const str_dpi in hiDPILegendImages) {
+        const new_dpi = parseFloat(str_dpi);
+        const new_dist = Math.abs(Math.log(new_dpi / dpi));
+        if (new_dist < dist) {
+          dist = new_dist;
+          found_dpi = new_dpi;
+          legendImage = hiDPILegendImages[str_dpi];
+        }
+      }
+    }
+
+    if (legendImage) {
+      return {
+        url: legendImage,
+        dpi: found_dpi,
+      };
+    }
+  }
+}

--- a/contribs/gmf/src/print/LegendMapFishPrintV3.js
+++ b/contribs/gmf/src/print/LegendMapFishPrintV3.js
@@ -140,13 +140,14 @@ export default class LegendMapFishPrintV3 {
       /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} */
       const groupClasses = [];
       /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass} */
-      const legendGroupItem = {classes: groupClasses};
+      const legendGroupItem = {};
       if (layer.get(LAYER_NODE_NAME_KEY)) {
         legendGroupItem.name = gettextCatalog.getString(layer.get(LAYER_NODE_NAME_KEY));
       }
+      legendGroupItem.classes = groupClasses;
       const sublayers = layer.getLayers();
-      sublayers.forEach((layer) => {
-        const child = this.collectLegendClassesInTree_(layer, currentThemes, scale, dpi, bbox);
+      sublayers.forEach((sublayer) => {
+        const child = this.collectLegendClassesInTree_(sublayer, currentThemes, scale, dpi, bbox);
         this.addClassItemToArray_(groupClasses, child);
       });
       return this.tryToSimplifyLegendGroup_(legendGroupItem);

--- a/contribs/gmf/src/print/LegendMapFishPrintV3.js
+++ b/contribs/gmf/src/print/LegendMapFishPrintV3.js
@@ -133,7 +133,7 @@ export default class LegendMapFishPrintV3 {
      * - Create a legend item for the group (with a name if the layer has a name, which should be the case
      *   except for the tree's top-level group).
      * - Call this function on layer's children and try to add the resulting legendItem to the group.
-     * - Return the group item.
+     * - Return the group item (simplified if possible).
      */
     if (layer instanceof olLayerGroup) {
       const gettextCatalog = this.gettextCatalog_;
@@ -149,7 +149,7 @@ export default class LegendMapFishPrintV3 {
         const child = this.collectLegendClassesInTree_(layer, currentThemes, scale, dpi, bbox);
         this.addClassItemToArray_(groupClasses, child);
       });
-      return legendGroupItem;
+      return this.tryToSimplifyLegendGroup_(legendGroupItem);
     }
 
     // Case of leaf layer: Create a legend class item matching the layer.
@@ -205,6 +205,22 @@ export default class LegendMapFishPrintV3 {
     if (classItem && (classItem.classes ? classItem.classes.length > 0 : true)) {
       classes.push(classItem);
     }
+  }
+
+  /**
+   * If a Legend item have only one children and the children name is identical to its name, then return
+   * only the children (cut one level).
+   * Otherwise return the given legend item.
+   * @param {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass} legendGroupItem A legend item.
+   * @return {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass} The same legend item or a
+   * shrunk one.
+   * @private
+   */
+  tryToSimplifyLegendGroup_(legendGroupItem) {
+    if (legendGroupItem.classes.length === 1 && legendGroupItem.classes[0].name === legendGroupItem.name) {
+      return legendGroupItem.classes[0];
+    }
+    return legendGroupItem;
   }
 
   /**
@@ -311,7 +327,7 @@ export default class LegendMapFishPrintV3 {
         legendLayerClasses.push(legendLayerItem);
       }
     });
-    return legendGroupItem;
+    return this.tryToSimplifyLegendGroup_(legendGroupItem);
   }
 
   /**

--- a/contribs/gmf/src/print/LegendMapFishPrintV3.js
+++ b/contribs/gmf/src/print/LegendMapFishPrintV3.js
@@ -37,7 +37,7 @@ export default class LegendMapFishPrintV3 {
    * @param {angular.gettext.gettextCatalog} gettextCatalog Gettext catalog.
    * @param {import("ngeo/map/LayerHelper.js").LayerHelper} ngeoLayerHelper The ngeo Layer Helper service.
    * @param {import("gmf/datasource/ExternalDataSourcesManager.js").ExternalDatSourcesManager} gmfExternalDataSourcesManager The manager of external datasources.
-   * @param {import('gmf/options.js').OptionsLegendType} legendOptions The options for the legend.
+   * @param {import("gmf/options.js").OptionsLegendType} legendOptions The options for the legend.
    * @param {import("ol/Map.js").default} map the map to extract the legend from.
    */
   constructor(gettextCatalog, ngeoLayerHelper, gmfExternalDataSourcesManager, legendOptions, map) {
@@ -183,15 +183,25 @@ export default class LegendMapFishPrintV3 {
     const wmsGroups = this.gmfExternalDataSourcesManager_.wmsGroups;
 
     /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} */
-    const classes = [];
+    const topClasses = [];
 
     wmsGroups.forEach((group) => {
+      /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} */
+      const groupClasses = [];
+      /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass} */
+      const legendGroupItem = {
+        name: group.title,
+        classes: groupClasses,
+      };
+
       group.dataSourcesCollection.forEach((dataSource) => {
-        this.addClassItemToArray_(classes, this.getLegendItemFromExternalDatasource_(dataSource, scale));
+        this.addClassItemToArray_(groupClasses, this.getLegendItemFromExternalDatasource_(dataSource, scale));
       });
+
+      this.addClassItemToArray_(topClasses, this.tryToSimplifyLegendGroup_(legendGroupItem));
     });
 
-    return classes;
+    return topClasses;
   }
 
   /**

--- a/contribs/gmf/test/spec/all.js
+++ b/contribs/gmf/test/spec/all.js
@@ -21,6 +21,7 @@
 
 import 'gmf/sass/vars.scss';
 import './beforeeach.js';
+import './classes/legendmapfishprintv3.spec.js';
 import './controllers/gmfprintcontroller.spec.js';
 import './controllers/calculateCssVars.spec.js';
 import './services/share.spec.js';

--- a/contribs/gmf/test/spec/classes/legendmapfishprintv3.spec.js
+++ b/contribs/gmf/test/spec/classes/legendmapfishprintv3.spec.js
@@ -1,0 +1,69 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2021 Camptocamp SA
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import angular from 'angular';
+import olMap from 'ol/Map.js';
+import LegendMapFishPrintV3 from 'gmf/print/LegendMapFishPrintV3.js';
+
+describe('gmf.print.LegendMapFishPrintV3', () => {
+  /*
+   * @param {angular.gettext.gettextCatalog} gettextCatalog Gettext catalog.
+   * @param {import("ngeo/map/LayerHelper.js").LayerHelper} ngeoLayerHelper The ngeo Layer Helper service.
+   * @param {import("gmf/datasource/ExternalDataSourcesManager.js").ExternalDatSourcesManager} gmfExternalDataSourcesManager The manager of external datasources.
+   * @param {import('gmf/options.js').OptionsLegendType} legendOptions The options for the legend.
+   * @param {import("ol/Map.js").default} map the map to extract the legend from.
+   */
+  //constructor(gettextCatalog, ngeoLayerHelper, gmfExternalDataSourcesManager, legendOptions, map) {
+
+  /** @type {import('gmf/print/LegendMapFishPrintV3.js').default} */
+  let legendMapFishPrintV3 = null;
+
+  beforeEach(() => {
+    angular.mock.inject(($injector) => {
+      const gettextCatalog = $injector.get('gettextCatalog');
+      const ngeoLayerHelper = $injector.get('ngeoLayerHelper');
+      const gmfExternalDataSourcesManager = $injector.get('gmfExternalDataSourcesManager');
+      const legendOptions = {
+        label: {qgis: true},
+        params: {
+          qgis: {
+            ITEMFONTFAMILY: 'DejaVu Sans',
+            ITEMFONTSIZE: '8',
+            LAYERFONTFAMILY: 'DejaVu Sans',
+            LAYERFONTSIZE: '10',
+          },
+        },
+      };
+      const map = new olMap({});
+      legendMapFishPrintV3 = new LegendMapFishPrintV3(
+        gettextCatalog,
+        ngeoLayerHelper,
+        gmfExternalDataSourcesManager,
+        legendOptions,
+        map
+      );
+    });
+  });
+
+  it('Should be instantiated', () => {
+    expect(legendMapFishPrintV3).toBeTruthy();
+  });
+});

--- a/contribs/gmf/test/spec/classes/legendmapfishprintv3.spec.js
+++ b/contribs/gmf/test/spec/classes/legendmapfishprintv3.spec.js
@@ -21,7 +21,15 @@
 
 import angular from 'angular';
 import olMap from 'ol/Map.js';
+import olCollection from 'ol/Collection.js';
+import olLayerGroup from 'ol/layer/Group.js';
+import olLayerTile from 'ol/layer/Tile.js';
+import olLayerLayer from 'ol/layer/Layer.js';
+import olSourceImageWMS from 'ol/source/ImageWMS.js';
+import olSourceTileImage from 'ol/source/TileImage.js';
+import {LAYER_NODE_NAME_KEY} from 'ngeo/map/LayerHelper.js';
 import LegendMapFishPrintV3 from 'gmf/print/LegendMapFishPrintV3.js';
+import {DATALAYERGROUP_NAME} from 'gmf/index.js';
 
 describe('gmf.print.LegendMapFishPrintV3', () => {
   /*
@@ -36,23 +44,69 @@ describe('gmf.print.LegendMapFishPrintV3', () => {
   /** @type {import('gmf/print/LegendMapFishPrintV3.js').default} */
   let legendMapFishPrintV3 = null;
 
+  const layerTile = new olLayerTile({
+    source: new olSourceTileImage({
+      attributions: 'foo',
+    }),
+  });
+  layerTile.set('capabilitiesStyles', [{legendURL: [{href: 'http://tile.com/icon'}]}]);
+  layerTile.set(LAYER_NODE_NAME_KEY, 'layerTile');
+
+  const sourceWMS1 = new olSourceImageWMS({
+    params: {LAYERS: 'layerwms1, layerwms2'},
+    url: 'http://wmslayer1.com',
+    serverType: 'qgis',
+  });
+  const layerWMS1 = new olLayerLayer({source: sourceWMS1});
+  layerWMS1.set(LAYER_NODE_NAME_KEY, 'layerwms1');
+
+  const sourceWMS2 = new olSourceImageWMS({
+    params: {LAYERS: 'layerwms'},
+    url: 'http://wmslayer2.com',
+    serverType: 'qgis',
+  });
+
+  const layerWMS2 = new olLayerLayer({source: sourceWMS2});
+  // Same name than then unique WMS layer: it will be simplified.
+  layerWMS2.set(LAYER_NODE_NAME_KEY, 'layerwms');
+
+  const mapLayerGroup = new olLayerGroup();
+  const map = new olMap({
+    layers: mapLayerGroup,
+  });
+
+  const setMapLayers =
+    /**
+     * Add layers in a named group and add this group to the map.
+     * @param {import('ol/layer/Layer').default<import("ol/source/Source.js").default>[]} layers the array
+     * of layers to add to the map.
+     * @param {string} groupName The group name.
+     */
+    (layers, groupName) => {
+      const layerGroup = new olLayerGroup();
+      layerGroup.setLayers(new olCollection(layers));
+      layerGroup.set('groupName', DATALAYERGROUP_NAME); // For layerHelper to find the group.
+      layerGroup.set(LAYER_NODE_NAME_KEY, groupName);
+      mapLayerGroup.setLayers(new olCollection([layerGroup]));
+    };
+
+  const legendOptions = {
+    label: {qgis: true},
+    params: {
+      qgis: {
+        ITEMFONTFAMILY: 'DejaVu Sans',
+        ITEMFONTSIZE: '8',
+        LAYERFONTFAMILY: 'DejaVu Sans',
+        LAYERFONTSIZE: '10',
+      },
+    },
+  };
+
   beforeEach(() => {
     angular.mock.inject(($injector) => {
       const gettextCatalog = $injector.get('gettextCatalog');
       const ngeoLayerHelper = $injector.get('ngeoLayerHelper');
       const gmfExternalDataSourcesManager = $injector.get('gmfExternalDataSourcesManager');
-      const legendOptions = {
-        label: {qgis: true},
-        params: {
-          qgis: {
-            ITEMFONTFAMILY: 'DejaVu Sans',
-            ITEMFONTSIZE: '8',
-            LAYERFONTFAMILY: 'DejaVu Sans',
-            LAYERFONTSIZE: '10',
-          },
-        },
-      };
-      const map = new olMap({});
       legendMapFishPrintV3 = new LegendMapFishPrintV3(
         gettextCatalog,
         ngeoLayerHelper,
@@ -65,5 +119,69 @@ describe('gmf.print.LegendMapFishPrintV3', () => {
 
   it('Should be instantiated', () => {
     expect(legendMapFishPrintV3).toBeTruthy();
+  });
+
+  it('Should make legend for a wms with two layers', () => {
+    setMapLayers([layerWMS1], 'layerGroup');
+    const legend = legendMapFishPrintV3.getLegend([], 25000, 254, [0, 0]);
+    expect(legend).toEqual({
+      'classes': [
+        {
+          'name': 'layerGroup',
+          'classes': [
+            {
+              'name': 'layerwms1',
+              'classes': [
+                {
+                  'name': 'layerwms1',
+                  'icons': [
+                    'http://wmslayer1.com?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=layerwms1&SCALE=25000&DPI=254&BBOX=0%2C0&SRS=EPSG%3A3857&WIDTH=NaN&HEIGHT=NaN&ITEMFONTFAMILY=DejaVu%20Sans&ITEMFONTSIZE=8&LAYERFONTFAMILY=DejaVu%20Sans&LAYERFONTSIZE=10',
+                  ],
+                  'dpi': 254,
+                },
+                {
+                  'name': ' layerwms2',
+                  'icons': [
+                    'http://wmslayer1.com?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=%20layerwms2&SCALE=25000&DPI=254&BBOX=0%2C0&SRS=EPSG%3A3857&WIDTH=NaN&HEIGHT=NaN&ITEMFONTFAMILY=DejaVu%20Sans&ITEMFONTSIZE=8&LAYERFONTFAMILY=DejaVu%20Sans&LAYERFONTSIZE=10',
+                  ],
+                  'dpi': 254,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('Should make legend for a wms with one layer having the same name than the group', () => {
+    // Same group name than the layer: it will be simplified.
+    setMapLayers([layerWMS2], 'layerwms');
+    const legend = legendMapFishPrintV3.getLegend([], 25000, 254, [0, 0]);
+    expect(legend).toEqual({
+      'classes': [
+        {
+          'name': 'layerwms',
+          'icons': [
+            'http://wmslayer2.com?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=layerwms&SCALE=25000&DPI=254&BBOX=0%2C0&SRS=EPSG%3A3857&WIDTH=NaN&HEIGHT=NaN&ITEMFONTFAMILY=DejaVu%20Sans&ITEMFONTSIZE=8&LAYERFONTFAMILY=DejaVu%20Sans&LAYERFONTSIZE=10',
+          ],
+          'dpi': 254,
+        },
+      ],
+    });
+  });
+
+  it('Should make legend for a tile layer', () => {
+    // Same group name than the layer: it will be simplified.
+    setMapLayers([layerTile], 'layerTile');
+    const legend = legendMapFishPrintV3.getLegend([], 25000, 254, [0, 0]);
+    expect(legend).toEqual({
+      'classes': [
+        {
+          'name': 'layerTile',
+          'icons': ['http://tile.com/icon'],
+        },
+      ],
+    });
   });
 });

--- a/src/map/LayerHelper.js
+++ b/src/map/LayerHelper.js
@@ -66,6 +66,12 @@ export function LayerHelper($q, $http, ngeoTilesPreloadingLimit) {
 }
 
 /**
+ * Layer node name key in layer parameters.
+ * To identify the OpenLayers layer by its name.
+ */
+export const LAYER_NODE_NAME_KEY = 'layerNodeName';
+
+/**
  * @private
  * @hidden
  */
@@ -116,8 +122,8 @@ LayerHelper.prototype.copyProperties = function (layerFrom, layerTo, opt_exclude
  * @param {string=} opt_time time parameter for layer queryable by time/period
  * @param {Object<string, string>=} opt_params WMS parameters.
  * @param {string=} opt_crossOrigin crossOrigin.
- * @param {unknown=} opt_customSourceOptions Some initial options.
- * @param {unknown=} opt_customLayerOptions The layer opacity.
+ * @param {unknown=} opt_customSourceOptions Some layer's source initial options.
+ * @param {unknown=} opt_customLayerOptions Some layer initial options.
  * @return {import("ol/layer/Image.js").default} WMS Layer.
  */
 LayerHelper.prototype.createBasicWMSLayer = function (
@@ -416,7 +422,7 @@ LayerHelper.prototype.getFlatLayers_ = function (layer, array, computedOpacity) 
 };
 
 /**
- * Get a layer that has a `layerName` property equal to a given layer name from
+ * Get a layer that has the LAYER_NODE_NAME_KEY property equal to a given layer name from
  * an array of layers. If one of the layers in the array is a group, then the
  * layers contained in that group are searched as well.
  * @param {string} layerName The name of the layer we're looking for.
@@ -430,7 +436,7 @@ LayerHelper.prototype.getLayerByName = function (layerName, layers) {
     if (layer instanceof olLayerGroup) {
       const sublayers = layer.getLayers().getArray();
       found = this.getLayerByName(layerName, sublayers);
-    } else if (layer.get('layerNodeName') === layerName) {
+    } else if (layer.get(LAYER_NODE_NAME_KEY) === layerName) {
       found = layer;
     }
     return !!found;

--- a/src/print/mapfish-print-v3.js
+++ b/src/print/mapfish-print-v3.js
@@ -265,8 +265,10 @@
 
 /**
  * @typedef {Object} MapFishPrintLegendClass
- * @property {string} name
- * @property {string[]} icons
+ * @property {string} [name]
+ * @property {string[]} [icons]
+ * @property {number} [dpi]
+ * @property {MapFishPrintLegendClass[]} [classes]
  */
 
 /**


### PR DESCRIPTION
For GSGMF-1367

Spec:
- Provide to the print the layer group information from the client.
- Display only one name if layername is identical to the group name.

Done:

- I've moved the legend creation in a specific class in a specific file.
- I've cut the function into multiple smaller function.
- Legend classes are now embedded in other legend class to provide the hierarchical group representation of layers to the print.
- Group name are now sent to the print.
- Legend creation is now tested.


Without adaptation of the legend print template, the legend will looks not so good.
