### PR TITLE
Search result highlight

### DIFF
--- a/contribs/gmf/src/search/component.js
+++ b/contribs/gmf/src/search/component.js
@@ -383,6 +383,11 @@ export class SearchController {
         ? [this.map.getView().getProjection()]
         : this.ngeoAutoProjection_.getProjectionList(this.options.coordinatesProjections);
 
+    // Merge typeahead options from the controller options with the constant options
+    if (this.typeaheadOptions) {
+      Object.assign(this.options, this.typeaheadOptions);
+    }
+
     this.initDatasets_();
 
     this.listeners = this.mergeListeners_(this.additionalListeners, {


### PR DESCRIPTION
Not sure what is the best way to set the value correctly.
`this.option.highlight` is the value that the component will use in the end.
The initial value was set to `this.typeaheadOptions` object but not used so I re-added the Object.assign used in the 2.5 code. We could as well just set directly the `this.option` object with the correct highlight value.