### PR TITLE
Avoid logout call

### DIFF
--- a/contribs/gmf/src/authentication/Service.js
+++ b/contribs/gmf/src/authentication/Service.js
@@ -192,7 +192,8 @@ export class AuthenticationService extends olEventsEventTarget {
   }
 
   handleDisconnection() {
-    this.logout();
+    const noReload = this.noReloadRole_ ? this.getRolesNames().includes(this.noReloadRole_) : false;
+    this.resetUser_(noReload);
     const eventDisconnect = new ngeoCustomEvent('disconnected', {user: this.user_});
     this.dispatchEvent(eventDisconnect);
   }


### PR DESCRIPTION
The actual logout was superfluous and  giving an error on second tab. Now just doing the user reset.

Fix: GSGMF-1587