### PR TITLE
Update Mapillary to v4.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -358,11 +358,6 @@ contribs/dist: .build/build-dll.timestamp
 	[ -e node_modules/@geoblocks/proj/gen-ts ] || (cd node_modules/@geoblocks/proj/src; npx --package typescript@4.0.2 tsc --declaration)
 	touch node_modules/@geoblocks/proj/gen-ts
 
-	[ -e node_modules/mapillary-js/gen-ts ] || (cd node_modules/mapillary-js; npm install --ignore-scripts)
-	[ -e node_modules/mapillary-js/gen-ts ] || (cd node_modules/mapillary-js; node_modules/.bin/tsc --declaration)
-	[ -e node_modules/mapillary-js/gen-ts ] || find node_modules/mapillary-js/src -name '*.ts'|grep -v .d.ts| while read f; do rm "$$f"; done
-	touch node_modules/mapillary-js/gen-ts
-
 	touch $@
 
 contribs/gmf/build/angular-locale_%.js: package.json

--- a/buildtools/webpack.commons.js
+++ b/buildtools/webpack.commons.js
@@ -253,7 +253,7 @@ module.exports = function (config) {
         olcs: 'ol-cesium/src/olcs',
         'jquery-ui/datepicker': 'jquery-ui/ui/widgets/datepicker', // For angular-ui-date
         proj4: 'proj4/lib',
-        'mapillary-js/src/Mapillary': 'mapillary-js/dist/mapillary.min.js',
+        'mapillary-js/src/Mapillary': 'mapillary-js/dist/mapillary.js',
         '@geoblocks/proj': '@geoblocks/proj/src',
       },
     },

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "ol": "6.5.0",
     "ol-cesium": "2.12.0",
     "ol-layerswitcher": "3.8.3",
-    "mapillary-js": "2.21.0",
+    "mapillary-js": "4.0.0",
     "parse-absolute-css-unit": "1.0.2",
     "popper.js": "1.16.1",
     "prettier": "2.2.1",

--- a/src/streetview/component.js
+++ b/src/streetview/component.js
@@ -73,7 +73,7 @@ function ngeoStreetviewTemplateUrl($attrs, ngeoStreetviewTemplateUrl) {
 /**
  * This component is used to integrate a streetview tool (googlestreetview or mapillary)
  * The tool has to be declared in the constant 'ngeoStreetviewOptions'. For mapillary
- * the key (clientId) is needed as well.
+ * the key (accessToken) is needed as well.
  *
  * module.constant('ngeoStreetviewOptions', {
  *  'viewer': 'google',
@@ -98,6 +98,7 @@ class StreetviewController {
   /**
    * @param {JQuery} $element Element.
    * @param {angular.IScope} $scope Scope.
+   * @param {angular.IHttpService} $http Angular $http service.
    * @param {import("ngeo/map/FeatureOverlayMgr.js").FeatureOverlayMgr} ngeoFeatureOverlayMgr Ngeo
    * @param {angular.auto.IInjectorService} $injector Main injector.
    * @param {angular.ITimeoutService} $timeout
@@ -106,7 +107,7 @@ class StreetviewController {
    * @ngdoc controller
    * @ngname NgeoStreetviewController
    */
-  constructor($element, $scope, ngeoFeatureOverlayMgr, $injector, $timeout) {
+  constructor($element, $scope, $http, ngeoFeatureOverlayMgr, $injector, $timeout) {
     // Binding properties
 
     /**
@@ -166,6 +167,12 @@ class StreetviewController {
      * @private
      */
     this.element_ = $element;
+
+    /**
+     * Angular $http service.
+     * @private
+     */
+    this.http_ = $http;
 
     // Inner properties
 
@@ -309,14 +316,16 @@ class StreetviewController {
     if (!this.options || !this.options.key) {
       throw new Error('Missing mapillary key');
     }
-    const clientId = this.options.key;
+    const accessToken = this.options.key;
     //wait for the mly div to be there before making the service which needs it
     this.timeout_(() => {
       const mapillaryService = new MapillaryService(
         this.scope_,
+        this.timeout_,
+        this.http_,
         this.map,
         this.handlePanoramaPositionChange_,
-        clientId
+        accessToken
       );
       this.scope_.$watch(
         () => this.panelWidth,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,9 @@
       "@geoblocks/proj/*": [
         "node_modules/@geoblocks/proj/*"
       ],
+      "mapillary-js/*": [
+        "node_modules/mapillary-js/dist/mapillary.d.ts"
+      ],
       "moment": [
         "node_modules/moment/moment.d.ts"
       ],


### PR DESCRIPTION
For GEO-4868

Demo: https://camptocamp.github.io/ngeo/update_mapillary_GEO-4868/examples/contribs/gmf/apps/desktop_alt.html?

Mapillary with Mapillary-js v2 doesn't work anymore. I upgrade to v4.0.0 (latest so far).
I had to provide a new token. See: https://github.com/camptocamp/demo_geomapfish/pull/273

Maybe we can clean more, the api looks better (but still weight 1.1M).

Note: with `mapillary-js/dist/mapillary.js` we use the the minified js as before. The **not** minified js is `mapillary-js/dist/mapillary.unminified.js`