### PR TITLE
Add polyfill in api

### DIFF
--- a/api/dist/apihelp/apihelp.html
+++ b/api/dist/apihelp/apihelp.html
@@ -39,6 +39,7 @@
          }
         </style>
         <link href="github.css" rel="stylesheet" type="text/css" media="screen">
+        <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,default-3.6,Array.prototype.includes,Object.entries,Object.values" crossorigin="anonymous"></script>
         <script src="rainbow-custom.min.js"></script>
         <script src="../api.js"></script>
         <link href="../api.css" rel="stylesheet" type="text/css">
@@ -53,6 +54,10 @@
             <h2>Basis</h2>
             <p>To use the API you should add the following HTML:</p>
             <pre><code data-language="html">
+&lt;script
+  src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,default-3.6,Array.prototype.includes,Object.entries,Object.values"
+  crossorigin="anonymous"&gt;
+&lt;/script&gt;
 &lt;link href="https://geomapfish-demo-2-6.camptocamp.com/api.css" rel="stylesheet"&gt;
 &lt;script src="https://geomapfish-demo-2-6.camptocamp.com/api.js?version=2"&gt;&lt;/script&gt;
 &lt;script&gt;


### PR DESCRIPTION
Not in any issue yet, but I think that's not a bad idea to have (and propose) the same polyfill in api than in the apps.
What do you think ?

I found that because on Ipad, it says "unknow loop for of"... and refuse to read the maps, the loop looks coming from OpenLayers.