### PR TITLE
Move jquery import out of component

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ can be compiled with any modern bundler.
 - Update webpack to version 5
 - Let the users choose the version of peerDependencies
 - Remove not used offline and ol-cesium related code.
+- Move jquery and jquery-ui import out of components.
 
 # 2.8
 

--- a/contribs/gmf/examples/common_dependencies.js
+++ b/contribs/gmf/examples/common_dependencies.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2024 Camptocamp SA
+// Copyright (c) 2018-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -19,7 +19,7 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import 'jquery';
+import 'ngeo/misc/common-jquery-dependencies';
 import 'angular';
 import 'angular-gettext';
 import 'bootstrap';

--- a/contribs/gmf/test/spec/beforeeach.js
+++ b/contribs/gmf/test/spec/beforeeach.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2014-2024 Camptocamp SA
+// Copyright (c) 2014-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -19,6 +19,7 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import 'ngeo/misc/common-jquery-dependencies';
 import angular from 'angular';
 import 'angular-dynamic-locale';
 import gmfContextualdataComponent from 'gmf/contextualdata/component';

--- a/src/controllers/AbstractAppController.js
+++ b/src/controllers/AbstractAppController.js
@@ -19,7 +19,7 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import 'jquery';
+import 'ngeo/misc/common-jquery-dependencies';
 import angular from 'angular';
 import 'angular-gettext';
 import 'angular-dynamic-locale';

--- a/src/layertree/timeSliderComponent.js
+++ b/src/layertree/timeSliderComponent.js
@@ -1,7 +1,7 @@
 Controller.$inject = ['ngeoWMSTime', 'ngeoDebounce'];
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2024 Camptocamp SA
+// Copyright (c) 2016-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -20,10 +20,10 @@ Controller.$inject = ['ngeoWMSTime', 'ngeoDebounce'];
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// jquery-ui/ui/widgets/slider must be imported by your main controller.
 import angular from 'angular';
 import ngeoMiscWMSTime from 'ngeo/misc/WMSTime';
 import ngeoMiscDebounce from 'ngeo/misc/debounce';
-import 'jquery-ui/ui/widgets/slider';
 import 'angular-ui-slider';
 import htmlTemplate from './timesliderComponent.html';
 

--- a/src/map/swipe.js
+++ b/src/map/swipe.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2024 Camptocamp SA
+// Copyright (c) 2019-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -19,10 +19,10 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// jquery-ui/ui/widgets/draggable must be imported by your main controller.
 import angular from 'angular';
 import {listen, unlistenByKey} from 'ol/events';
 import RenderEvent from 'ol/render/Event';
-import 'jquery-ui/ui/widgets/draggable';
 import htmlTemplate from './swipe.html';
 /**
  * @type {angular.IModule}

--- a/src/message/displaywindowComponent.js
+++ b/src/message/displaywindowComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2024 Camptocamp SA
+// Copyright (c) 2017-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -19,9 +19,9 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// jquery-ui/ui/widgets/resizable must be imported by your main controller.
+// jquery-ui/ui/widgets/draggable must be imported by your main controller.
 import angular from 'angular';
-import 'jquery-ui/ui/widgets/resizable';
-import 'jquery-ui/ui/widgets/draggable';
 import 'angular-sanitize';
 import htmlTemplate from './displaywindowComponent.html';
 

--- a/src/message/modalComponent.js
+++ b/src/message/modalComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2024 Camptocamp SA
+// Copyright (c) 2015-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -19,8 +19,8 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// jquery-ui/ui/widgets/draggable must be imported by your main controller.
 import angular from 'angular';
-import 'jquery-ui/ui/widgets/draggable';
 import 'bootstrap/js/src/modal';
 
 /**

--- a/src/misc/common-jquery-dependencies.js
+++ b/src/misc/common-jquery-dependencies.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2025 Camptocamp SA
+// Copyright (c) 2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -19,15 +19,14 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import 'ngeo/misc/common-jquery-dependencies';
-import 'angular';
-import 'angular-gettext';
-import 'bootstrap';
-/*
- * Auto redirect to https to prevent CORS exceptions
- */
-if (window.location.protocol === 'http:' && window.location.hostname !== 'localhost') {
-  const restOfUrl = window.location.href.substr(5);
-  /** @type {Location} */
-  window.location.href = `https:${restOfUrl}`;
-}
+import 'jquery';
+import 'jquery-ui/ui/widgets/slider';
+import 'jquery-ui/ui/widgets/draggable';
+import 'jquery-ui/ui/widgets/resizable';
+import 'jquery-ui/ui/widgets/sortable';
+import 'jquery-ui-touch-punch';
+import 'jquery-datetimepicker/jquery.datetimepicker';
+import 'jquery-ui/ui/i18n/datepicker-fr';
+import 'jquery-ui/ui/i18n/datepicker-en-GB';
+import 'jquery-ui/ui/i18n/datepicker-de';
+import 'jquery-ui/ui/i18n/datepicker-it';

--- a/src/misc/datepickerComponent.js
+++ b/src/misc/datepickerComponent.js
@@ -2,7 +2,7 @@ Controller.$inject = ['$scope', 'ngeoTime', 'gettextCatalog'];
 datePickerComponent.$inject = ['ngeoDatePickerTemplateUrl', '$timeout'];
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2024 Camptocamp SA
+// Copyright (c) 2016-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -25,12 +25,6 @@ import angular from 'angular';
 import ngeoMiscTime from 'ngeo/misc/Time';
 import 'angular-ui-date';
 import htmlTemplate from './datepickerComponent.html';
-
-// FIXME: import the locales in the applications
-import 'jquery-ui/ui/i18n/datepicker-fr';
-import 'jquery-ui/ui/i18n/datepicker-en-GB';
-import 'jquery-ui/ui/i18n/datepicker-de';
-import 'jquery-ui/ui/i18n/datepicker-it';
 
 /**
  * @type {angular.IModule}

--- a/src/misc/datetimepickerComponent.js
+++ b/src/misc/datetimepickerComponent.js
@@ -1,7 +1,7 @@
 Controller.$inject = ['$element', 'gettextCatalog'];
 // The MIT License (MIT)
 //
-// Copyright (c) 2018-2024 Camptocamp SA
+// Copyright (c) 2018-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -20,9 +20,9 @@ Controller.$inject = ['$element', 'gettextCatalog'];
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// jquery-datetimepicker/jquery.datetimepicker must be imported by your main controller.
 import angular from 'angular';
 import DateFormatter from 'ngeo/misc/php-date-formatter';
-import 'jquery-datetimepicker/jquery.datetimepicker';
 
 /**
  * @type {angular.IModule}

--- a/src/misc/sortableComponent.js
+++ b/src/misc/sortableComponent.js
@@ -1,7 +1,7 @@
 sortableComponent.$inject = ['$timeout'];
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2024 Camptocamp SA
+// Copyright (c) 2015-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -20,9 +20,9 @@ sortableComponent.$inject = ['$timeout'];
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// jquery-ui/ui/widgets/sortable must be imported by your main controller.
+// jquery-ui-touch-punch must be imported by your main controller.
 import angular from 'angular';
-import 'jquery-ui/ui/widgets/sortable';
-import 'jquery-ui-touch-punch';
 
 /**
  * @typedef {Object} miscSortableOptions

--- a/src/query/windowComponent.js
+++ b/src/query/windowComponent.js
@@ -8,7 +8,7 @@ QueryWindowController.$inject = [
 ];
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2024 Camptocamp SA
+// Copyright (c) 2016-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -27,6 +27,7 @@ QueryWindowController.$inject = [
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// jquery-ui/ui/widgets/resizable must be imported by your main controller.
 import angular from 'angular';
 import downloadCsvService from 'ngeo/download/Csv';
 import ngeoMapFeatureOverlayMgr from 'ngeo/map/FeatureOverlayMgr';
@@ -36,7 +37,6 @@ import ngeoQueryMapQuerent from 'ngeo/query/MapQuerent';
 import olCollection from 'ol/Collection';
 import {isEmpty} from 'ol/obj';
 import {buildStyle} from 'ngeo/options';
-import 'jquery-ui/ui/widgets/resizable';
 import 'angular-animate';
 import 'angular-touch';
 import 'bootstrap/js/src/collapse';


### PR DESCRIPTION
To avoid double import of jquery, it's now the responsability of the app to load wanted jquery and jquery dependencies.

datepicker are still not working. I use here a more aggressive method, but I think that makes sens. That allows the user to have more choice on what he want to import.
<!-- pull request links -->
See JIRA issue: [GSGMF-2118](https://jira.camptocamp.com/browse/GSGMF-2118).
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9603/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9603/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9603/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9603/merge/apidoc/)

[GSGMF-2118]: https://camptocamp.atlassian.net/browse/GSGMF-2118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ