### PR TITLE
Fix LIDAR

### DIFF
--- a/contribs/gmf/apps/desktop_alt/Controller.js
+++ b/contribs/gmf/apps/desktop_alt/Controller.js
@@ -37,6 +37,7 @@ import appBase from '../appmodule.js';
 import gmfImportModule from 'gmf/import/module.js';
 import gmfFloorModule from 'gmf/floor/module.js';
 import gmfLidarprofileModule from 'gmf/lidarprofile/module.js';
+import ngeoMiscToolActivate from 'ngeo/misc/ToolActivate.js';
 import ngeoStreetviewModule from 'ngeo/streetview/module.js';
 import ngeoRoutingModule from 'ngeo/routing/module.js';
 import ngeoStatemanagerWfsPermalink from 'ngeo/statemanager/WfsPermalink.js';
@@ -67,6 +68,14 @@ class Controller extends AbstractDesktopController {
     if (this.dimensions.FLOOR == undefined) {
       this.dimensions.FLOOR = '*';
     }
+
+    /**
+     * @type {boolean}
+     */
+    this.drawLidarprofilePanelActive = false;
+
+    const drawLidarprofilePanelActive = new ngeoMiscToolActivate(this, 'drawLidarprofilePanelActive');
+    this.ngeoToolActivateMgr.registerTool('mapTools', drawLidarprofilePanelActive, false);
   }
 
   /**

--- a/contribs/gmf/apps/desktop_alt/index.html.ejs
+++ b/contribs/gmf/apps/desktop_alt/index.html.ejs
@@ -226,10 +226,10 @@
               </div>
             </div>
           </div>
-          <div ng-show="mainCtrl.drawLidarprofilePanelActive" class="row profile-panel">
+          <div ng-show="mainCtrl.drawLidarprofilePanelActive" class="row lidar-profile-panel">
             <div class="col-sm-12">
               <div class="gmf-app-tools-content-heading">
-                {{'Lidar profile'|translate}}
+                {{'Lidar profile (only on the canton of Neuchâtel)'|translate}}
                 <a class="btn close" ng-click="mainCtrl.drawLidarprofilePanelActive = false">&times;</a>
               </div>
               <gmf-lidarprofile-panel

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -242,7 +242,7 @@ export class AbstractDesktopController extends AbstractAPIController {
      * The ngeo ToolActivate manager service.
      * @type {import("ngeo/misc/ToolActivateMgr.js").ToolActivateMgr}
      */
-    const ngeoToolActivateMgr = $injector.get('ngeoToolActivateMgr');
+    this.ngeoToolActivateMgr = $injector.get('ngeoToolActivateMgr');
 
     /**
      * @type {import('gmf/datasource/DataSourceBeingFiltered.js').DataSourceBeingFiltered}
@@ -256,25 +256,25 @@ export class AbstractDesktopController extends AbstractAPIController {
     this.gmfLayerBeingSwipe = $injector.get('gmfLayerBeingSwipe');
 
     const editFeatureActivate = new ngeoMiscToolActivate(this, 'editFeatureActive');
-    ngeoToolActivateMgr.registerTool('mapTools', editFeatureActivate, false);
+    this.ngeoToolActivateMgr.registerTool('mapTools', editFeatureActivate, false);
 
     const streetViewActivate = new ngeoMiscToolActivate(this, 'streetViewActive');
-    ngeoToolActivateMgr.registerTool('mapTools', streetViewActivate, false);
+    this.ngeoToolActivateMgr.registerTool('mapTools', streetViewActivate, false);
 
     const contextdataActivate = new ngeoMiscToolActivate(this, 'contextdataActive');
-    ngeoToolActivateMgr.registerTool('mapTools', contextdataActivate, false);
+    this.ngeoToolActivateMgr.registerTool('mapTools', contextdataActivate, false);
 
     const drawFeatureActivate = new ngeoMiscToolActivate(this, 'drawFeatureActive');
-    ngeoToolActivateMgr.registerTool('mapTools', drawFeatureActivate, false);
+    this.ngeoToolActivateMgr.registerTool('mapTools', drawFeatureActivate, false);
 
     const drawProfilePanelActivate = new ngeoMiscToolActivate(this, 'drawProfilePanelActive');
-    ngeoToolActivateMgr.registerTool('mapTools', drawProfilePanelActivate, false);
+    this.ngeoToolActivateMgr.registerTool('mapTools', drawProfilePanelActivate, false);
 
     const printPanelActivate = new ngeoMiscToolActivate(this, 'printPanelActive');
-    ngeoToolActivateMgr.registerTool('mapTools', printPanelActivate, false);
+    this.ngeoToolActivateMgr.registerTool('mapTools', printPanelActivate, false);
 
     const routingPanelActive = new ngeoMiscToolActivate(this, 'routingPanelActive');
-    ngeoToolActivateMgr.registerTool('mapTools', routingPanelActive, false);
+    this.ngeoToolActivateMgr.registerTool('mapTools', routingPanelActive, false);
 
     /**
      * @type {?import("ol/geom/LineString.js").default}

--- a/contribs/gmf/src/lidarprofile/Utils.js
+++ b/contribs/gmf/src/lidarprofile/Utils.js
@@ -260,13 +260,7 @@ export default class {
     // Draw the profile canvas (the points) into the new canvas.
     const profileCanvas = d3select('#gmf-lidarprofile-container .lidar-canvas');
     const profileCanvasEl = /** @type {HTMLCanvasElement} */ (profileCanvas.node());
-    ctx.drawImage(
-      profileCanvasEl,
-      margin.left,
-      margin.top,
-      w - (margin.left + margin.right),
-      h - (margin.top + margin.bottom)
-    );
+    ctx.drawImage(profileCanvasEl, margin.left, margin.top);
 
     // Add transforms the profile into an image.
     const exportImage = new Image();

--- a/contribs/gmf/src/lidarprofile/panelComponent.html
+++ b/contribs/gmf/src/lidarprofile/panelComponent.html
@@ -27,7 +27,7 @@
           ng-if="!!$ctrl.line"
           ng-click="$ctrl.resetPlot()"
           data-toggle="tooltip" data-placement="left" data-original-title="{{'Reset profile'|translate}}">
-          <span class="fa fa-refresh"></span>
+          <span class="fa fa-sync"></span>
         </button>
       </div>
       <hr>

--- a/contribs/gmf/src/lidarprofile/panelComponent.js
+++ b/contribs/gmf/src/lidarprofile/panelComponent.js
@@ -22,11 +22,7 @@
 import angular from 'angular';
 import gmfLidarprofileConfig from 'gmf/lidarprofile/Config.js';
 import gmfLidarprofileManager from 'gmf/lidarprofile/Manager.js';
-import gmfProfileDrawLineComponent from 'gmf/profile/drawLineComponent.js';
-import ngeoMiscBtnComponent from 'ngeo/misc/btnComponent.js';
 import ngeoDownloadCsv from 'ngeo/download/Csv.js';
-import ngeoMiscToolActivate from 'ngeo/misc/ToolActivate.js';
-import ngeoMiscToolActivateMgr from 'ngeo/misc/ToolActivateMgr.js';
 
 /**
  * @type {angular.IModule}
@@ -35,10 +31,7 @@ import ngeoMiscToolActivateMgr from 'ngeo/misc/ToolActivateMgr.js';
 const myModule = angular.module('gmfLidarprofilePanel', [
   gmfLidarprofileConfig.name,
   gmfLidarprofileManager.name,
-  gmfProfileDrawLineComponent.name,
-  ngeoMiscBtnComponent.name,
   ngeoDownloadCsv.name,
-  ngeoMiscToolActivateMgr.name,
 ]);
 
 myModule.value(
@@ -171,16 +164,6 @@ export class Controller {
      */
     this.ngeoCsvDownload_ = ngeoCsvDownload;
 
-    /**
-     * @type {import("ngeo/misc/ToolActivateMgr.js").ToolActivateMgr}
-     * @private
-     */
-    this.ngeoToolActivateMgr_ = ngeoToolActivateMgr;
-
-    // Initialize the tools inside of the tool manager
-    this.tool = new ngeoMiscToolActivate(this, 'active');
-    this.ngeoToolActivateMgr_.registerTool('mapTools', this.tool, false);
-
     // Activate the controls inside the panel.
     $scope.$watch(
       () => this.active,
@@ -215,7 +198,6 @@ export class Controller {
   initConfigAndActivateTool_() {
     this.profileConfig_.initProfileConfig().then((resp) => {
       this.ready = true;
-      this.ngeoToolActivateMgr_.activateTool(this.tool);
     });
   }
 
@@ -227,12 +209,9 @@ export class Controller {
     if (activate === true) {
       if (!this.ready) {
         this.initConfigAndActivateTool_();
-      } else {
-        this.ngeoToolActivateMgr_.activateTool(this.tool);
       }
     } else {
       this.clearAll();
-      this.ngeoToolActivateMgr_.deactivateTool(this.tool);
     }
   }
 


### PR DESCRIPTION
To try on desktop alt, over canton Neuchâtel.

From ticket  GSGMF-1486 :

- Fix refresh button
- Fix Lidar export-png size (was shrunk because of a smaller size of canvas than in the original)

From #6907 :

- Fix css (don't re-use drawProfile class)
- Use more standard open/close system panel (fix always closing panel)

Other:

- Set the title of the tool's panel to say that it works only on Neuchâtel.