### PR TITLE
Fix versions in CI, add 2.6

### DIFF
--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -2,8 +2,7 @@ checks:
   required_workflows:
     main.yaml: False
     rebuild.yaml: False
-  versions:
-    rebuild: False
+  versions: False
   codespell:
     ignore_re:
       - ^contribs/gmf/test/spec/data/themescapabilities\.js$


### PR DESCRIPTION
It is the correct way to correct check version on 2.6 ?

And it is useful to have the 2.6 in the audit ?