### PR TITLE
Ignore permalink on manual background selection

### DIFF
--- a/contribs/gmf/src/authentication/component.js
+++ b/contribs/gmf/src/authentication/component.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import gmfAuthenticationService from 'gmf/authentication/Service.js';
+import {gmfBackgroundlayerStatus} from 'gmf/backgroundlayerselector/status.js';
 import {MessageType} from 'ngeo/message/Message.js';
 import ngeoMessageNotification from 'ngeo/message/Notification.js';
 
@@ -335,8 +336,8 @@ class AuthenticationController {
    * Calls the authentication service login method.
    */
   login() {
+    this.manualLoginLogout_();
     const gettextCatalog = this.gettextCatalog;
-
     const errors = [];
     if (this.loginVal === '') {
       errors.push(gettextCatalog.getString('The username is required.'));
@@ -361,6 +362,7 @@ class AuthenticationController {
    * Calls the authentication service logout method.
    */
   logout() {
+    this.manualLoginLogout_();
     const gettextCatalog = this.gettextCatalog;
     this.gmfAuthenticationService_.logout()
       .then(() => {
@@ -369,6 +371,14 @@ class AuthenticationController {
       .catch(() => {
         this.setError_(gettextCatalog.getString('Could not log out.'));
       });
+  }
+
+  /**
+   * Effects on manual try to login/logout.
+   */
+  manualLoginLogout_() {
+    // Set the user could lead to a new background.
+    gmfBackgroundlayerStatus.touchedByUser = true;
   }
 
   /**

--- a/contribs/gmf/src/backgroundlayerselector/component.js
+++ b/contribs/gmf/src/backgroundlayerselector/component.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+import {gmfBackgroundlayerStatus} from 'gmf/backgroundlayerselector/status.js';
 import gmfThemeThemes from 'gmf/theme/Themes.js';
 import ngeoMapBackgroundLayerMgr from 'ngeo/map/BackgroundLayerMgr.js';
 import * as olEvents from 'ol/events.js';
@@ -216,6 +217,7 @@ Controller.prototype.getSetBgLayerOpacity = function(val) {
  * @param {boolean=} opt_silent Do not notify listeners.
  */
 Controller.prototype.setLayer = function(layer, opt_silent) {
+  gmfBackgroundlayerStatus.touchedByUser = true;
   const opacity = this.opacityLayer ? this.opacityLayer.getOpacity() : 0;
   this.bgLayer = layer;
   this.backgroundLayerMgr_.set(this.map, layer);

--- a/contribs/gmf/src/backgroundlayerselector/status.js
+++ b/contribs/gmf/src/backgroundlayerselector/status.js
@@ -1,0 +1,8 @@
+/**
+ * To know the status of the background layer
+ * @typedef {Object} gmfBackgroundlayerStatus
+ * @property {boolean} touchedByUser Is the background layer (potentially) manually set by the user ?
+ */
+export const gmfBackgroundlayerStatus = {
+  touchedByUser: false,
+};

--- a/contribs/gmf/src/controllers/AbstractAppController.js
+++ b/contribs/gmf/src/controllers/AbstractAppController.js
@@ -5,6 +5,7 @@ import 'angular-dynamic-locale';
 import bootstrap from 'gmf/controllers/bootstrap.js';
 import gmfAuthenticationModule from 'gmf/authentication/module.js';
 import gmfBackgroundlayerselectorComponent from 'gmf/backgroundlayerselector/component.js';
+import {gmfBackgroundlayerStatus} from 'gmf/backgroundlayerselector/status.js';
 import gmfDatasourceModule from 'gmf/datasource/module.js';
 import gmfDisclaimerComponent from 'gmf/disclaimer/component.js';
 import gmfDrawingModule from 'gmf/drawing/module.js';
@@ -511,7 +512,7 @@ export function AbstractAppController(config, map, $scope, $injector) {
     this.gmfThemes_.getBgLayers().then((layers) => {
       let background;
       if (!skipPermalink) {
-        // get the background from the permalink
+        // get the initial background from the permalink
         background = this.permalink_.getBackgroundLayer(layers);
       }
       if (!background) {
@@ -734,8 +735,10 @@ AbstractAppController.prototype.setDefaultBackground_ = function(theme) {
   this.gmfThemes_.getBgLayers().then((layers) => {
     let layer;
 
-    // get the background from the permalink
-    layer = this.permalink_.getBackgroundLayer(layers);
+    // get the initial background from the permalink
+    if (!gmfBackgroundlayerStatus.touchedByUser) {
+      layer = this.permalink_.getBackgroundLayer(layers);
+    }
 
     if (!layer && this.gmfUser.functionalities) {
       // get the background from the user settings

--- a/contribs/gmf/src/search/component.js
+++ b/contribs/gmf/src/search/component.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import {COORDINATES_LAYER_NAME} from 'gmf/index.js';
+import {gmfBackgroundlayerStatus} from 'gmf/backgroundlayerselector/status.js';
 import gmfLayertreeTreeManager from 'gmf/layertree/TreeManager.js';
 import gmfSearchFulltextSearch from 'gmf/search/FulltextSearch.js';
 import gmfThemeThemes, {findThemeByName} from 'gmf/theme/Themes.js';
@@ -980,6 +981,7 @@ class SearchController {
           this.gmfThemes_.getThemesObject().then((themes) => {
             const theme = findThemeByName(themes, actionData);
             if (theme) {
+              gmfBackgroundlayerStatus.touchedByUser = true;
               this.gmfTreeManager_.addFirstLevelGroups(theme.children);
             }
           });

--- a/contribs/gmf/src/theme/selectorComponent.js
+++ b/contribs/gmf/src/theme/selectorComponent.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+import {gmfBackgroundlayerStatus} from 'gmf/backgroundlayerselector/status.js';
 import gmfThemeManager from 'gmf/theme/Manager.js';
 import gmfThemeThemes from 'gmf/theme/Themes.js';
 import * as olEvents from 'ol/events.js';
@@ -161,6 +162,7 @@ Controller.prototype.setThemes_ = function() {
  *     the theme should be added but it's already added.
  */
 Controller.prototype.setTheme = function(theme, opt_silent) {
+  gmfBackgroundlayerStatus.touchedByUser = true;
   if (theme) {
     this.gmfThemeManager.addTheme(theme, opt_silent);
   }


### PR DESCRIPTION
Fix GSGMF-1249

We can't determine when app is fully loaded. So I've applied the invert logic: Specify when a user touch the background selection And from then, start to ignore the permalink.

I'll do more cleaning on 2.6