### PR TITLE
Update arrow position (draw) on modify

### DIFF
--- a/contribs/gmf/src/drawing/featureStyleComponent.js
+++ b/contribs/gmf/src/drawing/featureStyleComponent.js
@@ -315,7 +315,8 @@ Controller.prototype.handleGeometryChange_ = function () {
   this.measure = this.featureHelper_.getMeasure(this.feature);
 
   const showMeasure = this.featureHelper_.getShowMeasureProperty(this.feature);
-  if (showMeasure) {
+  const showArrow = this.featureHelper_.getShowArrowsProperty(this.feature);
+  if (showMeasure || showArrow) {
     this.handleFeatureChange_();
   }
 

--- a/src/misc/FeatureHelper.js
+++ b/src/misc/FeatureHelper.js
@@ -1191,6 +1191,15 @@ FeatureHelper.prototype.getShowLabelProperty = function (feature) {
 
 /**
  * @param {olFeature<import("ol/geom/Geometry.js").default>} feature Feature.
+ * @return {boolean} Show at least one arrow.
+ */
+FeatureHelper.prototype.getShowArrowsProperty = function (feature) {
+  const arrowDirection = feature.get(ngeoFormatFeatureProperties.ARROW_DIRECTION);
+  return arrowDirection !== undefined && arrowDirection !== ArrowDirections.NONE;
+};
+
+/**
+ * @param {olFeature<import("ol/geom/Geometry.js").default>} feature Feature.
  * @return {number} Size.
  */
 FeatureHelper.prototype.getSizeProperty = function (feature) {


### PR DESCRIPTION
Fix GSGMF-1463

Without this PR, move a line with arrows and arrows are left at the same place.
Now arrows move with the line.

@sbrunner I'm not sure what to do to solve the CI issue: Remove the "backport 2.6" tag or add a new branch/update the list:

```
Run check versions
  :: versions: The backport labels do not have the right list of versions [2.4, 2.5, 2.6, master] != [2.4, 2.5, master]
  Error:  versions: The backport labels do not have the right list of versions [2.4, 2.5, 2.6, master] != [2.4, 2.5, master]
```