### PR TITLE
Fix permalink: avoid using ng-include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,6 +269,8 @@ contribs/dist: .build/build-dll.timestamp
 	cp ./contribs/gmf/apps/desktop/header.html .build/examples-hosted/contribs/gmf/apps/desktop
 	mkdir -p .build/examples-hosted/contribs/gmf/apps/desktop_alt
 	cp ./contribs/gmf/apps/desktop_alt/header.html .build/examples-hosted/contribs/gmf/apps/desktop_alt
+	mkdir -p .build/examples-hosted/contribs/gmf/apps/oeedit
+	cp ./contribs/gmf/apps/oeedit/header.html .build/examples-hosted/contribs/gmf/apps/oeedit
 	touch $@
 
 .build/examples-hosted/index.html: \

--- a/contribs/gmf/apps/desktop/index.html.ejs
+++ b/contribs/gmf/apps/desktop/index.html.ejs
@@ -17,7 +17,7 @@
         <%=require('gmf/icons/spinner.svg?viewbox&height=1em')%>
       </i>
     </div>
-    <ng-include src="'desktop/header.html'"></ng-include>
+    <gmf-header gmf-header-template-url="desktop/header.html"></gmf-header>
     <main>
       <div class="gmf-app-data-panel"
            ngeo-resizemap="mainCtrl.map"

--- a/contribs/gmf/apps/desktop_alt/index.html.ejs
+++ b/contribs/gmf/apps/desktop_alt/index.html.ejs
@@ -17,7 +17,7 @@
         <%=require('gmf/icons/spinner.svg?viewbox&height=1em')%>
       </i>
     </div>
-    <ng-include src="'desktop_alt/header.html'"></ng-include>
+    <gmf-header gmf-header-template-url="desktop_alt/header.html"></gmf-header>
     <main>
       <div class="gmf-app-data-panel"
            ngeo-resizemap="mainCtrl.map"

--- a/contribs/gmf/apps/oeedit/header.html
+++ b/contribs/gmf/apps/oeedit/header.html
@@ -1,0 +1,8 @@
+<header>
+  <div class="logo">
+    <span></span>
+  </div>
+  <div class="logo-right">
+    <span></span>
+  </div>
+</header>

--- a/contribs/gmf/apps/oeedit/index.html.ejs
+++ b/contribs/gmf/apps/oeedit/index.html.ejs
@@ -12,14 +12,7 @@
     <% } %>
   </head>
   <body ng-class="{'gmf-profile-chart-active': !!profileChartActive}">
-    <header>
-      <div class="logo">
-        <span></span>
-      </div>
-      <div class="logo-right">
-        <span></span>
-      </div>
-    </header>
+    <gmf-header gmf-header-template-url="oeedit/header.html"></gmf-header>
     <main>
       <div class="gmf-app-data-panel">
         <div class="gmf-app-header">

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -28,6 +28,7 @@ import gmfDatasourceDataSourceBeingFiltered from 'gmf/datasource/DataSourceBeing
 import gmfDrawingModule from 'gmf/drawing/module.js';
 import gmfEditingModule from 'gmf/editing/module.js';
 import gmfFiltersModule from 'gmf/filters/module.js';
+import gmfHeaderModule from 'gmf/header/module.js';
 import gmfPermalinkShareComponent from 'gmf/permalink/shareComponent.js';
 import gmfPrintModule from 'gmf/print/module.js';
 import gmfProfileModule from 'gmf/profile/module.js';
@@ -567,6 +568,7 @@ const myModule = angular.module('GmfAbstractDesktopControllerModule', [
   gmfDrawingModule.name,
   gmfEditingModule.name,
   gmfFiltersModule.name,
+  gmfHeaderModule.name,
   gmfImportModule.name,
   gmfPermalinkShareComponent.name,
   gmfPrintModule.name,

--- a/contribs/gmf/src/header/component.html
+++ b/contribs/gmf/src/header/component.html
@@ -1,0 +1,1 @@
+<header></header>

--- a/contribs/gmf/src/header/component.js
+++ b/contribs/gmf/src/header/component.js
@@ -1,0 +1,82 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2021 Camptocamp SA
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import angular from 'angular';
+
+/**
+ * @type {angular.IModule}
+ * @hidden
+ */
+const myModule = angular.module('gmfHeader', []);
+
+myModule.run(
+  /**
+   * @ngInject
+   * @param {angular.ITemplateCacheService} $templateCache
+   */
+  ($templateCache) => {
+    // @ts-ignore: webpack
+    $templateCache.put('gmf/header/component', require('./component.html'));
+  }
+);
+
+myModule.value(
+  'gmfHeaderTemplateUrl',
+  /**
+   * @param {JQuery} $element Element.
+   * @param {angular.IAttributes} $attrs Attributes.
+   * @return {string} Template URL.
+   */
+  ($element, $attrs) => {
+    const templateUrl = $attrs.gmfHeaderTemplateUrl;
+    return templateUrl !== undefined ? templateUrl : 'gmf/header/component';
+  }
+);
+
+/**
+ * @param {JQuery} $element Element.
+ * @param {angular.IAttributes} $attrs Attributes.
+ * @param {function(JQuery, angular.IAttributes): string} gmfHeaderTemplateUrl
+ *    Template function.
+ * @return {string} Template URL.
+ * @ngInject
+ * @private
+ * @hidden
+ */
+function gmfHeaderTemplateUrl($element, $attrs, gmfHeaderTemplateUrl) {
+  return gmfHeaderTemplateUrl($element, $attrs);
+}
+
+/**
+ * Provide an "header" component that only provide an html template. Do that instead of use
+ * ng-include because otherwise it breaks the permalink (maybe related to the bug described in the
+ * StatemanagerLocation in src/statemanager/Location.js)
+ *
+ * @ngdoc component
+ * @ngname gmfHeader
+ */
+const headerComponent = {
+  templateUrl: gmfHeaderTemplateUrl,
+};
+
+myModule.component('gmfHeader', headerComponent);
+
+export default myModule;

--- a/contribs/gmf/src/header/module.js
+++ b/contribs/gmf/src/header/module.js
@@ -1,0 +1,28 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2021 Camptocamp SA
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import angular from 'angular';
+import gmfHeaderComponent from 'gmf/header/component.js';
+
+/**
+ * @type {angular.IModule}
+ */
+export default angular.module('gmfHeaderModule', [gmfHeaderComponent.name]);

--- a/contribs/gmf/src/mainmodule.js
+++ b/contribs/gmf/src/mainmodule.js
@@ -28,6 +28,7 @@ import gmfDisclaimerModule from 'gmf/disclaimer/module.js';
 import gmfDrawingModule from 'gmf/drawing/module.js';
 import gmfEditingModule from 'gmf/editing/module.js';
 import gmfFiltersModule from 'gmf/filters/module.js';
+import gmfHeaderModule from 'gmf/header/module.js';
 import gmfImportModule from 'gmf/import/module.js';
 import gmfLayertreeModule from 'gmf/layertree/module.js';
 import gmfLidarprofileModule from 'gmf/lidarprofile/module.js';
@@ -50,6 +51,7 @@ export default angular.module('gmf', [
   gmfDrawingModule.name,
   gmfEditingModule.name,
   gmfFiltersModule.name,
+  gmfHeaderModule.name,
   gmfImportModule.name,
   gmfLayertreeModule.name,
   gmfLidarprofileModule.name,


### PR DESCRIPTION
Fix GSGMF-1469

### Why permalink was broken and fix

The commit that break the permalink is surprisingly this innocent one: https://github.com/camptocamp/ngeo/pull/6375

It looks than using `ng-include` create problem with the `$location` service. Maybe it's related to this warning: https://github.com/camptocamp/ngeo/blob/779251e31115d77ffd2451deac5670336e9fa97f/src/statemanager/Location.js#L29-L33
I've not investigate more in depth. ng-include breaks our permalink.

To avoid using `ng-include`, I've create a directive for the header. It's fare more line of code (even without every comments), but it works and it's still possible to override the partial.

Another possibility would be to investigate into the permalink and the `$location` service to know why we have this issue but it could cost us a lot of time...

### Others

 1. I've added the custom header in the oeedit view.
 1. In some components we have one other way to override the html (via attributes). I think that's an old way to do things, useless and I'm not even sure it works. I don't have implemented the others way here. (For instance see: https://github.com/camptocamp/ngeo/blob/779251e31115d77ffd2451deac5670336e9fa97f/contribs/gmf/src/backgroundlayerselector/component.js#L36-L47)

### TODO

I'll update the c2cgeoportal changelog