### PR TITLE
Make displayquerygrid height overridable

### DIFF
--- a/contribs/gmf/src/query/grid.scss
+++ b/contribs/gmf/src/query/grid.scss
@@ -23,14 +23,13 @@
 
 @import '~gmf/sass/vars.scss';
 
-$grid-height: 15.62rem;
-$table-height: $grid-height - $app-margin - 2 * $map-tools-size;
+$table-height: $displayquerygrid-height - $app-margin - 2 * $map-tools-size;
 
 .panel.gmf-displayquerygrid {
   padding: $half-app-margin;
   border-top: solid 0.06rem black;
   background-color: white;
-  height: $grid-height;
+  height: $displayquerygrid-height;
   position: fixed;
   width: 100%;
 
@@ -98,5 +97,5 @@ $table-height: $grid-height - $app-margin - 2 * $map-tools-size;
 }
 
 .gmf-query-grid-active main {
-  height: calc(100% - #{$grid-height});
+  height: calc(100% - #{$displayquerygrid-height});
 }

--- a/contribs/gmf/src/sass/vars_only.scss
+++ b/contribs/gmf/src/sass/vars_only.scss
@@ -61,6 +61,7 @@ $hover-background-color: lighten($brand-primary, $standard-variation) !default;
 $brand-secondary-dark: darken($brand-secondary, $standard-variation) !default;
 
 $displayquerywindow-desktop-height: 15rem !default;
+$displayquerygrid-height: 15.62rem !default;
 
 // Z-indexes
 $below-content-index: 1;


### PR DESCRIPTION
(tested in GMF 2.5 but seems the same with GMF master)

When trying to customize GMF's gmf-displayquerygrid height, overridding ``$grid-height`` in the project's ``vars_desktop.scss`` as for the colors (eg. ``$brand-primary``) has no effect.

It seems because ``$grid-height`` is directly set in https://github.com/camptocamp/ngeo/blob/master/contribs/gmf/src/query/grid.scss#L26 (right before using it in the grid styles) instead of being added to https://github.com/camptocamp/ngeo/blob/master/contribs/gmf/src/sass/vars_only.scss 

This PR moves the var in the ``vars_only.scss`` and rename it.

Tested successfully in a GMF 2.5 project.