### PR TITLE
Fix oeedit with 2d geom GEO-4161

### DIFF
--- a/contribs/gmf/src/objectediting/coordinate.js
+++ b/contribs/gmf/src/objectediting/coordinate.js
@@ -12,7 +12,7 @@
  * @hidden
  */
 export function coordinatesToXY0(coordinates) {
-  if (coordinates.length > 2) {
+  if (coordinates.length >= 2) {
     const coord = /** @type{import("ol/coordinate.js").Coordinate} */(coordinates);
     return [coord[0], coord[1]];
   }


### PR DESCRIPTION
Fix GEO-4161

On oeedit save, we call this method to remove the third (or more) dimension to have a 2D coordinate.
But if the saved coordinate is already a 2D coordinate, the result is undefined as nothing is returned.
Now, the result is the 2D coordinate.

The process will still fail with a 1D coordinate or no coordinate, the function will still return undefined. But I think that in this case, the error is clear enough, no need to add an error log.

As it's oeedit, it will be hard to test, sorry...
But I was able to check the code in the project of the original issue.