### PR TITLE
Reset mode on self tab ctrl+key combination

### DIFF
--- a/src/query/ModeSelector.js
+++ b/src/query/ModeSelector.js
@@ -141,6 +141,7 @@ export class QueryModeSelector {
     // Event listeners
     olEventsListen(document, 'keydown', this.handleKeyDown_, this);
     olEventsListen(document, 'keyup', this.handleKeyUp_, this);
+    setInterval(this.checkPageFocus_.bind(this), 200);
   }
 
   /**
@@ -213,7 +214,8 @@ export class QueryModeSelector {
     let updateScope = false;
 
     if (this.previousMode_) {
-      // TODO
+      // If the ctrl key is pressed with another key (but not an action key), reset to
+      // the default mode. (For instance to avoid to keep a previous mode after a ctrl+p.)
       if (isEventUsinCtrlKey(evt) && !this.keysAction_.includes(key)) {
         updateScope = this.reset_();
       }
@@ -279,6 +281,19 @@ export class QueryModeSelector {
 
     if (updateScope) {
       this.rootScope_.$apply();
+    }
+  }
+
+  /**
+   * Check the focus on the page determined by the browser.
+   * If the page is not anymore focus then reset the mode.
+   * @private
+   */
+  checkPageFocus_() {
+    if (!document.hasFocus() && this.previousMode_) {
+      if (this.reset_()) {
+        this.rootScope_.$apply();
+      }
     }
   }
 


### PR DESCRIPTION
For GSGMF-1689

Current commit: It retablish the default mode on self-tab combination, `like ctrl+p`.

Possible further step:
- To disable `ctrl + t` (new tab), we could use  https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API, it's safe but doesn't handle `ctrl + n`.
- To disable `ctrl + n` (and also `ctrl + t`) we could make a loop every second (or more, or less), to check if the page have the focus. That should work but it's heavy and relatively ugly.... See: https://developer.mozilla.org/en-US/docs/Web/API/Document/hasFocus

What should I do ? @sbrunner ?