### PR TITLE
Fix CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.9.3
 glob2==0.7
 htmlmin==0.1.12
-Mako==1.1.4
+Mako==1.2.2
 requests==2.25.1
 transifex-client==0.14.2


### PR DESCRIPTION
  -> Vulnerability found in mako version 1.1.4
     Vulnerability ID: 50870
     Affected spec: <1.2.2
     ADVISORY: Mako 1.2.2 includes a fix for a REDoS
     vulnerability.https://github.com/sqlalchemy/mako/issues/366
     PVE-2022-50870
     For more information, please visit
     https://pyup.io/vulnerabilities/PVE-2022-50870/50870/