### PR TITLE
Fix search coordinates

### DIFF
--- a/contribs/gmf/src/search/component.js
+++ b/contribs/gmf/src/search/component.js
@@ -293,8 +293,9 @@ export class SearchController {
     /**
      * Supported projections for coordinates search.
      * @type {import('ol/proj/Projection.js').default[]}
+     * @private
      */
-    this.coordinatesProjectionsInstances = [];
+    this.coordinatesProjectionsInstances_ = [];
 
     /**
      * @type {import("ngeo/map/FeatureOverlay.js").FeatureOverlay}
@@ -377,7 +378,7 @@ export class SearchController {
    * Called on initialization of the controller.
    */
   $onInit() {
-    this.coordinatesProjectionsInstances =
+    this.coordinatesProjectionsInstances_ =
       this.options.coordinatesProjections === undefined
         ? [this.map.getView().getProjection()]
         : this.ngeoAutoProjection_.getProjectionList(this.options.coordinatesProjections);
@@ -690,7 +691,7 @@ export class SearchController {
         coordinates,
         extent,
         viewProjection,
-        this.options.coordinatesProjections
+        this.coordinatesProjectionsInstances_.map((proj) => proj.getCode())
       );
       if (position === null) {
         return;


### PR DESCRIPTION
Fix GSGMF-1504

Given coordinates are now `2056` , we have code that transforms it to a 2056 projection, with correct code `EPSG:2056`. I've change the code to use it (it's called but not used since ngeo 2.3...)

@sbrunner the search on desktop understand now only EPSG:2056. Should I adapt the manual tests booklet ? (Desktop alt understand 21781, 3857, 2056, precise desktop_alt and add `850000 5900000` to test EPSG:3857).

@sbrunner  Also, on 2.5, we don't support 3857 but 4326. I've added a PR here: https://github.com/camptocamp/demo_geomapfish/pull/209
Should I also set the const vars in c2cgeoportal to add this 4326 projection ?  
