### PR TITLE
Remove double import of jquery-datepicker

### DIFF
--- a/src/editing/editFeatureComponent.js
+++ b/src/editing/editFeatureComponent.js
@@ -15,7 +15,7 @@ Controller.$inject = [
 ];
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2024 Camptocamp SA
+// Copyright (c) 2016-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -40,7 +40,6 @@ import gmfEditingSnapping from 'gmf/editing/Snapping';
 import gmfEditingXSDAttributes from 'gmf/editing/XSDAttributes';
 import {getLayer as syncLayertreeMapGetLayer} from 'gmf/layertree/SyncLayertreeMap';
 import DateFormatter from 'ngeo/misc/php-date-formatter';
-import 'jquery-datetimepicker/jquery.datetimepicker';
 import ngeoEditingAttributesComponent from 'ngeo/editing/attributesComponent';
 import ngeoEditingCreatefeatureComponent from 'ngeo/editing/createfeatureComponent';
 import {deleteCondition} from 'ngeo/utils';

--- a/srcapi/elements/BaseElement.ts
+++ b/srcapi/elements/BaseElement.ts
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2021-2024 Camptocamp SA
+// Copyright (c) 2021-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -69,11 +69,9 @@ export default class GmfBaseElement extends LitElement {
 
   // bootstrap/font-awesome
 
-  /* eslint-disable @typescript-eslint/no-unsafe-member-access */
   static resetStyle: CSSResult = cssReset;
   static bootstrapStyle: CSSResult = cssBootstrap;
   static fontawesomeStyle: CSSResult = cssFontawesome;
-  /* eslint-enable @typescript-eslint/no-unsafe-member-access */
 
   // Make some Bootstrap values configurable
   static bootstrapVarStyle: CSSResult = css`
@@ -172,7 +170,6 @@ export default class GmfBaseElement extends LitElement {
 
   /**
    * Init the config and allows to override it in the inherited class.
-   *
    * @param {Configuration} configuration The configuration object.
    * @abstract
    * @protected


### PR DESCRIPTION
src/editing/editFeatureComponent.js AND src/misc/datepickerComponent.js import datepicker.
And we can see that there are two jquery on the debugger, at the "datepicker not found" error. The "other" jquery has it, I think removing this jquery could fix this issue.

We could have the same issue with the drag element or resize, or swipe. But I don't have any draggable/resizable element in the desktop alt. To keep in mind if we have such issue again (and if this fix really fix the issue).
<!-- pull request links -->
See JIRA issue: [GSGMF-2118](https://jira.camptocamp.com/browse/GSGMF-2118).
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9584/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9584/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9584/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9584/merge/apidoc/)

[GSGMF-2118]: https://camptocamp.atlassian.net/browse/GSGMF-2118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ