### PR TITLE
Fix CVE

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,7 @@ jobs:
         if: github.repository == 'camptocamp/ngeo'
 
       - uses: actions/setup-python@v2
-      - run: python -m pip install setuptools
+      - run: python -m pip install setuptools pyyaml
       - run: python -m pip install --requirement=ci/requirements.txt
 
       - name: Checks

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.7.1
 glob2==0.6
 htmlmin==0.1.12
-Mako==1.0.9
+Mako==1.2.3
 requests==2.27.1
 transifex-client==0.12.5  # rq.filter: <=0.12.5
 urllib3==1.26.8


### PR DESCRIPTION
   -> Vulnerability found in mako version 1.0.9
     Vulnerability ID: 50870
     Affected spec: <1.2.2
     ADVISORY: Mako 1.2.2 includes a fix for a REDoS
     vulnerability.https://github.com/sqlalchemy/mako/issues/366
     PVE-2022-50870
     For more information, please visit
     https://pyup.io/vulnerabilities/PVE-2022-50870/50870/