### PR TITLE
Clean desktop alt lidar active property and css

### DIFF
--- a/contribs/gmf/apps/desktop_alt/Controller.js
+++ b/contribs/gmf/apps/desktop_alt/Controller.js
@@ -35,11 +35,9 @@ import gmfControllersAbstractDesktopController, {
 import appBase from '../appmodule';
 import gmfImportModule from 'gmf/import/module';
 import gmfFloorModule from 'gmf/floor/module';
-import ngeoMiscToolActivate from 'ngeo/misc/ToolActivate';
 import ngeoStreetviewModule from 'ngeo/streetview/module';
 import ngeoRoutingModule from 'ngeo/routing/module';
 import ngeoStatemanagerWfsPermalink from 'ngeo/statemanager/WfsPermalink';
-import panels from 'gmfapi/store/panels';
 
 /**
  * @private
@@ -54,20 +52,6 @@ class Controller extends AbstractDesktopController {
     if (this.dimensions.FLOOR == undefined) {
       this.dimensions.FLOOR = '*';
     }
-
-    /**
-     * @type {boolean}
-     */
-    this.drawLidarprofilePanelActive = false;
-    const drawLidarprofilePanelActive = new ngeoMiscToolActivate(this, 'drawLidarprofilePanelActive');
-    this.ngeoToolActivateMgr.registerTool('mapTools', drawLidarprofilePanelActive, false);
-    const $timeout = $injector.get('$timeout');
-    panels.getActiveToolPanel().subscribe({
-      next: (panel) => {
-        this.drawLidarprofilePanelActive = panel === 'lidar';
-        $timeout(() => {}); // this triggered on DOM click, we call $timeout to force Angular digest
-      },
-    });
   }
 
   /**

--- a/contribs/gmf/apps/desktop_alt/sass/desktop_alt.scss
+++ b/contribs/gmf/apps/desktop_alt/sass/desktop_alt.scss
@@ -63,7 +63,7 @@ div .ngeo-displaywindow {
   $displaywindow-min-height: 15rem;
   left: calc($app-margin + $left-panel-width + $displaywindow-min-height / 2);
   right: initial;
-  top: $topbar-height + $app-margin + 3 * $map-tools-size;
+  top: calc($topbar-height + $app-margin + 3 * $map-tools-size);
 }
 
 .offset-info-icon {


### PR DESCRIPTION
- Remove missing calc warning in css
- Remove useless drawLidarprofilePanelActive property
<!-- pull request links -->
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9484/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9484/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9484/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9484/merge/apidoc/)