### PR TITLE
Fix CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Mako==1.2.0
 requests==2.27.1
 transifex-client==0.14.3
 polib==1.1.1
+urllib3==1.26.5


### PR DESCRIPTION
    Pin urllib3@1.25.8 to urllib3@1.26.5 to fix
    ✗ Regular Expression Denial of Service (ReDoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-URLLIB3-1533435] in urllib3@1.25.8
      introduced by requests@2.27.1 > urllib3@1.25.8
    ✗ HTTP Header Injection [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-URLLIB3-1014645] in urllib3@1.25.8
      introduced by requests@2.27.1 > urllib3@1.25.8