### PR TITLE
Fix blank line on grid (do resize map)

### DIFF
--- a/contribs/gmf/apps/desktop/index.html.ejs
+++ b/contribs/gmf/apps/desktop/index.html.ejs
@@ -332,7 +332,7 @@
         gmf-displayquerygrid-active="mainCtrl.queryGridActive"
         gmf-displayquerygrid-map="::mainCtrl.map"
         ngeo-resizemap="mainCtrl.map"
-        ngeo-resizemap-state="queryGridActive">
+        ngeo-resizemap-state="mainCtrl.queryGridActive">
       </gmf-displayquerygrid>
     </footer>
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,default-3.6,Array.prototype.includes,Object.entries,Object.values"></script>

--- a/contribs/gmf/apps/desktop_alt/index.html.ejs
+++ b/contribs/gmf/apps/desktop_alt/index.html.ejs
@@ -375,7 +375,7 @@
         gmf-displayquerygrid-active="mainCtrl.queryGridActive"
         gmf-displayquerygrid-map="::mainCtrl.map"
         ngeo-resizemap="mainCtrl.map"
-        ngeo-resizemap-state="queryGridActive">
+        ngeo-resizemap-state="mainCtrl.queryGridActive">
       </gmf-displayquerygrid>
     </footer>
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,default-3.6,Array.prototype.includes,Object.entries,Object.values"></script>


### PR DESCRIPTION
Same fix as for https://jira.camptocamp.com/browse/GEO-3866

Under the grid, a blank line can appear as the map-resize is disconnected to the queryGridActivate value.
Appear almost always with the filter tool (and interfaces with the grid). You can test the bug on the GMF demo 2-6
This fix correct that.