### PR TITLE
Clean permalink only of removed groups

### DIFF
--- a/contribs/gmf/src/layertree/TreeManager.js
+++ b/contribs/gmf/src/layertree/TreeManager.js
@@ -268,9 +268,10 @@ LayertreeTreeManager.prototype.reorderChild_ = function (array, old_index, new_i
 
 /**
  * Update the application state with the list of first level groups in the tree
- * @param {Array<import('gmf/themes.js').GmfGroup>} groups firstlevel groups of the tree
+ * @param {Array<import('gmf/themes.js').GmfGroup>} groups current firstlevel groups of the tree
+ * @param {Array<import('gmf/themes.js').GmfGroup>} removedGroups groups removed within this operation.
  */
-LayertreeTreeManager.prototype.updateTreeGroupsState_ = function (groups) {
+LayertreeTreeManager.prototype.updateTreeGroupsState_ = function (groups, removedGroups) {
   /**
    * @type {Object<string, string>}
    */
@@ -280,7 +281,7 @@ LayertreeTreeManager.prototype.updateTreeGroupsState_ = function (groups) {
   if (this.$injector_.has('gmfPermalink')) {
     /** @type {import("gmf/permalink/Permalink.js").PermalinkService} */ (this.$injector_.get(
       'gmfPermalink'
-    )).cleanParams(groups);
+    )).cleanParams(removedGroups);
   }
 };
 
@@ -346,7 +347,7 @@ LayertreeTreeManager.prototype.addFirstLevelGroup_ = function (group) {
     });
     this.initialLevelFirstGroups_ = undefined;
     //Update the permalink
-    this.updateTreeGroupsState_(this.root.children);
+    this.updateTreeGroupsState_(this.root.children, []);
     // Reset the groups and the promise state. Don't reset the
     // numberOfGroupsToAddInThisDigestLoop, it must persist because the layers
     // will be added into the map after that the layertree template is
@@ -432,8 +433,8 @@ LayertreeTreeManager.prototype.removeGroup = function (group) {
     return false;
   });
   if (found) {
-    children.splice(index, 1);
-    this.updateTreeGroupsState_(children);
+    const removedChildren = children.splice(index, 1);
+    this.updateTreeGroupsState_(children, removedChildren);
   }
 };
 
@@ -606,7 +607,7 @@ LayertreeTreeManager.prototype.refreshFirstLevelGroups_ = function (themes) {
 
   // Wait that Angular has created the layetree, then update the permalink.
   this.$timeout_(() => {
-    this.updateTreeGroupsState_(this.root.children);
+    this.updateTreeGroupsState_(this.root.children, []);
   });
 };
 


### PR DESCRIPTION
For GSGMF-1527

Step to reproduce the issue (From the ticket and without this PR as this PR fix it):

```
- Open https://geomapfish-demo-2-6.camptocamp.com/desktop_alt
- Click on the "clear all" link in the layertree, right under the themes selector
- Add the "Heritage" theme
- Uncheck the "Bank" layer
- Add the "Water management" theme
- Copy the URL in the address bar and paste it in a new tab => the "Bank" layer is on despite it was off in the initial tab
```

With this PR, we remove from the permalink **only** the elements that have been removed from the tree. Before, if we add on groups, he removed all the sub_groups by removing all the `tree_group_layers_<groupName>`.

As this debug is for one existing GMF 2.5 app, I backport it to GMF 2.5. (Sorry, I should have started to work directly on 2.5...)