### PR TITLE
Reverse order print legend

### DIFF
--- a/contribs/gmf/src/print/LegendMapFishPrintV3.js
+++ b/contribs/gmf/src/print/LegendMapFishPrintV3.js
@@ -89,13 +89,12 @@ export default class LegendMapFishPrintV3 {
    * @return {unknown?} Legend object for print report or null.
    */
   getLegend(currentThemes, scale, dpi, bbox) {
-    /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} */
-    const legendInternal = this.getInternalLegendItems_(currentThemes, scale, dpi, bbox);
+   /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} */
+    const internalLegend = this.getInternalLegendItems_(currentThemes, scale, dpi, bbox);
     /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} */
     const externalLegend = this.getExternalLegendItems_(scale);
-
     /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegend} */
-    const legend = {classes: [...legendInternal, ...externalLegend]};
+    const legend = {classes: [...externalLegend, ...internalLegend]};
 
     return legend.classes.length > 0 ? legend : null;
   }
@@ -147,7 +146,8 @@ export default class LegendMapFishPrintV3 {
       }
       legendGroupItem.classes = groupClasses;
       const sublayers = layer.getLayers();
-      sublayers.forEach((sublayer) => {
+      // Iterate with a "reverse" to have top-level layers at the top of the legend.
+      sublayers.getArray().reverse().forEach((sublayer) => {
         const child = this.collectLegendClassesInTree_(sublayer, currentThemes, scale, dpi, bbox);
         this.addClassItemToArray_(groupClasses, child);
       });
@@ -302,7 +302,8 @@ export default class LegendMapFishPrintV3 {
     }
     // For each name in a WMS layer.
     const layerNames = /** @type {string} */ (source.getParams().LAYERS).split(',');
-    layerNames.forEach((name) => {
+    // Iterate with a "reverse" to have top-level layers at the top of the legend.
+    layerNames.reverse().forEach((name) => {
       // Don't add classes without legend url or from layers without any
       // active name.
       if (name.length !== 0) {

--- a/contribs/gmf/src/print/LegendMapFishPrintV3.js
+++ b/contribs/gmf/src/print/LegendMapFishPrintV3.js
@@ -89,7 +89,7 @@ export default class LegendMapFishPrintV3 {
    * @return {unknown?} Legend object for print report or null.
    */
   getLegend(currentThemes, scale, dpi, bbox) {
-   /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} */
+    /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} */
     const internalLegend = this.getInternalLegendItems_(currentThemes, scale, dpi, bbox);
     /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} */
     const externalLegend = this.getExternalLegendItems_(scale);
@@ -111,10 +111,7 @@ export default class LegendMapFishPrintV3 {
   getInternalLegendItems_(currentThemes, scale, dpi, bbox) {
     const dataLayerGroup = this.ngeoLayerHelper_.getGroupFromMap(this.map_, DATALAYERGROUP_NAME);
     const legend = this.collectLegendClassesInTree_(dataLayerGroup, currentThemes, scale, dpi, bbox);
-    /** @type {import('ngeo/print/mapfish-print-v3').MapFishPrintLegendClass[]} */
-    const legendClasses = [];
-    this.addClassItemToArray_(legendClasses, legend);
-    return legendClasses;
+    return legend ? legend.classes : [];
   }
 
   /**
@@ -145,9 +142,9 @@ export default class LegendMapFishPrintV3 {
         legendGroupItem.name = gettextCatalog.getString(layer.get(LAYER_NODE_NAME_KEY));
       }
       legendGroupItem.classes = groupClasses;
-      const sublayers = layer.getLayers();
       // Iterate with a "reverse" to have top-level layers at the top of the legend.
-      sublayers.getArray().reverse().forEach((sublayer) => {
+      const sublayers = layer.getLayers().getArray().reverse();
+      sublayers.forEach((sublayer) => {
         const child = this.collectLegendClassesInTree_(sublayer, currentThemes, scale, dpi, bbox);
         this.addClassItemToArray_(groupClasses, child);
       });

--- a/contribs/gmf/test/spec/classes/legendmapfishprintv3.spec.js
+++ b/contribs/gmf/test/spec/classes/legendmapfishprintv3.spec.js
@@ -135,16 +135,16 @@ describe('gmf.print.LegendMapFishPrintV3', () => {
               'name': 'layerwms1',
               'classes': [
                 {
-                  'name': 'layerwms1',
+                  'name': ' layerwms2',
                   'icons': [
-                    'http://wmslayer1.com?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=layerwms1&SCALE=25000&DPI=254&BBOX=0%2C0&SRS=EPSG%3A3857&WIDTH=NaN&HEIGHT=NaN&ITEMFONTFAMILY=DejaVu%20Sans&ITEMFONTSIZE=8&LAYERFONTFAMILY=DejaVu%20Sans&LAYERFONTSIZE=10',
+                    'http://wmslayer1.com?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=%20layerwms2&SCALE=25000&DPI=254&BBOX=0%2C0&SRS=EPSG%3A3857&WIDTH=NaN&HEIGHT=NaN&ITEMFONTFAMILY=DejaVu%20Sans&ITEMFONTSIZE=8&LAYERFONTFAMILY=DejaVu%20Sans&LAYERFONTSIZE=10',
                   ],
                   'dpi': 254,
                 },
                 {
-                  'name': ' layerwms2',
+                  'name': 'layerwms1',
                   'icons': [
-                    'http://wmslayer1.com?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=%20layerwms2&SCALE=25000&DPI=254&BBOX=0%2C0&SRS=EPSG%3A3857&WIDTH=NaN&HEIGHT=NaN&ITEMFONTFAMILY=DejaVu%20Sans&ITEMFONTSIZE=8&LAYERFONTFAMILY=DejaVu%20Sans&LAYERFONTSIZE=10',
+                    'http://wmslayer1.com?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=layerwms1&SCALE=25000&DPI=254&BBOX=0%2C0&SRS=EPSG%3A3857&WIDTH=NaN&HEIGHT=NaN&ITEMFONTFAMILY=DejaVu%20Sans&ITEMFONTSIZE=8&LAYERFONTFAMILY=DejaVu%20Sans&LAYERFONTSIZE=10',
                   ],
                   'dpi': 254,
                 },
@@ -166,16 +166,16 @@ describe('gmf.print.LegendMapFishPrintV3', () => {
         {
           'classes': [
             {
-              'name': 'layerwms1',
+              'name': ' layerwms2',
               'icons': [
-                'http://wmslayer1.com?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=layerwms1&SCALE=25000&DPI=254&BBOX=0%2C0&SRS=EPSG%3A3857&WIDTH=NaN&HEIGHT=NaN&ITEMFONTFAMILY=DejaVu%20Sans&ITEMFONTSIZE=8&LAYERFONTFAMILY=DejaVu%20Sans&LAYERFONTSIZE=10',
+                'http://wmslayer1.com?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=%20layerwms2&SCALE=25000&DPI=254&BBOX=0%2C0&SRS=EPSG%3A3857&WIDTH=NaN&HEIGHT=NaN&ITEMFONTFAMILY=DejaVu%20Sans&ITEMFONTSIZE=8&LAYERFONTFAMILY=DejaVu%20Sans&LAYERFONTSIZE=10',
               ],
               'dpi': 254,
             },
             {
-              'name': ' layerwms2',
+              'name': 'layerwms1',
               'icons': [
-                'http://wmslayer1.com?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=%20layerwms2&SCALE=25000&DPI=254&BBOX=0%2C0&SRS=EPSG%3A3857&WIDTH=NaN&HEIGHT=NaN&ITEMFONTFAMILY=DejaVu%20Sans&ITEMFONTSIZE=8&LAYERFONTFAMILY=DejaVu%20Sans&LAYERFONTSIZE=10',
+                'http://wmslayer1.com?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=layerwms1&SCALE=25000&DPI=254&BBOX=0%2C0&SRS=EPSG%3A3857&WIDTH=NaN&HEIGHT=NaN&ITEMFONTFAMILY=DejaVu%20Sans&ITEMFONTSIZE=8&LAYERFONTFAMILY=DejaVu%20Sans&LAYERFONTSIZE=10',
               ],
               'dpi': 254,
             },

--- a/contribs/gmf/test/spec/classes/legendmapfishprintv3.spec.js
+++ b/contribs/gmf/test/spec/classes/legendmapfishprintv3.spec.js
@@ -76,17 +76,30 @@ describe('gmf.print.LegendMapFishPrintV3', () => {
 
   const setMapLayers =
     /**
-     * Add layers in a named group and add this group to the map.
-     * @param {import('ol/layer/Layer').default<import("ol/source/Source.js").default>[]} layers the array
-     * of layers to add to the map.
+     * Add layers in a "data" group and to the map.
+     * This first "data" group is not kept in the legend. Only deeper levels are kept.
+     * @param {import('ol/layer/Group').default[]} layers the array of layers to add to the map.
+     */
+    (layers) => {
+      const layerGroup = new olLayerGroup();
+      layerGroup.setLayers(new olCollection(layers));
+      layerGroup.set('groupName', DATALAYERGROUP_NAME); // For layerHelper to find the group.
+      mapLayerGroup.setLayers(new olCollection([layerGroup]));
+    };
+
+  const addlayersInGroup =
+    /**
+     * Add layers in a group and return this group.
+     * @param {import('ol/layer/Layer').default<import("ol/source/Source.js").default>[]} layers the
+     * array of layers to add to the map.
      * @param {string} groupName The group name.
+     * @return {import('ol/layer/Group').default} a layer group.
      */
     (layers, groupName) => {
       const layerGroup = new olLayerGroup();
       layerGroup.setLayers(new olCollection(layers));
-      layerGroup.set('groupName', DATALAYERGROUP_NAME); // For layerHelper to find the group.
       layerGroup.set(LAYER_NODE_NAME_KEY, groupName);
-      mapLayerGroup.setLayers(new olCollection([layerGroup]));
+      return layerGroup;
     };
 
   const legendOptions = {
@@ -124,7 +137,8 @@ describe('gmf.print.LegendMapFishPrintV3', () => {
   });
 
   it('Should make legend for a wms with two layers', () => {
-    setMapLayers([layerWMS1], 'layerGroup');
+    const group = addlayersInGroup([layerWMS1], 'layerGroup');
+    setMapLayers([group]);
     const legend = legendMapFishPrintV3.getLegend([], 25000, 254, [0, 0]);
     expect(legend).toEqual({
       'classes': [
@@ -157,29 +171,26 @@ describe('gmf.print.LegendMapFishPrintV3', () => {
   });
 
   it('Should make legend for a wms with two layers (no title)', () => {
-    setMapLayers([layerWMS1], 'layerGroup');
+    const group = addlayersInGroup([layerWMS1], 'layerGroup');
+    setMapLayers([group]);
     // @ts-ignore: private.
     legendMapFishPrintV3.gmfLegendOptions_.showGroupsTitle = false;
     const legend = legendMapFishPrintV3.getLegend([], 25000, 254, [0, 0]);
     expect(legend).toEqual({
       'classes': [
         {
-          'classes': [
-            {
-              'name': ' layerwms2',
-              'icons': [
-                'http://wmslayer1.com?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=%20layerwms2&SCALE=25000&DPI=254&BBOX=0%2C0&SRS=EPSG%3A3857&WIDTH=NaN&HEIGHT=NaN&ITEMFONTFAMILY=DejaVu%20Sans&ITEMFONTSIZE=8&LAYERFONTFAMILY=DejaVu%20Sans&LAYERFONTSIZE=10',
-              ],
-              'dpi': 254,
-            },
-            {
-              'name': 'layerwms1',
-              'icons': [
-                'http://wmslayer1.com?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=layerwms1&SCALE=25000&DPI=254&BBOX=0%2C0&SRS=EPSG%3A3857&WIDTH=NaN&HEIGHT=NaN&ITEMFONTFAMILY=DejaVu%20Sans&ITEMFONTSIZE=8&LAYERFONTFAMILY=DejaVu%20Sans&LAYERFONTSIZE=10',
-              ],
-              'dpi': 254,
-            },
+          'name': ' layerwms2',
+          'icons': [
+            'http://wmslayer1.com?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=%20layerwms2&SCALE=25000&DPI=254&BBOX=0%2C0&SRS=EPSG%3A3857&WIDTH=NaN&HEIGHT=NaN&ITEMFONTFAMILY=DejaVu%20Sans&ITEMFONTSIZE=8&LAYERFONTFAMILY=DejaVu%20Sans&LAYERFONTSIZE=10',
           ],
+          'dpi': 254,
+        },
+        {
+          'name': 'layerwms1',
+          'icons': [
+            'http://wmslayer1.com?FORMAT=image%2Fpng&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=layerwms1&SCALE=25000&DPI=254&BBOX=0%2C0&SRS=EPSG%3A3857&WIDTH=NaN&HEIGHT=NaN&ITEMFONTFAMILY=DejaVu%20Sans&ITEMFONTSIZE=8&LAYERFONTFAMILY=DejaVu%20Sans&LAYERFONTSIZE=10',
+          ],
+          'dpi': 254,
         },
       ],
     });
@@ -187,7 +198,8 @@ describe('gmf.print.LegendMapFishPrintV3', () => {
 
   it('Should make legend for a wms with one layer having the same name than the group', () => {
     // Same group name than the layer: it will be simplified.
-    setMapLayers([layerWMS2], 'layerwms');
+    const group = addlayersInGroup([layerWMS2], 'layerwms');
+    setMapLayers([group]);
     const legend = legendMapFishPrintV3.getLegend([], 25000, 254, [0, 0]);
     expect(legend).toEqual({
       'classes': [
@@ -204,7 +216,8 @@ describe('gmf.print.LegendMapFishPrintV3', () => {
 
   it('Should make legend for a tile layer', () => {
     // Same group name than the layer: it will be simplified.
-    setMapLayers([layerTile], 'layerTile');
+    const group = addlayersInGroup([layerTile], 'layerTile');
+    setMapLayers([group]);
     const legend = legendMapFishPrintV3.getLegend([], 25000, 254, [0, 0]);
     expect(legend).toEqual({
       'classes': [


### PR DESCRIPTION
For GSGMF-1367
Look at https://github.com/camptocamp/c2cgeoportal/pull/7694 for the list of PR for this ticket.

- Fix layer order
- Remove first layerGroup (technical group) to have the real first level in bold and without indentation.

**Now you can test the indented legend in the example**

There is still one fix to come but in another PR