### PR TITLE
Really fix edit panel activation

### DIFF
--- a/src/canvas/ToolButtonsImplElements.ts
+++ b/src/canvas/ToolButtonsImplElements.ts
@@ -106,7 +106,7 @@ export class ToolButtonFilter extends ToolButtonElement {
 @customElement('gmf-editing-button')
 export class ToolButtonEditing extends ToolButtonElement {
   constructor() {
-    super('edit');
+    super('editing');
   }
 
   render(): TemplateResult {

--- a/src/controllers/AbstractDesktopController.js
+++ b/src/controllers/AbstractDesktopController.js
@@ -168,7 +168,7 @@ export class AbstractDesktopController extends AbstractAPIController {
         this.drawFeatureActive = panel === 'draw';
         this.drawProfilePanelActive = panel === 'profile';
         this.routingPanelActive = panel === 'routing';
-        this.editFeatureActivate = panel === 'edit';
+        this.editFeatureActive = panel === 'editing';
         this.googleStreetViewActive = panel === 'googlestreetview';
         this.mapillaryStreetViewActive = panel === 'mapillary';
         $timeout(() => {}); // this triggered on DOM click, we call $timeout to force Angular digest


### PR DESCRIPTION
Follow-up of PR #9909.

Changing the panel name in the tool button is a breaking change since it requires to change the slot name in the main HTML document, so change the panel name in the listener instead.

Additionnally, there still was a mismatch in the name of the AbstractDesktopController class field and the tool active property name (editFeatureActive)

<!-- pull request links -->
See JIRA issue: [GSGRAUB-142](https://jira.camptocamp.com/browse/GSGRAUB-142).
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9911/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9911/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9911/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9911/merge/apidoc/)

[GSGRAUB-142]: https://camptocamp.atlassian.net/browse/GSGRAUB-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ