### PR TITLE
GSGMF-2138-time-input: handle angular part in angular

### DIFF
--- a/contribs/gmf/examples/datepicker.html
+++ b/contribs/gmf/examples/datepicker.html
@@ -14,7 +14,13 @@
     <ul>
       <li>
         <p>Select a period with a datepicker</p>
-        <gmf-datepicker ng-prop-time="ctrl.wmsTimeRangeMode" ng-prop-onchange_cb="ctrl.onDateRangeSelected">
+        <gmf-datepicker
+          ngeo-event
+          ngeo-event-on="'change'"
+          ngeo-event-model="time"
+          ngeo-event-cb="ctrl.onDateRangeSelected(time)"
+          ng-prop-time="ctrl.wmsTimeRangeMode"
+        >
         </gmf-datepicker>
       </li>
 
@@ -27,7 +33,13 @@
 
       <li>
         <p>Select a single date with a datepicker</p>
-        <gmf-datepicker ng-prop-time="ctrl.wmsTimeValueMode" ng-prop-onchange_cb="ctrl.onDateSelected">
+        <gmf-datepicker
+          ngeo-event
+          ngeo-event-on="'change'"
+          ngeo-event-model="time"
+          ngeo-event-cb="ctrl.onDateSelected(time)"
+          ng-prop-time="ctrl.wmsTimeValueMode"
+        >
         </gmf-datepicker>
       </li>
 

--- a/contribs/gmf/examples/datepicker.js
+++ b/contribs/gmf/examples/datepicker.js
@@ -25,10 +25,11 @@ import angular from 'angular';
 import 'gmf/time-input/datepicker';
 import ngeoMiscWMSTime from 'ngeo/misc/WMSTime';
 import {TimePropertyWidgetEnum, TimePropertyResolutionEnum, TimePropertyModeEnum} from 'ngeo/datasource/OGC';
+import ngeoEventDirective from 'ngeo/misc/customEventDirective';
 import options from './options';
 
 /** @type {angular.IModule} **/
-const myModule = angular.module('gmfapp', ['gettext', ngeoMiscWMSTime.name]);
+const myModule = angular.module('gmfapp', ['gettext', ngeoMiscWMSTime.name, ngeoEventDirective.name]);
 
 MainController.$inject = ['$scope', 'ngeoWMSTime'];
 
@@ -38,13 +39,6 @@ MainController.$inject = ['$scope', 'ngeoWMSTime'];
  * @param {import('ngeo/misc/WMSTime').WMSTime} ngeoWMSTime wmstime service.
  */
 function MainController($scope, ngeoWMSTime) {
-  /**
-   * Allow not-angularjs to run a digest loop.
-   */
-  window.runAngularDigestLoop = () => {
-    $scope.$digest();
-  };
-
   /**
    * @type {import('ngeo/misc/WMSTime').WMSTime}
    */

--- a/contribs/gmf/examples/timeslider.html
+++ b/contribs/gmf/examples/timeslider.html
@@ -12,8 +12,11 @@
       <li>Select a period with a timeslider</li>
       <li>
         <gmf-timeslider
+          ngeo-event
+          ngeo-event-on="'change'"
+          ngeo-event-model="time"
+          ngeo-event-cb="ctrl.onDateRangeSelected(time)"
           ng-prop-time="ctrl.wmsTimeRangeMode"
-          ng-prop-onchange_cb="ctrl.onDateRangeSelected"
         ></gmf-timeslider>
       </li>
 
@@ -27,8 +30,11 @@
       <li style="margin-top: 50px">Select a single date with a timeslider</li>
       <li>
         <gmf-timeslider
+          ngeo-event
+          ngeo-event-on="'change'"
+          ngeo-event-model="time"
+          ngeo-event-cb="ctrl.onDateSelected(time)"
           ng-prop-time="ctrl.wmsTimeValueMode"
-          ng-prop-onchange_cb="ctrl.onDateSelected"
         ></gmf-timeslider>
       </li>
 

--- a/contribs/gmf/examples/timeslider.js
+++ b/contribs/gmf/examples/timeslider.js
@@ -26,9 +26,10 @@ import 'gmf/time-input/timeslider';
 import ngeoMiscWMSTime from 'ngeo/misc/WMSTime';
 import {TimePropertyWidgetEnum, TimePropertyResolutionEnum, TimePropertyModeEnum} from 'ngeo/datasource/OGC';
 import options from './options';
+import ngeoEventDirective from 'ngeo/misc/customEventDirective';
 
 /** @type {angular.IModule} **/
-const myModule = angular.module('gmfapp', ['gettext', ngeoMiscWMSTime.name]);
+const myModule = angular.module('gmfapp', ['gettext', ngeoMiscWMSTime.name, ngeoEventDirective.name]);
 
 MainController.$inject = ['$rootScope', 'ngeoWMSTime'];
 
@@ -38,13 +39,6 @@ MainController.$inject = ['$rootScope', 'ngeoWMSTime'];
  * @param {import('ngeo/misc/WMSTime').WMSTime} ngeoWMSTime wmstime service.
  */
 function MainController($scope, ngeoWMSTime) {
-  /**
-   * Allow not-angularjs to run a digest loop.
-   */
-  window.runAngularDigestLoop = () => {
-    $scope.$digest();
-  };
-
   /**
    * @type {import('ngeo/misc/WMSTime').WMSTime}
    */

--- a/src/controllers/AbstractAppController.js
+++ b/src/controllers/AbstractAppController.js
@@ -203,13 +203,6 @@ export function AbstractAppController($scope, $injector, mobile) {
   window['map'] = map;
 
   /**
-   * Allow not-angularjs to run a digest loop.
-   */
-  window['runAngularDigestLoop'] = () => {
-    this.$scope.$root.$digest();
-  };
-
-  /**
    * Location service
    *
    * @type {import('ngeo/statemanager/Location').StatemanagerLocation}

--- a/src/filter/ruleComponent.js
+++ b/src/filter/ruleComponent.js
@@ -34,6 +34,8 @@ import ngeoMiscToolActivate from 'ngeo/misc/ToolActivate';
 import ngeoMiscToolActivateMgr from 'ngeo/misc/ToolActivateMgr';
 import {RuleOperatorType, RuleSpatialOperatorType, RuleTemporalOperatorType} from 'ngeo/rule/Rule';
 import ngeoRuleGeometry from 'ngeo/rule/Geometry';
+import ngeoEventDirective from 'ngeo/misc/customEventDirective';
+import 'gmf/time-input/datepicker';
 import {getUid as olUtilGetUid} from 'ol/util';
 import olCollection from 'ol/Collection';
 import {listen, unlistenByKey} from 'ol/events';
@@ -43,7 +45,6 @@ import olStyleFill from 'ol/style/Fill';
 import {CollectionEvent} from 'ol/Collection';
 import Feature from 'ol/Feature';
 import htmlTemplate from './rulecomponent.html';
-import 'gmf/time-input/datepicker';
 
 /**
  * @typedef {Object} MenuEventTarget
@@ -63,6 +64,7 @@ const myModule = angular.module('ngeoRule', [
   ngeoFilterRuleHelper.name,
   ngeoMiscFeatureHelper.name,
   ngeoMiscToolActivateMgr.name,
+  ngeoEventDirective.name,
 ]);
 myModule.run(
   /**
@@ -383,18 +385,6 @@ export class RuleController {
      * @type {import('ol/events').EventsKey[]}
      */
     this.listenerKeys_ = [];
-
-    /**
-     * onDateRangeSelected with bound context.
-     * @type {RuleController.onDateRangeSelected}
-     */
-    this.onDateRangeSelectedBind = this.onDateRangeSelected.bind(this);
-
-    /**
-     * onDateSelected with bound context.
-     * @type {RuleController.onDateSelected}
-     */
-    this.onDateSelectedBind = this.onDateSelected.bind(this);
   }
 
   /**

--- a/src/filter/rulecomponent.html.js
+++ b/src/filter/rulecomponent.html.js
@@ -51,11 +51,21 @@ export default `<div class="dropdown">
       >
         <div ng-switch="$ctrl.clone.operator">
           <div ng-switch-when="..|time_during" ng-switch-when-separator="|">
-            <gmf-datepicker ng-prop-time="$ctrl.timeRangeMode" ng-prop-onchange_cb="$ctrl.onDateRangeSelectedBind">
+            <gmf-datepicker
+              ngeo-event
+              ngeo-event-on="'change'"
+              ngeo-event-model="time"
+              ngeo-event-cb="$ctrl.onDateRangeSelected(time)"
+              ng-prop-time="$ctrl.timeRangeMode">
             </gmf-datepicker>
           </div>
           <div ng-switch-default>
-            <gmf-datepicker ng-prop-time="$ctrl.timeValueMode" ng-prop-onchange_cb="$ctrl.onDateSelectedBind">
+            <gmf-datepicker
+             ngeo-event
+             ngeo-event-on="'change'"
+             ngeo-event-model="time"
+             ngeo-event-cb="$ctrl.onDateSelected(time)"
+             ng-prop-time="$ctrl.timeValueMode">
             </gmf-datepicker>
           </div>
         </div>

--- a/src/layertree/component.html.js
+++ b/src/layertree/component.html.js
@@ -135,18 +135,20 @@ export default `<div class="gmf-layertree-root-tools" ng-if="layertreeCtrl.isRoo
       <div ngeo-popover-content>
         <gmf-datepicker
           ng-if="::layertreeCtrl.node.time.widget === 'datepicker'"
-          ng-prop-time="layertreeCtrl.node.time"
-          ng-prop-args="layertreeCtrl"
-          ng-prop-onchange_cb="gmfLayertreeCtrl.updateTimeDataBind"
-        >
+          ngeo-event
+          ngeo-event-on="'change'"
+          ngeo-event-model="time"
+          ngeo-event-cb="gmfLayertreeCtrl.updateTimeData(layertreeCtrl, time)"
+          ng-prop-time="layertreeCtrl.node.time">
         </gmf-datepicker>
 
         <gmf-timeslider
           ng-if="::layertreeCtrl.node.time.widget === 'slider'"
-          ng-prop-time="layertreeCtrl.node.time"
-          ng-prop-args="layertreeCtrl"
-          ng-prop-onchange_cb="gmfLayertreeCtrl.updateTimeDataBind"
-        >
+          ngeo-event
+          ngeo-event-on="'change'"
+          ngeo-event-model="time"
+          ngeo-event-cb="gmfLayertreeCtrl.updateTimeData(layertreeCtrl, time)"
+          ng-prop-time="layertreeCtrl.node.time">
         </gmf-timeslider>
       </div>
     </span>

--- a/src/layertree/component.js
+++ b/src/layertree/component.js
@@ -57,6 +57,7 @@ import ngeoMiscSyncArrays from 'ngeo/misc/syncArrays';
 import ngeoMiscWMSTime from 'ngeo/misc/WMSTime';
 import 'gmf/time-input/timeslider';
 import 'gmf/time-input/datepicker';
+import ngeoEventDirective from 'ngeo/misc/customEventDirective';
 import olLayerTile from 'ol/layer/WebGLTile';
 import olLayerLayer from 'ol/layer/Layer';
 import {isEmpty} from 'ol/obj';
@@ -95,6 +96,7 @@ const myModule = angular.module('gmfLayertreeComponent', [
   ngeoLayertreeController.name,
   ngeoMapLayerHelper.name,
   ngeoMiscWMSTime.name,
+  ngeoEventDirective.name,
   gmfLayerBeingSwipe.name,
 ]);
 
@@ -348,12 +350,6 @@ export function Controller(
    */
   this.$timeout_ = $timeout;
 
-  /**
-   * updateTimeData with bound context.
-   * @type {Controller.prototype.updateTimeData}
-   */
-  this.updateTimeDataBind = this.updateTimeData.bind(this);
-
   // enter digest cycle on node collapse
   $element.on('shown.bs.collapse', () => {
     this.scope_.$apply();
@@ -541,11 +537,11 @@ Controller.prototype.getNodeState = function (treeCtrl) {
  *
  * LayertreeController.prototype.updateTimeData - description
  *
- * @param {import('ngeo/datasource/OGC').TimeRange} time The start
  * @param {import('ngeo/layertree/Controller').LayertreeController} layertreeCtrl ngeo layertree controller
+ * @param {import('ngeo/datasource/OGC').TimeRange} time The start
  * and optionally the end datetime (for time range selection) selected by user
  */
-Controller.prototype.updateTimeData = function (time, layertreeCtrl) {
+Controller.prototype.updateTimeData = function (layertreeCtrl, time) {
   this.updateWMSTimeLayerState(layertreeCtrl, time);
   this.gmfPermalink_.refreshLayerTime(layertreeCtrl, time);
 };

--- a/src/misc/customEventDirective.ts
+++ b/src/misc/customEventDirective.ts
@@ -1,0 +1,59 @@
+import angular, {IDirective} from 'angular';
+
+/**
+ * @type {angular.IModule}
+ */
+const myModule = angular.module('ngeoEvent', []);
+
+/**
+ * This directive makes a bridge between custom events and AngularJS.
+ * It allows to listen to custom events and react to changes with AngularJS.
+ * Example:
+ *   <my-emitter
+ *    ngeo-event
+ *    ngeo-event-model=myEventValue
+ *    ngeo-event-on="'my-event-name'"
+ *    ngeo-event-cb="ctrl.myCallback(myEventValue, 'an arg')"/>
+ * @returns {angular.IDirective} Directive Definition Object.
+ */
+const ngeoEventDirective = () => {
+  return {
+    restrict: 'A',
+    scope: {
+      'model': '=ngeoEventModel',
+      'on': '<ngeoEventOn',
+      'cb': '&ngeoEventCb',
+    },
+    link: function (scope: angular.IScope, element: HTMLElement[]) {
+      // @ts-ignore: scope.on
+      const eventName = `${scope.on}`;
+      // @ts-ignore: scope.cb
+      const cb = scope.cb as () => void;
+      if (!eventName) {
+        console.error('Missing event name, did you forget the quotes around the "on" attribute?');
+        return;
+      }
+      if (!cb) {
+        console.error('Missing callback, did you forget the callback "cb" attribute?');
+        return;
+      }
+      // On event listened, update the model with the value and
+      // let AngularJs know the value by running an apply.
+      // then run a second apply to call the callback with the updated model.
+      element[0].addEventListener(eventName, (event: Event) => {
+        const cEvent: CustomEvent = event as CustomEvent;
+        scope.$apply(() => {
+          // @ts-ignore: scope.cb
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          scope.model = cEvent.detail;
+        });
+        scope.$apply(() => {
+          cb();
+        });
+      });
+    },
+  } as IDirective;
+};
+
+myModule.directive('ngeoEvent', ngeoEventDirective);
+export default myModule;

--- a/src/time-input/datepicker.ts
+++ b/src/time-input/datepicker.ts
@@ -3,6 +3,12 @@ import i18next from 'i18next';
 import {customElement} from 'lit/decorators.js';
 import GmfTimeInput from 'gmf/time-input/time-input';
 
+/**
+ * Gives you a datepicker (simple or range) based on OGC time.
+ * Based on GmfTimeInput.
+ * Example:
+ * <gmf-datepicker time="myTimeConfig"></gmf-datepicker>
+ */
 @customElement('gmf-datepicker')
 export default class GmfDatepicker extends GmfTimeInput {
   static styles: CSSResult[] = [

--- a/src/time-input/timeslider.ts
+++ b/src/time-input/timeslider.ts
@@ -4,6 +4,12 @@ import {css, CSSResult, html, TemplateResult, unsafeCSS} from 'lit';
 import {debounce} from 'ngeo/misc/debounce2';
 import {TimePropertyResolutionEnum} from 'gmf/datasource/OGC';
 
+/**
+ * Gives you a timeslider (simple or range) based on OGC time.
+ * Based on GmfTimeInput.
+ * Example:
+ * <gmf-timeslider time="myTimeConfig"></gmf-timeslider>
+ */
 @customElement('gmf-timeslider')
 export default class GmfTimeslider extends GmfTimeInput {
   @state() protected sliderStart?: number;
@@ -11,7 +17,7 @@ export default class GmfTimeslider extends GmfTimeInput {
   private isInitialRendering = true;
   private datesSteps: number[];
   private readonly onSliderRelease = debounce(() => {
-    this.callCb();
+    this.emitChangeEvent();
   }, 300);
 
   static readonly styles: CSSResult[] = [


### PR DESCRIPTION
Second PR for GSGMF-2138

Previously, I ran the callback into the time-input. Which is complicated with the anguarjs context. And it was also strange to command an angularjs digest loop from lit.

My aim (and initial) was to add a "ng-change" listener on the directive to avoid that, but that's not possible as ng-change only listen on some specific markup.

I've created here directive to listen to custom event. Now:
 - Lit time-input only emits the time event and is cleaner
 - My angular directive listen to events and run a callback with the changed value.

I think it's cleaner now.
<!-- pull request links -->
See JIRA issue: [GSGMF-2138](https://jira.camptocamp.com/browse/GSGMF-2138).
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9615/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9615/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9615/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9615/merge/apidoc/)

[GSGMF-2138]: https://camptocamp.atlassian.net/browse/GSGMF-2138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ