### PR TITLE
Hide cog icons in mobile layertree on inactive layers

### DIFF
--- a/src/layertree/mobile.scss
+++ b/src/layertree/mobile.scss
@@ -31,6 +31,10 @@ nav.gmf-mobile-nav-left .gmf-layertree-node a[data-toggle] {
 }
 
 .gmf-layertree-node {
+  .off > .gmf-layertree-right-buttons {
+    display: none;
+  }
+
   .ngeo-sortable-handle {
     display: none;
   }


### PR DESCRIPTION
Fix  [GSGMF-1828](https://jira.camptocamp.com/browse/GSGMF-1828)

.off class is applied to the parent element when the layers state is inactive (so ">" selector).