### PR TITLE
Fix CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ beautifulsoup4==4.7.1
 glob2==0.6
 htmlmin==0.1.12
 Mako==1.0.9
-requests==2.22.0
+requests==2.27.1
 transifex-client==0.12.5  # rq.filter: <=0.12.5
-urllib3==1.25.9
+urllib3==1.26.8


### PR DESCRIPTION
```
  +==============================================================================+
  |                                                                              |
  |                               /$$$$$$            /$$                         |
  |                              /$$__  $$          | $$                         |
  |           /$$$$$$$  /$$$$$$ | $$  \__//$$$$$$  /$$$$$$   /$$   /$$           |
  |          /$$_____/ |____  $$| $$$$   /$$__  $$|_  $$_/  | $$  | $$           |
  |         |  $$$$$$   /$$$$$$$| $$_/  | $$$$$$$$  | $$    | $$  | $$           |
  |          \____  $$ /$$__  $$| $$    | $$_____/  | $$ /$$| $$  | $$           |
  |          /$$$$$$$/|  $$$$$$$| $$    |  $$$$$$$  |  $$$$/|  $$$$$$$           |
  |         |_______/  \_______/|__/     \_______/   \___/   \____  $$           |
  |                                                          /$$  | $$           |
  |                                                         |  $$$$$$/           |
  |  by pyup.io                                              \______/            |
  |                                                                              |
  +==============================================================================+
  | REPORT                                                                       |
  | checked 7 packages, using free DB (updated once a month)                     |
  +============================+===========+==========================+==========+
  | package                    | installed | affected                 | ID       |
  +============================+===========+==========================+==========+
  | urllib3                    | 1.25.9    | <1.26.5                  | 43975    |
  +==============================================================================+
  | Urllib3 1.26.5 includes a fix for CVE-2021-33503: An issue was discovered in |
  | urllib3 before 1.26.5. When provided with a URL containing many @ characters |
  | in the authority component, the authority regular expression exhibits        |
  | catastrophic backtracking, causing a denial of service if a URL were passed  |
  | as a parameter or redirected to via an HTTP redirect.                        |
  | https://github.com/advisories/GHSA-q2q7-5pp4-w6pg                            |
  +==============================================================================+
```