### PR TITLE
Rename Rule.expression to Rule.literal

### DIFF
--- a/src/filter/component.js
+++ b/src/filter/component.js
@@ -293,18 +293,18 @@ export class FilterController {
   }
 
   /**
-   * @return {boolean} True if at least one rule is currently defined with an expression.
+   * @return {boolean} True if at least one rule is currently defined with a literal.
    */
   hasARuleActive() {
     let customRuleActive = false;
     let directedRuleActive = false;
     for (const rule of this.customRules) {
-      if (rule.expression) {
+      if (rule.literal) {
         customRuleActive = true;
       }
     }
     for (const rule of this.directedRules) {
-      if (rule.expression) {
+      if (rule.literal) {
         directedRuleActive = true;
       }
     }

--- a/src/filter/ruleComponent.js
+++ b/src/filter/ruleComponent.js
@@ -425,7 +425,7 @@ export class RuleController {
       this.clone.type === ngeoFormatAttributeType.DATE ||
       this.clone.type === ngeoFormatAttributeType.DATETIME
     ) {
-      // Watch 'expression'
+      // Watch 'literal'
       this.unlisteners_.push(
         this.scope_.$watch(
           /**
@@ -435,7 +435,8 @@ export class RuleController {
             if (!this.clone) {
               throw new Error('Missing clone');
             }
-            return this.clone.getExpression();
+            const literal = /** @type {string|number} */ (this.clone.literal);
+            return literal;
           },
           /**
            * @param {string|number} newVal
@@ -482,7 +483,7 @@ export class RuleController {
     } else if (this.clone.type === ngeoFormatAttributeType.GEOMETRY) {
       // Watch 'operator' of clone. Make sure any existing geometry is
       // supported by the newly selected operator. If it doesn't, reset
-      // the expression, i.e. geometry.
+      // the literal, i.e. geometry.
       this.unlisteners_.push(
         this.scope_.$watch(
           () => {
@@ -508,7 +509,7 @@ export class RuleController {
                     if (!this.clone) {
                       throw new Error('Missing clone');
                     }
-                    this.clone.setExpression(null);
+                    this.clone.literal = null;
                   }
                 }
               }
@@ -517,14 +518,14 @@ export class RuleController {
         )
       );
 
-      // Watch 'expression' of clone. Set 'geomType' property accordingly.
+      // Watch 'literal' of clone. Set 'geomType' property accordingly.
       this.unlisteners_.push(
         this.scope_.$watch(
           () => {
             if (!this.clone) {
               throw new Error('Missing clone');
             }
-            return this.clone.expression;
+            return this.clone.literal;
           },
           (newVal) => {
             if (newVal) {
@@ -539,7 +540,7 @@ export class RuleController {
         )
       );
 
-      // Watch both 'expression', 'active' and the modify control to be all
+      // Watch both 'literal', 'active' and the modify control to be all
       // thruthy. When that's the case, the clone feature is added to the
       // selection collection.
       this.unlisteners_.push(
@@ -551,11 +552,11 @@ export class RuleController {
             if (!this.rule) {
               throw new Error('Missing rule');
             }
-            const hasExpression = this.clone.getExpression() !== null;
+            const hasLiteral = this.clone.literal !== null;
             const isActive = this.rule.active === true;
             const editToolIsActive =
               this.modify_.getActive() || this.rotate_.getActive() || this.translate_.getActive();
-            return hasExpression && isActive && editToolIsActive;
+            return hasLiteral && isActive && editToolIsActive;
           },
           (newVal) => {
             if (newVal) {
@@ -656,7 +657,7 @@ export class RuleController {
 
   /**
    * Called when a choice is clicked, when using a `ngeo.rule.Select` rule type.
-   * Add/remove the choice to/from the `expression` of the rule.
+   * Add/remove the choice to/from the `literal` of the rule.
    * @param {string} choice Choice that has been clicked.
    */
   toggleChoiceSelection(choice) {
@@ -664,14 +665,14 @@ export class RuleController {
       throw new Error('Missing clone');
     }
     const rule = this.clone;
-    const choices = rule.getExpression() ? /** @type {string} */ (rule.getExpression()).split(',') : [];
+    const choices = rule.literal ? /** @type {string[]} */ (rule.literal) : [];
     const idx = choices.indexOf(choice);
     if (idx > -1) {
       choices.splice(idx, 1);
     } else {
       choices.push(choice);
     }
-    rule.setExpression(choices.length ? choices.join(',') : null);
+    rule.literal = choices.length ? choices : null;
   }
 
   /**
@@ -681,7 +682,7 @@ export class RuleController {
     if (!this.clone) {
       throw new Error('Missing clone');
     }
-    this.clone.setExpression(date.start);
+    this.clone.literal = date.start;
   }
 
   /**
@@ -1035,7 +1036,7 @@ export class RuleController {
 
 /**
  * The rule component is bound to a `import('ngeo/rule/Rule.js').default` object and shows UI
- * components to be able to edit its properties, such as: operator, expression,
+ * components to be able to edit its properties, such as: operator, literal,
  * etc. The actual properties depend on the type of rule.
  *
  * Also, changes are not made on-the-fly. A button must be clicked for the

--- a/src/filter/rulecomponent.html
+++ b/src/filter/rulecomponent.html
@@ -165,7 +165,7 @@
             class="form-group ol-unselectable"
             ng-repeat="choice in ::$ctrl.clone.choices">
           <input
-              ng-checked="$ctrl.clone.getExpression() && $ctrl.clone.getExpression().split(',').indexOf(choice) > -1"
+              ng-checked="$ctrl.clone.literal && $ctrl.clone.literal.indexOf(choice) > -1"
               ng-click="$ctrl.toggleChoiceSelection(choice)"
               type="checkbox"
               value="choice" />
@@ -193,12 +193,12 @@
                 type="number"
                 class="form-control"
                 ng-if="$ctrl.clone.type === 'number'"
-                ng-model="$ctrl.clone.expression"/>
+                ng-model="$ctrl.clone.literal"/>
             <input
                 type="text"
                 class="form-control"
                 ng-if="$ctrl.clone.type !== 'number'"
-                ng-model="$ctrl.clone.expression"/>
+                ng-model="$ctrl.clone.literal"/>
           </div>
         </div>
       </div>
@@ -245,7 +245,7 @@
         </div>
         <div ng-switch-default>
           <span>{{ $ctrl.operatorsShortFormat[$ctrl.rule.operator] }}</span>
-          <span>{{ $ctrl.timeToDate($ctrl.rule.getExpression()) }}</span>
+          <span>{{ $ctrl.timeToDate($ctrl.rule.literal) }}</span>
         </div>
       </div>
     </div>
@@ -277,7 +277,7 @@
     </div>
 
     <div ng-switch-when="select">
-      <span ng-repeat="choice in $ctrl.rule.getExpression().split(',')">
+      <span ng-repeat="choice in $ctrl.rule.literal">
         {{ choice | translate }}{{ $last ? '' : ', ' }}
       </span>
     </div>
@@ -292,7 +292,7 @@
         </div>
         <div ng-switch-default>
           <span>{{ $ctrl.operatorsShortFormat[$ctrl.rule.operator] }}</span>
-          <span>{{ $ctrl.rule.getExpression() }}</span>
+          <span>{{ $ctrl.rule.literal }}</span>
         </div>
       </div>
     </div>

--- a/src/format/filter.js
+++ b/src/format/filter.js
@@ -51,7 +51,7 @@ export class DateIsBetween extends olFormatFilterComparison {
 }
 
 /**
- * Creates a `<PropertyIsBetween>` comparison operator to test whether an expression
+ * Creates a `<PropertyIsBetween>` comparison operator to test whether a property
  * value lies within a time range given by a lower and upper bound (inclusive).
  *
  * @param {!string} propertyName Name of the context property to compare.

--- a/src/rule/Date.js
+++ b/src/rule/Date.js
@@ -27,6 +27,7 @@ import ngeoRuleRule from 'ngeo/rule/Rule.js';
  * @typedef {Object} DateOptions
  * @property {boolean} [active=false] (RuleOptions)
  * @property {number|string} [expression] (RuleOptions)
+ * @property {number|string|string[]} [literal] (RuleOptions)
  * @property {boolean} [isCustom] (RuleOptions)
  * @property {number} [lowerBoundary] (RuleOptions)
  * @property {string} name (RuleOptions)

--- a/src/rule/Rule.js
+++ b/src/rule/Rule.js
@@ -24,17 +24,18 @@ import {unlistenByKey} from 'ol/events.js';
 /**
  * @typedef {Object} RuleOptions
  * @property {boolean} [active=false] Whether the rule is active or not. Used by the `ngeo-rule` component.
- * @property {number|string} [expression] The expression of the rule. The expression and boundaries are
+ * @property {number|string} [expression] Deprecated. Use literal instead. Kept for compatibility with saved filters.
+ * @property {number|string|string[]} [literal] The literal of the rule. The literal and boundaries are
  *    mutually exclusives.
  * @property {boolean} [isCustom] Whether the rule is a custom one or not. Defaults to `true`.
- * @property {number} [lowerBoundary] The lower boundary of the rule. The expression and boundaries are
+ * @property {number} [lowerBoundary] The lower boundary of the rule. The literal and boundaries are
  *    mutually exclusives.
  * @property {string} name The human-readable name of the rule.
  * @property {string} [operator] The rule operator.
  * @property {string[]} [operators] The rule operators.
  * @property {string} propertyName The property name (a.k.a. the attribute name).
  * @property {string} [type] The type of rule.
- * @property {number} [upperBoundary] The upper boundary of the rule. The expression and boundaries are
+ * @property {number} [upperBoundary] The upper boundary of the rule. The literal and boundaries are
  *    mutually exclusives.
  */
 
@@ -46,7 +47,7 @@ import {unlistenByKey} from 'ol/events.js';
 
 /**
  * @typedef {Object} RuleSimpleValue
- * @property {number|string} expression The expression of the rule value.
+ * @property {number|string|string[]} literal The literal of the rule value.
  * extends RuleBaseValue
  * @property {string} operator The operator of the rule value.
  * @property {string} propertyName The property name of the rule value
@@ -109,7 +110,7 @@ export default class Rule {
    *
    * - a property name, for example 'city_name'
    * - an operator, for example 'is equal to'
-   * - and an expression, for example 'Chicoutimi'.
+   * - and an literal, for example 'Chicoutimi'.
    *
    * A rule is useful to hold those properties and change them on the fly.
    * For example, changing an operator from 'is equal to' to 'like'.
@@ -120,7 +121,7 @@ export default class Rule {
    * not null.
    *
    * When the operator is `between`, the `lowerBoundary` and `upperBoundary`
-   * properties are used instead of `expression`.
+   * properties are used instead of `literal`.
    *
    * @param {RuleOptions} options Options.
    */
@@ -135,20 +136,15 @@ export default class Rule {
     this.active = options.active === true;
 
     /**
-     * The expression of the rule. The expression and boundaries are mutually
+     * The literal of the rule. The literal and boundaries are mutually
      * exclusives.
-     *
-     * Note: exported (instead of private) due to the problem with the
-     * compiler. See the getter/setter methods below...  As a setter, the
-     * `expression` property would support being bond to an `ng-model`. Without
-     * it, it can't unless we expose the property directly.
-     *
-     * @type {?number|string}
+     * @type {?number|string|string[]}
+     * @protected
      */
-    this.expression = options.expression !== undefined ? options.expression : null;
+    this.literal_ = options.literal !== undefined ? options.literal : null;
 
     /**
-     * The lower boundary of the rule. The expression and boundaries are
+     * The lower boundary of the rule. The literal and boundaries are
      * mutually exclusives.
      * @type {?number}
      */
@@ -161,7 +157,7 @@ export default class Rule {
     this.operator = options.operator || null;
 
     /**
-     * The upper boundary of the rule. The expression and boundaries are
+     * The upper boundary of the rule. The literal and boundaries are
      * mutually exclusives.
      * @type {?number}
      */
@@ -214,23 +210,17 @@ export default class Rule {
   }
 
   /**
-   * The `expression` property does not have conventionnal getter/setters
-   * method because of a limitation of the compiler. It doesn't support
-   * yet having such methods being extended in child classes.
-   *
-   * See: https://github.com/google/closure-compiler/issues/1089
-   *
-   * @return {?number|string} Expression
+   * @return {?number|string|string[]} Literal
    */
-  getExpression() {
-    return this.expression;
+  get literal() {
+    return this.literal_;
   }
 
   /**
-   * @param {?number|string} expression Expression
+   * @param {?number|string|string[]} literal Literal
    */
-  setExpression(expression) {
-    this.expression = expression;
+  set literal(literal) {
+    this.literal_ = literal;
   }
 
   // === Static property getters/setters ===
@@ -278,7 +268,7 @@ export default class Rule {
   get value() {
     let value = null;
 
-    const expression = this.getExpression();
+    const literal = this.literal;
     const lowerBoundary = this.lowerBoundary;
     const operator = this.operator;
     const propertyName = this.propertyName;
@@ -295,9 +285,9 @@ export default class Rule {
           };
         }
       } else {
-        if (expression !== null) {
+        if (literal !== null) {
           value = {
-            expression,
+            literal,
             operator,
             propertyName,
           };
@@ -311,12 +301,12 @@ export default class Rule {
   // === Other utility methods ===
 
   /**
-   * Reset the following properties to `null`: expression, lowerBoundary,
+   * Reset the following properties to `null`: literal, lowerBoundary,
    * upperBoundary.
    */
   reset() {
-    if (this.getExpression() !== null) {
-      this.setExpression(null);
+    if (this.literal !== null) {
+      this.literal = null;
     }
     if (this.lowerBoundary !== null) {
       this.lowerBoundary = null;

--- a/src/rule/Select.js
+++ b/src/rule/Select.js
@@ -28,6 +28,7 @@ import ngeoRuleRule, {RuleOperatorType} from 'ngeo/rule/Rule.js';
  * @property {string[]} choices List of choices available for selection.
  * @property {boolean} [active=false] (RuleOptions)
  * @property {number|string} [expression] (RuleOptions)
+ * @property {number|string|string[]} [literal] (RuleOptions)
  * @property {boolean} [isCustom] (RuleOptions)
  * @property {number} [lowerBoundary] (RuleOptions)
  * @property {string} name (RuleOptions)
@@ -46,7 +47,7 @@ export default class extends ngeoRuleRule {
    * A select rule, which allows the selection of multiple values among a list
    * of choices.
    *
-   * The expression property holds the list of selected choices, which is
+   * The literal property holds the list of selected choices, which is
    * comma-separated.
    *
    * @param {SelectOptions} options Options.
@@ -83,9 +84,8 @@ export default class extends ngeoRuleRule {
   get selectedChoices() {
     /** @type {string[]} */
     let selectedChoices;
-    if (this.expression) {
-      const stringExpression = String(this.expression);
-      selectedChoices = stringExpression.split(',');
+    if (this.literal) {
+      selectedChoices = /** @type {string[]} */ (this.literal);
     } else {
       selectedChoices = [];
     }

--- a/src/rule/Text.js
+++ b/src/rule/Text.js
@@ -38,6 +38,7 @@ import ngeoRuleRule, {RuleOperatorType} from 'ngeo/rule/Rule.js';
  * @property {boolean} [exceedLength]
  * @property {boolean} [active=false] (RuleOptions)
  * @property {number|string} [expression] (RuleOptions)
+ * @property {number|string|string[]} [literal] (RuleOptions)
  * @property {boolean} [isCustom] (RuleOptions)
  * @property {number} [lowerBoundary] (RuleOptions)
  * @property {string} name (RuleOptions)


### PR DESCRIPTION
And change type from {number|string} to {number|string|string[]}.
To avoid using comma as separator in "select" rules.