### PR TITLE
Fix child notification

### DIFF
--- a/src/layertree/Controller.js
+++ b/src/layertree/Controller.js
@@ -204,7 +204,7 @@ export function LayertreeController($scope, $rootScope, $attrs) {
 /**
  * Return the current state.
  *
- * @returns {string} 'on', 'off', 'indeterminate'.
+ * @returns {string} 'on', 'off', 'indeterminate', or '' if the children are not initialized.
  */
 LayertreeController.prototype.getState = function () {
   return this.state_;
@@ -302,7 +302,7 @@ LayertreeController.prototype.refreshState = function (opt_onChild, opt_broadcas
 /**
  * Return the current state, calculate on all its children recursively.
  *
- * @returns {string} 'on', 'off' or 'indeterminate'.
+ * @returns {string} 'on', 'off', 'indeterminate', or '' if the children are not initialized.
  */
 LayertreeController.prototype.getCalculateState = function () {
   const group = /** @type {import('gmf/themes').GmfGroup} */ (this.node);
@@ -314,7 +314,7 @@ LayertreeController.prototype.getCalculateState = function () {
   /** @type {string} */
   let previousChildState;
   this.children.some((child) => {
-    childState = child.getCalculateState();
+    childState = child.getState();
     if (previousChildState) {
       if (previousChildState !== childState) {
         childState = 'indeterminate';

--- a/test/spec/directives/layertree.spec.js
+++ b/test/spec/directives/layertree.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2022 Camptocamp SA
+// Copyright (c) 2016-2023 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -149,11 +149,21 @@ describe('ngeo.layertree.component', () => {
 
   it('Get calculate state', () => {
     const treeNode0 = roottreeCtrl.children[0];
-    const treeLeaf01 = treeNode0.children[1];
-    treeLeaf01.state_ = 'on';
-    expect(roottreeCtrl.getCalculateState()).toBe('indeterminate');
+    const treeLeaf01 = treeNode0.children[0];
+    const treeLeaf02 = treeNode0.children[1];
+    expect(treeNode0.getState()).toBe('off');
+    expect(treeLeaf01.getState()).toBe('off');
+    expect(treeLeaf02.getState()).toBe('off');
+    expect(roottreeCtrl.getState()).toBe('off');
+    treeLeaf02.state_ = 'on';
     expect(treeNode0.getCalculateState()).toBe('indeterminate');
-    expect(treeLeaf01.getCalculateState()).toBe('on');
+    expect(roottreeCtrl.getCalculateState()).toBe('off');
+    treeNode0.refreshState();
+    expect(treeNode0.getState()).toBe('indeterminate');
+    expect(treeLeaf01.getState()).toBe('off');
+    expect(treeLeaf02.getState()).toBe('on');
+    expect(roottreeCtrl.getState()).toBe('indeterminate');
+    expect(roottreeCtrl.getCalculateState()).toBe('indeterminate');
   });
 
   it('Get first parent tree', () => {


### PR DESCRIPTION
Fix [GEO-6859](https://jira.camptocamp.com/browse/GEO-6859)

Currently:
The parent get a refreshState
=> getCalculateState on the parent
=> getCalculateState=>'' on the children becaude the children are not initialized (getState=>'off')
Then the child get a refreshState
=> getCalculateState on the child => 'off' because the children are initialised
=> no notification to the parent because the state didn't changed...
