### PR TITLE
Fallback tiles without WebGL

### DIFF
--- a/src/datasource/Manager.js
+++ b/src/datasource/Manager.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2023 Camptocamp SA
+// Copyright (c) 2017-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -37,6 +37,7 @@ import ngeoMiscWMSTime from 'ngeo/misc/WMSTime';
 import {getUid as olUtilGetUid} from 'ol/util';
 import {listen} from 'ol/events';
 import olLayerTile from 'ol/layer/WebGLTile';
+import olLayerNotWebGLTile from 'ol/layer/Tile';
 import {clear as clearObject} from 'ol/obj';
 import olLayerImage from 'ol/layer/Image';
 import olSourceImageWMS from 'ol/source/ImageWMS';
@@ -948,7 +949,9 @@ export class DatasourceManager {
    * @hidden
    */
   updateLayerFilter_(layer) {
-    if (!(layer instanceof olLayerImage || layer instanceof olLayerTile)) {
+    if (
+      !(layer instanceof olLayerImage || layer instanceof olLayerTile || layer instanceof olLayerNotWebGLTile)
+    ) {
       return;
     }
     const source = layer.getSource();

--- a/src/editing/editFeatureComponent.js
+++ b/src/editing/editFeatureComponent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2023 Camptocamp SA
+// Copyright (c) 2016-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -63,6 +63,7 @@ import olFormatGeoJSON from 'ol/format/GeoJSON';
 import olInteractionModify from 'ol/interaction/Modify';
 import olLayerImage from 'ol/layer/Image';
 import olLayerTile from 'ol/layer/WebGLTile';
+import olLayerNotWebGLTile from 'ol/layer/Tile';
 import olStyleFill from 'ol/style/Fill';
 import olStyleStyle from 'ol/style/Style';
 import olStyleText from 'ol/style/Text';
@@ -612,7 +613,7 @@ Controller.prototype.$onInit = function () {
 
   // (1.1) Set editable WMS layer
   const layer = syncLayertreeMapGetLayer(this.editableTreeCtrl);
-  if (layer instanceof olLayerImage || layer instanceof olLayerTile) {
+  if (layer instanceof olLayerImage || layer instanceof olLayerTile || layer instanceof olLayerNotWebGLTile) {
     this.editableWMSLayer_ = layer;
   }
 

--- a/src/layertree/SyncLayertreeMap.js
+++ b/src/layertree/SyncLayertreeMap.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2024 Camptocamp SA
+// Copyright (c) 2016-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -26,8 +26,8 @@ import {DATASOURCE_ID, LAYER_NODE_NAME_KEY, NODE_IS_LEAF} from 'ngeo/map/LayerHe
 import ngeoMiscWMSTime from 'ngeo/misc/WMSTime';
 import {getUid as olUtilGetUid} from 'ol/util';
 import olLayerImage from 'ol/layer/Image';
-import olLayerTile from 'ol/layer/WebGLTile';
 import Group from 'ol/layer/Group';
+import {createLayerTileOrWebGLTile} from 'ngeo/utils';
 
 /**
  * Service to create layer based on a ngeo.layertree.Controller with a
@@ -415,7 +415,7 @@ SyncLayertreeMap.prototype.initGmfLayerInANotMixedGroup_ = function (treeCtrl, m
  *     later).
  */
 SyncLayertreeMap.prototype.createWMTSLayer_ = function (gmfLayerWMTS) {
-  const newLayer = new olLayerTile();
+  const newLayer = createLayerTileOrWebGLTile();
   if (!gmfLayerWMTS.url) {
     throw new Error('Missing gmfLayerWMTS.url');
   }

--- a/src/layertree/component.js
+++ b/src/layertree/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2023 Camptocamp SA
+// Copyright (c) 2016-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -51,6 +51,7 @@ import olSourceTileWMS from 'ol/source/TileWMS';
 import olSourceWMTS from 'ol/source/WMTS';
 import LayerBase from 'ol/layer/Base';
 import {getUid} from 'ol/util';
+import olLayerNotWebGLTile from 'ol/layer/Tile';
 
 import 'bootstrap/js/src/collapse';
 
@@ -640,7 +641,7 @@ Controller.prototype.getLegendsObject = function (treeCtrl) {
 
   const layer = treeCtrl.layer;
   if (gmfLayer.type === 'WMTS') {
-    if (!(layer instanceof olLayerTile)) {
+    if (!(layer instanceof olLayerTile || layer instanceof olLayerNotWebGLTile)) {
       throw new Error('Wrong layer');
     }
     const wmtsLegendURL = this.layerHelper_.getWMTSLegendURL(layer);

--- a/src/map/LayerHelper.js
+++ b/src/map/LayerHelper.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2023 Camptocamp SA
+// Copyright (c) 2016-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -24,7 +24,6 @@ import olFormatMVT from 'ol/format/MVT';
 import olFormatWMTSCapabilities from 'ol/format/WMTSCapabilities';
 import olLayerGroup from 'ol/layer/Group';
 import olLayerImage from 'ol/layer/Image';
-import olLayerTile from 'ol/layer/WebGLTile';
 import olLayerLayer from 'ol/layer/Layer';
 import olLayerVectorTile from 'ol/layer/VectorTile';
 import {isEmpty} from 'ol/obj';
@@ -35,6 +34,7 @@ import olSourceWMTS, {optionsFromCapabilities} from 'ol/source/WMTS';
 import {appendParams as olUriAppendParams} from 'ol/uri';
 import {stylefunction as olMapboxStyleStylefunction} from 'ol-mapbox-style';
 import {ServerType} from 'ngeo/datasource/OGC';
+import {createLayerTileOrWebGLTile} from 'ngeo/utils';
 
 /**
  * Provides help functions that helps you to create and manage layers.
@@ -284,12 +284,13 @@ LayerHelper.prototype.createWMTSLayerFromCapabilitites = function (
 ) {
   opt_maxResolution = this.fixResolution_(opt_maxResolution);
   const parser = new olFormatWMTSCapabilities();
-  const layer = new olLayerTile({
+  const layerOptions = {
     preload: this.tilesPreloadingLimit_,
     minResolution: opt_minResolution,
     maxResolution: opt_maxResolution,
     className: 'canvas3d',
-  });
+  };
+  const layer = createLayerTileOrWebGLTile(layerOptions);
   const $q = this.$q_;
 
   return this.$http_.get(capabilitiesURL, {cache: true}).then((response) => {
@@ -357,11 +358,12 @@ LayerHelper.prototype.createWMTSLayerFromCapabilititesObj = function (
     source.updateDimensions(opt_dimensions);
   }
 
-  const result = new olLayerTile({
+  const layerOptions = {
     preload: Infinity,
     source: source,
     className: 'canvas3d',
-  });
+  };
+  const result = createLayerTileOrWebGLTile(layerOptions);
   result.set('capabilitiesStyles', layerCap.Style);
   return result;
 };

--- a/src/objectediting/component.js
+++ b/src/objectediting/component.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2024 Camptocamp SA
+// Copyright (c) 2016-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -52,6 +52,7 @@ import MultiPolygon from 'ol/geom/MultiPolygon';
 import GeometryCollection from 'ol/geom/GeometryCollection';
 import olLayerImage from 'ol/layer/Image';
 import olLayerTile from 'ol/layer/WebGLTile';
+import olLayerNotWebGLTile from 'ol/layer/Tile';
 import olInteractionModify from 'ol/interaction/Modify';
 import olStyleCircle from 'ol/style/Circle';
 import olStyleFill from 'ol/style/Fill';
@@ -935,7 +936,11 @@ Controller.prototype.registerTreeCtrl_ = function (treeCtrl) {
   // Set editable WMS layer for refresh purpose
   if (nodeLayer.id === this.layerNodeId) {
     const layer = syncLayertreeMapGetLayer(treeCtrl);
-    if (layer instanceof olLayerImage || layer instanceof olLayerTile) {
+    if (
+      layer instanceof olLayerImage ||
+      layer instanceof olLayerTile ||
+      layer instanceof olLayerNotWebGLTile
+    ) {
       this.editableWMSLayer_ = layer;
     }
   }

--- a/src/print/LegendMapFishPrintV3.js
+++ b/src/print/LegendMapFishPrintV3.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2021-2023 Camptocamp SA
+// Copyright (c) 2021-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -21,6 +21,7 @@
 
 import olLayerGroup from 'ol/layer/Group';
 import olLayerTile from 'ol/layer/WebGLTile';
+import olLayerNotWebGLTile from 'ol/layer/Tile';
 import ImageWMS from 'ol/source/ImageWMS';
 import {dpi as screenDpi} from 'ngeo/utils';
 import {LAYER_NODE_NAME_KEY} from 'ngeo/map/LayerHelper';
@@ -179,7 +180,7 @@ export default class LegendMapFishPrintV3 {
       return null;
     }
     // Layer is a tile, get the legend for this tile layer.
-    if (layerLeaf instanceof olLayerTile) {
+    if (layerLeaf instanceof olLayerTile || layerLeaf instanceof olLayerNotWebGLTile) {
       return this.getLegendItemFromTileLayer_(nodeLeaf, layerLeaf, dpi);
     }
     // Layer is a wms layer.

--- a/src/print/Service.js
+++ b/src/print/Service.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2023 Camptocamp SA
+// Copyright (c) 2015-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -25,6 +25,7 @@ import ngeoMapLayerHelper from 'ngeo/map/LayerHelper';
 import {stableSort} from 'ol/array';
 import olLayerImage from 'ol/layer/Image';
 import olLayerTile from 'ol/layer/WebGLTile';
+import olLayerNotWebGLTile from 'ol/layer/Tile';
 import olLayerVector from 'ol/layer/Vector';
 import * as olSize from 'ol/size';
 import olSourceImageWMS from 'ol/source/ImageWMS';
@@ -246,7 +247,7 @@ PrintService.prototype.encodeMap_ = function (map, scale, object, destinationPri
 PrintService.prototype.encodeLayer = function (arr, layer, resolution, destinationPrintDpi) {
   if (layer instanceof olLayerImage) {
     this.encodeImageLayer_(arr, layer);
-  } else if (layer instanceof olLayerTile) {
+  } else if (layer instanceof olLayerTile || layer instanceof olLayerNotWebGLTile) {
     this.encodeTileLayer_(arr, layer);
   } else if (layer instanceof olLayerVector) {
     this.encodeVectorLayer(arr, layer, resolution, destinationPrintDpi);
@@ -381,7 +382,7 @@ function getAbsoluteUrl_(url) {
  * @param {import('ol/layer/WebGLTile').default<import('ol/source/Tile').default>} layer Layer.
  */
 PrintService.prototype.encodeTileLayer_ = function (arr, layer) {
-  if (!(layer instanceof olLayerTile)) {
+  if (!(layer instanceof olLayerTile || layer instanceof olLayerNotWebGLTile)) {
     throw new Error('layer not instance of olLayerTile');
   }
   const source = layer.getSource();
@@ -397,7 +398,7 @@ PrintService.prototype.encodeTileLayer_ = function (arr, layer) {
  * @param {import('ol/layer/WebGLTile').default<import('ol/source/Tile').default>} layer Layer.
  */
 PrintService.prototype.encodeTileWmtsLayer_ = function (arr, layer) {
-  if (!(layer instanceof olLayerTile)) {
+  if (!(layer instanceof olLayerTile || layer instanceof olLayerNotWebGLTile)) {
     throw new Error('layer not instance of olLayerTile');
   }
   const source = layer.getSource();
@@ -461,7 +462,7 @@ PrintService.prototype.encodeTileWmtsLayer_ = function (arr, layer) {
  * @param {import('ol/layer/WebGLTile').default<import('ol/source/Tile').default>} layer Layer.
  */
 PrintService.prototype.encodeTileWmsLayer_ = function (arr, layer) {
-  if (!(layer instanceof olLayerTile)) {
+  if (!(layer instanceof olLayerTile || layer instanceof olLayerNotWebGLTile)) {
     throw new Error('layer not instance of olLayerTile');
   }
   const source = layer.getSource();

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,20 +28,34 @@ import olGeomPoint from 'ol/geom/Point';
 import olGeomPolygon from 'ol/geom/Polygon';
 import {getTopLeft, getTopRight, getBottomLeft, getBottomRight} from 'ol/extent';
 import {MAC} from 'ol/has';
-import {getContext} from 'ol/webgl';
+import WebGLHelper from 'ol/webgl/Helper';
 import olLayerTile from 'ol/layer/WebGLTile';
 import olLayerNotWebGLTile from 'ol/layer/Tile';
 
 let isWebGLSupportedCheck;
 /**
+ * Rely on deep OL usage of WebGL to know if WebGL is
+ * supported or not.
  * @returns true if WebGl is supported, false otherwise.
  */
 export const isWebGLSupported = () => {
   if (isWebGLSupportedCheck !== undefined) {
     return isWebGLSupportedCheck;
   }
-  const canvas = document.createElement('canvas');
-  isWebGLSupportedCheck = getContext(canvas) instanceof WebGLRenderingContext;
+  try {
+    const helper = new WebGLHelper();
+    const gl = helper.getGL();
+    if (gl instanceof WebGLRenderingContext) {
+      const vertexShaderSource = gl.createShader(gl.VERTEX_SHADER);
+      helper.compileShader(vertexShaderSource, gl.VERTEX_SHADER);
+      isWebGLSupportedCheck = true;
+    } else {
+      isWebGLSupportedCheck = false;
+    }
+  } catch (e) {
+    isWebGLSupportedCheck = false;
+    console.error(e);
+  }
   if (!isWebGLSupportedCheck) {
     console.error(
       'WebGL is not supported on this browser. The portal could be slower and some functions could not work as expected.'

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2022 Camptocamp SA
+// Copyright (c) 2016-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -28,6 +28,40 @@ import olGeomPoint from 'ol/geom/Point';
 import olGeomPolygon from 'ol/geom/Polygon';
 import {getTopLeft, getTopRight, getBottomLeft, getBottomRight} from 'ol/extent';
 import {MAC} from 'ol/has';
+import {getContext} from 'ol/webgl';
+import olLayerTile from 'ol/layer/WebGLTile';
+import olLayerNotWebGLTile from 'ol/layer/Tile';
+
+let isWebGLSupportedCheck;
+/**
+ * @returns true if WebGl is supported, false otherwise.
+ */
+export const isWebGLSupported = () => {
+  if (isWebGLSupportedCheck !== undefined) {
+    return isWebGLSupportedCheck;
+  }
+  const canvas = document.createElement('canvas');
+  isWebGLSupportedCheck = getContext(canvas) instanceof WebGLRenderingContext;
+  if (!isWebGLSupportedCheck) {
+    console.error(
+      'WebGL is not supported on this browser. The portal could be slower and some functions could not work as expected.'
+    );
+  }
+  return isWebGLSupportedCheck;
+};
+
+/**
+ * Return a WebGLTile if WebGL is supported. Otherwise, fallback on not WebGL Tile Layer.
+ * @param {import('ol/layer/WebGLTile').Options} [options] the layer options.
+ * @returns {(import('ol/layer/WebGLTile').default | import('ol/layer/Tile').default)}
+ * @static
+ */
+export const createLayerTileOrWebGLTile = (options) => {
+  if (isWebGLSupported()) {
+    return new olLayerTile(options);
+  }
+  return new olLayerNotWebGLTile(options);
+};
 
 /**
  * Return whether the passed event has the 'ctrl' key (or 'meta' key on Mac) pressed or not.


### PR DESCRIPTION
For https://camptocamp.atlassian.net/browse/GSSCHWYZ-437

Waiting https://github.com/camptocamp/schwyz_geoportal/pull/463 to test the detection on partially supported WebGL.

Without WebGL or with partial support of WebGL, ol can crash and the portal works, but without some elements, or without the whole map (it depends on the device).

I detect support of WebGL (based on OL function) and provide `ol/layer/Tiles` instead of `ol/layer/WebGLTile` if WebGL is not supported. The properties of both classes are currently the same and differs only by the rendering. Therefore, I leave the typing on "WebGLTile" when possible (It's only a fallback for rare cases).
<!-- pull request links -->
See JIRA issue: [GSSCHWYZ-437](https://jira.camptocamp.com/browse/GSSCHWYZ-437).
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9619/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9619/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9619/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9619/merge/apidoc/)

[GSSCHWYZ-437]: https://camptocamp.atlassian.net/browse/GSSCHWYZ-437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ