### PR TITLE
Display login message when authentication is required on private layers

### DIFF
--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -51,6 +51,7 @@ import olStyleText from 'ol/style/Text';
 
 import 'gmfapi/index';
 import panels from 'gmfapi/store/panels';
+import user, {LoginMessageState} from 'gmfapi/store/user';
 
 import 'gmf/controllers/vars_desktop.scss';
 import 'gmf/controllers/desktop.scss';
@@ -173,8 +174,22 @@ export class AbstractDesktopController extends AbstractAPIController {
             this.printPanelActive = newVal;
           }
         }
+        if (panels === null || !panels.includes('auth')) {
+          user.setLoginMessage(LoginMessageState.EMPTY);
+        }
       },
     });
+
+    user.getLoginMessage().subscribe({
+      next: (message) => {
+        this.loginInfoMessage = message;
+        if (message) {
+          // Open the auth panel if a message is displayed
+          panels.openToolPanel('auth');
+        }
+      },
+    });
+
     // Don't deactivate ngeoQuery on print activation
     $scope.$watch(
       () => this.printPanelActive,

--- a/src/auth/FormElement.ts
+++ b/src/auth/FormElement.ts
@@ -44,8 +44,8 @@ export type PasswordValidator = {
 
 @customElement('gmf-auth-form')
 export default class GmfAuthForm extends GmfBaseElement {
-  @property({type: String}) loginInfoMessage = '';
   @property({type: Object}) private passwordValidator: PasswordValidator = null;
+  @state() private loginInfoMessage = '';
   @state() private isLoading = false;
   @state() private disconnectedShown = false;
   @state() private resetPasswordShown = false;
@@ -69,6 +69,11 @@ export default class GmfAuthForm extends GmfBaseElement {
           this.setOtpImage_();
           this.checkUserMustChangeItsPassword_();
           this.onUserStateUpdate_(user.getState());
+        },
+      }),
+      user.getLoginMessage().subscribe({
+        next: (message: string) => {
+          this.loginInfoMessage = message;
         },
       })
     );

--- a/src/auth/PanelElement.ts
+++ b/src/auth/PanelElement.ts
@@ -33,7 +33,6 @@ import ToolPanelElement from 'gmfapi/elements/ToolPanelElement';
 
 @customElement('gmf-auth-panel')
 export default class GmfAuthPanel extends ToolPanelElement {
-  @property({type: String}) loginInfoMessage = '';
   @property({type: Boolean}) postLoading = false;
   @property({type: Object}) passwordValidator: PasswordValidator = null;
   @state() private customCSS_ = '';
@@ -78,10 +77,7 @@ export default class GmfAuthPanel extends ToolPanelElement {
         ${unsafeCSS(this.customCSS_)}
       </style>
       ${this.getTitle(i18next.t('Login'))}
-      <gmf-auth-form
-        .loginInfoMessage=${this.loginInfoMessage}
-        .passwordValidator=${this.passwordValidator}
-      ></gmf-auth-form>
+      <gmf-auth-form .passwordValidator=${this.passwordValidator}></gmf-auth-form>
       ${spinnerTemplate}
     `;
   }

--- a/src/auth/component.spec.ts
+++ b/src/auth/component.spec.ts
@@ -22,7 +22,7 @@
 import gmfAuthenticationService from 'ngeo/auth/service';
 
 import configuration, {Configuration} from 'gmfapi/store/config';
-import user, {UserState} from 'gmfapi/store/user';
+import user, {UserState, LoginMessageState} from 'gmfapi/store/user';
 
 describe('Auth component', () => {
   context('panel', () => {
@@ -42,13 +42,12 @@ describe('Auth component', () => {
     });
 
     it('displays an info message', () => {
-      cy.visit('iframe.html?id=auth-form--empty&args=loginInfoMessage:a_msg');
-      cy.get('.alert span').should('have.length', 1).first().should('have.text', 'a_msg');
+      cy.visit('iframe.html?id=auth-form--empty&args=loginInfoMessage:true');
+      cy.get('.alert span').should('have.length', 1).first().should('have.text', LoginMessageState.REQUIRED);
     });
 
     it('displays a form with a user and a message', () => {
-      cy.visit('iframe.html?id=auth-form--with-user&args=loginInfoMessage:logged');
-      cy.get('.alert span').should('have.length', 1).first().should('have.text', 'logged');
+      cy.visit('iframe.html?id=auth-form--with-user&args=loginInfoMessage:false');
       cy.get('input').should('have.length', 2).first().should('have.value', 'Logout');
       cy.get('.form-group span').first().should('have.text', 'Logged in as');
       cy.get('.form-group strong').first().should('have.text', 'George');

--- a/src/auth/component.stories.ts
+++ b/src/auth/component.stories.ts
@@ -24,7 +24,7 @@
 
 import './FormElement';
 import './PanelElement';
-import user, {UserState, User} from 'gmfapi/store/user';
+import user, {UserState, User, LoginMessageState} from 'gmfapi/store/user';
 
 export default {
   title: 'Auth Form',
@@ -39,19 +39,17 @@ type Args = {
   /**
    * The info message.
    */
-  loginInfoMessage: string;
+  loginInfoMessage: boolean;
 };
 
 const Template = (args: Args) => {
   user.setUser(args.user, UserState.READY);
-  return `
-    <gmf-auth-form
-      loginInfoMessage="${args.loginInfoMessage}">
-    </gmf-auth-form>`;
+  user.setLoginMessage(args.loginInfoMessage ? LoginMessageState.REQUIRED : LoginMessageState.EMPTY);
+  return '<gmf-auth-form></gmf-auth-form>';
 };
 
 const defaultProperties: Args = {
-  loginInfoMessage: '',
+  loginInfoMessage: false,
   user: null,
 };
 

--- a/srcapi/store/user.ts
+++ b/srcapi/store/user.ts
@@ -103,6 +103,12 @@ export enum UserState {
   NOT_INITIALIZED = 'not initialized',
 }
 
+export enum LoginMessageState {
+  EMPTY = '',
+  REQUIRED = 'Some layers in this link are not accessible to unauthenticated users. ' +
+    'Please log in to see whole data.',
+}
+
 /**
  * Object used to expose the login user information.
  *
@@ -129,8 +135,16 @@ export class UserModel {
    */
   state_: UserState;
 
+  /**
+   * The login message when a private layer is opened in the permalink
+   *
+   * @private
+   */
+  loginMessage_: BehaviorSubject<string>;
+
   constructor() {
     this.properties_ = new BehaviorSubject<User>(this.getEmptyUserProperties());
+    this.loginMessage_ = new BehaviorSubject<string>(LoginMessageState.EMPTY);
     this.state_ = UserState.NOT_INITIALIZED;
   }
 
@@ -146,6 +160,22 @@ export class UserModel {
    */
   getState(): UserState {
     return this.state_;
+  }
+
+  /**
+   * @returns The observable login message.
+   */
+  getLoginMessage(): BehaviorSubject<string> {
+    return this.loginMessage_;
+  }
+
+  /**
+   * Set the current login message
+   *
+   * @param messageState The new login message.
+   */
+  setLoginMessage(messageState: LoginMessageState): void {
+    this.loginMessage_.next(messageState);
   }
 
   /**


### PR DESCRIPTION
Probably not the cleanest implementation possible, but do the job with the following requirements:

- Switch to another tool panel should reset the login message to empty state
- Close the panel or collapse it should reset the login message to empty state
- If login is required will both broadcast an event for desktop the AngularJS way and use the store to change the store Observable for desktop_alt

Missing:

- Translation of the message value

NB: I had to fix the promises adding some catch() and the gmfUser naming in the permalink.js so it is a bit of a mess for this file...