### PR TITLE
Clean more theme object in test to avoid strange error

### DIFF
--- a/contribs/gmf/test/spec/services/treemanager.spec.js
+++ b/contribs/gmf/test/spec/services/treemanager.spec.js
@@ -104,6 +104,8 @@ describe('gmf.layertree.TreeManager', () => {
     $timeout.flush();
 
     expect(spy.calls.count()).toBe(1);
+    cleanObject(group0);
+    cleanObject(group1);
     expect(gmfTreeManager.root.children[0]).toEqual(group1);
     expect(gmfTreeManager.root.children[1]).toEqual(group0);
   });


### PR DESCRIPTION
Was already backported in 2.6 in #7985 

I hope other test case doesn't do this strange error.