### PR TITLE
Fix exposition of gmfapi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ contribs/dist: .build/build-dll.timestamp
 	touch $@
 
 .build/node_modules.timestamp: package.json
-	npm install
+	npm install || npm install --ignore-scripts
 	# Installed from peer dependency from ol-layerswitcher and that breaks our types
 	rm -rf ./node_modules/@types/openlayers
 	mkdir -p $(dir $@)

--- a/buildtools/webpack.commons.js
+++ b/buildtools/webpack.commons.js
@@ -71,7 +71,7 @@ module.exports = function (config) {
   });
 
   rules.push({
-    test: path.resolve(__dirname, '../srcapi/index.ts'),
+    test: /\/srcapi\/index.[tj]s$/,
     use: {
       loader: 'expose-loader',
       options: {


### PR DESCRIPTION
Currently, on https://geomapfish-demo-2-9.camptocamp.com/ we have the error:
`window.gmfapi is undefined`
<!-- pull request links -->
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9508/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9508/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9508/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9508/merge/apidoc/)