### PR TITLE
CI updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,7 @@
     'github>camptocamp/gs-renovate-config-preset:security.json5#1.4.2',
   ],
   separateMultipleMajor: true,
-  baseBranches: ['master', '2.7', '2.8', '2.9'],
+  baseBranchPatterns: ['master', '2.7', '2.8', '2.9'],
   customManagers: [
     {
       matchStrings: ['(?<depName>[^\\s]+): (?<currentValue>[^\\s]+) # (?<datasource>[^\\s]+)'],


### PR DESCRIPTION
This is done by the automated script named upgrade-ci-2025

<!-- pull request links -->
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9873/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9873/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9873/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9873/merge/apidoc/)