### PR TITLE
GSGGR-117 backport fix feature loading

### DIFF
--- a/src/editing/Snapping.js
+++ b/src/editing/Snapping.js
@@ -13,7 +13,7 @@ EditingSnappingService.$inject = [
 ];
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2024 Camptocamp SA
+// Copyright (c) 2016-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -659,9 +659,13 @@ EditingSnappingService.prototype.loadItemFeatures_ = function (item) {
   const featureRequest = xmlSerializer.serializeToString(featureRequestXml);
   const url = item.wfsConfig.url;
   item.requestDeferred = this.q_.defer();
+  const headers = {
+    'Content-Type': 'text/xml',
+  };
   this.http_
     .post(url, featureRequest, {
       timeout: item.requestDeferred.promise,
+      headers: headers,
     })
     .then((response) => {
       // (1) Unset requestDeferred


### PR DESCRIPTION
Missed to add backport label when merging.
<!-- pull request links -->
See JIRA issue: [GSGGR-117](https://jira.camptocamp.com/browse/GSGGR-117).
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9571/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9571/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9571/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9571/merge/apidoc/)

[GSGGR-117]: https://camptocamp.atlassian.net/browse/GSGGR-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ