### PR TITLE
Retablish search clear button to true per default

### DIFF
--- a/contribs/gmf/src/search/component.html
+++ b/contribs/gmf/src/search/component.html
@@ -6,7 +6,7 @@
     ngeo-search-datasets="$ctrl.datasets"
     ngeo-search-listeners="$ctrl.listeners">
   <span class="gmf-clear-button ng-hide"
-    ng-hide="!$ctrl.options.clearButton || $ctrl.inputValue == '' && $ctrl.featureOverlay_.isEmpty()"
+    ng-hide="!$ctrl.clearButton || $ctrl.inputValue == '' && $ctrl.featureOverlay_.isEmpty()"
     ng-click="$ctrl.onClearButton()">
   </span>
 </div>

--- a/contribs/gmf/src/search/component.js
+++ b/contribs/gmf/src/search/component.js
@@ -339,7 +339,12 @@ export class SearchController {
      */
     this.additionalListeners = {};
 
-    if (!this.options.clearButton) {
+    /**
+     * @type {boolean}
+     */
+    this.clearButton = this.options.clearButton !== false;
+
+    if (this.clearButton) {
       // Empty the search field on focus and blur.
       this.element_.find('input').on('focus blur', () => {
         this.clear();
@@ -766,7 +771,7 @@ export class SearchController {
    * @private
    */
   setTTDropdownVisibility_() {
-    if (this.options.clearButton) {
+    if (this.clearButton) {
       const ttDropdown = this.element_.find('.twitter-typeahead .tt-menu');
       this.inputValue ? ttDropdown.show() : ttDropdown.hide();
     }
@@ -905,7 +910,7 @@ export class SearchController {
    * @private
    */
   leaveSearch_() {
-    if (!this.options.clearButton) {
+    if (!this.clearButton) {
       this.clear();
     }
     this.blur();
@@ -915,7 +920,7 @@ export class SearchController {
    * @private
    */
   close_() {
-    if (!this.options.clearButton) {
+    if (!this.clearButton) {
       this.setTTDropdownVisibility_();
     }
   }


### PR DESCRIPTION
Fix GSGMF-1482

The `clearButton` in search was and still must be to `true` per default.

See also: https://github.com/camptocamp/demo_geomapfish/pull/188