### PR TITLE
Fix OIDC login on mobile

### DIFF
--- a/src/auth/FormElement.ts
+++ b/src/auth/FormElement.ts
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2021-2024 Camptocamp SA
+// Copyright (c) 2021-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -126,6 +126,7 @@ export default class GmfAuthForm extends GmfBaseElement {
     if (configuration.gmfCustomCSS && configuration.gmfCustomCSS.authentication !== undefined) {
       this.customCSS_ = configuration.gmfCustomCSS.authentication;
     }
+    this._updateOpenIdConnectUrl();
   }
 
   static styles: CSSResult[] = [


### PR DESCRIPTION
When the openIdConnectBaseUrl is modified, the openIdConnectUrl should also be updated.
<!-- pull request links -->
See JIRA issue: [GSGMF-2114](https://jira.camptocamp.com/browse/GSGMF-2114).
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9583/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9583/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9583/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9583/merge/apidoc/)

[GSGMF-2114]: https://camptocamp.atlassian.net/browse/GSGMF-2114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ