### PR TITLE
Change attribute types to ngeoFormatAttributeTypes

### DIFF
--- a/src/datasource/Helper.js
+++ b/src/datasource/Helper.js
@@ -217,6 +217,7 @@ export class DatasourceHelper {
   createDataSourceAttributesFromOGCAttributes_(dataSource) {
     let attributes = null;
 
+    const formatWFSAttribute = new ngeoFormatWFSAttribute();
     const ogcAttributes = dataSource.ogcAttributesWFS;
     if (ogcAttributes) {
       attributes = [];
@@ -237,9 +238,9 @@ export class DatasourceHelper {
         // then the attribute type is set to geometry and geomType is
         // set depending on the geometry type. This is handled by the
         // method below. If the type is not any geometry one, then set
-        // the one that was given.
+        // it to a ngeoFormatAttributeType.
         if (!ngeoAttributeSetGeometryType(attribute, `gml:${type}`)) {
-          attribute.type = type.toLowerCase();
+          formatWFSAttribute.setAttributeType(attribute, type.toLowerCase());
         }
 
         attributes.push(attribute);

--- a/src/format/WFSAttribute.js
+++ b/src/format/WFSAttribute.js
@@ -42,6 +42,30 @@ export default class {
   }
 
   /**
+   * @param {import('ngeo/format/Attribute.js').Attribute} attribute
+   * @param {string} type the type
+   */
+  setAttributeType(attribute, type) {
+    if (type === 'gml:TimeInstantType' || type === 'dateTime') {
+      attribute.type = ngeoFormatAttributeType.DATETIME;
+    } else if (type === 'date') {
+      attribute.type = ngeoFormatAttributeType.DATE;
+    } else if (type === 'time') {
+      attribute.type = ngeoFormatAttributeType.TIME;
+    } else if (type === 'decimal' || type === 'double') {
+      attribute.type = ngeoFormatAttributeType.NUMBER;
+      attribute.numType = FormatNumberType.FLOAT;
+    } else if (type === 'integer' || type === 'long') {
+      attribute.type = ngeoFormatAttributeType.NUMBER;
+      attribute.numType = FormatNumberType.INTEGER;
+    } else if (type === 'boolean') {
+      attribute.type = ngeoFormatAttributeType.BOOLEAN;
+    } else {
+      attribute.type = ngeoFormatAttributeType.TEXT;
+    }
+  }
+
+  /**
    * @param {Object} object Complex type element
    * @return {import('ngeo/format/Attribute.js').Attribute} Attribute
    * @private
@@ -61,23 +85,7 @@ export default class {
     const type = object.type;
 
     if (!setGeometryType(attribute, type)) {
-      if (type === 'gml:TimeInstantType' || type === 'dateTime') {
-        attribute.type = ngeoFormatAttributeType.DATETIME;
-      } else if (type === 'date') {
-        attribute.type = ngeoFormatAttributeType.DATE;
-      } else if (type === 'time') {
-        attribute.type = ngeoFormatAttributeType.TIME;
-      } else if (type === 'decimal' || type === 'double') {
-        attribute.type = ngeoFormatAttributeType.NUMBER;
-        attribute.numType = FormatNumberType.FLOAT;
-      } else if (type === 'integer' || type === 'long') {
-        attribute.type = ngeoFormatAttributeType.NUMBER;
-        attribute.numType = FormatNumberType.INTEGER;
-      } else if (type === 'boolean') {
-        attribute.type = ngeoFormatAttributeType.BOOLEAN;
-      } else {
-        attribute.type = ngeoFormatAttributeType.TEXT;
-      }
+      this.setAttributeType(attribute, type);
     }
 
     return attribute;


### PR DESCRIPTION
For filtering only the default rules were available for numbers, because the attribute types were not changed to ngeoFormatAttributeTypes (double -> number).