### PR TITLE
Rename 'Apply' button in rule creating form

### DIFF
--- a/src/filter/rulecomponent.html
+++ b/src/filter/rulecomponent.html
@@ -207,7 +207,7 @@
         <button
             class="btn btn-sm btn-default"
             ng-click="$ctrl.apply()"
-            type="button">{{'Add' | translate}}</button>
+            type="button">{{'OK' | translate}}</button>
         <button
             class="btn btn-sm btn-default"
             ng-click="$ctrl.cancel()"

--- a/src/filter/rulecomponent.html
+++ b/src/filter/rulecomponent.html
@@ -207,7 +207,7 @@
         <button
             class="btn btn-sm btn-default"
             ng-click="$ctrl.apply()"
-            type="button">{{'Apply' | translate}}</button>
+            type="button">{{'Add' | translate}}</button>
         <button
             class="btn btn-sm btn-default"
             ng-click="$ctrl.cancel()"


### PR DESCRIPTION
Because the button only adds a rule and does not apply it yet.

I have noticed several users confused because filters were not actually applied to the map when pressing the "Apply" button available in the form to add filters. Instead, one has to eventually press the global "Apply filter" button to have the set of filters applied.

![Screenshot from 2021-02-10 18-32-33](https://user-images.githubusercontent.com/1192331/107547973-619c4b80-6bce-11eb-9286-07c3130d5413.png)


I suggest to remove this confusion by simpling renaming the button to "Add". Eventually the users will press the "Apply filter" button when they are done setting rules.