### PR TITLE
Disable webpack-dev-server renovate updates on 2.8 branch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -79,5 +79,11 @@
       matchPackageNames: ['@types/d3-dispatch'],
       enabled: false,
     },
+    /** Disable webpack-dev-server updates on 2.8 branch */
+    {
+      matchBaseBranches: ['2.8'],
+      matchPackageNames: ['webpack-dev-server'],
+      enabled: false,
+    },
   ],
 }


### PR DESCRIPTION
## Summary

Disable Renovate updates for `webpack-dev-server` on the 2.8 stabilization branch.

## Context

- `webpack-dev-server` should not be updated on the 2.8 branch
- Follows the same pattern as the existing rule for `@types/d3-dispatch`

<!-- pull request links -->
[Examples](https://camptocamp.github.io/ngeo/refs/pull/10163/merge/examples/)
[Storybook](https://camptocamp.github.io/ngeo/refs/pull/10163/merge/storybook/)
[API help](https://camptocamp.github.io/ngeo/refs/pull/10163/merge/api/apihelp/apihelp.html)
[API documentation](https://camptocamp.github.io/ngeo/refs/pull/10163/merge/apidoc/)