### PR TITLE
Lazy load legend images

### DIFF
--- a/src/layertree/component.html
+++ b/src/layertree/component.html
@@ -39,6 +39,7 @@
       <img
         ng-if="::(legendIconUrl=gmfLayertreeCtrl.getLegendIconURL(layertreeCtrl))"
         ng-src="{{::legendIconUrl}}"
+        loading="lazy"
       />
     </div>
   </a>


### PR DESCRIPTION
Load https://carto.grand-chatellerault.fr/theme/ads 20x faster.

There is 793 legend images / 930 requests at loading time => 2min

Legend images are put in queue before tiles, and WMS layers, portal is not usable before 2 min.

With this change it takes 6 sec: https://lamiseretest.grand-chatellerault.fr/theme/ads

I made the PR on 2.8, but IMHO it could be backported on all supported versions.

Note: This comes with the side effect that legend images start loading after expanding the group and appear while receiving images. Not sure we need an option for this.

<!-- pull request links -->
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9393/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9393/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9393/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9393/merge/apidoc/)