### PR TITLE
Remove use of i18next translation in desktop_alt

### DIFF
--- a/contribs/gmf/apps/desktop_alt/index.html.ejs
+++ b/contribs/gmf/apps/desktop_alt/index.html.ejs
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{mainCtrl.lang}}" ng-controller="AlternativeDesktopController as mainCtrl" ng-strict-di>
   <head>
-    <title data-i18n="Alternative Desktop Application">GeoMapFish</title>
+    <title translate>Alternative Desktop Application</title>
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="dynamicUrl" content="https://geomapfish-demo-2-7.camptocamp.com/dynamic.json">
@@ -37,7 +37,7 @@
               <b ng-if="!mainCtrl.gmfThemeManager.isLoading()">{{mainCtrl.gmfThemeManager.getThemeName() | translate}}</b>
             </span>
             <span ng-if="!mainCtrl.gmfThemeManager.modeFlush">
-              <b ng-if="!mainCtrl.gmfThemeManager.themeName" data-i18n="Themes"></b>
+              <b ng-if="!mainCtrl.gmfThemeManager.themeName" translate>Themes</b>
             </span>
           </a>
           <gmf-themeselector class="dropdown-menu"


### PR DESCRIPTION
We cannot fetch the translations from i18next outside of the web-components for now.