### PR TITLE
Move date-picker popover above the resize-panel-left button

### DIFF
--- a/src/sass/popover.scss
+++ b/src/sass/popover.scss
@@ -30,7 +30,7 @@ $popover-action-max-width: calc(($popover-max-width / $popover-nb-col) * 4);
 
 .popover {
   border-radius: 0;
-  z-index: $above-content-index;
+  z-index: $search-index;
   .popover-body {
     ul {
       margin-bottom: 0;


### PR DESCRIPTION
Use more appropriate `z-index: 5` to have the date-picker popup (from a layer with time) above the left-panel-resize button.
<!-- pull request links -->
See JIRA issue: [GSGMF-2135](https://jira.camptocamp.com/browse/GSGMF-2135).
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9597/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9597/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9597/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9597/merge/apidoc/)

[GSGMF-2135]: https://camptocamp.atlassian.net/browse/GSGMF-2135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ