### PR TITLE
Disable modifying geometry if 'geom' is part of readonlyAttributes

### DIFF
--- a/src/editing/attributescomponent.html.js
+++ b/src/editing/attributescomponent.html.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2024 Camptocamp SA
+// Copyright (c) 2024-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -21,6 +21,11 @@
 
 export default `<fieldset ng-disabled="attrCtrl.disabled">
   <div class="form-group" ng-repeat="attribute in ::attrCtrl.attributes">
+    <div ng-if="attribute.type === 'geometry' && attribute.readonly">
+      <br/>
+      {{ 'The geometries of this layer cannot be modified.' | translate }}
+      <br/>
+    </div>
     <div ng-if="attribute.type !== 'geometry'">
       <label ng-if="::attribute.type !== 'boolean'" class="col-form-label"
         >{{ ::attribute.name | translate }}

--- a/src/editing/editFeatureComponent.js
+++ b/src/editing/editFeatureComponent.js
@@ -713,10 +713,23 @@ Controller.prototype.$onInit = function () {
   );
 
   // (3) Get attributes
-  this.gmfXSDAttributes_.getAttributes(this.editableNode_.id).then(this.setAttributes_.bind(this));
+  this.gmfXSDAttributes_.getAttributes(this.editableNode_.id).then((attributes) => {
+    this.setAttributes_(attributes);
+    this.setLayerStyle();
+  });
 
   // (4) Toggle
   this.toggle_(true);
+};
+
+/**Set the style on the editable layer */
+Controller.prototype.setLayerStyle = function () {
+  if (!this.vectorLayer) {
+    throw new Error('Missing vectorLayer');
+  }
+  if (getGeometryAttribute(this.attributes) && getGeometryAttribute(this.attributes).readonly) {
+    this.vectorLayer.setStyle((feature) => this.ngeoFeatureHelper_.createNoEditingSelectionStyles(feature));
+  }
 };
 
 /**
@@ -1355,7 +1368,9 @@ Controller.prototype.handleFeatureChange_ = function (newFeature, oldFeature) {
       listen(newFeature, 'propertychange', this.handleFeaturePropertyChange_, this),
       listen(geom, 'change', this.handleFeatureGeometryChange_, this),
     );
-    this.registerInteractions_();
+    if (getGeometryAttribute(this.attributes) && !getGeometryAttribute(this.attributes).readonly) {
+      this.registerInteractions_();
+    }
     this.gmfSnapping_.ensureSnapInteractionsOnTop();
 
     // The `ui-date` triggers an unwanted change, i.e. it converts the text

--- a/src/misc/FeatureHelper.js
+++ b/src/misc/FeatureHelper.js
@@ -7,7 +7,7 @@ FeatureHelper.$inject = [
 ];
 // The MIT License (MIT)
 //
-// Copyright (c) 2016-2024 Camptocamp SA
+// Copyright (c) 2016-2025 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -700,6 +700,68 @@ FeatureHelper.prototype.createEditingStyles = function (feature) {
 
     // (2) Anything else than 'Point' requires the vertex style as well
     styles.push(this.getVertexStyle(true));
+  }
+  return styles;
+};
+
+FeatureHelper.prototype.createNoEditingSelectionStyles = function (feature) {
+  // (1) Style definition depends on geometry type
+  const white = [255, 255, 255, 1];
+  const grey = [128, 128, 128, 0.7];
+  const width = 2;
+  const styles = [];
+  const geom = feature.getGeometry();
+  if (!geom) {
+    throw new Error('Missing geom');
+  }
+  const type = geom.getType();
+  if (type === 'Point' || type === 'MultiPoint') {
+    styles.push(
+      new olStyleStyle({
+        image: new olStyleCircle({
+          radius: width * 4,
+          fill: new olStyleFill({
+            color: grey,
+          }),
+          stroke: new olStyleStroke({
+            color: white,
+            width: width / 2,
+          }),
+        }),
+        zIndex: Infinity,
+      }),
+    );
+  } else {
+    if (type === 'LineString' || type === 'MultiLineString') {
+      styles.push(
+        new olStyleStyle({
+          stroke: new olStyleStroke({
+            color: white,
+            width: width + 2,
+          }),
+        }),
+      );
+      styles.push(
+        new olStyleStyle({
+          stroke: new olStyleStroke({
+            color: grey,
+            width: width,
+          }),
+        }),
+      );
+    } else {
+      styles.push(
+        new olStyleStyle({
+          stroke: new olStyleStroke({
+            color: grey,
+            width: width / 2,
+          }),
+          fill: new olStyleFill({
+            color: [255, 255, 255, 0.5],
+          }),
+        }),
+      );
+    }
   }
   return styles;
 };


### PR DESCRIPTION
This PR makes that, while editing an item, the geometries can not be modified, if the geometry attribute name is part of the metadata 'readonlyAttributes' of the layer.
If the geometry is not editable, the selected item is highlighted in grey without vertices.
<!-- pull request links -->
See JIRA issue: [GSGGR-39](https://jira.camptocamp.com/browse/GSGGR-39).
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9640/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9640/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9640/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9640/merge/apidoc/)

[GSGGR-39]: https://camptocamp.atlassian.net/browse/GSGGR-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ