### PR TITLE
Use alert instead of modal to show changed password (simple message)

### DIFF
--- a/contribs/gmf/src/authentication/component.html
+++ b/contribs/gmf/src/authentication/component.html
@@ -79,8 +79,6 @@
           ng-click="$ctrl.logout()" />
     </div>
   </form>
-
-  <div ng-show="$ctrl.error" class="gmf-authentication-error help-block"></div>
 </div>
 
 <div ng-if="!$ctrl.gmfUser.username">
@@ -123,29 +121,9 @@
     </div>
   </form>
 
-  <div ng-show="$ctrl.error" class="gmf-authentication-error help-block"></div>
-
-  <ngeo-modal
-      ng-model="$ctrl.resetPasswordModalShown">
-    <div class="modal-header ui-draggable-handle">
-      <button type="button"
-              class="close"
-              data-dismiss="modal"
-              aria-label="{{'Close' | translate}}">
-        <span aria-hidden="true">&times;</span>
-      </button>
-      <h4 class="modal-title">
-        {{'Password forgotten?' | translate}}
-      </h4>
-    </div>
-    <div class="modal-body" translate>
-      A new password has just been sent to you by e-mail.
-    </div>
-    <div class="modal-footer">
-      <button type="button"
-              class="btn btn-default"
-              data-dismiss="modal">{{'OK' | translate}}</button>
-    </div>
-  </ngeo-modal>
-
+  <div ng-if="$ctrl.resetPasswordShown" class="alert alert-info" translate>
+    A new password has just been sent to you by e-mail.
+  </div>
 </div>
+
+<div ng-show="$ctrl.error" class="gmf-authentication-error help-block"></div>

--- a/contribs/gmf/src/authentication/component.js
+++ b/contribs/gmf/src/authentication/component.js
@@ -221,7 +221,7 @@ class AuthenticationController {
     /**
      * @type {boolean}
      */
-    this.resetPasswordModalShown = false;
+    this.resetPasswordShown = false;
 
     /**
      * @type {boolean}
@@ -394,7 +394,7 @@ class AuthenticationController {
 
     this.gmfAuthenticationService_.resetPassword(this.loginVal)
       .then(() => {
-        this.resetPasswordModalShown = true;
+        this.resetPasswordShown = true;
         this.resetError_();
       })
       .catch(() => {


### PR DESCRIPTION
Fix GSGMF-1478

Authentication modal do not work on mobile, as the right menu use "position: fixed" (as the modal black screen), the childen elements can't appears above...

Solution: the modal is not really useful. I'll display the message in a simple alert, in the component.

From 2.6, I'll have another modal to move to a simple message (lost connection message).
