### PR TITLE
Fix cypress config and ci workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -90,6 +90,8 @@ jobs:
       - run: make check-examples-checker
         if: github.event_name != 'pull_request_target'
       # Cypress tests
+      - run: make serve-gmf-apps &
+        if: github.event_name != 'pull_request_target'
       - run: npm run test-cli
         if: github.event_name != 'pull_request_target'
       # Webpack build of ngeo/gmf examples and gmf apps

--- a/cypress.json
+++ b/cypress.json
@@ -1,7 +1,7 @@
 {
   "baseUrl": "http://localhost:6006",
-  "integrationFolder": "src",
-  "testFiles": "**/*.spec.ts",
+  "integrationFolder": "./",
+  "testFiles": "+(src|srcapi)/**/*.spec.ts",
   "includeShadowDom": true,
   "defaultCommandTimeout": 10000
 }


### PR DESCRIPTION
Some things that were buggy when starting doing automation of testbook.

Cypress `integrationFolder` is not supporting multiple paths so we need to trick it with glob in the `testFiles` parameter...