### PR TITLE
RxJS User implementation

### DIFF
--- a/contribs/gmf/apps/appmodule.js
+++ b/contribs/gmf/apps/appmodule.js
@@ -54,7 +54,6 @@ appModule.config([
  */
 appModule.run(($injector) => {
   AngularServices.auth = $injector.get('gmfAuthenticationService');
-  AngularServices.user = $injector.get('gmfUser');
   AngularServices.notification = $injector.get('ngeoNotification');
 });
 

--- a/contribs/gmf/examples/editfeature.js
+++ b/contribs/gmf/examples/editfeature.js
@@ -73,7 +73,20 @@ function MainController($scope, gmfEditFeature) {
   /**
    * @type {import('gmf/authentication/Service.js').User}
    */
-  this.gmfUser = user.getConfig().value;
+  this.gmfUser = null;
+
+  /**
+   * @type {Subscription[]}
+   * @private
+   */
+  this.subscriptions_ = [];
+
+  this.subscriptions_.push(
+    user.getProperties().subscribe({
+      next: (value) => this.gmfUser = value
+    })
+  );
+
 
   /**
    * @type {import("ol/source/ImageWMS.js").default}
@@ -164,6 +177,13 @@ MainController.prototype.handleMapSingleClick_ = function (evt) {
   this.pending = true;
 
   this.scope_.$apply();
+};
+
+/**
+ * Clear subscriptions.
+ */
+MainController.prototype.$onDestroy = function () {
+  this.subscriptions_.forEach((sub) => sub.unsubscribe());
 };
 
 /**

--- a/contribs/gmf/examples/editfeature.js
+++ b/contribs/gmf/examples/editfeature.js
@@ -40,6 +40,8 @@ import olSourceOSM from 'ol/source/OSM.js';
 import olSourceImageWMS from 'ol/source/ImageWMS.js';
 import options, {MAPSERVER_PROXY} from './options.js';
 
+import user from 'ngeo/store/user.ts';
+
 /**
  * @type {angular.IModule}
  * @hidden
@@ -54,11 +56,10 @@ const myModule = angular.module('gmfapp', [
 /**
  * @param {angular.IScope} $scope Angular scope.
  * @param {import("gmf/editing/EditFeature.js").EditingEditFeature} gmfEditFeature Gmf edit feature service.
- * @param {import('gmf/authentication/Service.js').User} gmfUser User.
  * @class
  * @ngInject
  */
-function MainController($scope, gmfEditFeature, gmfUser) {
+function MainController($scope, gmfEditFeature) {
   /**
    * @type {angular.IScope}
    */
@@ -72,7 +73,7 @@ function MainController($scope, gmfEditFeature, gmfUser) {
   /**
    * @type {import('gmf/authentication/Service.js').User}
    */
-  this.gmfUser = gmfUser;
+  this.gmfUser = user.getConfig().value;
 
   /**
    * @type {import("ol/source/ImageWMS.js").default}

--- a/contribs/gmf/examples/editfeatureselector.js
+++ b/contribs/gmf/examples/editfeatureselector.js
@@ -84,7 +84,19 @@ function MainController($scope, gmfThemes, gmfTreeManager, ngeoFeatureHelper, ng
   /**
    * @type {import('gmf/authentication/Service.js').User}
    */
-  this.gmfUser = user.getConfig().value;
+  this.gmfUser = null;
+
+  /**
+   * @type {Subscription[]}
+   * @private
+   */
+  this.subscriptions_ = [];
+
+  this.subscriptions_.push(
+    user.getProperties().subscribe({
+      next: (value) => this.gmfUser = value
+    })
+  );
 
   /**
    * @type {import("ngeo/misc/FeatureHelper.js").FeatureHelper}
@@ -166,6 +178,13 @@ function MainController($scope, gmfThemes, gmfTreeManager, ngeoFeatureHelper, ng
     trigger: 'hover',
   });
 }
+
+/**
+ * Clear subscriptions.
+ */
+MainController.prototype.$onDestroy = function () {
+  this.subscriptions_.forEach((sub) => sub.unsubscribe());
+};
 
 myModule.controller('MainController', MainController);
 

--- a/contribs/gmf/examples/editfeatureselector.js
+++ b/contribs/gmf/examples/editfeatureselector.js
@@ -46,6 +46,8 @@ import olSourceOSM from 'ol/source/OSM.js';
 import olSourceVector from 'ol/source/Vector.js';
 import options from './options.js';
 
+import user from 'ngeo/store/user.ts';
+
 /**
  * @type {angular.IModule}
  * @hidden
@@ -67,14 +69,13 @@ const myModule = angular.module('gmfapp', [
  * @param {import("gmf/theme/Themes.js").ThemesService} gmfThemes The gmf themes service.
  * @param {import("gmf/layertree/TreeManager.js").LayertreeTreeManager} gmfTreeManager gmf Tree Manager
  *    service.
- * @param {import('gmf/authentication/Service.js').User} gmfUser User.
  * @param {import("ngeo/misc/FeatureHelper.js").FeatureHelper} ngeoFeatureHelper Ngeo feature helper service.
  * @param {import("ngeo/misc/ToolActivateMgr.js").ToolActivateMgr} ngeoToolActivateMgr Ngeo ToolActivate
  *    manager service.
  * @ngInject
  * @class
  */
-function MainController($scope, gmfThemes, gmfTreeManager, gmfUser, ngeoFeatureHelper, ngeoToolActivateMgr) {
+function MainController($scope, gmfThemes, gmfTreeManager, ngeoFeatureHelper, ngeoToolActivateMgr) {
   /**
    * @type {angular.IScope}
    */
@@ -83,7 +84,7 @@ function MainController($scope, gmfThemes, gmfTreeManager, gmfUser, ngeoFeatureH
   /**
    * @type {import('gmf/authentication/Service.js').User}
    */
-  this.gmfUser = gmfUser;
+  this.gmfUser = user.getConfig().value;
 
   /**
    * @type {import("ngeo/misc/FeatureHelper.js").FeatureHelper}

--- a/contribs/gmf/src/authentication/Service.js
+++ b/contribs/gmf/src/authentication/Service.js
@@ -323,7 +323,7 @@ export class AuthenticationService {
 
   /**
    * @param {AuthenticationLoginResponse} respData Response.
-   * @param {userState} UserState state of the user.
+   * @param {UserState} userState state of the user.
    * @private
    */
   setUser_(respData, userState) {
@@ -335,7 +335,7 @@ export class AuthenticationService {
   }
 
   /**
-   * @param {userState} UserState state of the user.
+   * @param {UserState} userState state of the user.
    * @param {boolean} noReload Don't request a new user object from
    * the back-end after logging out, defaults to false.
    * @private

--- a/contribs/gmf/src/authentication/Service.js
+++ b/contribs/gmf/src/authentication/Service.js
@@ -20,11 +20,9 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import angular from 'angular';
-import ngeoCustomEvent from 'ngeo/CustomEvent.js';
-import olEventsEventTarget from 'ol/events/Target.js';
 import * as Sentry from '@sentry/browser';
 
-import user from 'ngeo/store/user.ts'
+import user, {UserState} from 'ngeo/store/user.ts'
 
 /**
  * Availables functionalities.
@@ -109,7 +107,7 @@ export const RouteSuffix = {
  * - resetPassword
  * @hidden
  */
-export class AuthenticationService extends olEventsEventTarget {
+export class AuthenticationService {
   /**
    * @param {angular.IHttpService} $http Angular http service.
    * @param {angular.IScope} $rootScope The directive's scope.
@@ -129,8 +127,6 @@ export class AuthenticationService extends olEventsEventTarget {
     gmfAuthenticationNoReloadRole,
     $interval
   ) {
-    super();
-
     /**
      * @type {angular.IHttpService}
      * @private
@@ -154,7 +150,7 @@ export class AuthenticationService extends olEventsEventTarget {
      * @type {User}
      * @private
      */
-    this.user_ = user.getConfig().value;
+    this.user_ = user.getProperties().value;
 
     /**
      * Don't request a new user object from the back-end after
@@ -193,9 +189,7 @@ export class AuthenticationService extends olEventsEventTarget {
 
   handleDisconnection() {
     const noReload = this.noReloadRole_ ? this.getRolesNames().includes(this.noReloadRole_) : false;
-    this.resetUser_(noReload);
-    const eventDisconnect = new ngeoCustomEvent('disconnected', {user: this.user_});
-    this.dispatchEvent(eventDisconnect);
+    this.resetUser_(UserState.DISCONNECTED, noReload);
   }
 
   /**
@@ -235,7 +229,7 @@ export class AuthenticationService extends olEventsEventTarget {
         }
       )
       .then((resp) => {
-        this.setUser_(resp.data, true);
+        this.setUser_(resp.data, UserState.LOGGED_IN);
       });
   }
 
@@ -276,7 +270,7 @@ export class AuthenticationService extends olEventsEventTarget {
     const noReload = this.noReloadRole_ ? this.getRolesNames().includes(this.noReloadRole_) : false;
     const url = `${this.baseUrl_}/${RouteSuffix.LOGOUT}`;
     return this.$http_.get(url, {withCredentials: true}).then(() => {
-      this.resetUser_(noReload);
+      this.resetUser_(UserState.LOGGED_OUT, noReload);
     });
   }
 
@@ -322,55 +316,33 @@ export class AuthenticationService extends olEventsEventTarget {
    * @private
    */
   handleLogin_(checkingLoginStatus, resp) {
-    if (resp.data.is_password_changed === false) {
-      const event = new ngeoCustomEvent('mustChangePassword', {user: resp.data});
-      this.dispatchEvent(event);
-      return;
-    }
-    this.setUser_(resp.data, !checkingLoginStatus);
-    if (checkingLoginStatus) {
-      const event = new ngeoCustomEvent('ready', {user: this.user_});
-      this.dispatchEvent(event);
-    }
+    const userState = checkingLoginStatus ? UserState.READY : UserState.LOGGED_IN;
+    this.setUser_(resp.data, userState);
     return resp;
   }
 
   /**
    * @param {AuthenticationLoginResponse} respData Response.
-   * @param {boolean} emitEvent Emit a login event?
+   * @param {userState} UserState state of the user.
+   * @private
    */
-  setUser_(respData, emitEvent) {
+  setUser_(respData, userState) {
     Sentry.setUser({
       username: respData.username,
     });
 
-    for (const key in this.user_) {
-      // @ts-ignore: unsupported syntax
-      this.user_[key] = null;
-    }
-    for (const key in respData) {
-      // @ts-ignore: unsupported syntax
-      this.user_[key] = respData[key];
-    }
-    if (emitEvent && respData.username !== undefined) {
-      const event = new ngeoCustomEvent('login', {user: this.user_});
-      this.dispatchEvent(event);
-    }
+    user.setUser(respData, userState);
   }
 
   /**
-   * @private
+   * @param {userState} UserState state of the user.
    * @param {boolean} noReload Don't request a new user object from
    * the back-end after logging out, defaults to false.
+   * @private
    */
-  resetUser_(noReload) {
-    noReload = noReload || false;
-    for (const key in this.user_) {
-      // @ts-ignore: unsupported syntax
-      this.user_[key] = null;
-    }
-    const event = new ngeoCustomEvent('logout', {user: this.user_});
-    this.dispatchEvent(event);
+  resetUser_(userState, noReload) {
+    const emptyUserProperties = user.getEmptyUserProperties();
+    user.setUser(emptyUserProperties, userState);
     if (!noReload) {
       this.load_();
     }

--- a/contribs/gmf/src/authentication/Service.js
+++ b/contribs/gmf/src/authentication/Service.js
@@ -150,7 +150,12 @@ export class AuthenticationService {
      * @type {User}
      * @private
      */
-    this.user_ = user.getProperties().value;
+    this.user_ = null;
+    user.getProperties().subscribe({
+      next: (properties) => {
+        this.user_ = properties;
+      }
+    });
 
     /**
      * Don't request a new user object from the back-end after
@@ -252,10 +257,14 @@ export class AuthenticationService {
         withCredentials: true,
       })
       .then((resp) => this.onSuccessfulLogin(resp))
-      .then((resp) => this.handleLogin_(false, resp));
+      .then(
+        (resp) => this.handleLogin_(false, resp),
+        (resp) => console.error('Login fail.')
+      );
   }
 
   /**
+   * Method defined in the aim to be replaced.
    * @param {AuthenticationLoginResponsePromise} resp Ajax response.
    * @return {AuthenticationLoginResponsePromise} Response.
    */

--- a/contribs/gmf/src/authentication/Service.js
+++ b/contribs/gmf/src/authentication/Service.js
@@ -24,6 +24,8 @@ import ngeoCustomEvent from 'ngeo/CustomEvent.js';
 import olEventsEventTarget from 'ol/events/Target.js';
 import * as Sentry from '@sentry/browser';
 
+import user from 'ngeo/store/user.ts'
+
 /**
  * Availables functionalities.
  * @typedef {Object} AuthenticationFunctionalities
@@ -112,7 +114,6 @@ export class AuthenticationService extends olEventsEventTarget {
    * @param {angular.IHttpService} $http Angular http service.
    * @param {angular.IScope} $rootScope The directive's scope.
    * @param {string} authenticationBaseUrl URL to "authentication" web service.
-   * @param {User} gmfUser User.
    * @param {import('gmf/options.js').gmfAuthenticationConfig} gmfAuthenticationConfig
    *    The configuration
    * @param {import('gmf/options.js').gmfAuthenticationNoReloadRole} gmfAuthenticationNoReloadRole
@@ -124,7 +125,6 @@ export class AuthenticationService extends olEventsEventTarget {
     $http,
     $rootScope,
     authenticationBaseUrl,
-    gmfUser,
     gmfAuthenticationConfig,
     gmfAuthenticationNoReloadRole,
     $interval
@@ -154,7 +154,7 @@ export class AuthenticationService extends olEventsEventTarget {
      * @type {User}
      * @private
      */
-    this.user_ = gmfUser;
+    this.user_ = user.getConfig().value;
 
     /**
      * Don't request a new user object from the back-end after
@@ -383,12 +383,5 @@ export class AuthenticationService extends olEventsEventTarget {
  */
 const myModule = angular.module('gmfAuthenticationService', []);
 myModule.service('gmfAuthenticationService', AuthenticationService);
-
-myModule.value('gmfUser', {
-  functionalities: null,
-  is_password_changed: null,
-  roles: null,
-  username: null,
-});
 
 export default myModule;

--- a/contribs/gmf/src/authentication/component.js
+++ b/contribs/gmf/src/authentication/component.js
@@ -30,6 +30,8 @@ import {listen} from 'ol/events.js';
 // @ts-ignore
 import qruri from 'qruri';
 
+import user from 'ngeo/store/user.ts';
+
 /**
  * @typedef {import("gmf/authentication/Service").AuthenticationLoginResponsePromise} AuthenticationLoginResponsePromise
  */
@@ -141,7 +143,6 @@ export class AuthenticationController {
    * @param {angular.gettext.gettextCatalog} gettextCatalog Gettext catalog.
    * @param {import("gmf/authentication/Service.js").AuthenticationService} gmfAuthenticationService
    *    GMF Authentication service
-   * @param {import('gmf/authentication/Service.js').User} gmfUser User.
    * @param {import("ngeo/message/Notification.js").MessageNotification} ngeoNotification Ngeo notification
    *    service.
    * @param {import('gmf/options.js').gmfAuthenticationConfig} gmfAuthenticationConfig The configuration
@@ -155,7 +156,6 @@ export class AuthenticationController {
     gmfTwoFactorAuth,
     gettextCatalog,
     gmfAuthenticationService,
-    gmfUser,
     ngeoNotification,
     gmfAuthenticationConfig
   ) {
@@ -168,7 +168,7 @@ export class AuthenticationController {
     /**
      * @type {import('gmf/authentication/Service.js').User}
      */
-    this.gmfUser = gmfUser;
+    this.gmfUser = user.getConfig().value;
 
     /**
      * @type {angular.gettext.gettextCatalog}

--- a/contribs/gmf/src/authentication/component.js
+++ b/contribs/gmf/src/authentication/component.js
@@ -25,7 +25,6 @@ import {gmfBackgroundlayerStatus} from 'gmf/backgroundlayerselector/status.js';
 import {MessageType} from 'ngeo/message/Message.js';
 import ngeoMessageNotification from 'ngeo/message/Notification.js';
 import ngeoMessageModalComponent from 'ngeo/message/modalComponent.js';
-import {listen} from 'ol/events.js';
 
 // @ts-ignore
 import qruri from 'qruri';
@@ -318,21 +317,21 @@ export class AuthenticationController {
    */
   $onDestroy() {
     this.subscriptions_.forEach((sub) => sub.unsubscribe());
-  };
+  }
 
   /**
    * @private
    */
   setOtpImage_() {
     if (this.gmfUser.otp_uri) {
-      this.otpImage = qruri(val, {
+      this.otpImage = qruri(this.gmfUser.otp_uri, {
         margin: 2,
       });
     }
   }
 
   /**
-   * @params {UserState} state of the user.
+   * @param {UserState} userState state of the user.
    * @private
    */
   onUserStateUpdate_(userState) {

--- a/contribs/gmf/src/authentication/component.js
+++ b/contribs/gmf/src/authentication/component.js
@@ -293,12 +293,12 @@ export class AuthenticationController {
      */
     this.subscriptions_ = [];
     this.subscriptions_.push(
-      user.getState().subscribe({
-        next: (userState) => {
-          this.gmfUser = user.getProperties().value;
+      user.getProperties().subscribe({
+        next: (properties) => {
+          this.gmfUser = properties;
           this.setOtpImage_();
           this.checkUserMustChangeItsPassword_();
-          this.onUserStateUpdate_(userState);
+          this.onUserStateUpdate_(user.getState());
         }
       })
     );

--- a/contribs/gmf/src/controllers/AbstractAppController.js
+++ b/contribs/gmf/src/controllers/AbstractAppController.js
@@ -62,6 +62,8 @@ import olInteractionDragPan from 'ol/interaction/DragPan.js';
 import {noModifierKeys} from 'ol/events/condition.js';
 import 'regenerator-runtime/runtime';
 
+import user from 'ngeo/store/user.ts';
+
 /**
  * Application abstract controller.
  *
@@ -389,7 +391,7 @@ export function AbstractAppController($scope, $injector, mobile) {
   /**
    * @type {import('gmf/authentication/Service.js').User}
    */
-  this.gmfUser = $injector.get('gmfUser');
+  this.gmfUser = user.getConfig().value;
 
   /**
    * @type {import("ngeo/statemanager/Service.js").StatemanagerService}

--- a/contribs/gmf/src/controllers/AbstractAppController.js
+++ b/contribs/gmf/src/controllers/AbstractAppController.js
@@ -308,7 +308,7 @@ export function AbstractAppController($scope, $injector, mobile) {
     // Reload themes and background layer when login status changes.
     this.gmfThemes.loadThemes(roleId);
 
-    if (user.getState().value !== UserState.READY) {
+    if (user.getState() !== UserState.READY) {
       const themeName = this.permalink_.defaultThemeNameFromFunctionalities();
       this.gmfThemeManager.updateCurrentTheme(themeName, previousThemeName, true);
     }
@@ -321,10 +321,11 @@ export function AbstractAppController($scope, $injector, mobile) {
    */
   this.gmfUser = null;
 
-  // On user state update, set features user based.
-  user.getState().subscribe({
-    next: (userState) => {
-      this.gmfUser = user.getProperties().value;
+  // On user update, set features user based.
+  user.getProperties().subscribe({
+    next: (properties) => {
+      this.gmfUser = properties;
+      const userState = user.getState();
       if (userState === UserState.NOT_INITIALIZED) {
         return;
       }

--- a/contribs/gmf/src/filters/filterselectorComponent.js
+++ b/contribs/gmf/src/filters/filterselectorComponent.js
@@ -351,7 +351,7 @@ export class FilterSelectorController {
    */
   $onDestroy() {
     this.subscriptions_.forEach((sub) => sub.unsubscribe());
-  };
+  }
 
   /**
    * @private

--- a/contribs/gmf/src/filters/filterselectorComponent.js
+++ b/contribs/gmf/src/filters/filterselectorComponent.js
@@ -44,6 +44,8 @@ import ngeoMapFeatureOverlayMgr from 'ngeo/map/FeatureOverlayMgr.js';
 
 import 'bootstrap/js/src/dropdown.js';
 
+import user from 'ngeo/store/user.ts';
+
 /**
  * @type {angular.IModule}
  * @hidden
@@ -120,7 +122,6 @@ export class FilterSelectorController {
    * @param {import("gmf/datasource/Helper.js").DatasourceHelper} gmfDataSourcesHelper Gmf data
    *     sources helper service.
    * @param {import("gmf/filters/SavedFilters.js").SavedFilter} gmfSavedFilters Gmf saved filters service.
-   * @param {import('gmf/authentication/Service.js').User} gmfUser User.
    * @param {import("ngeo/message/Notification.js").MessageNotification} ngeoNotification Ngeo notification
    *    service.
    * @param {import("ngeo/map/FeatureOverlayMgr.js").FeatureOverlayMgr} ngeoFeatureOverlayMgr Ngeo
@@ -137,7 +138,6 @@ export class FilterSelectorController {
     gmfDataSourceBeingFiltered,
     gmfDataSourcesHelper,
     gmfSavedFilters,
-    gmfUser,
     ngeoNotification,
     ngeoFeatureOverlayMgr,
     ngeoRuleHelper
@@ -211,7 +211,7 @@ export class FilterSelectorController {
      * @type {import('gmf/authentication/Service.js').User}
      * @private
      */
-    this.gmfUser_ = gmfUser;
+    this.gmfUser_ = user.getConfig().value;
 
     $scope.$watch(() => this.gmfUser_.functionalities, this.handleGmfUserFunctionalitiesChange_.bind(this));
 

--- a/contribs/gmf/src/filters/filterselectorComponent.js
+++ b/contribs/gmf/src/filters/filterselectorComponent.js
@@ -211,9 +211,22 @@ export class FilterSelectorController {
      * @type {import('gmf/authentication/Service.js').User}
      * @private
      */
-    this.gmfUser_ = user.getConfig().value;
+    this.gmfUser_ = null;
 
-    $scope.$watch(() => this.gmfUser_.functionalities, this.handleGmfUserFunctionalitiesChange_.bind(this));
+    /**
+     * @type {Subscription[]}
+     * @private
+     */
+    this.subscriptions_ = [];
+
+    this.subscriptions_.push(
+      user.getProperties().subscribe({
+        next: (value) => {
+          this.gmfUser_ = value
+          this.handleGmfUserFunctionalitiesChange_();
+        }
+      })
+    );
 
     /**
      * @type {import("ngeo/message/Notification.js").MessageNotification}
@@ -332,6 +345,13 @@ export class FilterSelectorController {
     // Initialize the data sources registration
     this.toggleDataSourceRegistration_();
   }
+
+  /**
+   * Clear subscriptions.
+   */
+  $onDestroy() {
+    this.subscriptions_.forEach((sub) => sub.unsubscribe());
+  };
 
   /**
    * @private

--- a/contribs/gmf/src/permalink/Permalink.js
+++ b/contribs/gmf/src/permalink/Permalink.js
@@ -56,6 +56,8 @@ import olLayerGroup from 'ol/layer/Group.js';
 import {CollectionEvent} from 'ol/Collection.js';
 import {buildStyle} from 'ngeo/options.js';
 
+import user from 'ngeo/store/user.ts';
+
 /**
  * @enum {string}
  * @hidden
@@ -450,7 +452,7 @@ export function PermalinkService(
   /**
    * @type {?import('gmf/authentication/Service.js').User}
    */
-  this.gmfUser_ = $injector.has('gmfUser') ? $injector.get('gmfUser') : null;
+  this.gmfUser = user.getConfig().value;
 
   /**
    * @type {?import("ol/Map.js").default}

--- a/contribs/gmf/src/permalink/Permalink.js
+++ b/contribs/gmf/src/permalink/Permalink.js
@@ -450,9 +450,12 @@ export function PermalinkService(
   this.ngeoWfsPermalink_ = $injector.has('ngeoWfsPermalink') ? $injector.get('ngeoWfsPermalink') : null;
 
   /**
-   * @type {?import('gmf/authentication/Service.js').User}
+   * @type {import('gmf/authentication/Service.js').User}
    */
-  this.gmfUser = user.getConfig().value;
+  this.gmfUser = null;
+  user.getProperties().subscribe({
+    next: (value) => this.gmfUser = value
+  });
 
   /**
    * @type {?import("ol/Map.js").default}

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -69,39 +69,71 @@ export interface User {
   otp_url: string;
 }
 
+export enum UserState {
+  LOGGED_IN = 'logged in',
+  LOGGED_OUT = 'logged out',
+  DISCONNECTED = 'disconnected',
+  READY = 'ready',
+  NOT_INITIALIZED = 'not initialized',
+}
+
 export class UserModel {
   /**
-   * The observable user's config.
+   * The observable user's properties. The default user is empty.
    * @private
    */
-  config_: BehaviorSubject<User>;
+  properties_: BehaviorSubject<User>;
+
+  /**
+   * The observable state of the user. Default to NOT_INITIALIZED.
+   * @private
+   */
+  state_: BehaviorSubject<UserState>;
 
   constructor() {
-    const defaultUser: User = {
-      email: null,
-      is_intranet: null,
-      functionalities: null,
-      is_password_changed: null,
-      roles: null,
-      username: null,
-      otp_key: null,
-      otp_url: null,
+    this.properties_ = new BehaviorSubject<User>(this.getEmptyUserProperties());
+    this.state_ = new BehaviorSubject<UserState>(UserState.NOT_INITIALIZED);
+  }
+
+  /**
+   * Return the observable user's properties.
+   */
+  getProperties(): BehaviorSubject<User> {
+    return this.properties_;
+  }
+
+  /**
+   * Return the observable user state.
+   */
+  getState(): BehaviorSubject<UserState> {
+    return this.state_;
+  }
+
+  /**
+   * Set the current User's properties and state.
+   */
+  setUser(properties: User, state: UserState) {
+    if (properties === null) {
+      console.error('The user can not be null');
     }
-    this.config_ = new BehaviorSubject<User>(defaultUser);
+    this.state_.next(state);
+    this.properties_.next(properties);
   }
 
   /**
-   * Return the observable User's config.
+   * Return an empty user.
    */
-  getConfig(): BehaviorSubject<User> {
-    return this.config_;
-  }
-
-  /**
-   * Set the current User's config.
-   */
-  setConfig(config: User) {
-    this.config_.next(config);
+  getEmptyUserProperties(): User {
+    return {
+        email: null,
+        is_intranet: null,
+        functionalities: null,
+        is_password_changed: null,
+        roles: null,
+        username: null,
+        otp_key: null,
+        otp_url: null,
+    };
   }
 }
 

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -88,11 +88,11 @@ export class UserModel {
    * The observable state of the user. Default to NOT_INITIALIZED.
    * @private
    */
-  state_: BehaviorSubject<UserState>;
+  state_: UserState;
 
   constructor() {
     this.properties_ = new BehaviorSubject<User>(this.getEmptyUserProperties());
-    this.state_ = new BehaviorSubject<UserState>(UserState.NOT_INITIALIZED);
+    this.state_ = UserState.NOT_INITIALIZED;
   }
 
   /**
@@ -105,7 +105,7 @@ export class UserModel {
   /**
    * Return the observable user state.
    */
-  getState(): BehaviorSubject<UserState> {
+  getState(): UserState {
     return this.state_;
   }
 
@@ -116,7 +116,7 @@ export class UserModel {
     if (properties === null) {
       console.error('The user can not be null');
     }
-    this.state_.next(state);
+    this.state_ = state;
     this.properties_.next(properties);
   }
 

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -77,7 +77,17 @@ export class UserModel {
   config_: BehaviorSubject<User>;
 
   constructor() {
-    this.config_ = new BehaviorSubject<User>(null);
+    const defaultUser: User = {
+      email: null,
+      is_intranet: null,
+      functionalities: null,
+      is_password_changed: null,
+      roles: null,
+      username: null,
+      otp_key: null,
+      otp_url: null,
+    }
+    this.config_ = new BehaviorSubject<User>(defaultUser);
   }
 
   /**


### PR DESCRIPTION
A complete integration of the new User based on the rxjs store.
We can discuss on that Friday. There is other implementation possibility, I think this one is good.

Some interesting points:

- It was already working on the (small) first commit. But the original implementation is strange (because `gmfUser` was a constante).
- Simplify the code at some points: no more mix of OpenLayer and ngeo events, no injection... 
- My last commit set back the userState (logged in, logged out, ready...) to a simple string.  Reason in the commit message:
```
With two observable, if you subscribe to one, you have
no guarantee that the other is already up to date. Even
if they are updated at the same time !
```
- I've seen that the (old/gmf) auth component is initialized three times by AngularJs, but only destroyed one time ! There is only one component, I don't get why we have two time this component initialized at the same time. It's risky... 