### PR TITLE
Add a "flat legend possibility" (no groups title)

### DIFF
--- a/contribs/gmf/src/options.js
+++ b/contribs/gmf/src/options.js
@@ -224,6 +224,8 @@
  * @property {Object<string, Object<string, string>>} params The key is the server type (`mapserver`,
  *    `qgis`, ...) or `image` for an URL from a metadata. The value is some additional parameters set in the
  *    query string.
+ * @property {boolean} [showGroupsTitle] Display or not groups title in the legend. default to
+ *    true. Switching to false is useful to obtains a "flat" legend.
  */
 
 /**

--- a/contribs/gmf/src/print/LegendMapFishPrintV3.js
+++ b/contribs/gmf/src/print/LegendMapFishPrintV3.js
@@ -67,6 +67,7 @@ export default class LegendMapFishPrintV3 {
       useBbox: true,
       label: {},
       params: {},
+      showGroupsTitle: true,
     };
     if (legendOptions) {
       Object.assign(this.gmfLegendOptions_, legendOptions);
@@ -141,7 +142,7 @@ export default class LegendMapFishPrintV3 {
       const groupClasses = [];
       /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass} */
       const legendGroupItem = {};
-      if (layer.get(LAYER_NODE_NAME_KEY)) {
+      if (layer.get(LAYER_NODE_NAME_KEY) && this.gmfLegendOptions_.showGroupsTitle) {
         legendGroupItem.name = gettextCatalog.getString(layer.get(LAYER_NODE_NAME_KEY));
       }
       legendGroupItem.classes = groupClasses;
@@ -190,9 +191,11 @@ export default class LegendMapFishPrintV3 {
       const groupClasses = [];
       /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass} */
       const legendGroupItem = {
-        name: group.title,
         classes: groupClasses,
       };
+      if (this.gmfLegendOptions_.showGroupsTitle) {
+        legendGroupItem.name = group.title;
+      }
 
       group.dataSourcesCollection.forEach((dataSource) => {
         this.addClassItemToArray_(groupClasses, this.getLegendItemFromExternalDatasource_(dataSource, scale));
@@ -220,7 +223,7 @@ export default class LegendMapFishPrintV3 {
 
   /**
    * If a Legend item have only one children and the children name is identical to its name, then return
-   * only the children (cut one level).
+   * only the children (cut one level). Shrink also if both names are null or undefined.
    * Otherwise return the given legend item.
    * @param {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass} legendGroupItem A legend item.
    * @return {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass} The same legend item or a
@@ -292,9 +295,11 @@ export default class LegendMapFishPrintV3 {
     const legendLayerClasses = [];
     /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass} */
     const legendGroupItem = {
-      name: gettextCatalog.getString(layer.get(LAYER_NODE_NAME_KEY)),
       classes: legendLayerClasses,
     };
+    if (this.gmfLegendOptions_.showGroupsTitle) {
+      legendGroupItem.name = gettextCatalog.getString(layer.get(LAYER_NODE_NAME_KEY));
+    }
     // For each name in a WMS layer.
     const layerNames = /** @type {string} */ (source.getParams().LAYERS).split(',');
     layerNames.forEach((name) => {

--- a/contribs/gmf/test/spec/classes/legendmapfishprintv3.spec.js
+++ b/contribs/gmf/test/spec/classes/legendmapfishprintv3.spec.js
@@ -156,6 +156,35 @@ describe('gmf.print.LegendMapFishPrintV3', () => {
     });
   });
 
+  it('Should make legend for a wms with two layers (no title)', () => {
+    setMapLayers([layerWMS1], 'layerGroup');
+    // @ts-ignore: private.
+    legendMapFishPrintV3.gmfLegendOptions_.showGroupsTitle = false;
+    const legend = legendMapFishPrintV3.getLegend([], 25000, 254, [0, 0]);
+    expect(legend).toEqual({
+      'classes': [
+        {
+          'classes': [
+            {
+              'name': 'layerwms1',
+              'icons': [
+                'http://wmslayer1.com?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=layerwms1&SCALE=25000&DPI=254&BBOX=0%2C0&SRS=EPSG%3A3857&WIDTH=NaN&HEIGHT=NaN&ITEMFONTFAMILY=DejaVu%20Sans&ITEMFONTSIZE=8&LAYERFONTFAMILY=DejaVu%20Sans&LAYERFONTSIZE=10',
+              ],
+              'dpi': 254,
+            },
+            {
+              'name': ' layerwms2',
+              'icons': [
+                'http://wmslayer1.com?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=%20layerwms2&SCALE=25000&DPI=254&BBOX=0%2C0&SRS=EPSG%3A3857&WIDTH=NaN&HEIGHT=NaN&ITEMFONTFAMILY=DejaVu%20Sans&ITEMFONTSIZE=8&LAYERFONTFAMILY=DejaVu%20Sans&LAYERFONTSIZE=10',
+              ],
+              'dpi': 254,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it('Should make legend for a wms with one layer having the same name than the group', () => {
     // Same group name than the layer: it will be simplified.
     setMapLayers([layerWMS2], 'layerwms');
@@ -187,7 +216,7 @@ describe('gmf.print.LegendMapFishPrintV3', () => {
     });
   });
 
-  it('Should make legend for an external datasource', () => {
+  const prepareExternalDatasource = () => {
     const dsOptions = {
       'id': 1,
       'name': 'External layer',
@@ -237,6 +266,10 @@ describe('gmf.print.LegendMapFishPrintV3', () => {
     );
     gmfExternalDataSourcesManager.wmsGroupsCollection.push(wmsGroup1);
     gmfExternalDataSourcesManager.wmsGroupsCollection.push(wmsGroup2);
+  };
+
+  it('Should make legend for an external datasource', () => {
+    prepareExternalDatasource();
     const legend = legendMapFishPrintV3.getLegend([], 25000, 254, [0, 0]);
     expect(legend).toEqual({
       'classes': [
@@ -261,6 +294,43 @@ describe('gmf.print.LegendMapFishPrintV3', () => {
           'name': 'External layer legend 2',
           'icons': [
             'https://external.2.test.legend.ch?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=ch.test.2.legend.externallayer&SCALE=25000',
+          ],
+        },
+      ],
+    });
+  });
+
+  it('Should make legend for an external datasource (no title)', () => {
+    prepareExternalDatasource();
+    // @ts-ignore: private.
+    legendMapFishPrintV3.gmfLegendOptions_.showGroupsTitle = false;
+    const legend = legendMapFishPrintV3.getLegend([], 25000, 254, [0, 0]);
+    expect(legend).toEqual({
+      'classes': [
+        {
+          'classes': [
+            {
+              'name': 'External layer legend 1',
+              'icons': [
+                'https://external.1.test.legend.ch?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=ch.test.1.legend.externallayer&SCALE=25000',
+              ],
+            },
+            {
+              'name': 'External layer legend 1',
+              'icons': [
+                'https://external.1.test.legend.ch?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=ch.test.1.legend.externallayer&SCALE=25000',
+              ],
+            },
+          ],
+        },
+        {
+          'classes': [
+            {
+              'name': 'External layer legend 2',
+              'icons': [
+                'https://external.2.test.legend.ch?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=ch.test.2.legend.externallayer&SCALE=25000',
+              ],
+            },
           ],
         },
       ],


### PR DESCRIPTION
GSGMF-1367.

We can't identify groups title in a MapFishPrint template.
That means we can't remove them if we don't want them.
This commit add a possibility to remove groups title by
setting the new GMF Print Legend option "showGroupsTitle".

I'll add a note in the Changelog of c2cgeoportal to speak about this new variable.
But I'll not set the variable in the default vars file as I'll adapt the legend.jrxml to indent groups