### PR TITLE
Makes body element focusable for onKeyDown event

### DIFF
--- a/contribs/gmf/apps/desktop_alt/index.html.ejs
+++ b/contribs/gmf/apps/desktop_alt/index.html.ejs
@@ -11,7 +11,7 @@
     <link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet" crossorigin="anonymous">
     <% } %>
   </head>
-  <body ng-keydown="mainCtrl.onKeydown($event)">
+  <body ng-keydown="mainCtrl.onKeydown($event)" tabindex="0">
   <div ng-show="mainCtrl.loading" class="loading-mask">
     <i class="fa custom-spinner-loading fa-spin spinner-loading-mask">
       <%=require('gmf/icons/spinner.svg?viewbox&height=1em')%>


### PR DESCRIPTION
Non interactive elements such as body or div don't takes the focus when we want to handle keyboard events on them ... So it seems like we need to add the element to the tab index as the keyboard events is not currently handled. Tab index lists the elements that support keyboard focus.

https://developer.mozilla.org/fr/docs/Web/HTML/Global_attributes/tabindex