### PR TITLE
Correctly toggle print mask

### DIFF
--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -168,12 +168,8 @@ export class AbstractDesktopController extends AbstractAPIController {
 
     panels.getActiveToolPanel().subscribe({
       next: (panels) => {
-        if (panels !== null) {
-          const newVal = panels.includes('print');
-          if (newVal != this.printPanelActive) {
-            this.printPanelActive = newVal;
-          }
-        }
+        panels === 'print' ? (this.printPanelActive = true) : (this.printPanelActive = false);
+        $scope.$apply();
         if (panels === null || !panels.includes('auth')) {
           user.setLoginMessage(LoginMessageState.EMPTY);
         }

--- a/contribs/gmf/src/controllers/AbstractDesktopController.js
+++ b/contribs/gmf/src/controllers/AbstractDesktopController.js
@@ -166,10 +166,13 @@ export class AbstractDesktopController extends AbstractAPIController {
      */
     this.routingPanelActive = false;
 
+    const $timeout = $injector.get('$timeout');
+
     panels.getActiveToolPanel().subscribe({
       next: (panels) => {
         panels === 'print' ? (this.printPanelActive = true) : (this.printPanelActive = false);
-        $scope.$apply();
+        $timeout(() => {}); // this triggered on DOM click, we call $timeout to force Angular diggest
+
         if (panels === null || !panels.includes('auth')) {
           user.setLoginMessage(LoginMessageState.EMPTY);
         }


### PR DESCRIPTION
As we checked that the panel was not null in abstract controller, we did not set the value to false when the panel was closed so the mask in the print wasn't synced anymore with the correct value.