### PR TITLE
Fix lidar graph not updating with Zoom event

### DIFF
--- a/src/lidar/Manager.ts
+++ b/src/lidar/Manager.ts
@@ -115,7 +115,7 @@ export class LidarprofileManager {
 
   pointSum: number;
 
-  debouncer = debounce(this.updateData_.bind(this), 200);
+  debouncer = debounce(() => this.updateData_(), 200);
   /**
    * Provides a service to manage a D3js component to be used to draw an lidar point cloud profile chart.
    * Requires access to a Pytree webservice: https://github.com/sitn/pytree

--- a/src/lidar/Plot.ts
+++ b/src/lidar/Plot.ts
@@ -308,9 +308,9 @@ export default class {
         [0, 0],
         [this.width_, this.height_],
       ])
-      .on('zoom', this.zoomed.bind(this));
+      .on('zoom', (event: any) => this.zoomed(event));
 
-    zoom.on('end', this.zoomEnd.bind(this));
+    zoom.on('end', (event: any) => this.zoomEnd(event));
 
     this.previousDomainX = this.scaleX.domain();
     this.updateScaleX = this.scaleX;
@@ -361,6 +361,7 @@ export default class {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   zoomEnd(event: any): void {
     if (event.sourceEvent && this.moved_ === false) {
+      this.manager_.updateData();
       return;
     }
     this.moved_ = false;


### PR DESCRIPTION
The graph was updating only when it intercepted a "mouseMove" event but not the other types like "WheelEvent", so this fixes that.