### PR TITLE
Documentation: fix the hi DPI explanation

### DIFF
--- a/src/print/component.js
+++ b/src/print/component.js
@@ -180,7 +180,7 @@ function gmfPrintTemplateUrl($element, $attrs, gmfPrintTemplateUrl) {
  *
  * Used metadata:
  *
- *  - hiDPILegendImages: The URLs to the hi DPI images used as a legend in the layer tree. For WMS and
+ *  - hiDPILegendImages: The URLs to the hi DPI images used as a legend in the print. For WMS and
  *      WMTS layers.
  *  - printNativeAngle: Whether the print should rotate the symbols. For layer groups (only).
  *

--- a/src/themes.js
+++ b/src/themes.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2022 Camptocamp SA
+// Copyright (c) 2019-2023 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/themes.js
+++ b/src/themes.js
@@ -239,7 +239,7 @@
  * @property {string} [legendImage] The URL to the image used as a legend in the layer tree. For WMS and
  *      WMTS layers.
  * @property {Object<string, string>} [hiDPILegendImages] The URLs to the hi DPI images used as a legend
- *      in the layer tree. For WMS and WMTS layers.
+ *      in the print. For WMS and WMTS layers.
  * @property {string} [legendRule] The WMS 'RULE' parameter used to display the icon in the layer tree.
  *      "Short version" of the 'iconURL' metadata for WMS layers. For WMS layers.
  * @property {number} [maxQueryResolution] The max resolution where the layer is queryable. For WMTS and


### PR DESCRIPTION
The hiDPILegendImages setting is used only in the print component, fix the documentation for this setting accordingly.