### PR TITLE
Add argument to fix c2cgeoportal CI

### DIFF
--- a/buildtools/compile-catalog.js
+++ b/buildtools/compile-catalog.js
@@ -51,6 +51,7 @@ function main(inputs) {
 
 // If running this module directly then call the main function.
 if (require.main === module) {
+  program.argument('<string>');
   program.parse(process.argv);
   console.log('Compiling the files: ' + program.args.join(' ')); // eslint-disable-line no-console
   main(program.args);


### PR DESCRIPTION
error: too many arguments. Expected 0 arguments but got 2.
<!-- pull request links -->
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9650/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9650/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9650/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9650/merge/apidoc/)