### PR TITLE
Add options name for search options

### DIFF
--- a/contribs/gmf/src/search/component.js
+++ b/contribs/gmf/src/search/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2021 Camptocamp SA
+// Copyright (c) 2015-2022 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -126,6 +126,7 @@ function gmfSearchTemplateUrl($element, $attrs, gmfSearchTemplateUrl) {
  * @htmlAttribute {SearchComponentListeners} gmf-search-listeners The listeners.
  * @htmlAttribute {function=} gmf-search-on-init Optional function called when the component is initialized.
  * @htmlAttribute {function=} gmf-search-action Optional function called when no default action is defined.
+ * @htmlAttribute {string} gmf-search-options-name Optional options name when multiple search component are defined.
  * @ngdoc component
  * @ngname gmfSearch
  */
@@ -137,6 +138,7 @@ const searchComponent = {
     'additionalListeners': '<gmfSearchListeners',
     'onInitCallback': '<?gmfSearchOnInit',
     'searchActionCallback': '&?gmfSearchAction',
+    'optionsName': '@?gmfSearchOptionsName',
   },
   controller: 'gmfSearchController',
   templateUrl: gmfSearchTemplateUrl,
@@ -156,6 +158,7 @@ export class SearchController {
    * @param {angular.IScope} $scope The component's scope.
    * @param {angular.ICompileService} $compile Angular compile service.
    * @param {angular.ITimeoutService} $timeout Angular timeout service.
+   * @param {angular.auto.IInjectorService} $injector Angular injector service.
    * @param {angular.gettext.gettextCatalog} gettextCatalog Gettext catalog.
    * @param {import("ngeo/misc/AutoProjection.js").AutoProjectionService} ngeoAutoProjection The ngeo
    *    coordinates service.
@@ -181,6 +184,7 @@ export class SearchController {
     $scope,
     $compile,
     $timeout,
+    $injector,
     gettextCatalog,
     ngeoAutoProjection,
     ngeoSearchCreateGeoJSONBloodhound,
@@ -220,6 +224,11 @@ export class SearchController {
      * @private
      */
     this.timeout_ = $timeout;
+
+    /**
+     * @type {angular.auto.IInjectorService}
+     */
+    this.injector_ = $injector;
 
     /**
      * @type {angular.gettext.gettextCatalog}
@@ -345,6 +354,11 @@ export class SearchController {
      */
     this.clearButton = this.options.clearButton !== false;
 
+    /**
+     * @type {string}
+     */
+    this.optionsName = null;
+
     if (!this.clearButton) {
       // Empty the search field on focus and blur.
       this.element_.find('input').on('focus blur', () => {
@@ -378,6 +392,13 @@ export class SearchController {
    * Called on initialization of the controller.
    */
   $onInit() {
+    const config = this.optionsName || 'gmfSearchOptions';
+
+    /**
+     * @type {import('gmf/options.js').gmfSearchOptions}
+     */
+    this.options = this.injector_.get(config);
+
     this.coordinatesProjectionsInstances_ =
       this.options.coordinatesProjections === undefined
         ? [this.map.getView().getProjection()]


### PR DESCRIPTION
For instances using more than one search input, we need to support multiple configs in the vars like we do for the streetview component.