### PR TITLE
Use the same panel name in the tool button and panel listener

### DIFF
--- a/src/canvas/ToolButtonsImplElements.ts
+++ b/src/canvas/ToolButtonsImplElements.ts
@@ -106,7 +106,7 @@ export class ToolButtonFilter extends ToolButtonElement {
 @customElement('gmf-editing-button')
 export class ToolButtonEditing extends ToolButtonElement {
   constructor() {
-    super('editing');
+    super('edit');
   }
 
   render(): TemplateResult {


### PR DESCRIPTION
There was a mismatch of the panel name for the editing tool: 

- `editing` in the tool button element
- `edit` in the listener for panel changes in the AbstractDesktopController: 

https://github.com/camptocamp/ngeo/blob/3805a95121a63214cee9023a5d41e2f9748e959a/src/controllers/AbstractDesktopController.js#L171

This causes the editing tool to be improperly activated
