### PR TITLE
Add missing configuration in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
 [tool.black]
 line-length = 110
 target-version = ["py39"]
+
+[tool.poetry]
+name = "ngeo"
+version = "0.0.0"
+description = "AngularJS OpenLayers Library"
+authors = ["Camptocamp <info@camptocamp.com>"]


### PR DESCRIPTION
Needed to make `poetry --version` work, used in the audit.
<!-- pull request links -->
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9390/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9390/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9390/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9390/merge/apidoc/)