### PR TITLE
Better returns for proj registration

### DIFF
--- a/src/proj/EPSG_2056.js
+++ b/src/proj/EPSG_2056.js
@@ -19,7 +19,7 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import create from 'ngeo/proj/utils';
+import {createProjection} from 'ngeo/proj/utils';
 
 export const code = 'EPSG:2056';
 
@@ -37,8 +37,7 @@ const def = [
 ];
 const extent = [2420000, 1030000, 2900000, 1350000];
 
-const projections = {};
-projections[code] = {'definition': def, 'extent': extent};
-export const proj = create(projections);
+const projection = {'definition': def, 'extent': extent};
+export const proj = createProjection(code, projection);
 
 export default code;

--- a/src/proj/EPSG_21781.js
+++ b/src/proj/EPSG_21781.js
@@ -19,7 +19,7 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import create from 'ngeo/proj/utils';
+import {createProjection} from 'ngeo/proj/utils';
 
 export const code = 'EPSG:21781';
 
@@ -37,8 +37,7 @@ const def = [
 ];
 const extent = [420000, 30000, 900000, 350000];
 
-const projections = {};
-projections[code] = {'definition': def, 'extent': extent};
-export const proj = create(projections);
+const projection = {'definition': def, 'extent': extent};
+export const proj = createProjection(code, projection);
 
 export default code;


### PR DESCRIPTION
@sbrunner We could also drop these projection and register function (except the multiple one) and use https://github.com/geoblocks
<!-- pull request links -->
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9480/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9480/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9480/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9480/merge/apidoc/)