### PR TITLE
CI updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,6 +36,13 @@
       ],
       datasourceTemplate: 'github-tags',
     },
+    /** Python version in actions/setup-python action */
+    {
+      fileMatch: ['^\\.github/workflows/.*\\.yaml$'],
+      matchStrings: [' python-version: [\'"](?<currentValue>[0-9\\.]+)[\'"]'],
+      datasourceTemplate: 'python-version',
+      depNameTemplate: 'python',
+    },
   ],
   packageRules: [
     /** Auto merge the dev dependency update */
@@ -106,6 +113,11 @@
       matchBaseBranches: ['/^[0-9]+\\.[0-9]+$/'],
       matchDepNames: ['cheerio'],
       enabled: false,
+    },
+    /** Ungroup Python dependencies */
+    {
+      matchDepNames: ['python'],
+      groupName: 'Python',
     },
   ],
 }


### PR DESCRIPTION
This is done by the automated script named upgrade-c2cciutils-to-1.7
<!-- pull request links -->
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9500/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9500/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9500/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9500/merge/apidoc/)