### PR TITLE
Renovate: On the branch 2.7 don't allows to update @types/d3-dispatch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,5 +73,11 @@
       groupName: 'python',
       automerge: true,
     },
+    /** On the branch 2.7 don't allow to update @types/d3-dispatch */
+    {
+      matchBaseBranches: ['2.7'],
+      matchPackageNames: ['@types/d3-dispatch'],
+      enabled: false,
+    },
   ],
 }


### PR DESCRIPTION


<!-- pull request links -->
[Examples](https://camptocamp.github.io/ngeo/refs/pull/9915/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/9915/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/9915/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/9915/merge/apidoc/)