### PR TITLE
Fix the API help

### DIFF
--- a/buildtools/webpack.api.js
+++ b/buildtools/webpack.api.js
@@ -33,8 +33,6 @@ const babelPresetEnv = [
     },
     modules: false,
     loose: true,
-    useBuiltIns: 'usage',
-    corejs: 3,
   },
 ];
 
@@ -47,7 +45,6 @@ module.exports = (env, argv) => {
       rules: [
         {
           test: /\.js$/,
-          exclude: [/(core-js|strip-ansi)/],
           use: {
             loader: 'babel-loader',
             options: {
@@ -62,7 +59,6 @@ module.exports = (env, argv) => {
     output: {
       filename: 'api.js',
       path: dest,
-      libraryTarget: 'umd',
       libraryExport: 'default',
       library: library,
     },


### PR DESCRIPTION
Remove core-js, it shouldn't be needed because on 2.6 it wasn't present...

