### PR TITLE
Wmslayer name print legend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ test: .build/node_modules.timestamp .build/build-dll.timestamp
 
 .PHONY: test-debug
 test-debug: .build/node_modules.timestamp .build/build-dll.timestamp .build/node_modules_karma-chrome-launcher.timestamp
-	TS_NODE_PROJECT=disable.json ./node_modules/karma/bin/karma start karma-conf.js --browsers=Chrome --single-run=false --autoWatch=true --debug
+	TS_NODE_PROJECT=disable.json ./node_modules/karma/bin/karma start karma-conf.js --browsers=Chrome --single-run=false --autoWatch=true
 
 .build/node_modules_karma-chrome-launcher.timestamp:
 	npm install karma-chrome-launcher

--- a/contribs/gmf/src/layertree/SyncLayertreeMap.js
+++ b/contribs/gmf/src/layertree/SyncLayertreeMap.js
@@ -22,7 +22,7 @@
 import angular from 'angular';
 import gmfThemeThemes, {getNodeMinResolution, getNodeMaxResolution} from 'gmf/theme/Themes.js';
 import ngeoLayertreeController, {LayertreeVisitorDecision} from 'ngeo/layertree/Controller.js';
-import {LAYER_NODE_NAME_KEY} from 'ngeo/map/LayerHelper.js';
+import {DATASOURCE_ID, LAYER_NODE_NAME_KEY, NODE_IS_LEAF} from 'ngeo/map/LayerHelper.js';
 import ngeoMiscWMSTime from 'ngeo/misc/WMSTime.js';
 import {getUid as olUtilGetUid} from 'ol/util.js';
 import olLayerImage from 'ol/layer/Image.js';
@@ -273,7 +273,7 @@ SyncLayertreeMap.prototype.createLayerFromGroup_ = function (treeCtrl, mixed) {
       undefined // Source options
     );
 
-    layer.set('dataSourceId', groupNode.id);
+    layer.set(DATASOURCE_ID, groupNode.id);
 
     let hasActiveChildren = false;
     treeCtrl.traverseDepthFirst((ctrl) => {
@@ -341,9 +341,10 @@ SyncLayertreeMap.prototype.createLeafInAMixedGroup_ = function (treeCtrl, map) {
       ogcServer.credential ? 'use-credentials' : 'anonymous'
     );
   }
-  layer.set('dataSourceId', gmfLayer.id);
   // Update layer information and tree state.
+  layer.set(DATASOURCE_ID, gmfLayer.id);
   layer.set(LAYER_NODE_NAME_KEY, gmfLayer.name);
+  layer.set(NODE_IS_LEAF, true);
   this.updateLayerReferences_(gmfLayer, layer);
   const checked = gmfLayer.metadata.isChecked === true;
   if (checked) {

--- a/contribs/gmf/src/print/LegendMapFishPrintV3.js
+++ b/contribs/gmf/src/print/LegendMapFishPrintV3.js
@@ -23,7 +23,7 @@ import olLayerGroup from 'ol/layer/Group.js';
 import olLayerTile from 'ol/layer/Tile.js';
 import ImageWMS from 'ol/source/ImageWMS.js';
 import {dpi as screenDpi} from 'ngeo/utils.js';
-import {LAYER_NODE_NAME_KEY} from 'ngeo/map/LayerHelper.js';
+import {NODE_IS_LEAF, LAYER_NODE_NAME_KEY} from 'ngeo/map/LayerHelper.js';
 import {DATALAYERGROUP_NAME} from 'gmf/index.js';
 import ExternalOGC from 'gmf/datasource/ExternalOGC.js';
 import {findGroupByLayerNodeName, findObjectByName} from 'gmf/theme/Themes.js';
@@ -341,6 +341,14 @@ export default class LegendMapFishPrintV3 {
         legendLayerClasses.push(legendLayerItem);
       }
     });
+    // For wms layer in a mixed wms-group with only one element, do not show the name of the wms but only
+    // the name of the tree leaf node.
+    if (layer.get(NODE_IS_LEAF) && legendLayerClasses.length == 1) {
+      const firstLegendLayer = legendLayerClasses[0];
+      firstLegendLayer.name = legendGroupItem.name;
+      delete firstLegendLayer.classes;
+      return firstLegendLayer;
+    }
     return this.tryToSimplifyLegendGroup_(legendGroupItem);
   }
 

--- a/contribs/gmf/src/theme/Themes.js
+++ b/contribs/gmf/src/theme/Themes.js
@@ -20,7 +20,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import angular from 'angular';
-import ngeoMapLayerHelper from 'ngeo/map/LayerHelper.js';
+import ngeoMapLayerHelper, {DATASOURCE_ID} from 'ngeo/map/LayerHelper.js';
 import {getUid as olUtilGetUid} from 'ol/util.js';
 import * as olArray from 'ol/array.js';
 import olCollection from 'ol/Collection.js';
@@ -157,7 +157,7 @@ export class ThemesService extends olEventsEventTarget {
       const ids = [];
       getIds(item, ids);
       layer.set('querySourceIds', ids);
-      layer.set('dataSourceId', item.id);
+      layer.set(DATASOURCE_ID, item.id);
       return layer;
     };
 

--- a/src/map/LayerHelper.js
+++ b/src/map/LayerHelper.js
@@ -72,6 +72,18 @@ export function LayerHelper($q, $http, ngeoTilesPreloadingLimit) {
 export const LAYER_NODE_NAME_KEY = 'layerNodeName';
 
 /**
+ * Key to know if the layer is used as a leaf in a tree.
+ * In mixed WMS groups that would be probably the case but not in a
+ * not-mixed WMS groups where we want to toggle each wms names (sub-layers).
+ */
+export const NODE_IS_LEAF = 'layerIsLeaf';
+
+/**
+ * Id of the datasource
+ */
+export const DATASOURCE_ID = 'dataSourceId';
+
+/**
  * @private
  * @hidden
  */
@@ -209,8 +221,8 @@ LayerHelper.prototype.createBasicWMSLayerFromDataSource = function (dataSource, 
   // (3) Reference to the data source
   layer.set('querySourceIds', [dataSource.id]);
 
-  // (4) Set the `dataSourceId` property
-  layer.set('dataSourceId', dataSource.id);
+  // (4) Set the datasource id property
+  layer.set(DATASOURCE_ID, dataSource.id);
 
   return layer;
 };


### PR DESCRIPTION
For GSGMF-1367
Look at camptocamp/c2cgeoportal#7694 for the list of PR for this ticket.

**Change in Makefile**: `make serve-debug` throw an error `unknow parameter: debug` with karma 6. I'm able to debug without this parameter so I've deleted it. (I've not found a replacement, and I've not seen any effect).

**For the legende**:
Take the case of the `layer with a very very very ... long name` in our demo. In the tree it's a:
`Fonction OSM Mixed` (-> layergroup)
`layer with a very very very ... long name` (wms layer in a mixed group)
 **Not displayed**: `bank` (name of the wms layer)).

In 2.5, the legend shows:
`bank`
[legend-image]

In 2.6, previous to this PR, the legend shows:
`Fonction OSM Mixed` (-> layergroup)
`layer with a very very very ... long name` (wms layer in a mixed group)
`bank` (name of the wms layer).
[legend-image]

In 2.6, with this PR, the legend shows:
`Fonction OSM Mixed` (-> layergroup)
`layer with a very very very ... long name` (wms layer in a mixed group)
[legend-image]

The behaviors change a little bit but I think that's what is expected