### PR TITLE
Set ghost style

### DIFF
--- a/contribs/gmf/src/controllers/desktop.scss
+++ b/contribs/gmf/src/controllers/desktop.scss
@@ -257,6 +257,15 @@ gmf-search {
   z-index: 3;
 }
 
+.ui-resizable-helper {
+  border: 2px;
+  border-color: $brand-secondary-dark;
+  border-color: var(--brand-secondary);
+  background-color: $brand-secondary;
+  background-color: var(--brand-secondary);
+  opacity: .4;
+}
+
 .gmf-app-data-panel {
   display: block;
   float: left;


### PR DESCRIPTION
As noticed by @ger-benjamin for Mapilary, the ghost for left and right panel do not look the same. The reason is that the resizing of the right panel is not done on the panel itself, because it contains the app bar which should  not be stretched, but on its content. This PR proposes a solution to make them look more similar.