### PR TITLE
Add queryFeatureTypes metadata for WMS GetFeatureInfo parsing

### DIFF
--- a/src/datasource/Manager.js
+++ b/src/datasource/Manager.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2025 Camptocamp SA
+// Copyright (c) 2017-2026 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -578,7 +578,12 @@ export class DatasourceManager {
       // filtrable.
 
       const queryLayers = meta.queryLayers ? meta.queryLayers.split(',') : null;
-      wmsLayers = gmfLayerWMS.layers.split(',').map((childLayer) => {
+      const queryFeatureTypes =
+        Array.isArray(meta.queryFeatureTypes) && meta.queryFeatureTypes.length > 0
+          ? meta.queryFeatureTypes
+          : null;
+      const wmsLayerNames = gmfLayerWMS.layers.split(',');
+      wmsLayers = wmsLayerNames.map((childLayer) => {
         /** @type {import('ngeo/datasource/OGC').WMSLayer} */
         const item = {
           name: childLayer,
@@ -586,6 +591,9 @@ export class DatasourceManager {
         };
         if (queryLayers && !queryLayers.includes(childLayer)) {
           item.getData = false;
+        }
+        if (queryFeatureTypes) {
+          item.queryFeatureTypes = queryFeatureTypes;
         }
         return item;
       });

--- a/src/datasource/OGC.js
+++ b/src/datasource/OGC.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2025 Camptocamp SA
+// Copyright (c) 2017-2026 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -176,6 +176,8 @@ export const WMSInfoFormat = {
  * @property {boolean} [queryable] Whether the the layer is queryable or not. Defaults to `false`.
  * @property {boolean|undefined} [getData] If the layer is queryable and this property is set to
  *     false, then the layer won't be used in queries issued. Defaults to `true`.
+ * @property {string[]} [queryFeatureTypes] Feature type names to parse from WMS GetFeatureInfo
+ *     GML responses for this layer.
  */
 
 /**

--- a/src/query/Querent.js
+++ b/src/query/Querent.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2017-2025 Camptocamp SA
+// Copyright (c) 2017-2026 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -493,10 +493,16 @@ export class Querent {
     /** @type {import('ol/Feature').default<import('ol/geom/Geometry').default>[]} */
     let readFeatures;
     // Copy the types to be able to set it AND iterate on it.
-    const featureTypes = this.getSetOlFormatTypes_(dataSource, wfs).slice();
-    featureTypes.forEach((type) => {
-      // Assign temporarily a single feature type to read features separately.
-      this.getSetOlFormatTypes_(dataSource, wfs, [type]);
+    const formatTypes = this.getSetOlFormatTypes_(dataSource, wfs).slice();
+    const typeMappings = wfs
+      ? formatTypes.map((type) => ({
+          label: type,
+          parserTypes: [type],
+        }))
+      : this.getWMSReadTypeMappings_(dataSource, formatTypes);
+    typeMappings.forEach((mapping) => {
+      // Assign temporarily one or more parser types to read features separately.
+      this.getSetOlFormatTypes_(dataSource, wfs, mapping.parserTypes);
       if (wfs) {
         if (!dataSource.wfsFormat) {
           throw new Error('Missing wfsFormat');
@@ -514,15 +520,37 @@ export class Querent {
       }
       if (readFeatures.length > 0) {
         readFeatures.forEach((feature) => {
-          feature.set('ngeo_feature_type_', type);
+          feature.set('ngeo_feature_type_', mapping.label);
           features.push(feature);
         });
       }
     });
     // Re-set the value to the datasource.xxxFormat to be able to reuse
     // it later (in another query);
-    this.getSetOlFormatTypes_(dataSource, wfs, featureTypes);
+    this.getSetOlFormatTypes_(dataSource, wfs, formatTypes);
     return features;
+  }
+
+  /**
+   * Build WMS read mappings using query feature types when configured.
+   *
+   * @param {gmfDatasourceOGC} dataSource Data source that contains WMS layers.
+   * @param {string[]} layerNames Layer names configured in the WMS format.
+   * @returns {{label: string, parserTypes: string[]}[]} Read mappings.
+   * @private
+   */
+  getWMSReadTypeMappings_(dataSource, layerNames) {
+    return layerNames.map((layerName) => {
+      let parserTypes = [layerName];
+      const wmsLayer = (dataSource.wmsLayers || []).find((item) => item.name === layerName);
+      if (wmsLayer && Array.isArray(wmsLayer.queryFeatureTypes) && wmsLayer.queryFeatureTypes.length > 0) {
+        parserTypes = wmsLayer.queryFeatureTypes;
+      }
+      return {
+        label: layerName,
+        parserTypes,
+      };
+    });
   }
 
   /**

--- a/src/themes.js
+++ b/src/themes.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019-2024 Camptocamp SA
+// Copyright (c) 2019-2026 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -258,6 +258,8 @@
  * @property {number[]} [queryIconPosition] values to define the shape (bbox) to use to query
  *      the layer. The values are used like a padding in css with 1, 2, 3 or 4 comma separated
  *      values: all / top-bottom, left-right / top, right-left, bottom / top, right, bottom, left.
+ * @property {string[]} [queryFeatureTypes] List of feature type names to parse from WMS GetFeatureInfo
+ *      GML responses when the returned type names differ from the queried WMS layer name.
  * @property {string} [ogcServer] The corresponding OGC server. For WMTS and vector tiles layers.
  * @property {number} [opacity=1.0] Layer opacity. 1.0 means fully visible, 0 means invisible, for every
  *      kind of layers.

--- a/test/spec/services/querent.spec.js
+++ b/test/spec/services/querent.spec.js
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2020-2024 Camptocamp SA
+// Copyright (c) 2020-2026 Camptocamp SA
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -56,5 +56,44 @@ describe('ngeo.Querent', () => {
 
     result = ngeoQuerent.makeBboxWithQueryIconPosition_([1, 2, 3, 4, 5], resolution, coordinate);
     expect(result).toBe(null);
+  });
+
+  it('Builds WMS read mappings with queryFeatureTypes', () => {
+    const dataSource = {
+      wmsLayers: [
+        {
+          name: 'cadastre_parcels',
+          queryFeatureTypes: ['cadastre_parcels_polygon', 'cadastre_parcels_label'],
+        },
+      ],
+    };
+
+    const mappings = ngeoQuerent.getWMSReadTypeMappings_(dataSource, ['cadastre_parcels']);
+
+    expect(mappings).toEqual([
+      {
+        label: 'cadastre_parcels',
+        parserTypes: ['cadastre_parcels_polygon', 'cadastre_parcels_label'],
+      },
+    ]);
+  });
+
+  it('Builds WMS read mappings with layer names by default', () => {
+    const dataSource = {
+      wmsLayers: [
+        {
+          name: 'cadastre_buildings',
+        },
+      ],
+    };
+
+    const mappings = ngeoQuerent.getWMSReadTypeMappings_(dataSource, ['cadastre_buildings']);
+
+    expect(mappings).toEqual([
+      {
+        label: 'cadastre_buildings',
+        parserTypes: ['cadastre_buildings'],
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## What
- add `queryFeatureTypes` metadata as a real `string[]` list
- allow WMS GetFeatureInfo parsing to use alternate feature type names
- keep result grouping label on the original WMS layer name
- add unit tests for mapping behavior and default fallback

## Why
Some external WMS services return `msGMLOutput` feature types whose names differ from queried layer names. This change enables parsing those responses without changing `queryLayers` behavior.

## Notes
- `LAYERS`/`QUERY_LAYERS` request behavior is unchanged
- `queryFeatureTypes` is optional and backward compatible


<!-- pull request links -->
See JIRA issue: [GSSIT-129](https://jira.camptocamp.com/browse/GSSIT-129).
[Examples](https://camptocamp.github.io/ngeo/refs/pull/10137/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/10137/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/10137/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/10137/merge/apidoc/)

[GSSIT-129]: https://camptocamp.atlassian.net/browse/GSSIT-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ