### PR TITLE
Fix printed legend image - use layer node name

### DIFF
--- a/contribs/gmf/src/print/LegendMapFishPrintV3.js
+++ b/contribs/gmf/src/print/LegendMapFishPrintV3.js
@@ -245,8 +245,8 @@ export default class LegendMapFishPrintV3 {
    */
   getLegendItemFromTileLayer_(currentThemes, layer, dpi) {
     const gettextCatalog = this.gettextCatalog_;
-    const layerName = layer.get(LAYER_NODE_NAME_KEY);
-    let icon_dpi = this.getMetadataLegendImage_(currentThemes, layerName, dpi);
+    const layerNodeName = layer.get(LAYER_NODE_NAME_KEY);
+    let icon_dpi = this.getMetadataLegendImage_(currentThemes, layerNodeName, dpi);
     if (!icon_dpi) {
       const url = this.ngeoLayerHelper_.getWMTSLegendURL(layer);
       if (url) {
@@ -259,7 +259,7 @@ export default class LegendMapFishPrintV3 {
     // Add only classes without legend url.
     if (icon_dpi) {
       return {
-        name: gettextCatalog.getString(layerName),
+        name: gettextCatalog.getString(layerNodeName),
         icons: [icon_dpi.url],
       };
     }
@@ -294,8 +294,9 @@ export default class LegendMapFishPrintV3 {
     const legendGroupItem = {
       classes: legendLayerClasses,
     };
+    const layerNodeName = layer.get(LAYER_NODE_NAME_KEY);
     if (this.gmfLegendOptions_.showGroupsTitle) {
-      legendGroupItem.name = gettextCatalog.getString(layer.get(LAYER_NODE_NAME_KEY));
+      legendGroupItem.name = gettextCatalog.getString(layerNodeName);
     }
     // For each name in a WMS layer.
     const layerNames = /** @type {string} */ (source.getParams().LAYERS).split(',');
@@ -304,7 +305,7 @@ export default class LegendMapFishPrintV3 {
       // Don't add classes without legend url or from layers without any
       // active name.
       if (name.length !== 0) {
-        let icon_dpi = this.getMetadataLegendImage_(currentThemes, name, dpi);
+        let icon_dpi = this.getMetadataLegendImage_(currentThemes, layerNodeName, dpi);
         // @ts-ignore: private...
         const type = icon_dpi ? 'image' : source.serverType_;
         if (!icon_dpi) {
@@ -380,13 +381,13 @@ export default class LegendMapFishPrintV3 {
   /**
    * Return the metadata legendImage of a layer from the found corresponding node
    * or undefined.
-   * @param {string} layerName a layer name.
+   * @param {string} layerNodeName the layer name of the node.
    * @param {number} [dpi=96] the image DPI.
    * @param {Array<import('gmf/themes.js').GmfTheme>} currentThemes the current themes.
    * @return {LegendURLDPI|undefined} The legendImage with selected DPI or undefined.
    * @private
    */
-  getMetadataLegendImage_(currentThemes, layerName, dpi = -1) {
+  getMetadataLegendImage_(currentThemes, layerNodeName, dpi = -1) {
     if (dpi == -1) {
       dpi = screenDpi();
     }
@@ -395,7 +396,7 @@ export default class LegendMapFishPrintV3 {
     for (const theme of currentThemes) {
       getFlatNodes(theme, nodes);
     }
-    const node = findObjectByName(nodes, layerName);
+    const node = findObjectByName(nodes, layerNodeName);
 
     let found_dpi = dpi;
     let legendImage;


### PR DESCRIPTION
Fix GSGMF-1702

The layer name was given instead of the node name. The node.metadata was not reachable in some cases. Like in layer OSM time (interval popup): https://geomapfish-demo-2-6.camptocamp.com/theme/Demo?lang=fr&baselayer_ref=OSM%20map&theme=Demo&tree_group_opacity_Group=0.65&tree_enable_osm_time_r_dp=true&tree_time_osm_time_r_dp=2006-01%2F2013-12&tree_group_layers_Layers=&tree_group_layers_Layers-exclusive=&tree_enable_osm_scale=false&tree_group_layers_Group=&tree_group_layers_OSM%20functions=&tree_enable_ch.swisstopo.dreiecksvermaschung=false&tree_enable_ch.swisstopo.geologie-gravimetrischer_atlas=false&tree_enable_ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen=false&tree_enable_ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung=false&tree_enable_NPA%20localite%20noWFS=false&tree_enable_ch.bfe.solarenergie-eignung-fassaden=false&tree_enable_ch.bfe.solarenergie-eignung-daecher=false&tree_enable_osm_open=false&tree_enable_OSM%20map=false&tree_enable_osm_time_r_dp_2=false&tree_group_layers_Filters=&tree_enable_vd.regime_hydrique%20noWFS=false&tree_enable_osm_firestations%20no%20wfs=false&tree_groups=OSM%20functions%20mixed%2CLayers%2CLayers-exclusive%2CGroup%2COSM%20functions%2CExternal%2CFilters%20mixed%2CFilters%2CESRI%20no%20WFS%20no%20Geom (dumy metdata added to prove it)