### PR TITLE
CI updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -96,5 +96,10 @@
       enabled: false,
       matchDepNames: ['ol-cesium'],
     },
+    /** For security reason don't takes the too early packages on stabilization branches */
+    {
+      matchBaseBranches: ['/^[0-9]+\\.[0-9]+$/'],
+      minimumReleaseAge: '7 days',
+    },
   ],
 }

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -63,8 +63,3 @@ jobs:
         uses: andstor/file-existence-action@v3
         with:
           files: ci/dpkg-versions.yaml
-      - name: Update dpkg packages versions
-        run: ~/.venv/bin/c2cciutils-docker-versions-update --branch=${{ matrix.branch }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GOPASS_CI_GITHUB_TOKEN }}
-        if: steps.dpkg-versions.outputs.files_exists == 'true'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,5 @@
 # https://pre-commit.com/hooks.html
 
-ci:
-  autoupdate_schedule: quarterly
-  skip:
-    - copyright
-    - ripsecrets
-    - jsonschema-validator
-
 exclude: ^src/bootstrap-custom\.css\.map$
 
 repos:
@@ -142,3 +135,7 @@ repos:
     hooks:
       - id: jsonschema-validator
         files: ^ci/config\.yaml$
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 37.428.1
+    hooks:
+      - id: renovate-config-validator


### PR DESCRIPTION
This is done by the automated script named upgrade-c2cciutils-to-1.7
<!-- pull request links -->
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9485/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9485/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9485/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9485/merge/apidoc/)