### PR TITLE
Fix CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "jquery": "3.5.1",
     "jquery-datetimepicker": "2.5.21",
     "jquery-mousewheel": "3.1.13",
-    "jquery-ui": "1.13.0",
+    "jquery-ui": "1.13.2",
     "jquery-ui-touch-punch": "0.2.3",
     "jsdoc": "3.6.4",
     "jsdoc-plugin-typescript": "2.0.5",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.9.0
 glob2==0.7
 htmlmin==0.1.12
-Mako==1.1.2
+Mako==1.2.3
 requests==2.23.0
 transifex-client==0.12.5


### PR DESCRIPTION
  Title: [1084344] jQuery UI vulnerable to XSS when refreshing a checkboxradio with an HTML-like initial text label
  Severity: moderate
  CWE: CWE-79
  Vulnerable versions: <1.13.2
  Patched versions: >=1.13.2
  Recommendation: Upgrade to version 1.13.2 or later
  Version: 1.13.0
  Path: jquery-ui
  More info: https://github.com/advisories/GHSA-h6gj-6jjq-h8g9

  -> Vulnerability found in mako version 1.1.2
     Vulnerability ID: 50870
     Affected spec: <1.2.2
     ADVISORY: Mako 1.2.2 includes a fix for a REDoS
     vulnerability.https://github.com/sqlalchemy/mako/issues/366
     PVE-2022-50870
     For more information, please visit
     https://pyup.io/vulnerabilities/PVE-2022-50870/50870/