### PR TITLE
Better peer-dependencies

### DIFF
--- a/buildtools/check-example.js
+++ b/buildtools/check-example.js
@@ -24,9 +24,9 @@
 'use strict';
 
 const path = require('path');
+const URL = require('url');
 const fs = require('fs');
 const puppeteer = require('puppeteer');
-const parse = require('url-parse');
 
 const arg = process.argv[2];
 if (!arg) {
@@ -174,7 +174,7 @@ function loaded(page, browser) {
     } else if (url == 'https://sgx.geodatenzentrum.de/wmts_basemapde/1.0.0/WMTSCapabilities.xml') {
       request.respond(SgxCapabilities);
     } else if (
-      parse(url).host == parse(page_url).host ||
+      URL.parse(url).host === URL.parse(page_url).host ||
       url.startsWith('http://localhost:') ||
       url.startsWith('https://geomapfish-demo') ||
       url.startsWith('https://wmts.geo.admin.ch/') ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "angular-ui-slider": "0.4.0",
         "bootstrap": "4.6.2",
         "corejs-typeahead": "1.3.4",
-        "d3": "7.9.0",
         "file-saver": "2.0.5",
         "floatthead": "2.2.5",
         "i18next": "23.15.1",
@@ -41,7 +40,6 @@
         "lit-html": "3.2.0",
         "loc-i18next": "0.1.6",
         "moment": "2.30.1",
-        "ol": "10.2.1",
         "ol-layerswitcher": "4.1.2",
         "ol-mapbox-style": "12.3.5",
         "proj4": "2.12.1",
@@ -158,8 +156,8 @@
         "mapillary-js": "4.1.2"
       },
       "peerDependencies": {
-        "color-rgba": "3.0.0",
-        "color-space": "2.0.1"
+        "d3": ">=7.0.0",
+        "ol": ">=10.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -180,11 +178,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
+      "version": "7.26.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -192,7 +191,7 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.25.4",
+      "version": "7.26.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -200,20 +199,20 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.25.2",
+      "version": "7.26.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.0",
-        "@babel/helper-compilation-targets": "^7.25.2",
-        "@babel/helper-module-transforms": "^7.25.2",
-        "@babel/helpers": "^7.25.0",
-        "@babel/parser": "^7.25.0",
-        "@babel/template": "^7.25.0",
-        "@babel/traverse": "^7.25.2",
-        "@babel/types": "^7.25.2",
+        "@babel/code-frame": "^7.26.0",
+        "@babel/generator": "^7.26.0",
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.0",
+        "@babel/parser": "^7.26.0",
+        "@babel/template": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.26.0",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -253,49 +252,50 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.25.6",
+      "version": "7.26.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.6",
+        "@babel/parser": "^7.26.0",
+        "@babel/types": "^7.26.0",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/generator/node_modules/jsesc": {
-      "version": "2.5.2",
+      "version": "3.0.2",
       "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.24.7",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.24.7"
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.25.2",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.25.2",
-        "@babel/helper-validator-option": "^7.24.8",
-        "browserslist": "^4.23.1",
+        "@babel/compat-data": "^7.25.9",
+        "@babel/helper-validator-option": "^7.25.9",
+        "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -304,7 +304,7 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/browserslist": {
-      "version": "4.24.0",
+      "version": "4.24.2",
       "dev": true,
       "funding": [
         {
@@ -322,10 +322,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001663",
-        "electron-to-chromium": "^1.5.28",
+        "caniuse-lite": "^1.0.30001669",
+        "electron-to-chromium": "^1.5.41",
         "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.0"
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -372,16 +372,16 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.25.4",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.24.7",
-        "@babel/helper-member-expression-to-functions": "^7.24.8",
-        "@babel/helper-optimise-call-expression": "^7.24.7",
-        "@babel/helper-replace-supers": "^7.25.0",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-        "@babel/traverse": "^7.25.4",
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-member-expression-to-functions": "^7.25.9",
+        "@babel/helper-optimise-call-expression": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -400,38 +400,37 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.24.8",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.24.8",
-        "@babel/types": "^7.24.8"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.24.7",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.25.2",
+      "version": "7.26.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.24.7",
-        "@babel/helper-simple-access": "^7.24.7",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "@babel/traverse": "^7.25.2"
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -441,18 +440,18 @@
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.24.7",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.24.7"
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.8",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -460,13 +459,13 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.25.0",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.24.8",
-        "@babel/helper-optimise-call-expression": "^7.24.7",
-        "@babel/traverse": "^7.25.0"
+        "@babel/helper-member-expression-to-functions": "^7.25.9",
+        "@babel/helper-optimise-call-expression": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -476,45 +475,45 @@
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.24.7",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.24.7",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.8",
+      "version": "7.25.9",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
+      "version": "7.25.9",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.24.8",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -522,100 +521,22 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.6",
+      "version": "7.26.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.6"
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.26.0"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.6",
+      "version": "7.26.1",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.6"
+        "@babel/types": "^7.26.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -625,11 +546,11 @@
       }
     },
     "node_modules/@babel/plugin-syntax-flow": {
-      "version": "7.24.7",
+      "version": "7.26.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -639,11 +560,11 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.24.7",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -652,34 +573,12 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
-      "version": "7.8.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-optional-chaining": {
-      "version": "7.8.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.25.4",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.8"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -689,12 +588,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-properties": {
-      "version": "7.25.4",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.25.4",
-        "@babel/helper-plugin-utils": "^7.24.8"
+        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -704,12 +603,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-flow-strip-types": {
-      "version": "7.25.2",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.8",
-        "@babel/plugin-syntax-flow": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/plugin-syntax-flow": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -719,13 +618,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.24.8",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.24.8",
-        "@babel/helper-plugin-utils": "^7.24.8",
-        "@babel/helper-simple-access": "^7.24.7"
+        "@babel/helper-module-transforms": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-simple-access": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -735,12 +634,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.24.7",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -750,13 +648,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.24.8",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.8",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -766,12 +663,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-methods": {
-      "version": "7.25.4",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.25.4",
-        "@babel/helper-plugin-utils": "^7.24.8"
+        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -781,15 +678,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.25.2",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.24.7",
-        "@babel/helper-create-class-features-plugin": "^7.25.0",
-        "@babel/helper-plugin-utils": "^7.24.8",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-        "@babel/plugin-syntax-typescript": "^7.24.7"
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+        "@babel/plugin-syntax-typescript": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -799,13 +696,13 @@
       }
     },
     "node_modules/@babel/preset-flow": {
-      "version": "7.24.7",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7",
-        "@babel/helper-validator-option": "^7.24.7",
-        "@babel/plugin-transform-flow-strip-types": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/plugin-transform-flow-strip-types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -815,15 +712,15 @@
       }
     },
     "node_modules/@babel/preset-typescript": {
-      "version": "7.24.7",
+      "version": "7.26.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7",
-        "@babel/helper-validator-option": "^7.24.7",
-        "@babel/plugin-syntax-jsx": "^7.24.7",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.7",
-        "@babel/plugin-transform-typescript": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/plugin-syntax-jsx": "^7.25.9",
+        "@babel/plugin-transform-modules-commonjs": "^7.25.9",
+        "@babel/plugin-transform-typescript": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -833,7 +730,7 @@
       }
     },
     "node_modules/@babel/register": {
-      "version": "7.24.6",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -868,7 +765,7 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.6",
+      "version": "7.26.0",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -878,28 +775,28 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.0",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/code-frame": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.6",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.6",
-        "@babel/parser": "^7.25.6",
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.6",
+        "@babel/code-frame": "^7.25.9",
+        "@babel/generator": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.25.9",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -916,12 +813,11 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.6",
+      "version": "7.26.0",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -929,8 +825,6 @@
     },
     "node_modules/@chromatic-com/storybook": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@chromatic-com/storybook/-/storybook-3.2.0.tgz",
-      "integrity": "sha512-gnD29KvZ1yeAYNeo8PdpZLE94W6YynyIuqZ1+mFIhDKcSGf84jllqt2sXtwzXodrT38NWlM5kijTS9Hpo0Pf9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -953,8 +847,6 @@
     },
     "node_modules/@chromatic-com/storybook/node_modules/@storybook/channels": {
       "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.3.6.tgz",
-      "integrity": "sha512-6ahY0n1A19diR5cI63lhDEpMaDsq7LFtMOgWab2NwCsdXoEAl6anvDptyPWW60umN3HrDzSKFdpRx4imOEjlWw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -967,8 +859,6 @@
     },
     "node_modules/@chromatic-com/storybook/node_modules/@storybook/telemetry": {
       "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-8.3.6.tgz",
-      "integrity": "sha512-fhpbZok7mPeujjFxAKo2vuqhfjhv5BO/mHH7Z8QtgsYqeR7px56arDRgV6CngBZWgFvrQ2wBS0HPV4nB6YWvJQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -981,8 +871,6 @@
     },
     "node_modules/@chromatic-com/storybook/node_modules/@storybook/types": {
       "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.3.6.tgz",
-      "integrity": "sha512-EY+bjIxxmKkFrL7CyDQb3EXbmy0+Y9OieaPrNNM7QXTfGgp81lXhfqMX3HLMMjplk+rcxVJLyzXSBx0nIn91fQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -995,8 +883,6 @@
     },
     "node_modules/@chromatic-com/storybook/node_modules/chromatic": {
       "version": "11.16.1",
-      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-11.16.1.tgz",
-      "integrity": "sha512-pdpURz0tLp2EJSwfDUHJAf8xufkL/FGZmNuyebv03WkTOZPUAxBMZ19/Y6sFST6MQvUGy/2VI5eNWnfWLDLwhQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1046,7 +932,7 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "3.0.5",
+      "version": "3.0.6",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1065,7 +951,7 @@
         "performance-now": "^2.1.0",
         "qs": "6.13.0",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "^4.1.3",
+        "tough-cookie": "^5.0.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^8.3.2"
       },
@@ -1142,21 +1028,24 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
+      "version": "4.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.11.1",
+      "version": "4.12.1",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1234,7 +1123,7 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.0",
+      "version": "0.2.2",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1246,8 +1135,7 @@
     },
     "node_modules/@fortawesome/fontawesome-free": {
       "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.6.0.tgz",
-      "integrity": "sha512-60G28ke/sXdtS9KZCpZSHHkCbdsOGEhIUGlwq6yhY74UpTiToIh8np7A8yphhM4BWsvNFtIvLpi4co+h9Mr9Ow==",
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
       "engines": {
         "node": ">=6"
       }
@@ -1288,7 +1176,7 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1425,7 +1313,7 @@
       }
     },
     "node_modules/@jsonjoy.com/util": {
-      "version": "1.3.0",
+      "version": "1.5.0",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1549,7 +1437,7 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@mdx-js/react": {
-      "version": "3.0.1",
+      "version": "3.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1598,7 +1486,8 @@
     },
     "node_modules/@petamoriken/float16": {
       "version": "3.8.7",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pkgr/core": {
       "version": "0.1.1",
@@ -1851,48 +1740,48 @@
       }
     },
     "node_modules/@shikijs/core": {
-      "version": "1.21.0",
+      "version": "1.22.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/engine-javascript": "1.21.0",
-        "@shikijs/engine-oniguruma": "1.21.0",
-        "@shikijs/types": "1.21.0",
-        "@shikijs/vscode-textmate": "^9.2.2",
+        "@shikijs/engine-javascript": "1.22.2",
+        "@shikijs/engine-oniguruma": "1.22.2",
+        "@shikijs/types": "1.22.2",
+        "@shikijs/vscode-textmate": "^9.3.0",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.3"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "1.21.0",
+      "version": "1.22.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "1.21.0",
-        "@shikijs/vscode-textmate": "^9.2.2",
+        "@shikijs/types": "1.22.2",
+        "@shikijs/vscode-textmate": "^9.3.0",
         "oniguruma-to-js": "0.4.3"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "1.21.0",
+      "version": "1.22.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "1.21.0",
-        "@shikijs/vscode-textmate": "^9.2.2"
+        "@shikijs/types": "1.22.2",
+        "@shikijs/vscode-textmate": "^9.3.0"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "1.21.0",
+      "version": "1.22.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/vscode-textmate": "^9.2.2",
+        "@shikijs/vscode-textmate": "^9.3.0",
         "@types/hast": "^3.0.4"
       }
     },
     "node_modules/@shikijs/vscode-textmate": {
-      "version": "9.2.2",
+      "version": "9.3.0",
       "dev": true,
       "license": "MIT"
     },
@@ -1934,9 +1823,7 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "13.0.4",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.4.tgz",
-      "integrity": "sha512-wpUq+QiKxrWk7U2pdvNSY9fNX62/k+7eEdlQMO0A3rU8tQ+vvzY/WzBhMz+GbQlATXZlXWYQqFWNFcn1SVvThA==",
+      "version": "13.0.5",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2360,18 +2247,6 @@
         "url": "https://opencollective.com/storybook"
       }
     },
-    "node_modules/@storybook/components": {
-      "version": "8.3.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.3.4"
-      }
-    },
     "node_modules/@storybook/core": {
       "version": "8.3.4",
       "dev": true,
@@ -2672,8 +2547,8 @@
         "storybook": "^8.3.4"
       }
     },
-    "node_modules/@storybook/web-components/node_modules/@storybook/manager-api": {
-      "version": "8.3.4",
+    "node_modules/@storybook/web-components/node_modules/@storybook/components": {
+      "version": "8.3.6",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2681,11 +2556,23 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.3.4"
+        "storybook": "^8.3.6"
+      }
+    },
+    "node_modules/@storybook/web-components/node_modules/@storybook/manager-api": {
+      "version": "8.3.6",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.3.6"
       }
     },
     "node_modules/@storybook/web-components/node_modules/@storybook/preview-api": {
-      "version": "8.3.4",
+      "version": "8.3.6",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2693,11 +2580,11 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.3.4"
+        "storybook": "^8.3.6"
       }
     },
     "node_modules/@storybook/web-components/node_modules/@storybook/theming": {
-      "version": "8.3.4",
+      "version": "8.3.6",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2705,17 +2592,17 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.3.4"
+        "storybook": "^8.3.6"
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.7.26",
+      "version": "1.7.40",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.12"
+        "@swc/types": "^0.1.13"
       },
       "engines": {
         "node": ">=10"
@@ -2725,16 +2612,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.7.26",
-        "@swc/core-darwin-x64": "1.7.26",
-        "@swc/core-linux-arm-gnueabihf": "1.7.26",
-        "@swc/core-linux-arm64-gnu": "1.7.26",
-        "@swc/core-linux-arm64-musl": "1.7.26",
-        "@swc/core-linux-x64-gnu": "1.7.26",
-        "@swc/core-linux-x64-musl": "1.7.26",
-        "@swc/core-win32-arm64-msvc": "1.7.26",
-        "@swc/core-win32-ia32-msvc": "1.7.26",
-        "@swc/core-win32-x64-msvc": "1.7.26"
+        "@swc/core-darwin-arm64": "1.7.40",
+        "@swc/core-darwin-x64": "1.7.40",
+        "@swc/core-linux-arm-gnueabihf": "1.7.40",
+        "@swc/core-linux-arm64-gnu": "1.7.40",
+        "@swc/core-linux-arm64-musl": "1.7.40",
+        "@swc/core-linux-x64-gnu": "1.7.40",
+        "@swc/core-linux-x64-musl": "1.7.40",
+        "@swc/core-win32-arm64-msvc": "1.7.40",
+        "@swc/core-win32-ia32-msvc": "1.7.40",
+        "@swc/core-win32-x64-msvc": "1.7.40"
       },
       "peerDependencies": {
         "@swc/helpers": "*"
@@ -2746,7 +2633,7 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.7.26",
+      "version": "1.7.40",
       "cpu": [
         "x64"
       ],
@@ -2761,7 +2648,7 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.7.26",
+      "version": "1.7.40",
       "cpu": [
         "x64"
       ],
@@ -2781,7 +2668,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3390,7 +3277,7 @@
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.9",
+      "version": "4.17.12",
       "dev": true,
       "license": "MIT"
     },
@@ -3418,8 +3305,6 @@
     },
     "node_modules/@types/node": {
       "version": "22.8.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.2.tgz",
-      "integrity": "sha512-NzaRNFV+FZkvK/KLCsNdTvID0SThyrs5SHB6tsD/lajr22FGC73N2QeDPM2wHtVde8mgcXuSsHQkH5cX1pbPLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3441,9 +3326,8 @@
     },
     "node_modules/@types/openlayers": {
       "version": "4.6.23",
-      "resolved": "https://registry.npmjs.org/@types/openlayers/-/openlayers-4.6.23.tgz",
-      "integrity": "sha512-7jCPIa4D4LV03Rttae1AEqvkIN0+nc6Snz4IgA/IjsJD5O3ONxpscqIOdp1qAGuAsikR/ZC9vrPF9np8JRc6ig==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/pako": {
       "version": "1.0.7",
@@ -3491,7 +3375,7 @@
       "optional": true
     },
     "node_modules/@types/react": {
-      "version": "18.3.10",
+      "version": "18.3.12",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3555,7 +3439,7 @@
       "license": "MIT"
     },
     "node_modules/@types/sizzle": {
-      "version": "2.3.8",
+      "version": "2.3.9",
       "dev": true,
       "license": "MIT"
     },
@@ -3882,7 +3766,7 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "2.1.1",
+      "version": "2.1.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3904,12 +3788,12 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.1.1",
+      "version": "2.1.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.1",
-        "loupe": "^3.1.1",
+        "@vitest/pretty-format": "2.1.4",
+        "loupe": "^3.1.2",
         "tinyrainbow": "^1.2.0"
       },
       "funding": {
@@ -4115,7 +3999,7 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
+      "version": "8.14.0",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4550,6 +4434,7 @@
     },
     "node_modules/b4a": {
       "version": "1.6.7",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/babel-code-frame": {
@@ -5233,14 +5118,6 @@
         "to-fast-properties": "^1.0.3"
       }
     },
-    "node_modules/babel-types/node_modules/to-fast-properties": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/babylon": {
       "version": "6.18.0",
       "dev": true,
@@ -5285,12 +5162,11 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.3.0",
+      "version": "2.3.2",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "b4a": "^1.6.6",
         "streamx": "^2.20.0"
       }
     },
@@ -5720,7 +5596,7 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001664",
+      "version": "1.0.30001674",
       "dev": true,
       "funding": [
         {
@@ -5774,7 +5650,7 @@
       }
     },
     "node_modules/chai": {
-      "version": "5.1.1",
+      "version": "5.1.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6218,6 +6094,7 @@
     "node_modules/color-parse": {
       "version": "2.0.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "^2.0.0"
       }
@@ -6225,6 +6102,7 @@
     "node_modules/color-parse/node_modules/color-name": {
       "version": "2.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.20"
       }
@@ -6232,6 +6110,7 @@
     "node_modules/color-rgba": {
       "version": "3.0.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-parse": "^2.0.0",
         "color-space": "^2.0.0"
@@ -6239,7 +6118,8 @@
     },
     "node_modules/color-space": {
       "version": "2.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -6479,7 +6359,7 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
+      "version": "0.7.1",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6881,6 +6761,7 @@
     "node_modules/d3": {
       "version": "7.9.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-array": "3",
         "d3-axis": "3",
@@ -6920,6 +6801,7 @@
     "node_modules/d3-array": {
       "version": "3.2.4",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -6930,6 +6812,7 @@
     "node_modules/d3-axis": {
       "version": "3.0.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6937,6 +6820,7 @@
     "node_modules/d3-brush": {
       "version": "3.0.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -6951,6 +6835,7 @@
     "node_modules/d3-chord": {
       "version": "3.0.1",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-path": "1 - 3"
       },
@@ -6961,6 +6846,7 @@
     "node_modules/d3-color": {
       "version": "3.1.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6968,6 +6854,7 @@
     "node_modules/d3-contour": {
       "version": "4.0.2",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-array": "^3.2.0"
       },
@@ -6978,6 +6865,7 @@
     "node_modules/d3-delaunay": {
       "version": "6.0.4",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "delaunator": "5"
       },
@@ -6988,6 +6876,7 @@
     "node_modules/d3-dispatch": {
       "version": "3.0.1",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6995,6 +6884,7 @@
     "node_modules/d3-drag": {
       "version": "3.0.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-selection": "3"
@@ -7006,6 +6896,7 @@
     "node_modules/d3-dsv": {
       "version": "3.0.1",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "commander": "7",
         "iconv-lite": "0.6",
@@ -7029,6 +6920,7 @@
     "node_modules/d3-dsv/node_modules/commander": {
       "version": "7.2.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7036,6 +6928,7 @@
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7043,6 +6936,7 @@
     "node_modules/d3-fetch": {
       "version": "3.0.1",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-dsv": "1 - 3"
       },
@@ -7053,6 +6947,7 @@
     "node_modules/d3-force": {
       "version": "3.0.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-quadtree": "1 - 3",
@@ -7065,6 +6960,7 @@
     "node_modules/d3-format": {
       "version": "3.1.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7072,6 +6968,7 @@
     "node_modules/d3-geo": {
       "version": "3.1.1",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-array": "2.5.0 - 3"
       },
@@ -7082,6 +6979,7 @@
     "node_modules/d3-hierarchy": {
       "version": "3.1.2",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7089,6 +6987,7 @@
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3"
       },
@@ -7099,6 +6998,7 @@
     "node_modules/d3-path": {
       "version": "3.1.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7106,6 +7006,7 @@
     "node_modules/d3-polygon": {
       "version": "3.0.1",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7113,6 +7014,7 @@
     "node_modules/d3-quadtree": {
       "version": "3.0.1",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7120,6 +7022,7 @@
     "node_modules/d3-random": {
       "version": "3.0.1",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7127,6 +7030,7 @@
     "node_modules/d3-scale": {
       "version": "4.0.2",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-array": "2.10.0 - 3",
         "d3-format": "1 - 3",
@@ -7141,6 +7045,7 @@
     "node_modules/d3-scale-chromatic": {
       "version": "3.1.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-interpolate": "1 - 3"
@@ -7152,6 +7057,7 @@
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7159,6 +7065,7 @@
     "node_modules/d3-shape": {
       "version": "3.2.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-path": "^3.1.0"
       },
@@ -7169,6 +7076,7 @@
     "node_modules/d3-time": {
       "version": "3.1.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-array": "2 - 3"
       },
@@ -7179,6 +7087,7 @@
     "node_modules/d3-time-format": {
       "version": "4.1.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-time": "1 - 3"
       },
@@ -7189,6 +7098,7 @@
     "node_modules/d3-timer": {
       "version": "3.0.1",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7196,6 +7106,7 @@
     "node_modules/d3-transition": {
       "version": "3.0.1",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-dispatch": "1 - 3",
@@ -7213,6 +7124,7 @@
     "node_modules/d3-zoom": {
       "version": "3.0.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -7368,6 +7280,7 @@
     "node_modules/delaunator": {
       "version": "5.0.1",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "robust-predicates": "^3.0.2"
       }
@@ -7456,8 +7369,6 @@
     },
     "node_modules/diff": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -7566,8 +7477,9 @@
       "license": "MIT"
     },
     "node_modules/earcut": {
-      "version": "3.0.0",
-      "license": "ISC"
+      "version": "2.2.4",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -7627,7 +7539,7 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.30",
+      "version": "1.5.49",
       "dev": true,
       "license": "ISC"
     },
@@ -7671,7 +7583,7 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.6.1",
+      "version": "6.6.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7680,7 +7592,7 @@
         "@types/node": ">=10.0.0",
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
-        "cookie": "~0.4.1",
+        "cookie": "~0.7.2",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
@@ -7699,7 +7611,7 @@
       }
     },
     "node_modules/engine.io/node_modules/cookie": {
-      "version": "0.4.2",
+      "version": "0.7.2",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8462,7 +8374,7 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
+      "version": "4.21.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8471,7 +8383,7 @@
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -8634,9 +8546,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.2",
+      "version": "3.0.3",
       "dev": true,
-      "license": "MIT"
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -8903,7 +8815,7 @@
       "license": "MIT"
     },
     "node_modules/flow-parser": {
-      "version": "0.247.1",
+      "version": "0.250.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9029,7 +8941,7 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
+      "version": "4.0.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9216,6 +9128,7 @@
     "node_modules/geotiff": {
       "version": "2.1.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",
@@ -9230,24 +9143,12 @@
         "node": ">=10.19"
       }
     },
-    "node_modules/geotiff/node_modules/lerc": {
-      "version": "3.0.0",
-      "license": "Apache-2.0"
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -9967,7 +9868,7 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
+      "version": "2.0.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10205,20 +10106,20 @@
       }
     },
     "node_modules/i18next-parser/node_modules/parse5": {
-      "version": "7.1.2",
+      "version": "7.2.1",
       "license": "MIT",
       "dependencies": {
-        "entities": "^4.4.0"
+        "entities": "^4.5.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/i18next-parser/node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.0.0",
+      "version": "7.1.0",
       "license": "MIT",
       "dependencies": {
-        "domhandler": "^5.0.2",
+        "domhandler": "^5.0.3",
         "parse5": "^7.0.0"
       },
       "funding": {
@@ -10412,6 +10313,7 @@
     "node_modules/internmap": {
       "version": "2.0.3",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11302,6 +11204,11 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/lerc": {
+      "version": "3.0.0",
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "dev": true,
@@ -11598,6 +11505,14 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/long": {
+      "version": "3.2.0",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "dev": true,
@@ -11610,12 +11525,9 @@
       }
     },
     "node_modules/loupe": {
-      "version": "3.1.1",
+      "version": "3.1.2",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      }
+      "license": "MIT"
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
@@ -11677,7 +11589,7 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.11",
+      "version": "0.30.12",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11758,11 +11670,6 @@
     "node_modules/mapillary-js/node_modules/@types/node": {
       "version": "14.18.63",
       "license": "MIT",
-      "optional": true
-    },
-    "node_modules/mapillary-js/node_modules/earcut": {
-      "version": "2.2.4",
-      "license": "ISC",
       "optional": true
     },
     "node_modules/markdown-it": {
@@ -12245,7 +12152,7 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.20.0",
+      "version": "2.22.0",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -12502,6 +12409,7 @@
     "node_modules/ol": {
       "version": "10.2.1",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@types/rbush": "3.0.3",
         "color-rgba": "^3.0.0",
@@ -12536,11 +12444,18 @@
     },
     "node_modules/ol/node_modules/@types/rbush": {
       "version": "3.0.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/ol/node_modules/earcut": {
+      "version": "3.0.0",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ol/node_modules/pbf": {
       "version": "4.0.1",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "resolve-protobuf-schema": "^2.1.0"
       },
@@ -12550,11 +12465,13 @@
     },
     "node_modules/ol/node_modules/quickselect": {
       "version": "3.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ol/node_modules/rbush": {
       "version": "4.0.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "quickselect": "^3.0.0"
       }
@@ -12795,7 +12712,8 @@
     },
     "node_modules/parse-headers": {
       "version": "2.0.5",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parse-imports": {
       "version": "2.2.1",
@@ -12880,10 +12798,10 @@
       }
     },
     "node_modules/parse5-parser-stream/node_modules/parse5": {
-      "version": "7.1.2",
+      "version": "7.2.1",
       "license": "MIT",
       "dependencies": {
-        "entities": "^4.4.0"
+        "entities": "^4.5.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -13025,7 +12943,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/picocolors": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dev": true,
       "license": "ISC"
     },
@@ -13435,11 +13353,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/pump": {
       "version": "3.0.2",
       "dev": true,
@@ -13552,11 +13465,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "dev": true,
@@ -13583,6 +13491,7 @@
     "node_modules/quick-lru": {
       "version": "6.1.2",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13841,7 +13750,7 @@
       }
     },
     "node_modules/regex": {
-      "version": "4.3.2",
+      "version": "4.3.3",
       "dev": true,
       "license": "MIT"
     },
@@ -14241,7 +14150,8 @@
     },
     "node_modules/robust-predicates": {
       "version": "3.0.2",
-      "license": "Unlicense"
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/rsvp": {
       "version": "4.8.5",
@@ -14300,14 +14210,6 @@
       "optional": true,
       "dependencies": {
         "long": "^3.2.0"
-      }
-    },
-    "node_modules/s2-geometry/node_modules/long": {
-      "version": "3.2.0",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/safe-buffer": {
@@ -14402,7 +14304,7 @@
       }
     },
     "node_modules/sass/node_modules/readdirp": {
-      "version": "4.0.1",
+      "version": "4.0.2",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14708,15 +14610,15 @@
       }
     },
     "node_modules/shiki": {
-      "version": "1.21.0",
+      "version": "1.22.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "1.21.0",
-        "@shikijs/engine-javascript": "1.21.0",
-        "@shikijs/engine-oniguruma": "1.21.0",
-        "@shikijs/types": "1.21.0",
-        "@shikijs/vscode-textmate": "^9.2.2",
+        "@shikijs/core": "1.22.2",
+        "@shikijs/engine-javascript": "1.22.2",
+        "@shikijs/engine-oniguruma": "1.22.2",
+        "@shikijs/types": "1.22.2",
+        "@shikijs/vscode-textmate": "^9.3.0",
         "@types/hast": "^3.0.4"
       }
     },
@@ -14775,8 +14677,6 @@
     },
     "node_modules/sinon": {
       "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
-      "integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -14828,7 +14728,7 @@
       }
     },
     "node_modules/socket.io": {
-      "version": "4.8.0",
+      "version": "4.8.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15609,7 +15509,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/synckit": {
-      "version": "0.9.1",
+      "version": "0.9.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15838,11 +15738,8 @@
       }
     },
     "node_modules/text-decoder": {
-      "version": "1.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.6.4"
-      }
+      "version": "1.2.1",
+      "license": "Apache-2.0"
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -15945,6 +15842,22 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.57",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.57"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.57",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.3",
       "dev": true,
@@ -15954,10 +15867,11 @@
       }
     },
     "node_modules/to-fast-properties": {
-      "version": "2.0.0",
+      "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/to-readable-stream": {
@@ -15998,33 +15912,14 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.4",
+      "version": "5.0.0",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
+        "tldts": "^6.1.32"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/punycode": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -16165,7 +16060,7 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "0BSD"
     },
     "node_modules/tsutils": {
@@ -16299,7 +16194,7 @@
       }
     },
     "node_modules/typedoc/node_modules/yaml": {
-      "version": "2.5.1",
+      "version": "2.6.0",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -16382,7 +16277,7 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.19.8",
+      "version": "6.20.1",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -16483,11 +16378,11 @@
       }
     },
     "node_modules/unplugin": {
-      "version": "1.14.1",
+      "version": "1.15.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.12.1",
+        "acorn": "^8.14.0",
         "webpack-virtual-modules": "^0.6.2"
       },
       "engines": {
@@ -16541,15 +16436,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "node_modules/urlpattern-polyfill": {
@@ -16800,7 +16686,8 @@
     },
     "node_modules/web-worker": {
       "version": "1.3.0",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -17033,7 +16920,7 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/memfs": {
-      "version": "4.12.0",
+      "version": "4.14.0",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -17143,7 +17030,7 @@
       "license": "MIT"
     },
     "node_modules/webpack/node_modules/browserslist": {
-      "version": "4.24.0",
+      "version": "4.24.2",
       "dev": true,
       "funding": [
         {
@@ -17161,10 +17048,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001663",
-        "electron-to-chromium": "^1.5.28",
+        "caniuse-lite": "^1.0.30001669",
+        "electron-to-chromium": "^1.5.41",
         "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.0"
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -17330,7 +17217,7 @@
       "license": "MIT"
     },
     "node_modules/wkt-parser": {
-      "version": "1.3.3",
+      "version": "1.4.0",
       "license": "MIT"
     },
     "node_modules/word-wrap": {
@@ -17474,7 +17361,8 @@
     },
     "node_modules/xml-utils": {
       "version": "1.10.1",
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -17567,7 +17455,8 @@
     },
     "node_modules/zstddec": {
       "version": "0.1.0",
-      "license": "MIT AND BSD-3-Clause"
+      "license": "MIT AND BSD-3-Clause",
+      "peer": true
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "angular-ui-slider": "0.4.0",
     "bootstrap": "4.6.2",
     "corejs-typeahead": "1.3.4",
-    "d3": "7.9.0",
     "file-saver": "2.0.5",
     "floatthead": "2.2.5",
     "i18next": "23.15.1",
@@ -91,7 +90,6 @@
     "lit-html": "3.2.0",
     "loc-i18next": "0.1.6",
     "moment": "2.30.1",
-    "ol": "10.2.1",
     "ol-layerswitcher": "4.1.2",
     "ol-mapbox-style": "12.3.5",
     "proj4": "2.12.1",
@@ -99,12 +97,12 @@
     "rxjs": "7.8.1",
     "tinycolor2": "1.6.0"
   },
-  "_peerDependenciesComment_": "Dep. to fix sub-dependencies. Not used directly",
+  "_peerDependenciesComment_": "Dependencies with open range version, to grant liberties on final usage.",
   "peerDependencies": {
-    "color-rgba": "3.0.0",
-    "color-space": "2.0.1"
+    "d3": ">=7.0.0",
+    "ol": ">=10.0.0"
   },
-  "_optionalDependenciesComment_": "Dep. for plugins",
+  "_optionalDependenciesComment_": "Dep. for optional plugins",
   "optionalDependencies": {
     "jsts": "2.11.3",
     "mapillary-js": "4.1.2"


### PR DESCRIPTION
Change:

1. Ol moved to as peerDependencies. 
2. I don't see any usage of `color-rgba`, `color-space`. They were added to fix sub version, but everything looks working without them. I think we can get ride of them.

Open questions:
1.  We import all d3, we could be more selective. => Tried and was complicated, let see that in another PR
1. And do we want flexibility on more library ? Candidate:
   1.   file-saver
   1.   lit*
   1.   moment
   1.   ol mapbox
   1.   ol layerswitcher only used for css !)
   1.   qruri
   1.   rxjs
   1.   tinycolor
   1.   Others ?

=> Can be moved to peerDepedencies **on demand** later.

 
<!-- pull request links -->
See JIRA issue: [GSNGEO-19](https://jira.camptocamp.com/browse/GSNGEO-19).
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9504/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9504/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9504/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9504/merge/apidoc/)

[GSNGEO-19]: https://camptocamp.atlassian.net/browse/GSNGEO-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ