### PR TITLE
If zoom is undefined or null condition

### DIFF
--- a/src/geolocation/component.js
+++ b/src/geolocation/component.js
@@ -329,7 +329,7 @@ Controller.prototype.setPosition_ = function () {
 
   if (this.follow_) {
     this.viewChangedByMe_ = true;
-    if (this.options.zoom !== undefined) {
+    if (this.options.zoom || this.options.zoom === 0) {
       view.setCenter(position);
       view.setZoom(this.options.zoom);
     } else if (accuracy instanceof Polygon) {


### PR DESCRIPTION
Fix GSGMF-1610

When the zoom param is not set, null value should go in the "else" instead of "if".