### PR TITLE
Bump jquery-ui who has security issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "jquery": "3.5.1",
     "jquery-datetimepicker": "2.5.21",
     "jquery-mousewheel": "3.1.13",
-    "jquery-ui": "1.12.1",
+    "jquery-ui": "1.13.0",
     "jquery-ui-touch-punch": "0.2.3",
     "jsts": "2.0.4",
     "karma": "5.1.0",


### PR DESCRIPTION
  Title: [1004768] XSS in `*Text` options of the Datepicker widget in jquery-ui
  Severity: moderate
  CWE: CWE-79
  Vulnarable versions: <1.13.0
  Patched versions: >=1.13.0
  Recommendation: Upgrade to version 1.13.0 or later
  Version: 1.12.1
  Path: jquery-ui
  More info: https://github.com/advisories/GHSA-j7qv-pgf6-hvh4

  Title: [1004769] XSS in the `of` option of the `.position()` util in jquery-ui
  Severity: moderate
  CWE: CWE-79
  Vulnarable versions: <1.13.0
  Patched versions: >=1.13.0
  Recommendation: Upgrade to version 1.13.0 or later
  Version: 1.12.1
  Path: jquery-ui
  More info: https://github.com/advisories/GHSA-gpqq-952q-5327

  Title: [1004770] XSS in the `altField` option of the Datepicker widget in jquery-ui
  Severity: moderate
  CWE: CWE-79
  Vulnarable versions: <1.13.0
  Patched versions: >=1.13.0
  Recommendation: Upgrade to version 1.13.0 or later
  Version: 1.12.1
  Path: jquery-ui
  More info: https://github.com/advisories/GHSA-9gj3-hwp5-pmwc