### PR TITLE
Bindings for passwordValidator

### DIFF
--- a/contribs/gmf/apps/desktop_alt/index.html.ejs
+++ b/contribs/gmf/apps/desktop_alt/index.html.ejs
@@ -146,7 +146,6 @@
           ng-prop-login_info_message="mainCtrl.loginInfoMessage"
           ng-prop-post_loading="mainCtrl.postLoading"
           ng-prop-password_validator="mainCtrl.passwordValidator"
-          ng-prop-on_successful_login="mainCtrl.onSuccessfulLogin"
           ></ngeo-auth-panel>
           <div ng-show="mainCtrl.printPanelActive" class="row">
             <div class="col-sm-12">

--- a/contribs/gmf/apps/desktop_alt/index.html.ejs
+++ b/contribs/gmf/apps/desktop_alt/index.html.ejs
@@ -145,6 +145,8 @@
           ng-on-close-panel="mainCtrl.ngeoAuthActive = $event.detail"
           ng-prop-login_info_message="mainCtrl.loginInfoMessage"
           ng-prop-post_loading="mainCtrl.postLoading"
+          ng-prop-password_validator="mainCtrl.passwordValidator"
+          ng-prop-on_successful_login="mainCtrl.onSuccessfulLogin"
           ></ngeo-auth-panel>
           <div ng-show="mainCtrl.printPanelActive" class="row">
             <div class="col-sm-12">

--- a/src/auth/component.ts
+++ b/src/auth/component.ts
@@ -26,7 +26,6 @@ import AngularServices from 'ngeo/services';
 import {MessageType} from 'ngeo/message/Message.js';
 import {unsafeSVG} from 'lit/directives/unsafe-svg.js';
 import loadingSvg from 'gmf/icons/spinner.svg';
-import {AuthenticationLoginResponsePromise} from 'gmf/authentication/Service';
 import {gmfBackgroundlayerStatus} from 'gmf/backgroundlayerselector/status.js';
 import {Subscription} from 'rxjs';
 import user, {User, UserState} from 'ngeo/store/user';
@@ -44,9 +43,6 @@ type PasswordValidator = {
 export default class ngeoAuthComponent extends LitElementI18n {
   @property({type: String}) loginInfoMessage = '';
   @property({type: Object}) private passwordValidator: PasswordValidator = null;
-  @property({attribute: false}) onSuccessfulLogin: (
-    resp: AuthenticationLoginResponsePromise
-  ) => AuthenticationLoginResponsePromise = undefined;
   @state() private isLoading = false;
   @state() private disconnectedShown = false;
   @state() private resetPasswordShown = false;
@@ -70,7 +66,6 @@ export default class ngeoAuthComponent extends LitElementI18n {
           this.setOtpImage_();
           this.checkUserMustChangeItsPassword_();
           this.onUserStateUpdate_(user.getState());
-          this.onSucessfullLoginCallback_();
         },
       })
     );
@@ -309,15 +304,6 @@ export default class ngeoAuthComponent extends LitElementI18n {
     this.userMustChangeItsPassword = true;
   }
 
-  /**
-   * @private
-   */
-  onSucessfullLoginCallback_() {
-    if (this.onSuccessfulLogin) {
-      AngularServices.auth.onSuccessfulLogin = this.onSuccessfulLogin;
-    }
-  }
-
   // METHODS THAT CALL THE AUTHENTICATION SERVICE METHODS
 
   /**
@@ -358,7 +344,7 @@ export default class ngeoAuthComponent extends LitElementI18n {
       // Custom validation - If a passwordValidaor is set, use it to validate the new password.
       if (this.passwordValidator) {
         if (!this.passwordValidator.isPasswordValid(oldPwd)) {
-          errors.push(this.passwordValidator.notValidMessage);
+          errors.push(i18next.t(this.passwordValidator.notValidMessage));
         }
       }
 

--- a/src/auth/component.ts
+++ b/src/auth/component.ts
@@ -26,10 +26,10 @@ import AngularServices from 'ngeo/services';
 import {MessageType} from 'ngeo/message/Message.js';
 import {unsafeSVG} from 'lit/directives/unsafe-svg.js';
 import loadingSvg from 'gmf/icons/spinner.svg';
+import {AuthenticationLoginResponsePromise} from 'gmf/authentication/Service';
 import {gmfBackgroundlayerStatus} from 'gmf/backgroundlayerselector/status.js';
 import {Subscription} from 'rxjs';
-// @ts-ignore
-import user, {User, UserState} from 'ngeo/store/user.ts';
+import user, {User, UserState} from 'ngeo/store/user';
 // @ts-ignore
 import qruri from 'qruri';
 import i18next from 'i18next';
@@ -44,6 +44,9 @@ type PasswordValidator = {
 export default class ngeoAuthComponent extends LitElementI18n {
   @property({type: String}) loginInfoMessage = '';
   @property({type: Object}) private passwordValidator: PasswordValidator = null;
+  @property({attribute: false}) onSuccessfulLogin: (
+    resp: AuthenticationLoginResponsePromise
+  ) => AuthenticationLoginResponsePromise = undefined;
   @state() private isLoading = false;
   @state() private disconnectedShown = false;
   @state() private resetPasswordShown = false;
@@ -67,6 +70,7 @@ export default class ngeoAuthComponent extends LitElementI18n {
           this.setOtpImage_();
           this.checkUserMustChangeItsPassword_();
           this.onUserStateUpdate_(user.getState());
+          this.onSucessfullLoginCallback_();
         },
       })
     );
@@ -293,6 +297,9 @@ export default class ngeoAuthComponent extends LitElementI18n {
     }
   }
 
+  /**
+   * @private
+   */
   checkUserMustChangeItsPassword_() {
     if (this.gmfUser.is_password_changed !== false) {
       return;
@@ -300,6 +307,15 @@ export default class ngeoAuthComponent extends LitElementI18n {
     this.changingPasswordUsername_ = this.gmfUser.username;
     this.changingPassword = true;
     this.userMustChangeItsPassword = true;
+  }
+
+  /**
+   * @private
+   */
+  onSucessfullLoginCallback_() {
+    if (this.onSuccessfulLogin) {
+      AngularServices.auth.onSuccessfulLogin = this.onSuccessfulLogin;
+    }
   }
 
   // METHODS THAT CALL THE AUTHENTICATION SERVICE METHODS

--- a/src/auth/panel.ts
+++ b/src/auth/panel.ts
@@ -25,8 +25,6 @@ import {unsafeSVG} from 'lit/directives/unsafe-svg.js';
 import loadingSvg from 'gmf/icons/spinner.svg';
 import i18next from 'i18next';
 import {LitElementI18n} from 'ngeo/localize/i18n';
-
-import {AuthenticationLoginResponsePromise} from 'gmf/authentication/Service';
 import PasswordValidator from './component';
 
 import './component.ts';
@@ -37,9 +35,6 @@ export default class AuthPanel extends LitElementI18n {
   @property({type: String}) loginInfoMessage = '';
   @property({type: Boolean}) postLoading = false;
   @property({type: Object}) passwordValidator: PasswordValidator = null;
-  @property({attribute: false}) onSuccessfulLogin: (
-    resp: AuthenticationLoginResponsePromise
-  ) => AuthenticationLoginResponsePromise = undefined;
 
   protected render() {
     const spinnerTemplate = this.postLoading
@@ -60,7 +55,6 @@ export default class AuthPanel extends LitElementI18n {
           <ngeo-auth-component
             .loginInfoMessage=${this.loginInfoMessage}
             .passwordValidator=${this.passwordValidator}
-            .onSuccessfulLogin=${this.onSuccessfulLogin}
           ></ngeo-auth-component>
           ${spinnerTemplate}
         </div>

--- a/src/auth/panel.ts
+++ b/src/auth/panel.ts
@@ -26,6 +26,9 @@ import loadingSvg from 'gmf/icons/spinner.svg';
 import i18next from 'i18next';
 import {LitElementI18n} from 'ngeo/localize/i18n';
 
+import {AuthenticationLoginResponsePromise} from 'gmf/authentication/Service';
+import PasswordValidator from './component';
+
 import './component.ts';
 import './auth.css';
 
@@ -33,6 +36,10 @@ import './auth.css';
 export default class AuthPanel extends LitElementI18n {
   @property({type: String}) loginInfoMessage = '';
   @property({type: Boolean}) postLoading = false;
+  @property({type: Object}) passwordValidator: PasswordValidator = null;
+  @property({attribute: false}) onSuccessfulLogin: (
+    resp: AuthenticationLoginResponsePromise
+  ) => AuthenticationLoginResponsePromise = undefined;
 
   protected render() {
     const spinnerTemplate = this.postLoading
@@ -50,7 +57,11 @@ export default class AuthPanel extends LitElementI18n {
             ${i18next.t('Login')}
             <a class="btn close" @click=${this.closePanel}>&times;</a>
           </div>
-          <ngeo-auth-component .loginInfoMessage=${this.loginInfoMessage}></ngeo-auth-component>
+          <ngeo-auth-component
+            .loginInfoMessage=${this.loginInfoMessage}
+            .passwordValidator=${this.passwordValidator}
+            .onSuccessfulLogin=${this.onSuccessfulLogin}
+          ></ngeo-auth-component>
           ${spinnerTemplate}
         </div>
       </div>


### PR DESCRIPTION
PasswordValidator addition was straight-forward.

Final decision to drop onSuccessfulLogin, we can override it from the angular controller if needed.



Previously:
I have to assign the value of onSuccessfulLogin when the Angular controller is done initializing. Otherwise trying to do it outside the store getProperties().subscribe() get the value undefined and will not change later, as the Angular controller is not ready before the DOM of the web-component and there is no compatible watcher to lit-element.

On the matter of not using updated (https://lit.dev/docs/components/lifecycle/#reactive-update-cycle-completing):
The updated(changedProperties) works as watcher on attributes/properties in general, but not on @property({attribute: false}) as we need to bind the variable to a function and Lit only support string, boolean, number, array or object types.