### PR TITLE
CI updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,14 +3,14 @@
   'extends': [
     'github>camptocamp/gs-renovate-config-preset:base.json5#1.2.3',
     'github>camptocamp/gs-renovate-config-preset:group.json5#1.2.3',
-    'github>camptocamp/gs-renovate-config-preset:stabilization-branches.json5#1.2.3',
     'github>camptocamp/gs-renovate-config-preset:ci.json5#1.2.3',
     'github>camptocamp/gs-renovate-config-preset:preset.json5#1.2.3',
     'github>camptocamp/gs-renovate-config-preset:pre-commit.json5#1.2.3',
-    'github>camptocamp/gs-renovate-config-preset:own.json5#1.2.3',
     'github>camptocamp/gs-renovate-config-preset:json-schema.json5#1.2.3',
     'github>camptocamp/gs-renovate-config-preset:shellcheck.json5#1.2.3',
     'github>camptocamp/gs-renovate-config-preset:python.json5#1.2.3',
+    'github>camptocamp/gs-renovate-config-preset:stabilization-branches.json5#1.2.3',
+    'github>camptocamp/gs-renovate-config-preset:own.json5#1.2.3',
     'github>camptocamp/gs-renovate-config-preset:security.json5#1.2.3',
   ],
   separateMultipleMajor: true,
@@ -34,12 +34,6 @@
     {
       matchUpdateTypes: ['major'],
       dependencyDashboardApproval: true,
-    },
-    /** Accept only the patch on stabilization branches */
-    {
-      matchBaseBranches: ['/^[0-9]+\\.[0-9]+$/'],
-      matchUpdateTypes: ['major', 'minor', 'pin', 'digest', 'lockFileMaintenance', 'rollback', 'bump'],
-      enabled: false,
     },
     /** Group Webpack dependencies */
     {


### PR DESCRIPTION
This is done by the automated script named upgrade-ci-2025

<!-- pull request links -->
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9800/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9800/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9800/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9800/merge/apidoc/)